### PR TITLE
Document world_determinism as a content-identity check (#23)

### DIFF
--- a/tools/test_determinism.py
+++ b/tools/test_determinism.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Unit tests for world_determinism.py's content-identity check.
+
+Pins the documented contract: the determinism checker treats two dumps
+as identical when their tile *content* matches, independent of the order
+tiles appear in the array or the order keys appear in each tile object.
+A genuine content change must be detected and reported.
+
+Exit codes:
+  0 = all tests passed
+  1 = one or more tests failed
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from world_determinism import (  # type: ignore
+    canonical_dump, hash_dump, diff_dumps, field_diff_summary,
+)
+
+
+# ----- Helpers -------------------------------------------------------------
+
+def tile(x: int, y: int, **fields: Any) -> dict[str, Any]:
+    base = {"x": x, "y": y, "terrainZ": 1, "matId": 56, "fluidType": None}
+    base.update(fields)
+    return base
+
+
+def grid(w: int, h: int) -> list[dict[str, Any]]:
+    return [tile(x, y, terrainZ=x + y) for y in range(h) for x in range(w)]
+
+
+FAILURES: list[str] = []
+
+
+def expect(cond: bool, msg: str) -> None:
+    if not cond:
+        FAILURES.append(msg)
+        print(f"  FAIL: {msg}")
+    else:
+        print(f"  OK:   {msg}")
+
+
+# ----- Tests ---------------------------------------------------------------
+
+def test_array_order_is_ignored() -> None:
+    print("test_array_order_is_ignored")
+    a = grid(4, 4)
+    b = list(reversed(a))  # same tiles, different array order
+    expect(a != b, "the two lists really are in a different order")
+    expect(hash_dump(a) == hash_dump(b),
+           "same tiles in a different array order hash content-identical")
+
+
+def test_key_order_is_ignored() -> None:
+    print("test_key_order_is_ignored")
+    a = [tile(0, 0, terrainZ=5, matId=56, fluidType="river", fluidSurf=4)]
+    # Same tile, keys inserted in a different order.
+    b = [{"fluidSurf": 4, "fluidType": "river", "matId": 56,
+          "terrainZ": 5, "y": 0, "x": 0}]
+    expect(hash_dump(a) == hash_dump(b),
+           "same tile with reordered JSON keys hashes content-identical")
+
+
+def test_content_change_is_detected() -> None:
+    print("test_content_change_is_detected")
+    a = grid(4, 4)
+    b = grid(4, 4)
+    b[5] = tile(b[5]["x"], b[5]["y"], terrainZ=999)  # flip one field
+    expect(hash_dump(a) != hash_dump(b),
+           "a single differing field changes the content hash")
+    diffs = diff_dumps(a, b)
+    expect(len(diffs) == 1,
+           f"diff reports exactly the one changed tile (got {len(diffs)})")
+    summary = field_diff_summary(diffs)
+    expect(summary.get("terrainZ") == 1,
+           f"field summary attributes the change to terrainZ (got {summary})")
+
+
+def test_missing_tile_is_detected() -> None:
+    print("test_missing_tile_is_detected")
+    a = grid(4, 4)
+    b = grid(4, 4)[:-1]  # drop one tile
+    expect(hash_dump(a) != hash_dump(b),
+           "a missing tile changes the content hash")
+    summary = field_diff_summary(diff_dumps(a, b))
+    expect(summary.get("TILE_MISSING") == 1,
+           f"field summary flags the missing tile (got {summary})")
+
+
+def test_canonical_form_is_stable() -> None:
+    print("test_canonical_form_is_stable")
+    a = grid(3, 3)
+    b = list(reversed(a))
+    expect(canonical_dump(a) == canonical_dump(b),
+           "canonical_dump is byte-stable across array order")
+
+
+def main() -> int:
+    tests = [
+        test_array_order_is_ignored,
+        test_key_order_is_ignored,
+        test_content_change_is_detected,
+        test_missing_tile_is_detected,
+        test_canonical_form_is_stable,
+    ]
+    for t in tests:
+        t()
+        print()
+
+    if FAILURES:
+        print(f"\n{len(FAILURES)} test failure(s):")
+        for f in FAILURES:
+            print(f"  {f}")
+        return 1
+
+    print(f"\nAll {len(tests)} test groups passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/world_determinism.py
+++ b/tools/world_determinism.py
@@ -2,8 +2,23 @@
 """World generation determinism checker.
 
 Runs the synarchy --dump command N times for the same seed and verifies
-that the output is byte-identical across runs. If any run differs, reports
-which tiles differ and how.
+that the output is CONTENT-identical across runs: the same set of tiles,
+each with the same field values. If any run differs, reports which tiles
+differ and how.
+
+This is a content check, not a byte check. Tiles and JSON keys are sorted
+into a canonical form before hashing (see `canonical_dump`), so a run
+passes as long as the world *state* is reproducible — regardless of the
+order tiles happen to be laid out in the dump array.
+
+That is deliberate. Dump emission order is already a deterministic
+function of the requested region (app/Main.hs `dumpTilesJSON` iterates
+chunks then tiles in fixed order over settled state), so array order is
+not part of the world-determinism contract this tool guards. The tool
+exists to catch race conditions in chunk *generation* — i.e. content
+drift — and to be a precondition for the pure-pipeline refactor, which
+may legitimately reorder output; a benign reordering should not be
+reported as nondeterminism.
 
 Used to detect race conditions in chunk generation. A passing check is a
 necessary precondition for the pure pipeline refactor.
@@ -56,7 +71,15 @@ def run_dump(seed: int, world_size: int,
 # ----- Canonical hashing ---------------------------------------------------
 
 def canonical_dump(data: list[dict[str, Any]]) -> bytes:
-    """Sort tiles by (x, y) and serialize with sorted keys for stable hashing."""
+    """Canonical content form of a dump, independent of array/key order.
+
+    Sorts tiles by (x, y) and serializes each with sorted keys, so two
+    dumps with identical tile content hash equal even if the tiles appear
+    in a different array order or the JSON objects list their keys in a
+    different order. This defines the "content-identical" relation the
+    checker verifies — see the module docstring for why ordering is
+    normalized rather than enforced.
+    """
     sorted_tiles = sorted(data, key=lambda t: (t["x"], t["y"]))
     return json.dumps(sorted_tiles, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
@@ -153,11 +176,11 @@ def main() -> int:
     unique_hashes = set(hashes)
 
     if len(unique_hashes) == 1:
-        print(f"PASS: all {args.runs} runs produced identical output")
-        print(f"  hash: {hashes[0]}")
+        print(f"PASS: all {args.runs} runs produced content-identical output")
+        print(f"  content hash: {hashes[0]}")
         return 0
 
-    print(f"FAIL: {len(unique_hashes)} distinct outputs across {args.runs} runs",
+    print(f"FAIL: {len(unique_hashes)} distinct contents across {args.runs} runs",
           file=sys.stderr)
     print(f"  hashes: {[h[:16] + '...' for h in hashes]}", file=sys.stderr)
 


### PR DESCRIPTION
Closes #23.

## Problem
`tools/world_determinism.py`'s docstring, `--help`, and PASS message all claimed it verifies **byte-identical** dump output, but `canonical_dump` sorts tiles by `(x, y)` and serializes with sorted JSON keys before hashing. It has always been a **content** check, blind to array/key ordering — the wording was the bug, not the behavior.

## Decision: content-identical (not byte-identical)
I checked how `--dump` emits tiles: `app/Main.hs` `dumpTilesJSON` iterates the region with a fixed nested loop (`[cx1..cx2] × [cy1..cy2]`, then `ly`, `lx`) over already-settled, single-threaded state. So **array order is a deterministic function of the requested region, not part of the world-determinism contract** this tool guards.

The tool's stated purpose is to catch race conditions in chunk *generation* (content drift) and to be "a precondition for the pure pipeline refactor" — a refactor that may legitimately reorder dump output. A true byte check would flag that benign reordering as nondeterminism, causing spurious failures during exactly the work this tool supports. So content-identity is the correct semantic; I made the documentation match it rather than weakening the tool.

*(Alternative considered: make it truly byte-identical by hashing raw stdout. Rejected for the reason above — happy to flip if you'd rather the tool enforce output ordering too.)*

## Changes
- Reword the module docstring (flows into `--help`), the `canonical_dump` docstring, and the PASS/FAIL messages to say **content-identical**, with a note on why ordering is normalized rather than enforced.
- **No behavior change**: `canonical_dump` still sorts; the engine-level check runs exactly as before, just labeled honestly.
- Add `tools/test_determinism.py` (mirrors `test_audit.py`'s style) with the synthetic cases the issue asks for:
  - same tiles in a different **array order** → equal content hash
  - same tile with reordered **JSON keys** → equal content hash
  - a changed field → different hash, and `diff_dumps`/`field_diff_summary` attribute it to the right tile/field
  - a missing tile → detected and flagged `TILE_MISSING`

## Validation
- `python3 tools/test_determinism.py` → **all 5 test groups pass**.
- `python3 tools/test_audit.py` → **25/25 pass** (unchanged, regression check).
- `py_compile` clean; `--help` now reads "CONTENT-identical."
- Did not run the engine-level determinism sweep (`cabal --dump × N`): this change is doc/messaging + a pure unit test, and `canonical_dump`'s behavior is byte-for-byte unchanged, so the end-to-end check behaves identically to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)