### PR TITLE
Reject nonexistent page IDs in world.show (#48)

### DIFF
--- a/src/World/Thread/Command/UI.hs
+++ b/src/World/Thread/Command/UI.hs
@@ -39,23 +39,33 @@ import World.Thread.ChunkLoading (maxChunksPerTick)
 handleWorldShowCommand ∷ EngineEnv → LoggerState → WorldPageId → IO ()
 handleWorldShowCommand env logger pageId = do
     logDebug logger CatWorld $ "Showing world: " <> unWorldPageId pageId
-    
-    atomicModifyIORef' (worldManagerRef env) $ \mgr →
-        if pageId `elem` wmVisible mgr
-        then (mgr, ())
-        else (mgr { wmVisible = pageId : wmVisible mgr }, ())
-    
-    mgr ← readIORef (worldManagerRef env)
-    logDebug logger CatWorld $
-        "Visible worlds after show: " <> T.pack (show $ length $ wmVisible mgr)
 
-    -- Activate world in sim thread. The sim no longer holds the tile
-    -- ref — it emits WorldApplyFluids back to the world thread (the sole
-    -- writer of wsTilesRef) — so this is just an "is active" signal.
-    case lookup pageId (wmWorlds mgr) of
-        Just _worldState →
-            Q.writeQueue (simQueue env) SimActivateWorld
-        Nothing → pure ()
+    -- Only worlds that actually exist may enter wmVisible. Inserting a
+    -- nonexistent pageId would poison getActiveWorldId() (which reads the
+    -- head of wmVisible) and silently retarget every current-world API.
+    -- atomicModifyIORef' returns whether the world was found so the
+    -- existence check and the visible-list mutation share one consistent
+    -- snapshot of the manager.
+    found ← atomicModifyIORef' (worldManagerRef env) $ \mgr →
+        case lookup pageId (wmWorlds mgr) of
+            Nothing → (mgr, False)
+            Just _
+                | pageId `elem` wmVisible mgr → (mgr, True)
+                | otherwise →
+                    (mgr { wmVisible = pageId : wmVisible mgr }, True)
+
+    if not found
+    then logWarn logger CatWorld $
+        "Ignoring world.show for nonexistent world: " <> unWorldPageId pageId
+    else do
+        mgr ← readIORef (worldManagerRef env)
+        logDebug logger CatWorld $
+            "Visible worlds after show: " <> T.pack (show $ length $ wmVisible mgr)
+
+        -- Activate world in sim thread. The sim no longer holds the tile
+        -- ref — it emits WorldApplyFluids back to the world thread (the sole
+        -- writer of wsTilesRef) — so this is just an "is active" signal.
+        Q.writeQueue (simQueue env) SimActivateWorld
 
 handleWorldHideCommand ∷ EngineEnv → LoggerState → WorldPageId → IO ()
 handleWorldHideCommand env logger pageId = do


### PR DESCRIPTION
Fixes #48.

## Problem
`handleWorldShowCommand` prepended the requested `pageId` to `wmVisible` **before** checking whether the world existed in `wmWorlds`. So `world.show("ghost")` inserted a nonexistent world into the visible list. Because `world.getActiveWorldId()` reads the head of `wmVisible`, every "current world" API then targeted the ghost — including `scripts.pause`, whose timescale update stopped reaching the real world.

## Fix
Validate existence and mutate `wmVisible` inside a single `atomicModifyIORef'`, returning whether the world was found so the lookup and the insert share one consistent manager snapshot. Only real worlds enter `wmVisible`; a missing world logs a warning and is otherwise ignored, and `SimActivateWorld` is only signalled on success.

## Verification
Ran the issue's headless repro:

| step | before | after |
|------|--------|-------|
| `getActiveWorldId()` after `show("ghost")` | `"ghost"` | `"real"` |
| `getTimeScale("real")` after pause | `1.0` (bug) | `0.0` |

Log shows `Ignoring world.show for nonexistent world: ghost`.

Full headless test suite: **298 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)