### PR TITLE
Unify river dry-gap threshold across river tooling (#24)

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/tools/river_thresholds.py
+++ b/tools/river_thresholds.py
@@ -1,0 +1,27 @@
+"""Shared pass/fail thresholds for the river placement tooling.
+
+Single source of truth so the single-seed regression test
+(``test_river_pour.py``) and the multi-seed stress test
+(``test_river_stress.py``) agree on what counts as a failure.
+
+Each value is the MAXIMUM allowed count for that metric (inclusive):
+a run passes when its observed count is ``<= threshold``.
+
+Both tools expose ``--max-*`` CLI flags backed by these defaults, so an
+individual run can still be tightened or loosened without editing code.
+"""
+
+# River surface above an adjacent rendered body — should never happen.
+MAX_VISIBLE_DROPS = 0
+
+# No-fluid tiles wedged between a river and a body (ocean/lake).
+# The single-seed and multi-seed tools previously disagreed here
+# (15 vs 20); 20 is the unified value — the looser of the two, so no
+# previously-passing run newly fails.
+MAX_DRY_GAPS = 20
+
+# riverMask=true tiles that ended up with no fluid placed.
+MAX_MASK_DRY = 30
+
+# Consecutive river tiles running alongside ocean at high elevation.
+MAX_COASTAL_PARALLEL = 5

--- a/tools/test_river_pour.py
+++ b/tools/test_river_pour.py
@@ -22,7 +22,11 @@ import json
 import subprocess
 import sys
 import argparse
+import os
 from collections import defaultdict
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import river_thresholds as rt
 
 CHUNK_SIZE = 16
 
@@ -37,11 +41,12 @@ def parse_args():
     p.add_argument("--region", type=str, default=None,
                    help="chunk region cx1,cy1,cx2,cy2 (triggers cabal --dump when set without a path)")
     p.add_argument("--verbose", "-v", action="store_true")
-    # Thresholds for pass/fail
-    p.add_argument("--max-visible-drops", type=int, default=0)
-    p.add_argument("--max-dry-gaps", type=int, default=15)
-    p.add_argument("--max-mask-dry", type=int, default=30)
-    p.add_argument("--max-coastal-parallel", type=int, default=5)
+    # Thresholds for pass/fail (shared with test_river_stress.py via
+    # tools/river_thresholds.py — keep them in sync there, not here).
+    p.add_argument("--max-visible-drops", type=int, default=rt.MAX_VISIBLE_DROPS)
+    p.add_argument("--max-dry-gaps", type=int, default=rt.MAX_DRY_GAPS)
+    p.add_argument("--max-mask-dry", type=int, default=rt.MAX_MASK_DRY)
+    p.add_argument("--max-coastal-parallel", type=int, default=rt.MAX_COASTAL_PARALLEL)
     return p.parse_args()
 
 def run_dump(seed, worldSize, region):

--- a/tools/test_river_stress.py
+++ b/tools/test_river_stress.py
@@ -11,7 +11,11 @@ import json
 import subprocess
 import sys
 import argparse
+import os
 import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import river_thresholds as rt
 
 def parse_args():
     p = argparse.ArgumentParser(description="River placement stress test")
@@ -21,9 +25,13 @@ def parse_args():
     p.add_argument("--region", type=str, default="-4,-4,4,4")
     p.add_argument("--start-seed", type=int, default=1,
                    help="First seed to test")
+    # Thresholds shared with test_river_pour.py via tools/river_thresholds.py.
+    p.add_argument("--max-visible-drops", type=int, default=rt.MAX_VISIBLE_DROPS)
+    p.add_argument("--max-dry-gaps", type=int, default=rt.MAX_DRY_GAPS)
+    p.add_argument("--max-mask-dry", type=int, default=rt.MAX_MASK_DRY)
     return p.parse_args()
 
-def run_one_seed(seed, worldSize, region):
+def run_one_seed(seed, worldSize, region, thresholds):
     """Run dump + analysis for one seed. Returns (passed, stats_dict)."""
     cmd = [
         "cabal", "run", "exe:synarchy", "--",
@@ -93,15 +101,25 @@ def run_one_seed(seed, worldSize, region):
         "mask_dry": mask_dry,
     }
 
-    passed = vis_drops == 0 and dry_gaps <= 20 and mask_dry <= 30
+    passed = (vis_drops <= thresholds["visible_drops"]
+              and dry_gaps <= thresholds["dry_gaps"]
+              and mask_dry <= thresholds["mask_dry"])
     return passed, stats
 
 def main():
     args = parse_args()
     seeds = list(range(args.start_seed, args.start_seed + args.seeds))
+    thresholds = {
+        "visible_drops": args.max_visible_drops,
+        "dry_gaps": args.max_dry_gaps,
+        "mask_dry": args.max_mask_dry,
+    }
 
     print(f"River placement stress test: {len(seeds)} seeds, "
           f"worldSize={args.worldSize}, region={args.region}")
+    print(f"Thresholds: drops<={thresholds['visible_drops']}  "
+          f"dry_gaps<={thresholds['dry_gaps']}  "
+          f"mask_dry<={thresholds['mask_dry']}")
     print("=" * 70)
 
     results = []
@@ -110,7 +128,7 @@ def main():
 
     for i, seed in enumerate(seeds):
         t0 = time.time()
-        passed, stats = run_one_seed(seed, args.worldSize, args.region)
+        passed, stats = run_one_seed(seed, args.worldSize, args.region, thresholds)
         elapsed = time.time() - t0
 
         status = "PASS" if passed else "FAIL"


### PR DESCRIPTION
Closes #24.

## Problem
`tools/test_river_pour.py` defaulted `--max-dry-gaps` to **15**, while `tools/test_river_stress.py` hardcoded a **20**-gap limit. The single-seed regression test and the multi-seed stress test therefore disagreed on what counts as a river-placement failure. (The other two metrics — visible drops `0`, mask-dry `30` — already matched.)

## Fix
- New `tools/river_thresholds.py` holds the pass/fail thresholds as the single source of truth (`MAX_VISIBLE_DROPS`, `MAX_DRY_GAPS`, `MAX_MASK_DRY`, `MAX_COASTAL_PARALLEL`).
- Both tools import it for their `--max-*` argparse defaults. `test_river_stress.py` previously had the limits hardcoded in its pass expression and no CLI overrides — it now uses overridable flags backed by the shared constants, and prints the active thresholds at startup.
- Unified dry-gap value is **20** (the looser of the two) so no previously-passing run newly fails. To tighten the gate back to 15, change `MAX_DRY_GAPS` in the shared module in one place.
- Added `tools/.gitignore` for the `__pycache__/*.pyc` now produced because the tools import a shared module.

## Validation
- Both tools report identical defaults after the change (`dry_gaps=20`, `mask_dry=30`, `drops=0`).
- Ran `test_river_pour.py` end-to-end against a real seed-42 `--dump`; the script executes correctly and applies the unified `max 20` threshold. (That seed reports pre-existing world-quality failures — visible drops / dry gaps — which belong to the open worldgen-quality issues, not this tooling change; pass/fail behavior for it is unchanged since 25 gaps exceeds both the old 15 and new 20.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)