### PR TITLE
Group A (epic #101): canonical active-world resolver

### DIFF
--- a/src/Combat/Wounds.hs
+++ b/src/Combat/Wounds.hs
@@ -41,7 +41,7 @@ import qualified Data.Sequence as Seq
 import qualified Data.List as L
 import Data.IORef (readIORef, atomicModifyIORef')
 import Combat.Types (CombatEvent(..))
-import Engine.Core.State (EngineEnv(..))
+import Engine.Core.State (EngineEnv(..), activeWorldState)
 import Engine.Core.Log (logDebug, LogCategory(..))
 import qualified Engine.Core.Queue as Q
 import Unit.Types (UnitId(..), UnitInstance(..), UnitDef(..)
@@ -386,12 +386,12 @@ tickAllWounds env dt = do
     -- Active world's climate, for per-unit infection selection + onset speed.
     -- Nothing before a world exists (menu / pre-gen) → infection stays untyped.
     mClim ← do
-        manager ← readIORef (worldManagerRef env)
-        case wmWorlds manager of
-            ((_, ws):_) → do
+        mWs ← activeWorldState env
+        case mWs of
+            Just ws → do
                 mp ← readIORef (wsGenParamsRef ws)
                 pure (fmap (\p → (wgpClimateState p, wgpWorldSize p)) mp)
-            [] → pure Nothing
+            Nothing → pure Nothing
     -- One independent generator for this tick's infection-type rolls; split
     -- off statRNGRef (advances the master) so we don't race other consumers.
     tickGen ← atomicModifyIORef' (statRNGRef env) Random.splitGen

--- a/src/Engine/Core/State.hs
+++ b/src/Engine/Core/State.hs
@@ -5,7 +5,7 @@ import qualified Data.Vector as V
 import qualified Data.Map as Map
 import qualified Data.ByteString as BS
 import qualified Data.HashMap.Strict as HM
-import Data.IORef (IORef)
+import Data.IORef (IORef, readIORef)
 import Data.Sequence (Seq)
 import Control.Concurrent.STM.TVar (TVar)
 import System.Random (StdGen)
@@ -52,7 +52,8 @@ import Item.Types (ItemManager)
 import Equipment.Types (EquipmentClassManager)
 import Substance.Types (SubstanceManager)
 import Infection.Types (InfectionManager)
-import World.Types (WorldCommand, WorldManager, FloraCatalog)
+import World.Types (WorldCommand, WorldManager, FloraCatalog
+                   , WorldState, WorldPageId, wmWorlds, wmVisible)
 import World.Material (MaterialRegistry)
 import World.Generate.Config (WorldGenConfig)
 import Sim.Command.Types (SimCommand)
@@ -315,3 +316,31 @@ defaultWindowState = WindowState
   { wsWindowedPos  = (100, 100)
   , wsWindowedSize = (800, 600)
   }
+
+-- | The single canonical "active world" resolution rule. Every read of
+--   "the current world" must go through this (or 'activeWorldState' /
+--   'activeWorldPage') rather than pattern-matching @wmWorlds@/@wmVisible@
+--   inline — historically scattered code grabbed the head of @wmWorlds@
+--   (registration order) and acted on the wrong world (see epic #101).
+--
+--   Rule: the first visible world wins. If none are marked visible (a
+--   brief mid-transition window) fall back to the head of @wmWorlds@.
+--   Returns Nothing when no worlds are registered (main menu) or when the
+--   visible head has no backing 'WorldState' yet (do not silently fall
+--   through to a different world in that case).
+resolveActiveWorld ∷ WorldManager → Maybe (WorldPageId, WorldState)
+resolveActiveWorld mgr = case wmVisible mgr of
+    (pid:_) → (\ws → (pid, ws)) <$> lookup pid (wmWorlds mgr)
+    []      → case wmWorlds mgr of
+        (pw:_) → Just pw
+        []     → Nothing
+
+-- | 'resolveActiveWorld' over the live 'worldManagerRef', returning the
+--   active world's page id together with its state.
+activeWorldPage ∷ EngineEnv → IO (Maybe (WorldPageId, WorldState))
+activeWorldPage env = resolveActiveWorld <$> readIORef (worldManagerRef env)
+
+-- | The active world's 'WorldState' (its page id discarded). The common
+--   case for current-world reads that don't need the page id.
+activeWorldState ∷ EngineEnv → IO (Maybe WorldState)
+activeWorldState env = fmap snd <$> activeWorldPage env

--- a/src/Engine/Scripting/Lua/API/Camera.hs
+++ b/src/Engine/Scripting/Lua/API/Camera.hs
@@ -23,7 +23,7 @@ import UPrelude
 import Data.IORef (readIORef, atomicModifyIORef', writeIORef)
 import qualified Data.Text as T
 import qualified Data.Vector.Unboxed as VU
-import Engine.Core.State (EngineEnv(..))
+import Engine.Core.State (EngineEnv(..), resolveActiveWorld)
 import Engine.Core.Log (logInfo, LogCategory(..))
 import Engine.Graphics.Camera (Camera2D(..), CameraFacing(..), rotateCW, rotateCCW)
 import World.Grid
@@ -170,23 +170,25 @@ cameraGotoTileFn env = do
             -- This is a pure computation — no loaded chunks needed.
             manager ← readIORef (worldManagerRef env)
             registry ← readIORef (materialRegistryRef env)
-            forM_ (wmVisible manager) $ \pageId →
-                case lookup pageId (wmWorlds manager) of
-                    Just worldState → do
-                        mParams ← readIORef (wsGenParamsRef worldState)
-                        case mParams of
-                            Just params → do
-                                let seed      = wgpSeed params
-                                    worldSize = wgpWorldSize params
-                                    timeline  = wgpGeoTimeline params
-                                    plates    = generatePlates seed worldSize (wgpPlateCount params)
-                                    (baseElev, baseMat) = elevationAtGlobal seed plates worldSize gx gy
-                                    (finalElev, _) = applyTimelineFast timeline plates worldSize gx gy registry (baseElev, baseMat)
-                                    targetZ = finalElev + surfaceHeadroom
-                                atomicModifyIORef' (cameraRef env) $ \cam →
-                                    (cam { camZSlice = targetZ, camZTracking = True }, ())
-                            Nothing → return ()
-                    Nothing → return ()
+            -- Track the ACTIVE world only (was: loop every visible world,
+            -- last-wins — disagreed with the render-thread z-track and the
+            -- rotation hit-test, #81).
+            case resolveActiveWorld manager of
+                Just (_, worldState) → do
+                    mParams ← readIORef (wsGenParamsRef worldState)
+                    case mParams of
+                        Just params → do
+                            let seed      = wgpSeed params
+                                worldSize = wgpWorldSize params
+                                timeline  = wgpGeoTimeline params
+                                plates    = generatePlates seed worldSize (wgpPlateCount params)
+                                (baseElev, baseMat) = elevationAtGlobal seed plates worldSize gx gy
+                                (finalElev, _) = applyTimelineFast timeline plates worldSize gx gy registry (baseElev, baseMat)
+                                targetZ = finalElev + surfaceHeadroom
+                            atomicModifyIORef' (cameraRef env) $ \cam →
+                                (cam { camZSlice = targetZ, camZTracking = True }, ())
+                        Nothing → return ()
+                Nothing → return ()
 
         _ → pure ()
     return 0
@@ -250,11 +252,9 @@ findVisualCenterTile ∷ EngineEnv → CameraFacing → Float → Float → Int
                      → IO (Maybe (Int, Int, Int))
 findVisualCenterTile env facing cx cy zSlice = do
     wm ← readIORef (worldManagerRef env)
-    case wmVisible wm of
-        [] → return Nothing
-        (pageId:_) → case lookup pageId (wmWorlds wm) of
-            Nothing → return Nothing
-            Just ws → do
+    case resolveActiveWorld wm of
+        Nothing → return Nothing
+        Just (_, ws) → do
                 td ← readIORef (wsTilesRef ws)
                 let zMin = zSlice - viewDepth
                     tryZ z
@@ -282,22 +282,19 @@ findVisualCenterTile env facing cx cy zSlice = do
 lookupVisualCenterZ ∷ EngineEnv → CameraFacing → Float → Float → Int → IO (Maybe Int)
 lookupVisualCenterZ env facing cx cy zSlice = do
     wm ← readIORef (worldManagerRef env)
-    go (wmVisible wm) (wmWorlds wm)
+    case resolveActiveWorld wm of
+        Nothing → return Nothing
+        Just (_, ws) → do
+            td ← readIORef (wsTilesRef ws)
+            case lookupChunk chunkCoord td of
+                Just lc → return $ Just ((lcSurfaceMap lc) VU.! columnIndex lx ly)
+                Nothing → return Nothing
   where
     -- The visual center is shifted in Y by the height offset.
     -- We approximate by sampling at the camera's grid position
     -- (accurate for flat terrain, close enough for hilly terrain).
     (gx, gy) = worldToGrid facing cx cy
     (chunkCoord, (lx, ly)) = globalToChunk gx gy
-    go [] _ = return Nothing
-    go (pageId:rest) worlds =
-        case lookup pageId worlds of
-            Nothing → go rest worlds
-            Just ws → do
-                td ← readIORef (wsTilesRef ws)
-                case lookupChunk chunkCoord td of
-                    Just lc → return $ Just ((lcSurfaceMap lc) VU.! columnIndex lx ly)
-                    Nothing → go rest worlds
 
 -- | Rotate camera screen position one step clockwise.
 --   Derivation: CW facing rotates the screen axes (a,b) → (b,-a).

--- a/src/Engine/Scripting/Lua/API/Items.hs
+++ b/src/Engine/Scripting/Lua/API/Items.hs
@@ -23,7 +23,7 @@ import qualified HsLua as Lua
 import Control.Monad (foldM)
 import Data.IORef (readIORef, atomicModifyIORef')
 import System.Directory (doesFileExist)
-import Engine.Core.State (EngineEnv(..))
+import Engine.Core.State (EngineEnv(..), activeWorldState)
 import Engine.Core.Log (LogCategory(..), logInfo, logWarn)
 import Engine.Scripting.Lua.Types (LuaBackendState(..))
 import Engine.Scripting.Lua.API.YamlTextures (loadAndRegister)
@@ -195,13 +195,7 @@ loadItemYamlFn env backendState = do
 -- | Resolve the active (first visible) world's state — ground items
 --   live on the world page being played.
 activeWorld ∷ EngineEnv → IO (Maybe WorldState)
-activeWorld env = do
-    mgr ← readIORef (worldManagerRef env)
-    pure $ case wmVisible mgr of
-        (pid:_) → lookup pid (wmWorlds mgr)
-        []      → case wmWorlds mgr of
-            ((_, ws):_) → Just ws
-            []          → Nothing
+activeWorld = activeWorldState
 
 -- | item.listDefs() → array of {name, displayName, category, weight}
 --   Sorted by name for a stable debug-overlay listing.

--- a/src/Engine/Scripting/Lua/API/Structure.hs
+++ b/src/Engine/Scripting/Lua/API/Structure.hs
@@ -24,7 +24,7 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.Text.Encoding as TE
 import qualified HsLua as Lua
 import qualified Engine.Core.Queue as Q
-import Engine.Core.State (EngineEnv(..))
+import Engine.Core.State (EngineEnv(..), activeWorldPage, activeWorldState)
 import Engine.Asset.Handle (TextureHandle(..))
 import Structure.Types
 import Structure.Palette (internPath, TexPalette(..))
@@ -85,13 +85,13 @@ structurePlaceFn env = do
                                     ( HM.insert texId  (TextureHandle (fromIntegral tex))
                                     $ HM.insert faceId (TextureHandle (fromIntegral face)) m
                                     , () )
-                                mgr ← readIORef (worldManagerRef env)
-                                case wmWorlds mgr of
-                                    ((pageId, _):_) →
+                                mActive ← activeWorldPage env
+                                case mActive of
+                                    Just (pageId, _) →
                                         Q.writeQueue (worldQueue env)
                                             (WorldSetStructure pageId gxi gyi
                                                                slotTag texId faceId z)
-                                    [] → pure ()
+                                    Nothing → pure ()
                             _ → pure ()   -- no paths → not persisted (debug-only)
                     Lua.pushboolean True
                     return 1
@@ -134,15 +134,15 @@ structureCountFn env = do
 --   save/load (replayed from sdEdits).
 structureLoadedCountFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 structureLoadedCountFn env = do
-    mgr ← Lua.liftIO $ readIORef (worldManagerRef env)
-    case wmWorlds mgr of
-        ((_, ws):_) → do
+    mWs ← Lua.liftIO $ activeWorldState env
+    case mWs of
+        Just ws → do
             td ← Lua.liftIO $ readIORef (wsTilesRef ws)
             let n = sum [ HM.size (lcStructures lc)
                         | lc ← HM.elems (wtdChunks td) ]
             Lua.pushinteger (fromIntegral n)
             return 1
-        [] → Lua.pushinteger 0 >> return 1
+        Nothing → Lua.pushinteger 0 >> return 1
 
 -- | structure.paletteCount() → int — number of texture paths in the palette
 --   (debug probe for save/restore of the palette).

--- a/src/Engine/Scripting/Lua/API/Units.hs
+++ b/src/Engine/Scripting/Lua/API/Units.hs
@@ -104,7 +104,7 @@ import Data.IORef (readIORef, atomicModifyIORef')
 import Data.Maybe (fromMaybe)
 import qualified Data.List as L
 import qualified System.Random as Random
-import Engine.Core.State (EngineEnv(..))
+import Engine.Core.State (EngineEnv(..), activeWorldState)
 import Infection.Types (InfectionDef(..), lookupInfection)
 import Engine.Core.Log (LogCategory(..), logInfo, logDebug, logWarn)
 import Engine.Scripting.Lua.Types (LuaBackendState(..), LuaToEngineMsg(..))
@@ -1617,13 +1617,7 @@ unitDropEquipmentToGroundFn env = do
 -- | The active (shown) world, or the first one if none is explicitly
 --   shown. Mirrors the helper in API.Items.
 activeWorldU ∷ EngineEnv → IO (Maybe WorldState)
-activeWorldU env = do
-    mgr ← readIORef (worldManagerRef env)
-    pure $ case wmVisible mgr of
-        (pid:_) → lookup pid (wmWorlds mgr)
-        []      → case wmWorlds mgr of
-            ((_, ws):_) → Just ws
-            []          → Nothing
+activeWorldU = activeWorldState
 
 -- | unit.transferItemToBuilding(uid, bid, defName) → bool. Atomic
 --   move of one ItemInstance from the unit's inventory to the

--- a/src/Engine/Scripting/Lua/API/World.hs
+++ b/src/Engine/Scripting/Lua/API/World.hs
@@ -66,7 +66,7 @@ import Data.IORef (atomicModifyIORef', readIORef, writeIORef)
 import Control.Monad (when, forM_)
 import Control.Concurrent (threadDelay)
 import qualified Engine.Core.Queue as Q
-import Engine.Core.State (EngineEnv(..))
+import Engine.Core.State (EngineEnv(..), activeWorldState)
 import Engine.Core.Log (LogCategory(..), logWarn)
 import Engine.Asset.Handle (TextureHandle(..))
 import Engine.Scripting.Lua.Material (parseTextureType)
@@ -1165,9 +1165,9 @@ worldSetToolModeFn env = do
 --   see the world thread's view of the tool state.
 worldGetToolModeFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 worldGetToolModeFn env = do
-    manager ← Lua.liftIO $ readIORef (worldManagerRef env)
-    case wmWorlds manager of
-        ((_, ws):_) → do
+    mWs ← Lua.liftIO $ activeWorldState env
+    case mWs of
+        Just ws → do
             tm ← Lua.liftIO $ readIORef (wsToolModeRef ws)
             let s = case tm of
                     InfoTool    → "info"
@@ -1175,7 +1175,7 @@ worldGetToolModeFn env = do
                     MineTool    → "mine"
             Lua.pushstring s
             return 1
-        [] → do
+        Nothing → do
             Lua.pushnil
             return 1
 
@@ -1189,9 +1189,9 @@ worldGetToolModeFn env = do
 --   the 4th value (stage) is simply ignored by those callers.
 worldGetInitProgressFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 worldGetInitProgressFn env = do
-    manager ← Lua.liftIO $ readIORef (worldManagerRef env)
-    case wmWorlds manager of
-        ((_, worldState):_) → do
+    mWs ← Lua.liftIO $ activeWorldState env
+    case mWs of
+        Just worldState → do
             phase ← Lua.liftIO $ readIORef (wsLoadPhaseRef worldState)
             case phase of
                 LoadIdle → do
@@ -1215,7 +1215,7 @@ worldGetInitProgressFn env = do
                     Lua.pushinteger 1
                     Lua.pushstring "done"
             return 4
-        [] → do
+        Nothing → do
             Lua.pushinteger 0
             Lua.pushinteger 0
             Lua.pushinteger 0
@@ -1238,16 +1238,16 @@ worldWaitForInitFn env = do
   where
     waitLoop 0 = return ()
     waitLoop n = do
-        manager ← readIORef (worldManagerRef env)
-        case wmWorlds manager of
-            ((_, ws):_) → do
+        mWs ← activeWorldState env
+        case mWs of
+            Just ws → do
                 phase ← readIORef (wsLoadPhaseRef ws)
                 case phase of
                     LoadDone → return ()
                     _        → do
                         threadDelay 250000
                         waitLoop (n - 1)
-            [] → do
+            Nothing → do
                 threadDelay 250000
                 waitLoop (n - 1)
 

--- a/src/Engine/Scripting/Lua/API/WorldQuery.hs
+++ b/src/Engine/Scripting/Lua/API/WorldQuery.hs
@@ -21,7 +21,7 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
 import Data.IORef (readIORef, atomicModifyIORef')
 import Control.Concurrent (threadDelay)
-import Engine.Core.State (EngineEnv(..))
+import Engine.Core.State (EngineEnv(..), activeWorldState)
 import World.Types
 import World.Geology.Timeline.Types
 import World.Hydrology.Types
@@ -34,10 +34,10 @@ import World.Generate (globalToChunk)
 -- | Helper: get the first active world's tile data
 getWorldTileData ∷ EngineEnv → IO (Maybe WorldTileData)
 getWorldTileData env = do
-    manager ← readIORef (worldManagerRef env)
-    case wmWorlds manager of
-        ((_, ws):_) → Just <$> readIORef (wsTilesRef ws)
-        []          → pure Nothing
+    mWs ← activeWorldState env
+    case mWs of
+        Just ws → Just <$> readIORef (wsTilesRef ws)
+        Nothing → pure Nothing
 
 -- | world.getTerrainAt(gx, gy) → surfaceZ, terrainSurfaceZ or nil
 --   Returns the surface elevation and terrain-only surface elevation.
@@ -265,10 +265,10 @@ worldGetAreaFluidFn env = do
 -- | Helper: get the first active world's gen params
 getWorldGenParams ∷ EngineEnv → IO (Maybe WorldGenParams)
 getWorldGenParams env = do
-    manager ← readIORef (worldManagerRef env)
-    case wmWorlds manager of
-        ((_, ws):_) → readIORef (wsGenParamsRef ws)
-        []          → pure Nothing
+    mWs ← activeWorldState env
+    case mWs of
+        Just ws → readIORef (wsGenParamsRef ws)
+        Nothing → pure Nothing
 
 -- | world.getClimateAt(gx, gy) → { temp, summerTemp, winterTemp, precip,
 --   humidity, snow } | nil. Region climate sampled (bilinear) at a global
@@ -403,9 +403,9 @@ worldLoadChunksInRegionFn env = do
                          , y ← [min cy1 cy2 .. max cy1 cy2]
                          ]
             count ← Lua.liftIO $ do
-                manager ← readIORef (worldManagerRef env)
-                case wmWorlds manager of
-                    ((_, ws):_) → do
+                mWs ← activeWorldState env
+                case mWs of
+                    Just ws → do
                         -- Filter the requested coords against both the loaded
                         -- tiles and the pending/in-flight queue, race-free
                         -- against the world thread's load handoff.
@@ -433,7 +433,7 @@ worldLoadChunksInRegionFn env = do
                         -- removed (loaded) some coords in between.
                         atomicModifyIORef' (wsInitQueueRef ws) $ \q →
                             (q ++ needed, length needed)
-                    [] → pure 0
+                    Nothing → pure 0
             Lua.pushinteger (fromIntegral count)
             return 1
         _ → do
@@ -464,10 +464,10 @@ worldWaitForChunksFn env = do
                 threadDelay 250000
                 waitLoop (n - 1)
     checkRemaining = do
-        manager ← readIORef (worldManagerRef env)
-        case wmWorlds manager of
-            ((_, ws):_) → length <$> readIORef (wsInitQueueRef ws)
-            []          → pure 0
+        mWs ← activeWorldState env
+        case mWs of
+            Just ws → length <$> readIORef (wsInitQueueRef ws)
+            Nothing → pure 0
 
 -- | world.getHoverTile() → gx, gy or nil
 --   Returns the tile coordinates currently under the mouse cursor in
@@ -476,9 +476,9 @@ worldWaitForChunksFn env = do
 --   isometric tilt, camera facing, elevation, and u-wrap boundary.
 worldGetHoverTileFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 worldGetHoverTileFn env = do
-    manager ← Lua.liftIO $ readIORef (worldManagerRef env)
-    case wmWorlds manager of
-        ((_, ws):_) → do
+    mWs ← Lua.liftIO $ activeWorldState env
+    case mWs of
+        Just ws → do
             cs ← Lua.liftIO $ readIORef (wsCursorRef ws)
             case worldHoverTile cs of
                 Just (gx, gy) → do
@@ -488,7 +488,7 @@ worldGetHoverTileFn env = do
                 Nothing → do
                     Lua.pushnil
                     return 1
-        [] → do
+        Nothing → do
             Lua.pushnil
             return 1
 
@@ -500,9 +500,9 @@ worldGetHoverTileFn env = do
 --   to the tile center.
 worldGetHoverPosFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 worldGetHoverPosFn env = do
-    manager ← Lua.liftIO $ readIORef (worldManagerRef env)
-    case wmWorlds manager of
-        ((_, ws):_) → do
+    mWs ← Lua.liftIO $ activeWorldState env
+    case mWs of
+        Just ws → do
             cs ← Lua.liftIO $ readIORef (wsCursorRef ws)
             case worldHoverPos cs of
                 Just (hx, hy) → do
@@ -512,6 +512,6 @@ worldGetHoverPosFn env = do
                 Nothing → do
                     Lua.pushnil
                     return 1
-        [] → do
+        Nothing → do
             Lua.pushnil
             return 1

--- a/src/Engine/Scripting/Lua/Thread.hs
+++ b/src/Engine/Scripting/Lua/Thread.hs
@@ -23,7 +23,7 @@ import Engine.Scripting.Lua.DebugServer (DebugCommand(..), startDebugServer, pol
 import Engine.Asset.Types (AssetPool)
 import Engine.Core.Log (logWarn, logDebug, logInfo, LogCategory(..), LoggerState)
 import Engine.Core.Thread
-import Engine.Core.State (EngineEnv(..), EngineLifecycle(..))
+import Engine.Core.State (EngineEnv(..), EngineLifecycle(..), activeWorldState)
 import World.State.Types (wmWorlds, wsLoadPhaseRef, wsInitQueueRef, LoadPhase(..))
 import Engine.Core.Types (EngineConfig(..))
 import Engine.Event.Types (Event(..))
@@ -307,14 +307,14 @@ runWaitForInit env timeoutSec = loop (timeoutSec * 4) ⌦ \_ → fmtInitProgress
     loop ∷ Int → IO ()
     loop 0 = return ()
     loop n = do
-        mgr ← readIORef (worldManagerRef env)
-        case wmWorlds mgr of
-            ((_, ws):_) → do
+        mWs ← activeWorldState env
+        case mWs of
+            Just ws → do
                 phase ← readIORef (wsLoadPhaseRef ws)
                 case phase of
                     LoadDone → return ()
                     _        → threadDelay 250000 ≫ loop (n - 1)
-            [] → threadDelay 250000 ≫ loop (n - 1)
+            Nothing → threadDelay 250000 ≫ loop (n - 1)
 
 -- | Poll the active world's init queue until empty (or timeout); return
 --   the remaining chunk count (matches 'world.waitForChunks').
@@ -323,10 +323,10 @@ runWaitForChunks env timeoutSec = T.pack ∘ show ⊚ loop (timeoutSec * 4)
   where
     remaining ∷ IO Int
     remaining = do
-        mgr ← readIORef (worldManagerRef env)
-        case wmWorlds mgr of
-            ((_, ws):_) → length ⊚ readIORef (wsInitQueueRef ws)
-            []          → return 0
+        mWs ← activeWorldState env
+        case mWs of
+            Just ws → length ⊚ readIORef (wsInitQueueRef ws)
+            Nothing → return 0
     loop ∷ Int → IO Int
     loop 0 = remaining
     loop n = do
@@ -337,16 +337,16 @@ runWaitForChunks env timeoutSec = T.pack ∘ show ⊚ loop (timeoutSec * 4)
 --   values 'world.getInitProgress' returns: phase, current, total, stage.
 fmtInitProgress ∷ EngineEnv → IO Text
 fmtInitProgress env = do
-    mgr ← readIORef (worldManagerRef env)
-    case wmWorlds mgr of
-        ((_, ws):_) → do
+    mWs ← activeWorldState env
+    case mWs of
+        Just ws → do
             phase ← readIORef (wsLoadPhaseRef ws)
             return $ case phase of
                 LoadIdle           → fmt 0 0 0 "idle"
                 LoadPhase1 c t     → fmt 1 c t "setup"
                 LoadPhase2 rm t    → fmt 2 (t - rm) t "chunks"
                 LoadDone           → fmt 3 1 1 "done"
-        [] → return (fmt 0 0 0 "idle")
+        Nothing → return (fmt 0 0 0 "idle")
   where
     -- Match 'world.getInitProgress' over the console exactly: the stage
     -- string is rendered quoted by 'luaValueToText', so quote it here.

--- a/src/Structure/Render.hs
+++ b/src/Structure/Render.hs
@@ -29,7 +29,7 @@ import World.Grid (tileWidth, tileHeight, tileSideHeight
                   , tileHalfWidth, tileHalfDiamondHeight
                   , worldLayer, GridConfig(..), defaultGridConfig
                   , applyFacingF, gridToScreen)
-import World.Types (wmWorlds, wsTilesRef)
+import World.Types (WorldState, wsTilesRef)
 import World.Tile.Types (WorldTileData(..))
 import World.Chunk.Types (LoadedChunk(..))
 import Structure.Types
@@ -39,13 +39,14 @@ baseTileW = fromIntegral (gcTilePixelWidth defaultGridConfig)
 baseTileH ∷ Float
 baseTileH = fromIntegral (gcTilePixelHeight defaultGridConfig)
 
-renderStructureQuads ∷ EngineEnv → CameraFacing → Int → Int → Float
+-- | Gather structure quads for ONE world's state. The caller iterates the
+--   visible-world list (same source of truth as the terrain / ground-item /
+--   spoil passes) rather than this picking a world itself — historically it
+--   grabbed the head of @wmWorlds@ and could render a hidden world's
+--   structures over the visible one (#72).
+renderStructureQuads ∷ EngineEnv → WorldState → CameraFacing → Int → Int → Float
                      → IO (V.Vector SortableQuad)
-renderStructureQuads env facing zSlice effDepth tileAlpha = do
-    mgr ← readIORef (worldManagerRef env)
-    case wmWorlds mgr of
-        [] → return V.empty
-        ((_, ws):_) → do
+renderStructureQuads env ws facing zSlice effDepth tileAlpha = do
             td      ← readIORef (wsTilesRef ws)
             handles ← readIORef (texPaletteHandlesRef env)
             -- Gather structures across ALL loaded chunks' overlays, resolving

--- a/src/World/Render.hs
+++ b/src/World/Render.hs
@@ -12,7 +12,8 @@ import qualified Data.Vector.Unboxed as VU
 import qualified Data.Vector as V
 import Data.Maybe (isJust)
 import Data.IORef (readIORef, writeIORef, atomicModifyIORef')
-import Engine.Core.State (EngineEnv(..), EngineState(..), GraphicsState(..))
+import Engine.Core.State (EngineEnv(..), EngineState(..), GraphicsState(..)
+                         , resolveActiveWorld)
 import Engine.Core.Monad (EngineM)
 import Engine.Scene.Base (LayerId(..), ObjectId(..))
 import Engine.Scene.Types (RenderBatch(..), SortableQuad(..))
@@ -155,7 +156,13 @@ updateWorldTiles env = do
         else do
             let facing = camFacing camera
                 zSlice = camZSlice camera
-            renderStructureQuads env facing zSlice effDepth tileAlpha
+            stResults ← forM (wmVisible worldManager) $ \pageId →
+                case lookup pageId (wmWorlds worldManager) of
+                    Just worldState →
+                        renderStructureQuads env worldState facing zSlice
+                                             effDepth tileAlpha
+                    Nothing → return V.empty
+            return $ V.concat stResults
 
     ghostQuads ← if tileAlpha ≤ 0.001
         then return V.empty
@@ -172,23 +179,26 @@ updateWorldTiles env = do
         when (not (camZTracking camera)) $
             atomicModifyIORef' (cameraRef env) $ \cam →
                 (cam { camZTracking = True }, ())
+        -- Track the ACTIVE world's terrain under the camera. Previously this
+        -- looped every visible world and let the LAST one win, disagreeing
+        -- with camera.gotoTile (also last-wins) and findVisualCenterTile
+        -- (first-visible). All three now resolve the one active world (#81).
         worldManager' ← readIORef (worldManagerRef env)
-        forM_ (wmVisible worldManager') $ \pageId →
-            case lookup pageId (wmWorlds worldManager') of
-                Just worldState → do
-                    tileData ← readIORef (wsTilesRef worldState)
-                    let (camX, camY) = camPosition camera
-                        facing = camFacing camera
-                        (gx, gy) = worldToGrid facing camX camY
-                        (chunkCoord, (lx, ly)) = globalToChunk gx gy
-                    case lookupChunk chunkCoord tileData of
-                        Just lc → do
-                            let surfElev = (lcSurfaceMap lc) VU.! columnIndex lx ly
-                                targetZ = surfElev + surfaceHeadroom
-                            atomicModifyIORef' (cameraRef env) $ \cam →
-                                (cam { camZSlice = targetZ }, ())
-                        Nothing → return ()
-                Nothing → return ()
+        case resolveActiveWorld worldManager' of
+            Just (_, worldState) → do
+                tileData ← readIORef (wsTilesRef worldState)
+                let (camX, camY) = camPosition camera
+                    facing = camFacing camera
+                    (gx, gy) = worldToGrid facing camX camY
+                    (chunkCoord, (lx, ly)) = globalToChunk gx gy
+                case lookupChunk chunkCoord tileData of
+                    Just lc → do
+                        let surfElev = (lcSurfaceMap lc) VU.! columnIndex lx ly
+                            targetZ = surfElev + surfaceHeadroom
+                        atomicModifyIORef' (cameraRef env) $ \cam →
+                            (cam { camZSlice = targetZ }, ())
+                    Nothing → return ()
+            Nothing → return ()
 
     let allQuads = tileQuads <> worldCursorQuads <> spoilQuads
                 <> groundItemQuads


### PR DESCRIPTION
Part of epic #101. **Group A only** — wrong-world resolution, no data-model change.

## What
Adds one canonical active-world resolver to `Engine.Core.State`:
- `resolveActiveWorld :: WorldManager → Maybe (WorldPageId, WorldState)` (pure)
- `activeWorldState :: EngineEnv → IO (Maybe WorldState)`
- `activeWorldPage :: EngineEnv → IO (Maybe (WorldPageId, WorldState))`

Rule (unchanged from the old `getActiveWorldId`/`activeWorld`/`activeWorldU`, now deduped onto the shared helper): **first visible world wins**, fall back to the head of `wmWorlds` when none are visible (mid-transition), `Nothing` at the menu.

Every scattered `wmWorlds`-head (`((_, ws):_)`) and first/last-visible read that acted on the wrong world now routes through it.

## Issues closed
- **#49** — `loadChunksInRegion`/`waitForChunks`/`getInitProgress`/`waitForInit`/`getToolMode` (plus `getHoverTile`/`getHoverPos`, the tile/genparam query helpers, and the debug-console mirrors in `Lua.Thread`) follow the active world.
- **#72** — `renderStructureQuads` takes a `WorldState`; `World.Render` iterates `wmVisible` exactly like the terrain/cursor/ground-item/spoil passes instead of head-of-`wmWorlds`.
- **#75** — `structure.place` persists into the active world's page; `structure.loadedCount` reads it.
- **#79** — `Combat.Wounds.tickAllWounds` resolves climate from the active world.
- **#81** — render-thread Z-track loop, `camera.gotoTile`, `findVisualCenterTile`, `lookupVisualCenterZ` all resolve the one active world (ends first-visible vs last-visible disagreement).

## Verification
Headless (port 9011), all against the documented repros:
- #49 — active world w1: `loadChunksInRegion(20,20,20,20)` → `0` (already loaded); `getToolMode()` → `"mine"`. (Note: the issue's repro uses `"mine"`; the tool-mode string is actually `"tool_mine"` — unrelated quirk.)
- #75 — `floor(0,0)` lands in active w3 (`loadedCount` 0→1) and **survives** destroying the hidden head world w4 (stays 1; pre-fix it was written to w4 and dropped to 0).
- #81 — w1-alone zslice `52`, w2-alone `25`; both visible with w1 active → `52` (pre-fix: `25`, last-visible won).
- `cabal test synarchy-test-headless`: **298 examples, 0 failures**.

#72 (rendering) and #79 (combat-thread climate) are not pixel/internal-state observable headless, but are 1:1 swaps onto the same resolver verified by the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)