### PR TITLE
Treat dump-mode wait timeouts as seconds (#44)

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -466,31 +466,45 @@ runDump layers seed worldSize plateCount (cx1, cy1, cx2, cy2) = do
         exitFailure
     Right _ → pure ()
 
--- | Poll until world generation is done
+-- | Poll until world generation is done. The argument is a timeout in
+--   /seconds/; internally we poll every 250ms (4 iterations per second).
 waitForInit ∷ EngineEnv → Int → IO ()
-waitForInit _ 0 = hPutStrLn stderr "dump: init timeout"
-waitForInit env n = do
-    manager ← readIORef (worldManagerRef env)
-    case wmWorlds manager of
-        ((_, ws):_) → do
-            phase ← readIORef (wsLoadPhaseRef ws)
-            case phase of
-                LoadDone → hPutStrLn stderr "dump: init complete"
-                _        → threadDelay 250000 >> waitForInit env (n - 1)
-        [] → threadDelay 250000 >> waitForInit env (n - 1)
+waitForInit env seconds = go (seconds * pollsPerSecond)
+  where
+    go 0 = hPutStrLn stderr "dump: init timeout"
+    go n = do
+        manager ← readIORef (worldManagerRef env)
+        case wmWorlds manager of
+            ((_, ws):_) → do
+                phase ← readIORef (wsLoadPhaseRef ws)
+                case phase of
+                    LoadDone → hPutStrLn stderr "dump: init complete"
+                    _        → threadDelay pollInterval >> go (n - 1)
+            [] → threadDelay pollInterval >> go (n - 1)
 
--- | Poll until chunk init queue is empty
+-- | Poll until chunk init queue is empty. The argument is a timeout in
+--   /seconds/; internally we poll every 250ms (4 iterations per second).
 waitForChunks ∷ EngineEnv → Int → IO ()
-waitForChunks _ 0 = hPutStrLn stderr "dump: chunk load timeout"
-waitForChunks env n = do
-    manager ← readIORef (worldManagerRef env)
-    case wmWorlds manager of
-        ((_, ws):_) → do
-            remaining ← length <$> readIORef (wsInitQueueRef ws)
-            if remaining ≡ 0
-                then hPutStrLn stderr "dump: all chunks loaded"
-                else threadDelay 250000 >> waitForChunks env (n - 1)
-        [] → threadDelay 250000 >> waitForChunks env (n - 1)
+waitForChunks env seconds = go (seconds * pollsPerSecond)
+  where
+    go 0 = hPutStrLn stderr "dump: chunk load timeout"
+    go n = do
+        manager ← readIORef (worldManagerRef env)
+        case wmWorlds manager of
+            ((_, ws):_) → do
+                remaining ← length <$> readIORef (wsInitQueueRef ws)
+                if remaining ≡ 0
+                    then hPutStrLn stderr "dump: all chunks loaded"
+                    else threadDelay pollInterval >> go (n - 1)
+            [] → threadDelay pollInterval >> go (n - 1)
+
+-- | Poll cadence for the dump-mode wait helpers: a 250ms sleep between
+--   checks, so four polls make up one second of timeout budget.
+pollInterval ∷ Int
+pollInterval = 250000
+
+pollsPerSecond ∷ Int
+pollsPerSecond = 1000000 `div` pollInterval
 
 -- | Dump per-tile data in a chunk region as JSON.
 --   Every tile in the region gets one object. Fields are included


### PR DESCRIPTION
Closes #44.

## Problem
`waitForInit` and `waitForChunks` decrement their counter once per 250ms `threadDelay`, so their `Int` arguments were poll iterations, not seconds. This contradicted the call-site comments and made the real budget 4x shorter than intended:

- `waitForChunks env' 300` → 75s, not 300s
- the "Min 300s for tiny worlds" init floor was actually 75s
- `worldSize=256` got 256s, not the documented 300s minimum

## Fix
Reinterpret each helper's argument as a timeout in **seconds** and convert to polls internally (4 polls/second). The call sites are unchanged and now mean what their comments say. The 250ms cadence is factored into named `pollInterval` / `pollsPerSecond` bindings.

## Verification
- `cabal build exe:synarchy` — clean.
- `cabal run exe:synarchy -- --dump=terrain --seed 42 --worldSize 32 --region -1,-1,1,1` — exits 0, stderr shows `init complete` + `all chunks loaded`, emits 2304 valid tiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)