### PR TITLE
Don't start a TCP listener in dump mode (#46)

### DIFF
--- a/src/Engine/Scripting/Lua/DebugServer.hs
+++ b/src/Engine/Scripting/Lua/DebugServer.hs
@@ -42,6 +42,15 @@ data DebugCommand = DebugCommand
 --   serving other connections.
 startDebugServer ∷ Int → (Text → IO (Maybe Text))
                  → IO (Either Text (TQueue DebugCommand))
+startDebugServer 0 _ = do
+    -- Port 0 means dump mode: no TCP listener at all. Binding to port 0
+    -- would ask the OS for an ephemeral port, contradicting the
+    -- "no TCP server" dump-mode contract and opening a network surface.
+    -- Emit the ready marker on stderr (stdout is reserved for JSON) and
+    -- hand back an inert queue that nothing ever feeds.
+    hPutStrLn stderr "READY port=0"
+    hFlush stderr
+    Right <$> atomically newTQueue
 startDebugServer port builtin = do
     cmdQueue ← atomically newTQueue
     r ← try $ do
@@ -63,11 +72,9 @@ startDebugServer port builtin = do
         Right sock → do
             -- Ready signal on stdout — agents can wait for this line
             -- to know the debug console is accepting connections.
-            -- When port=0 (dump mode), write to stderr to keep stdout
-            -- clean for JSON output.
-            let readyHandle = if port ≡ 0 then stderr else stdout
-            hPutStrLn readyHandle ("READY port=" <> show port)
-            hFlush readyHandle
+            -- (Dump mode, port 0, is handled above and never reaches here.)
+            hPutStrLn stdout ("READY port=" <> show port)
+            hFlush stdout
             _ ← forkIO $ acceptLoop sock cmdQueue builtin `finally` close sock
             return (Right cmdQueue)
 


### PR DESCRIPTION
Fixes #46.

## Problem
Dump mode is documented as "No TCP server, no loop" and signals it by setting `ecDebugPort = 0`. But `Engine.Scripting.Lua.Thread` unconditionally called `startDebugServer port`, and `startDebugServer 0` did **not** disable the server — it bound to port `0`, which asks the OS for an ephemeral listening port. The process printed `READY port=0` while in fact listening on a real TCP port (e.g. `127.0.0.1:49796`), contradicting the dump-mode contract and opening an unnecessary network surface.

## Fix
Handle `port == 0` as a distinct case in `startDebugServer`:
- skip the socket bind/listen entirely (no listener),
- still emit the `READY port=0` marker on **stderr** (stdout stays reserved for JSON),
- return an inert command queue that nothing ever feeds.

The now-unreachable `port ≡ 0` branch in the binding path was simplified away.

## Verification
Live repro from the issue, against a running dump process:

```
$ lsof -nP -a -p <dump-pid> -iTCP -sTCP:LISTEN
```

- Before: dump process listened on an ephemeral `127.0.0.1:<port>`.
- After: **no LISTEN socket** on the dump process across its full lifetime; `READY port=0` still lands on stderr; JSON output is valid and unchanged (2304 tiles for a w64 `-1,-1,1,1` dump); exit code 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)