### PR TITLE
Render water side faces across chunk boundaries (#26)

### DIFF
--- a/src/World/Render/Quads.hs
+++ b/src/World/Render/Quads.hs
@@ -228,7 +228,8 @@ renderWorldQuads env worldState zoomAlpha snap = do
                 -- drops over cliff edges
                 !waterSideQuads = if chunkHasFluid
                     then waterSideFaceQuads lookupSlot lookupFmSlot textures facing
-                             coord fluidMap terrainSurfMap zSlice effectiveDepth
+                             coord fluidMap terrainSurfMap
+                             fluidMapLookup terrMapLookup zSlice effectiveDepth
                              zoomAlpha xOffset vb
                     else []
 

--- a/src/World/Render/SideDecoQuads.hs
+++ b/src/World/Render/SideDecoQuads.hs
@@ -31,14 +31,19 @@ waterSideFaceQuads ∷ (TextureHandle → Int)
                    → WorldTextures
                    → CameraFacing
                    → ChunkCoord
-                   → V.Vector (Maybe FluidCell)  -- ^ fluid map
-                   → VU.Vector Int               -- ^ terrain surface map
+                   → V.Vector (Maybe FluidCell)  -- ^ this chunk's fluid map
+                   → VU.Vector Int               -- ^ this chunk's terrain surface map
+                   → (ChunkCoord → Maybe (V.Vector (Maybe FluidCell)))
+                                                 -- ^ neighbour-chunk fluid lookup
+                   → (ChunkCoord → Maybe (VU.Vector Int))
+                                                 -- ^ neighbour-chunk terrain lookup
                    → Int → Int                   -- ^ zSlice, effectiveDepth
                    → Float → Float               -- ^ tileAlpha, xOffset
                    → ViewBounds
                    → [SortableQuad]
 waterSideFaceQuads lookupSlot lookupFmSlot textures facing coord
-                   fluidMap terrainSurfMap zSlice effDepth tileAlpha xOffset vb =
+                   fluidMap terrainSurfMap fluidLookup terrLookup
+                   zSlice effDepth tileAlpha xOffset vb =
     [ sq
     | lx ← [0 .. chunkSize - 1]
     , ly ← [0 .. chunkSize - 1]
@@ -46,13 +51,13 @@ waterSideFaceQuads lookupSlot lookupFmSlot textures facing coord
     , Just fc ← [fluidMap V.! idx]
     , fcType fc ≢ Ocean
     , let mySurf = fcSurface fc
-    -- Check each camera-visible cardinal neighbor
+    -- Check each camera-visible cardinal neighbor. A neighbor can sit in
+    -- the adjacent chunk (a waterfall/cliff right at a seam): resolve it
+    -- through the cross-chunk lookup exactly as waterSlopeAt does, so side
+    -- faces don't vanish at chunk boundaries.
     , (nx, ny, isLeftFace) ← neighborDirs facing lx ly
-    , nx ≥ 0, nx < chunkSize, ny ≥ 0, ny < chunkSize
-    , let nIdx = columnIndex nx ny
-          nFluid = fluidMap V.! nIdx
-          nTerrZ = terrainSurfMap VU.! nIdx
-          -- Bottom of the side-face stack depends on neighbor type:
+    , Just (nFluid, nTerrZ) ← [neighborCell nx ny]
+    , let -- Bottom of the side-face stack depends on neighbor type:
           --   Water neighbor: draw from neighbor water surface
           --   Dry neighbor: draw from neighbor terrain surface
           -- A 1-z gap is handled by the sloped water surface tile
@@ -73,6 +78,30 @@ waterSideFaceQuads lookupSlot lookupFmSlot textures facing coord
                             (fcType fc) gx gy z isLeftFace
                             zSlice effDepth tileAlpha xOffset vb)
     ]
+  where
+    -- Resolve a cardinal neighbor's (fluid cell, terrain surface z),
+    -- following a step out of this chunk into the adjacent one. Returns
+    -- Nothing only when that neighbor chunk isn't loaded — then the drop
+    -- is unknown, so we draw no side face (the same conservative default
+    -- waterSlopeAt uses at an unloaded seam).
+    neighborCell ∷ Int → Int → Maybe (Maybe FluidCell, Int)
+    neighborCell nx ny
+        | nx ≥ 0 ∧ nx < chunkSize ∧ ny ≥ 0 ∧ ny < chunkSize =
+            let nIdx = columnIndex nx ny
+            in Just (fluidMap V.! nIdx, terrainSurfMap VU.! nIdx)
+        | otherwise =
+            let ChunkCoord cx cy = coord
+                (cx', lx') = if nx < 0              then (cx - 1, nx + chunkSize)
+                             else if nx ≥ chunkSize then (cx + 1, nx - chunkSize)
+                             else                        (cx, nx)
+                (cy', ly') = if ny < 0              then (cy - 1, ny + chunkSize)
+                             else if ny ≥ chunkSize then (cy + 1, ny - chunkSize)
+                             else                        (cy, ny)
+                ncoord = ChunkCoord cx' cy'
+                nIdx   = columnIndex lx' ly'
+            in case (fluidLookup ncoord, terrLookup ncoord) of
+                   (Just nFM, Just nTM) → Just (nFM V.! nIdx, nTM VU.! nIdx)
+                   _                    → Nothing
 
 -- | Cardinal neighbor directions with face orientation.
 --   Returns (nx, ny, isLeftFace).

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -164,6 +164,7 @@ test-suite synarchy-test-headless
                    Test.Headless.Input.KeyNames
                    Test.Headless.World.Calendar
                    Test.Headless.River.Graph
+                   Test.Headless.World.Render.SideFace
     default-extensions: DefaultSignatures
                      , DuplicateRecordFields
                      , MagicHash

--- a/test-headless/Spec.hs
+++ b/test-headless/Spec.hs
@@ -29,6 +29,7 @@ import qualified Test.Headless.Sim.Seam as SimSeam
 import qualified Test.Headless.Input.KeyNames as InputKeyNames
 import qualified Test.Headless.World.Calendar as Calendar
 import qualified Test.Headless.River.Graph as RiverGraph
+import qualified Test.Headless.World.Render.SideFace as RenderSideFace
 
 main ∷ IO ()
 main = hspec $ do
@@ -64,3 +65,4 @@ main = hspec $ do
     describe "Input.KeyNames" InputKeyNames.spec
     describe "World.Calendar" Calendar.spec
     describe "River.Graph" RiverGraph.spec
+    describe "World.Render.SideFace" RenderSideFace.spec

--- a/test-headless/Test/Headless/World/Render/SideFace.hs
+++ b/test-headless/Test/Headless/World/Render/SideFace.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE Strict, UnicodeSyntax #-}
+-- | Pure tests for 'World.Render.SideDecoQuads.waterSideFaceQuads' — the
+--   water side-face (waterfall / water-cliff) generator.
+--
+--   The regression under test (issue #26): side faces used to be hard
+--   filtered to in-chunk neighbors, so a water drop landing right on a
+--   chunk seam produced no side face. The fix threads the same
+--   cross-chunk neighbor lookup that @waterSlopeAt@ already uses, so a
+--   neighbor sitting in the adjacent chunk is resolved instead of dropped.
+--
+--   No engine needed: @waterSideFaceQuads@ is pure. We hand-build a 16×16
+--   home chunk with one water tile on the east edge and feed neighbor
+--   chunks through the lookup callbacks. Slot lookups are stubbed
+--   (non-zero face-map slot so quads are emitted) and the view bounds
+--   accept every tile, so the emitted-quad COUNT is exactly the number of
+--   z-levels in the drop.
+module Test.Headless.World.Render.SideFace (spec) where
+
+import UPrelude
+import Test.Hspec
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as VU
+import Engine.Graphics.Camera (CameraFacing(..))
+import Engine.Scene.Types (SortableQuad)
+import World.Chunk.Types (ChunkCoord(..), chunkSize, columnIndex)
+import World.Fluid.Types (FluidCell(..), FluidType(..))
+import World.Render.SideDecoQuads (waterSideFaceQuads)
+import World.Render.Textures.Types (defaultWorldTextures)
+import World.Render.ViewBounds (ViewBounds(..))
+
+-- | One chunk's fluid map: all-empty, with the listed cells set.
+fluidMapWith ∷ [((Int, Int), FluidCell)] → V.Vector (Maybe FluidCell)
+fluidMapWith cells =
+    V.replicate (chunkSize * chunkSize) Nothing
+      V.// [ (columnIndex x y, Just fc) | ((x, y), fc) ← cells ]
+
+-- | One chunk's terrain-surface map: a flat base z with overrides.
+terrMapWith ∷ Int → [((Int, Int), Int)] → VU.Vector Int
+terrMapWith base overrides =
+    VU.replicate (chunkSize * chunkSize) base
+      VU.// [ (columnIndex x y, z) | ((x, y), z) ← overrides ]
+
+-- | View bounds that accept every tile, so visibility never trims a quad.
+allVisible ∷ ViewBounds
+allVisible = ViewBounds (-1.0e9) 1.0e9 (-1.0e9) 1.0e9
+
+-- | Drive the generator with a fixed camera/world setup. Slot lookup
+--   returns 0 (any tile texture) and the face-map slot a non-zero stub
+--   (so 'waterSideQuad' doesn't early-out), zSlice 10 / depth 64 so the
+--   whole drop is inside the rendered z-window.
+run ∷ V.Vector (Maybe FluidCell) → VU.Vector Int
+    → (ChunkCoord → Maybe (V.Vector (Maybe FluidCell)))
+    → (ChunkCoord → Maybe (VU.Vector Int))
+    → [SortableQuad]
+run fm tm fluidLookup terrLookup =
+    waterSideFaceQuads (\_ → 0) (\_ → 1.0) defaultWorldTextures
+        FaceSouth (ChunkCoord 0 0) fm tm fluidLookup terrLookup
+        10 64 1.0 0.0 allVisible
+
+spec ∷ Spec
+spec = describe "waterSideFaceQuads across chunk seams" $ do
+
+    -- Home chunk (0,0): one Lake tile on the EAST edge (lx = 15) at z=10.
+    -- Flat terrain at z=10 everywhere, so the in-chunk (left) neighbor is
+    -- level with the water and never draws — every emitted quad therefore
+    -- comes from the cross-chunk (right) neighbor.
+    let homeFluid = fluidMapWith [((15, 8), FluidCell Lake 10)]
+        homeTerr  = terrMapWith 10 []
+
+    it "renders side faces over a DRY drop in the adjacent chunk (the bug)" $ do
+        -- Neighbor chunk (1,0): dry, terrain at z=0 → a 10-tall waterfall
+        -- face straddling the seam. Before the fix this produced nothing.
+        let fluidLookup (ChunkCoord 1 0) = Just (fluidMapWith [])
+            fluidLookup _                = Nothing
+            terrLookup  (ChunkCoord 1 0) = Just (terrMapWith 0 [])
+            terrLookup  _                = Nothing
+        -- z = 0..9 → ten side-face quads.
+        length (run homeFluid homeTerr fluidLookup terrLookup) `shouldBe` 10
+
+    it "renders side faces over a LOWER-WATER drop in the adjacent chunk" $ do
+        -- Neighbor (0,8) holds water at surface 5 (< 10-1), so the stack
+        -- bottoms out on that surface: faces from z=5..9 (five quads).
+        let fluidLookup (ChunkCoord 1 0) =
+                Just (fluidMapWith [((0, 8), FluidCell Lake 5)])
+            fluidLookup _                = Nothing
+            terrLookup  (ChunkCoord 1 0) = Just (terrMapWith 0 [])
+            terrLookup  _                = Nothing
+        length (run homeFluid homeTerr fluidLookup terrLookup) `shouldBe` 5
+
+    it "draws nothing at the seam when the neighbor chunk is not loaded" $
+        -- Both lookups miss → the drop is unknown, so no side face (the
+        -- conservative default, matching waterSlopeAt at an unloaded seam).
+        length (run homeFluid homeTerr (const Nothing) (const Nothing))
+            `shouldBe` 0
+
+    it "still renders a waterfall face WITHIN a chunk (regression guard)" $ do
+        -- Water at interior tile (5,8); the in-chunk right neighbor (6,8)
+        -- is a dry 10-tile drop. No cross-chunk lookup is consulted.
+        let inFluid = fluidMapWith [((5, 8), FluidCell Lake 10)]
+            inTerr  = terrMapWith 10 [((6, 8), 0)]
+        length (run inFluid inTerr (const Nothing) (const Nothing))
+            `shouldBe` 10


### PR DESCRIPTION
Fixes #26.

## Problem
`waterSideFaceQuads` (`src/World/Render/SideDecoQuads.hs`) hard-filtered its cardinal-neighbor reads to the current chunk:

```haskell
, nx ≥ 0, nx < chunkSize, ny ≥ 0, ny < chunkSize
, let nFluid = fluidMap V.! nIdx
      nTerrZ = terrainSurfMap VU.! nIdx
```

So a water drop that lands exactly on a chunk seam produced **no** waterfall / water-cliff side face — the face vanished at the boundary. Meanwhile `waterSlopeAt`, in the same render pipeline, already resolves neighbors across chunks (`src/World/Render/Quads.hs:55-96`), so the sloped water *surface* continued past the seam while the *side face* did not.

## Fix
Thread the cross-chunk lookup functions that `Quads.hs` already builds (`fluidMapLookup` / `terrMapLookup`, `Quads.hs:139-144`) into `waterSideFaceQuads`, and resolve out-of-chunk neighbors through them via a small `neighborCell` helper that mirrors `waterSlopeAt`'s seam arithmetic.

- In-chunk neighbors read the local maps exactly as before (behavior unchanged).
- Out-of-chunk neighbors step into the adjacent chunk and read its fluid + terrain maps.
- When the neighbor chunk **isn't loaded**, `neighborCell` returns `Nothing` and no side face is drawn — the drop is unknown, the same conservative default `waterSlopeAt` uses at an unloaded seam (and identical to the pre-fix behavior at a boundary).
- The `≥ 2 z` waterfall threshold is left untouched, per the issue.

Single call site updated; no other callers.

## Tests
Added a pure headless spec — `Test.Headless.World.Render.SideFace` — that drives `waterSideFaceQuads` directly (it needs no engine) with hand-built chunks:

- **cross-chunk dry drop** → side faces now emitted (this is the bug; pre-fix produced 0 quads)
- **cross-chunk lower-water drop** → faces bottom out on the neighbor's water surface
- **unloaded-neighbor seam** → draws nothing (conservative default)
- **in-chunk waterfall** → still renders (regression guard)

```
World.Render.SideFace
  waterSideFaceQuads across chunk seams
    renders side faces over a DRY drop in the adjacent chunk (the bug) [✔]
    renders side faces over a LOWER-WATER drop in the adjacent chunk [✔]
    draws nothing at the seam when the neighbor chunk is not loaded [✔]
    still renders a waterfall face WITHIN a chunk (regression guard) [✔]
```

Full headless suite green: **298 examples, 0 failures, 1 pending**.

This is a render-layer-only change — it does not touch world generation, so the worldgen baseline / `world_check.py` tiers don't apply (`--dump` emits raw tile data, not render quads).

## Validation note
The headless test proves the quad-generation logic, but the **visual** confirmation (a real seam waterfall drawing its faces with no missing strip) is GUI-only and can't be run headless. Worth an eyeball pass: create a world with a river/lake spilling over a cliff that crosses a chunk boundary and confirm the side faces are continuous across the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)