### PR TITLE
Fix flora annual-cycle rendering to use day-of-year, not day-of-month (#25)

### DIFF
--- a/src/World/Flora/Render.hs
+++ b/src/World/Flora/Render.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE Strict, UnicodeSyntax #-}
 module World.Flora.Render
     ( resolveFloraTexture
+    , findActiveCycleStage  -- exported for annual-cycle selection tests
     ) where
 
 import UPrelude

--- a/src/World/Render/Quads.hs
+++ b/src/World/Render/Quads.hs
@@ -110,7 +110,11 @@ renderWorldQuads env worldState zoomAlpha snap = do
 
     let (fbW, fbH) = wcsFbSize snap
         facing = camFacing camera
-        dayOfYear = wdDay worldDate
+        -- Annual-cycle flora wants a year-relative ordinal day, not the
+        -- day-of-month field. Convert through the world calendar (falling
+        -- back to the default calendar when gen params aren't loaded yet).
+        calendar = maybe defaultCalendarConfig wgpCalender paramsM
+        dayOfYear = worldDateToDayOfYear calendar worldDate
 
     mBindless ← readIORef (textureSystemRef env)
     defFmSlotWord ← readIORef (defaultFaceMapSlotRef env)

--- a/src/World/Time/Types.hs
+++ b/src/World/Time/Types.hs
@@ -6,6 +6,7 @@ module World.Time.Types
     , advanceWorldTime
     , WorldDate(..)
     , defaultWorldDate
+    , worldDateToDayOfYear
     , CalendarConfig(..)
     , defaultCalendarConfig
     , SunConfig(..)
@@ -56,10 +57,24 @@ advanceWorldTime timeScale dtSeconds (WorldTime h m) =
 
 -- | World date (placeholder for seasons).
 --   Currently unused for sun angle calculation.
+--
+--   Calendar contract: the simplified world calendar gives every month
+--   the same length ('ccDaysPerMonth'), so a year has
+--   @ccDaysPerMonth * ccMonthsPerYear@ days. The fields below are
+--   /calendar/ components, NOT a year-relative day:
+--
+--     * 'wdMonth' is the month-of-year (@1 .. ccMonthsPerYear@).
+--     * 'wdDay'   is the day-of-/month/ (@1 .. ccDaysPerMonth@).
+--
+--   Anything that needs a year-relative \"ordinal day\" (e.g. flora
+--   annual-cycle stage selection) must convert through
+--   'worldDateToDayOfYear' — passing 'wdDay' directly aliases
+--   day-of-month with day-of-year and can never reach stages past the
+--   first month.
 data WorldDate = WorldDate
     { wdYear  ∷ !Int
-    , wdMonth ∷ !Int   -- ^ 1-12
-    , wdDay   ∷ !Int   -- ^ 1-31
+    , wdMonth ∷ !Int   -- ^ month-of-year, 1 .. ccMonthsPerYear
+    , wdDay   ∷ !Int   -- ^ day-of-month, 1 .. ccDaysPerMonth
     } deriving (Show, Eq)
 
 defaultWorldDate ∷ WorldDate
@@ -68,6 +83,31 @@ defaultWorldDate = WorldDate
     , wdMonth = 1
     , wdDay   = 1
     }
+
+-- | Convert a 'WorldDate' to a zero-based ordinal day-of-year, using the
+--   calendar's fixed month length.
+--
+--   The result is the number of whole days elapsed since the first day
+--   of the year, in @[0 .. daysPerYear - 1]@ where
+--   @daysPerYear = ccDaysPerMonth * ccMonthsPerYear@:
+--
+--     * month 1, day 1   → 0   (first day of the year)
+--     * month 1, day 2   → 1
+--     * the last day     → daysPerYear - 1
+--
+--   Zero-based to match how annual-cycle stage start days are authored
+--   (a stage beginning on the first day of the year uses start day 0).
+--   'wdMonth' and 'wdDay' are clamped into their valid ranges first, so
+--   an out-of-range 'WorldDate' can never produce a negative or
+--   past-end-of-year result. 'wdYear' is ignored: the cycle repeats
+--   every year.
+worldDateToDayOfYear ∷ CalendarConfig → WorldDate → Int
+worldDateToDayOfYear cc (WorldDate _ month day) =
+    let dpm = max 1 (ccDaysPerMonth cc)
+        mpy = max 1 (ccMonthsPerYear cc)
+        m   = max 1 (min mpy month)
+        d   = max 1 (min dpm day)
+    in (m - 1) * dpm + (d - 1)
 
 data CalendarConfig = CalendarConfig
     { ccDaysPerMonth  ∷ !Int      -- ^ e.g. 30

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -162,6 +162,7 @@ test-suite synarchy-test-headless
                    Test.Headless.Magma.Shape
                    Test.Headless.Sim.Seam
                    Test.Headless.Input.KeyNames
+                   Test.Headless.World.Calendar
     default-extensions: DefaultSignatures
                      , DuplicateRecordFields
                      , MagicHash

--- a/test-headless/Spec.hs
+++ b/test-headless/Spec.hs
@@ -27,6 +27,7 @@ import qualified Test.Headless.Combat.Wounds as CombatWounds
 import qualified Test.Headless.Magma.Shape as MagmaShape
 import qualified Test.Headless.Sim.Seam as SimSeam
 import qualified Test.Headless.Input.KeyNames as InputKeyNames
+import qualified Test.Headless.World.Calendar as Calendar
 
 main ∷ IO ()
 main = hspec $ do
@@ -60,3 +61,4 @@ main = hspec $ do
     describe "World.Magma.Shape" MagmaShape.spec
     describe "Sim.Fluid.Seam" SimSeam.spec
     describe "Input.KeyNames" InputKeyNames.spec
+    describe "World.Calendar" Calendar.spec

--- a/test-headless/Test/Headless/Unit/Pathing/AStar.hs
+++ b/test-headless/Test/Headless/Unit/Pathing/AStar.hs
@@ -13,6 +13,7 @@ import World.Chunk.Types (ChunkCoord(..), LoadedChunk(..), chunkSize)
 import World.Tile.Types (WorldTileData(..))
 import World.Fluid.Types (FluidCell(..), FluidType(..), emptyIceMap)
 import World.Flora.Types (emptyFloraChunkData)
+import Structure.Types (emptyChunkStructures)
 import Unit.Pathing.AStar
 
 flatChunk ∷ Int → LoadedChunk
@@ -32,6 +33,7 @@ flatChunk terrZ =
         , lcSideDeco          = VU.empty
         , lcWaterTableMap     = VU.empty
         , lcMagma             = Nothing
+        , lcStructures        = emptyChunkStructures
         }
 
 customChunk ∷ ((Int, Int) → (Int, Maybe FluidType)) → LoadedChunk
@@ -57,6 +59,7 @@ customChunk f =
         , lcSideDeco          = VU.empty
         , lcWaterTableMap     = VU.empty
         , lcMagma             = Nothing
+        , lcStructures        = emptyChunkStructures
         }
 
 worldWith ∷ LoadedChunk → WorldTileData

--- a/test-headless/Test/Headless/Unit/Pathing/Cost.hs
+++ b/test-headless/Test/Headless/Unit/Pathing/Cost.hs
@@ -14,6 +14,7 @@ import World.Chunk.Types (ChunkCoord(..), LoadedChunk(..), chunkSize, columnInde
 import World.Tile.Types (WorldTileData(..))
 import World.Fluid.Types (FluidCell(..), FluidType(..), emptyIceMap)
 import World.Flora.Types (emptyFloraChunkData)
+import Structure.Types (emptyChunkStructures)
 import Unit.Pathing.Cost
 
 -- | Build a single chunk at the origin with uniform terrain z and
@@ -35,6 +36,7 @@ flatChunk terrZ =
         , lcSideDeco          = VU.empty
         , lcWaterTableMap     = VU.empty
         , lcMagma             = Nothing
+        , lcStructures        = emptyChunkStructures
         }
 
 -- | Build a single chunk with per-tile terrain/fluid set by a function.
@@ -62,6 +64,7 @@ customChunk f =
         , lcSideDeco          = VU.empty
         , lcWaterTableMap     = VU.empty
         , lcMagma             = Nothing
+        , lcStructures        = emptyChunkStructures
         }
 
 worldWith ∷ LoadedChunk → WorldTileData

--- a/test-headless/Test/Headless/World/Calendar.hs
+++ b/test-headless/Test/Headless/World/Calendar.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE UnicodeSyntax #-}
+-- | Calendar / annual-cycle selection tests.
+--
+--   Regression guard for the day-of-month-aliased-as-day-of-year bug:
+--   the flora renderer used to feed 'wdDay' (a 1..31 day-of-month) into
+--   annual-cycle stage selection, so any stage starting after the first
+--   month was unreachable. These tests pin two things:
+--
+--     1. 'worldDateToDayOfYear' maps a 'WorldDate' to a zero-based
+--        year-relative ordinal day using the calendar's fixed month
+--        length, and clamps out-of-range components.
+--     2. 'findActiveCycleStage' picks the right stage for ordinal days
+--        well past day 31, and wraps for early-year days.
+module Test.Headless.World.Calendar (spec) where
+
+import UPrelude
+import Test.Hspec
+import Engine.Asset.Handle (TextureHandle(..))
+import World.Time.Types
+    (WorldDate(..), CalendarConfig(..), defaultCalendarConfig
+    , worldDateToDayOfYear)
+import World.Flora.Types (AnnualStage(..), AnnualStageTag(..))
+import World.Flora.Render (findActiveCycleStage)
+
+-- Default calendar is 30 days/month × 12 months = 360-day year.
+daysPerYear ∷ Int
+daysPerYear = ccDaysPerMonth defaultCalendarConfig
+            * ccMonthsPerYear defaultCalendarConfig
+
+doy ∷ Int → Int → Int
+doy month day = worldDateToDayOfYear defaultCalendarConfig
+                                     (WorldDate 1 month day)
+
+-- A four-stage annual cycle authored 0-based, like the real flora data
+-- (dormant 0, budding 60, flowering 120, senescing 270).
+stages ∷ [AnnualStage]
+stages =
+    [ AnnualStage CycleDormant    0   (TextureHandle 1)
+    , AnnualStage CycleBudding    60  (TextureHandle 2)
+    , AnnualStage CycleFlowering  120 (TextureHandle 3)
+    , AnnualStage CycleSenescing  270 (TextureHandle 4)
+    ]
+
+selectedTag ∷ Int → Maybe AnnualStageTag
+selectedTag d = asTag <$> findActiveCycleStage stages d
+
+spec ∷ Spec
+spec = do
+    describe "worldDateToDayOfYear" $ do
+        it "maps the first day of the year to 0" $
+            doy 1 1 `shouldBe` 0
+        it "advances within the first month" $
+            doy 1 2 `shouldBe` 1
+        it "accounts for whole months elapsed" $ do
+            doy 3 1  `shouldBe` 60    -- two 30-day months elapsed
+            doy 5 1  `shouldBe` 120
+            doy 10 1 `shouldBe` 270
+        it "maps the last day of the year to daysPerYear - 1" $
+            doy 12 30 `shouldBe` daysPerYear - 1
+        it "produces values past day 31 (the day-of-month ceiling)" $
+            doy 4 15 `shouldSatisfy` (> 31)
+        it "clamps out-of-range month/day instead of going negative or past year-end" $ do
+            worldDateToDayOfYear defaultCalendarConfig (WorldDate 1 0 0)
+                `shouldBe` 0
+            worldDateToDayOfYear defaultCalendarConfig (WorldDate 1 99 99)
+                `shouldBe` daysPerYear - 1
+
+    describe "findActiveCycleStage" $ do
+        it "selects the dormant stage at the start of the year" $
+            selectedTag (doy 1 1) `shouldBe` Just CycleDormant
+        it "selects stages that begin after the first month" $ do
+            selectedTag (doy 3 1)  `shouldBe` Just CycleBudding    -- day 60
+            selectedTag 90         `shouldBe` Just CycleBudding
+            selectedTag (doy 5 1)  `shouldBe` Just CycleFlowering  -- day 120
+            selectedTag 300        `shouldBe` Just CycleSenescing
+        it "wraps to the final stage for early-year days below all start days" $
+            -- With a 0-day stage present this resolves to dormant; a
+            -- cycle whose earliest start is > 0 must wrap to the last.
+            (asTag <$> findActiveCycleStage
+                [ AnnualStage CycleBudding   60  (TextureHandle 2)
+                , AnnualStage CycleSenescing 270 (TextureHandle 4) ] 10)
+                `shouldBe` Just CycleSenescing
+        it "would never reach late stages if fed day-of-month (the bug)" $
+            -- Any day-of-month (1..30) can only ever select dormant/budding,
+            -- never flowering/senescing — which is exactly why the render
+            -- site must convert through worldDateToDayOfYear.
+            map selectedTag [1 .. 30]
+                `shouldSatisfy` all (`elem` [Just CycleDormant, Just CycleBudding])


### PR DESCRIPTION
Closes #25.

## Problem
`World.Flora.Render.resolveFloraTexture` selects annual-cycle textures from a **year-relative ordinal day**, but `World.Render.Quads` passed `wdDay` straight from `WorldDate`. `wdDay` is the day-of-**month** (1–31), so any annual stage starting after the first month was unreachable — e.g. the temperate-deciduous cycle's flowering (day 120) and senescing (day 270) stages could never be selected. Flora annual rendering is live today, so this is a current correctness bug.

## Fix
- **New canonical converter** `World.Time.Types.worldDateToDayOfYear :: CalendarConfig -> WorldDate -> Int` — maps `(year, month, day)` to a **zero-based** ordinal day-of-year using the calendar's fixed month length (`ccDaysPerMonth × ccMonthsPerYear`), clamping out-of-range month/day. Zero-based to match how stage start days are authored in the flora YAML (a first-day stage uses `startDay: 0`).
- **Calendar contract documented in one place** — `WorldDate`'s haddock now states that `wdMonth`/`wdDay` are calendar components (month-of-year / day-of-month), not a year-relative day, and points callers at the converter.
- **Render call site** (`Quads.hs`) converts the world date through the active `CalendarConfig` (`wgpCalender`, falling back to `defaultCalendarConfig` before gen params load) instead of aliasing `wdDay` as the ordinal day.
- **Test** — `findActiveCycleStage` is exported and a new pure spec `Test.Headless.World.Calendar` covers the conversion, clamping, stage selection past day 31, wraparound, and a regression assertion that day-of-month input can never reach the late stages.

## Acceptance criteria (from the issue)
- ✅ Annual-cycle stages can be selected beyond day 31.
- ✅ The renderer no longer aliases day-of-month with day-of-year.
- ✅ The calendar/date contract is documented in one place (`WorldDate`).

## ⚠️ Incidental prerequisite (first commit)
While validating, I found `synarchy-test-headless` **has not compiled since `9b8c552b`** ("combat lunge, arena mode fixes, structure fixes"): that commit added a required strict field `lcStructures` to `LoadedChunk`, but the `Unit.Pathing.{Cost,AStar}` test helpers that hand-build `LoadedChunk` were never updated. The whole headless suite was dead. The first commit sets `lcStructures = emptyChunkStructures` in those builders (matching every production construction) so the suite — and this PR's new test — can run. It's a separate concern but a hard prerequisite, kept as its own commit. **Worth a glance: this means no headless test has run on master for the last two commits.**

## Validation
- `cabal build lib:synarchy` — clean.
- `cabal test synarchy-test-headless` — **287 examples, 0 failures, 1 pending** (suite restored from non-compiling).
- New `World.Calendar` spec: 10/10 pass.
- No `--dump` output or save format changes (flora isn't serialized to the dump), so no worldgen baseline re-capture or save-version bump is needed.

Not done headless: the actual on-screen pixels (flora texture swapping across a real date boundary) — that needs a GUI session. The data path is covered by the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)