### PR TITLE
Register engine.logError onto the Lua engine table (#53)

### DIFF
--- a/src/Engine/Core/Log.hs
+++ b/src/Engine/Core/Log.hs
@@ -25,7 +25,8 @@ module Engine.Core.Log
   , logWarn
   , logThreadWarn
   , logError
-  
+  , logThreadError
+
   -- * Structured logging
   , logDebugS
   , logInfoS
@@ -484,6 +485,10 @@ logThreadWarn ls cat msg = logThreadMessage ls LevelWarn cat msg Map.empty
 logError ∷ (HasCallStack, MonadIO m)
          ⇒ LoggerState → LogCategory → Text → m ()
 logError ls cat msg = logMessage ls LevelError cat msg Map.empty
+
+logThreadError ∷ (HasCallStack, MonadIO m)
+         ⇒ LoggerState → LogCategory → Text → m ()
+logThreadError ls cat msg = logThreadMessage ls LevelError cat msg Map.empty
 
 logDebugS ∷ (HasCallStack, MonadIO m)
           ⇒ LoggerState → LogCategory → Text → [(Text, Text)] → m ()

--- a/src/Engine/Scripting/Lua/API.hs
+++ b/src/Engine/Scripting/Lua/API.hs
@@ -28,7 +28,7 @@ import Engine.Scripting.Lua.API.Graphics (loadTextureFn, spawnSpriteFn, setPosFn
                                            , destroyFn, getUIScaleFn)
 import Engine.Scripting.Lua.API.YamlTextures (loadMaterialYamlFn, loadVegetationYamlFn
                                              , getTextureHandleFn, loadFloraYamlFn)
-import Engine.Scripting.Lua.API.Log (logInfoFn, logWarnFn, logDebugFn)
+import Engine.Scripting.Lua.API.Log (logInfoFn, logWarnFn, logErrorFn, logDebugFn)
 import Engine.Scripting.Lua.API.Input (isKeyDownFn, isActionDownFn,
                                        getMousePositionFn,
                                        isMouseButtonDownFn, getWindowSizeFn, 
@@ -109,6 +109,7 @@ registerLuaAPI lst env backendState = Lua.runWith lst $ do
   registerLuaFunction "debugThrow"        debugThrowFn
   registerLuaFunction "logInfo"           (logInfoFn env)
   registerLuaFunction "logWarn"           (logWarnFn env)
+  registerLuaFunction "logError"          (logErrorFn env)
   registerLuaFunction "logDebug"          (logDebugFn env)
   registerLuaFunction "showDebug"         (showDebugFn backendState)
   registerLuaFunction "hideDebug"         (hideDebugFn backendState)

--- a/src/Engine/Scripting/Lua/API/Log.hs
+++ b/src/Engine/Scripting/Lua/API/Log.hs
@@ -4,6 +4,7 @@ module Engine.Scripting.Lua.API.Log
   , getDebugCategoriesFn
   , logInfoFn
   , logWarnFn
+  , logErrorFn
   , logDebugFn
   ) where
 
@@ -62,6 +63,29 @@ logWarnFn env = do
                 fullMsg = "[" <> T.pack srcFileStripped <> ":"
                               <> T.pack (show srcLine) <> "] " <> msgText
             logThreadWarn logger CatLua fullMsg
+        Nothing → pure ()
+    return 0
+
+logErrorFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+logErrorFn env = do
+    msg ← Lua.tostring 1
+    -- Level 2: 0=C function, 1=logErrorFn wrapper, 2=Lua caller
+    mInfo ← getSourceInfo 2
+    let (srcFile, srcLine) = case mInfo of
+            Just info → (siSource info, siCurrentLine info)
+            Nothing   → ("<unknown>", 0)
+        srcFileStripped = dropDir srcFile
+        dropDir ('.':'/':ss) = dropDir ss
+        dropDir ('/':ss)     = ss
+        dropDir (_:ss)       = dropDir ss
+        dropDir _            = ""
+    case msg of
+        Just msgBS → Lua.liftIO $ do
+            logger ← readIORef (loggerRef env)
+            let msgText = TE.decodeUtf8 msgBS
+                fullMsg = "[" <> T.pack srcFileStripped <> ":"
+                              <> T.pack (show srcLine) <> "] " <> msgText
+            logThreadError logger CatLua fullMsg
         Nothing → pure ()
     return 0
 


### PR DESCRIPTION
Fixes #53.

## Problem
Several Lua scripts call `engine.logError(...)` on their error paths (`scripts/main_menu.lua:364`, `scripts/ui/button.lua:79`, `scripts/ui/panel.lua:182,221,278`), but `logError` was never registered onto the `engine` table — only `logInfo`, `logWarn`, and `logDebug` were. Those error paths therefore crashed with `attempt to call a nil value (field 'logError')` instead of logging.

## Fix (option 1 from the issue)
Register `logError` alongside the other log levels:
- `Engine.Scripting.Lua.API/Log.hs` — new `logErrorFn`, mirroring `logWarnFn` (source-location prefix, `CatLua`, error level); exported.
- `Engine.Scripting.Lua.API` — import and register it as `engine.logError`.
- `Engine.Core.Log` — add `logThreadError`, the thread-safe `LevelError` variant that was missing next to `logThreadInfo`/`Warn`/`Debug`.

## Verification
Built `exe:synarchy` (prod profile). Headless repro from the issue:

```
> return tostring(engine.logError)
"function: 0x..."          -- was "nil"
> engine.logError("...")    -- previously crashed; now logs:
2026-06-26 ... [ERROR] [Lua] [:1] ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)