### PR TITLE
Group B (epic #101): per-world simulation state

### DIFF
--- a/src/Sim/Command/Types.hs
+++ b/src/Sim/Command/Types.hs
@@ -26,9 +26,13 @@ data SimCommand
         --   terrain surface map
     | SimChunkUnloaded !WorldPageId !ChunkCoord
         -- ^ Chunk evicted from a world — stop simulating it
-    | SimTerrainModified !WorldPageId !ChunkCoord ![(Int, Int)]
-        -- ^ Terrain changed in a world at local indices:
-        --   [(localIndex, newElevation)]
+    | SimChunkEdited !WorldPageId !ChunkCoord !FluidMap !(VU.Vector Int)
+        -- ^ A live terrain/fluid edit landed in a world's chunk: page id,
+        --   coord, the post-edit fluid map and terrain surface (read from
+        --   the authoritative tiles). Re-seeds the sim chunk AND activates
+        --   it (and its cardinal neighbours) so the new fluid actually
+        --   flows/settles — re-using SimChunkLoaded here left the chunk
+        --   inactive, so edited fluid sat frozen (#60).
     | SimSetTickRate !Int
         -- ^ Tick rate in microseconds (default 100000 = 10Hz). Global.
     | SimPause
@@ -46,9 +50,8 @@ instance Show SimCommand where
     show (SimDeactivateWorld p)   = "SimDeactivateWorld " <> show p
     show (SimChunkLoaded p cc _ _) = "SimChunkLoaded " <> show p <> " " <> show cc
     show (SimChunkUnloaded p cc)  = "SimChunkUnloaded " <> show p <> " " <> show cc
-    show (SimTerrainModified p cc mods) =
-        "SimTerrainModified " <> show p <> " " <> show cc
-            <> " (" <> show (length mods) <> " tiles)"
+    show (SimChunkEdited p cc _ _) =
+        "SimChunkEdited " <> show p <> " " <> show cc
     show (SimSetTickRate r) = "SimSetTickRate " <> show r
     show SimPause  = "SimPause"
     show SimResume = "SimResume"

--- a/src/Sim/Command/Types.hs
+++ b/src/Sim/Command/Types.hs
@@ -8,40 +8,47 @@ import Control.Concurrent.MVar (MVar)
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU
 import World.Chunk.Types (ChunkCoord(..))
+import World.Page.Types (WorldPageId(..))
 import World.Fluid.Internal (FluidMap)
 
 data SimCommand
-    = SimActivateWorld
-        -- ^ A world became visible (WorldShow): start simulating. The
+    = SimActivateWorld !WorldPageId
+        -- ^ A world became visible (WorldShow): start simulating it. The
         --   sim no longer holds the tile ref — it emits 'WorldApplyFluids'
-        --   to the world thread, the sole writer of 'wsTilesRef'.
-    | SimDeactivateWorld
-        -- ^ Clear the active world (called on WorldHide/WorldDestroy)
-    | SimChunkLoaded !ChunkCoord !FluidMap !(VU.Vector Int)
-        -- ^ Chunk loaded: coord, initial fluid map, terrain surface map
-    | SimChunkUnloaded !ChunkCoord
-        -- ^ Chunk evicted — stop simulating
-    | SimTerrainModified !ChunkCoord ![(Int, Int)]
-        -- ^ Terrain changed at local indices: [(localIndex, newElevation)]
+        --   (tagged with this page id) to the world thread, the sole writer
+        --   of 'wsTilesRef'.
+    | SimDeactivateWorld !WorldPageId
+        -- ^ Drop one world's sim state (called on WorldHide/WorldDestroy).
+        --   Only that world's chunks/active flag are cleared; other
+        --   simulated worlds are untouched (#55, #61).
+    | SimChunkLoaded !WorldPageId !ChunkCoord !FluidMap !(VU.Vector Int)
+        -- ^ Chunk loaded in a world: page id, coord, initial fluid map,
+        --   terrain surface map
+    | SimChunkUnloaded !WorldPageId !ChunkCoord
+        -- ^ Chunk evicted from a world — stop simulating it
+    | SimTerrainModified !WorldPageId !ChunkCoord ![(Int, Int)]
+        -- ^ Terrain changed in a world at local indices:
+        --   [(localIndex, newElevation)]
     | SimSetTickRate !Int
-        -- ^ Tick rate in microseconds (default 100000 = 10Hz)
+        -- ^ Tick rate in microseconds (default 100000 = 10Hz). Global.
     | SimPause
     | SimResume
     | SimFastSettleAll !(MVar ())
-        -- ^ Synchronously run all settle ticks (no sleeping) until all
-        --   chunks have scsSettleTicks == 0 and no chunks are active.
-        --   Then emits a 'WorldApplyFluids' batch with an ack and waits
-        --   for the world thread to apply it, sets ssPaused, and signals
-        --   the MVar. Used by dump mode to get a stable simulation state
-        --   without waiting for the live sim loop.
+        -- ^ Synchronously run all settle ticks (no sleeping) across every
+        --   world until each chunk has scsSettleTicks == 0 and no chunk is
+        --   active. Then emits a 'WorldApplyFluids' batch (per world) with
+        --   an ack and waits for the world thread to apply it, sets
+        --   ssPaused, and signals the MVar. Used by dump mode to get a
+        --   stable simulation state without waiting for the live sim loop.
 
 instance Show SimCommand where
-    show SimActivateWorld         = "SimActivateWorld"
-    show SimDeactivateWorld       = "SimDeactivateWorld"
-    show (SimChunkLoaded cc _ _)  = "SimChunkLoaded " <> show cc
-    show (SimChunkUnloaded cc)    = "SimChunkUnloaded " <> show cc
-    show (SimTerrainModified cc mods) =
-        "SimTerrainModified " <> show cc <> " (" <> show (length mods) <> " tiles)"
+    show (SimActivateWorld p)     = "SimActivateWorld " <> show p
+    show (SimDeactivateWorld p)   = "SimDeactivateWorld " <> show p
+    show (SimChunkLoaded p cc _ _) = "SimChunkLoaded " <> show p <> " " <> show cc
+    show (SimChunkUnloaded p cc)  = "SimChunkUnloaded " <> show p <> " " <> show cc
+    show (SimTerrainModified p cc mods) =
+        "SimTerrainModified " <> show p <> " " <> show cc
+            <> " (" <> show (length mods) <> " tiles)"
     show (SimSetTickRate r) = "SimSetTickRate " <> show r
     show SimPause  = "SimPause"
     show SimResume = "SimResume"

--- a/src/Sim/Command/Types.hs
+++ b/src/Sim/Command/Types.hs
@@ -18,9 +18,15 @@ data SimCommand
         --   (tagged with this page id) to the world thread, the sole writer
         --   of 'wsTilesRef'.
     | SimDeactivateWorld !WorldPageId
-        -- ^ Drop one world's sim state (called on WorldHide/WorldDestroy).
-        --   Only that world's chunks/active flag are cleared; other
-        --   simulated worlds are untouched (#55, #61).
+        -- ^ A world was hidden: stop ticking it but KEEP its loaded chunks
+        --   so a later WorldShow can resume simulating them. Dropping the
+        --   chunks here left a hidden→shown world's sim inert, because
+        --   ChunkLoading never re-emits SimChunkLoaded for coords already in
+        --   wsTilesRef. Other worlds are untouched (#55).
+    | SimDropWorld !WorldPageId
+        -- ^ A world was destroyed: discard its sim state entirely (chunks +
+        --   active flag). Used on WorldDestroy / destroyAll, where the
+        --   chunks are gone for good (#61).
     | SimChunkLoaded !WorldPageId !ChunkCoord !FluidMap !(VU.Vector Int)
         -- ^ Chunk loaded in a world: page id, coord, initial fluid map,
         --   terrain surface map
@@ -48,6 +54,7 @@ data SimCommand
 instance Show SimCommand where
     show (SimActivateWorld p)     = "SimActivateWorld " <> show p
     show (SimDeactivateWorld p)   = "SimDeactivateWorld " <> show p
+    show (SimDropWorld p)         = "SimDropWorld " <> show p
     show (SimChunkLoaded p cc _ _) = "SimChunkLoaded " <> show p <> " " <> show cc
     show (SimChunkUnloaded p cc)  = "SimChunkUnloaded " <> show p <> " " <> show cc
     show (SimChunkEdited p cc _ _) =

--- a/src/Sim/Fluid/Active.hs
+++ b/src/Sim/Fluid/Active.hs
@@ -17,27 +17,26 @@ import Data.STRef (STRef, newSTRef, readSTRef, writeSTRef, modifySTRef')
 import Data.Bits ((.&.), (.|.), shiftL)
 import World.Chunk.Types (ChunkCoord(..), chunkSize)
 import World.Fluid.Types (FluidType(..), FluidCell(..))
-import Sim.State.Types (SimState(..), SimChunkState(..))
+import Sim.State.Types (SimWorldState(..), SimChunkState(..))
 import Sim.Fluid.Types (ActiveFluidCell(..), volumePerLevel, volumeToSurface)
 
 -- | Ticks at equilibrium before a chunk is deactivated.
 equilThreshold ∷ Int
 equilThreshold = 200
 
--- | Run one tick of volume-conserving simulation for all active chunks.
-simulateActiveTick ∷ SimState → SimState
-simulateActiveTick ss
-    | ssPaused ss = ss
-    | otherwise =
-        let chunks = ssChunks ss
+-- | Run one tick of volume-conserving simulation for all active chunks
+--   of ONE world. The engine-level pause guard is the caller's job.
+simulateActiveTick ∷ SimWorldState → SimWorldState
+simulateActiveTick sws =
+        let chunks = swsChunks sws
             activeChunks = HM.filter scsActive chunks
         in if HM.null activeChunks
-           then ss
+           then sws
            else let results = reconcileSeams
                                  (HM.mapWithKey (simulateActiveChunk chunks) activeChunks)
                     dirty = HM.foldlWithKey' (\acc cc (_, changed) →
                         if changed then HS.insert cc acc else acc
-                        ) (ssDirtyChunks ss) results
+                        ) (swsDirtyChunks sws) results
                     -- Merge updated active chunks back, handle deactivation
                     newChunks = HM.foldlWithKey' (\acc cc (scs, changed) →
                         let scs' = if changed
@@ -49,9 +48,9 @@ simulateActiveTick ss
                                     else scs'
                         in HM.insert cc scs'' acc
                         ) chunks results
-                in ss { ssChunks = newChunks
-                      , ssDirtyChunks = dirty
-                      }
+                in sws { swsChunks = newChunks
+                       , swsDirtyChunks = dirty
+                       }
 
 -- | Deactivate a chunk: bake active volumes back to passive fluid.
 deactivateInPlace ∷ SimChunkState → SimChunkState

--- a/src/Sim/State/Types.hs
+++ b/src/Sim/State/Types.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE Strict, UnicodeSyntax #-}
 module Sim.State.Types
     ( SimState(..)
+    , SimWorldState(..)
     , SimChunkState(..)
     , emptySimState
+    , emptySimWorldState
     ) where
 
 import UPrelude
@@ -11,18 +13,30 @@ import qualified Data.HashSet as HS
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU
 import World.Chunk.Types (ChunkCoord(..))
+import World.Page.Types (WorldPageId(..))
 import World.Fluid.Internal (FluidMap)
 import Sim.Fluid.Types (ActiveFluidCell(..))
 
+-- | Simulation state, scoped per world. Each visible/active world owns
+--   an independent 'SimWorldState' (its own chunk map, dirty set and
+--   active flag) keyed by 'WorldPageId', so one world's fluid sim can
+--   never contaminate another's tiles (epic #101 / #59). Tick rate and
+--   the engine-level pause are genuinely global and stay at the top.
 data SimState = SimState
-    { ssChunks      ∷ !(HM.HashMap ChunkCoord SimChunkState)
+    { ssWorlds      ∷ !(HM.HashMap WorldPageId SimWorldState)
     , ssTickRate    ∷ !Int              -- ^ Microseconds between ticks (default 100000)
-    , ssDirtyChunks ∷ !(HS.HashSet ChunkCoord)  -- ^ Chunks modified this tick
-    , ssPaused     ∷ !Bool
-    , ssWorldActive ∷ !Bool
-        -- ^ True between SimActivateWorld and SimDeactivateWorld. The sim
-        --   never holds the world's tile ref — it emits 'WorldApplyFluids'
-        --   to the world thread, the sole writer of 'wsTilesRef'.
+    , ssPaused      ∷ !Bool             -- ^ Engine-level (game) pause, all worlds
+    }
+
+-- | One world's simulation state.
+data SimWorldState = SimWorldState
+    { swsChunks      ∷ !(HM.HashMap ChunkCoord SimChunkState)
+    , swsDirtyChunks ∷ !(HS.HashSet ChunkCoord)  -- ^ Chunks modified this tick
+    , swsActive      ∷ !Bool
+        -- ^ True between SimActivateWorld and SimDeactivateWorld for THIS
+        --   world. The sim never holds the world's tile ref — it emits
+        --   'WorldApplyFluids' (tagged with this world's page id) to the
+        --   world thread, the sole writer of 'wsTilesRef'.
     }
 
 data SimChunkState = SimChunkState
@@ -38,9 +52,14 @@ data SimChunkState = SimChunkState
 
 emptySimState ∷ SimState
 emptySimState = SimState
-    { ssChunks      = HM.empty
+    { ssWorlds      = HM.empty
     , ssTickRate    = 100000  -- 10 Hz
-    , ssDirtyChunks = HS.empty
-    , ssPaused     = False
-    , ssWorldActive = False
+    , ssPaused      = False
+    }
+
+emptySimWorldState ∷ SimWorldState
+emptySimWorldState = SimWorldState
+    { swsChunks      = HM.empty
+    , swsDirtyChunks = HS.empty
+    , swsActive      = False
     }

--- a/src/Sim/Thread.hs
+++ b/src/Sim/Thread.hs
@@ -170,32 +170,47 @@ handleSimCommand env logger simStateRef cmd = do
                 modifyWorld pid (\sws →
                     sws { swsChunks = HM.delete coord (swsChunks sws) }) ss
 
-        SimTerrainModified pid coord mods → do
+        SimChunkEdited pid coord fluidMap terrainMap → do
             let sws = HM.lookupDefault emptySimWorldState pid (ssWorlds ss)
-            case HM.lookup coord (swsChunks sws) of
-                Nothing → pure ()
-                Just scs → do
-                    let terrV' = scsTerrain scs VU.// mods
-                        -- Activate the chunk for volume simulation
-                        activated = activateChunk (scs { scsTerrain = terrV'
-                                                       , scsSettleTicks = 24
-                                                       })
-                        -- Activate the 4 cardinal neighbours too, so dammed
-                        -- water can spill across the chunk seam: the seam
-                        -- exchange pass (Sim.Fluid.Active.reconcileSeams)
-                        -- needs both sides active to have a grid to transfer
-                        -- into. HM.adjust is a no-op for unloaded neighbours;
-                        -- activateChunk is idempotent for already-active ones.
-                        ChunkCoord cx cy = coord
-                        nbrCoords = [ ChunkCoord (cx + 1) cy, ChunkCoord (cx - 1) cy
-                                    , ChunkCoord cx (cy + 1), ChunkCoord cx (cy - 1) ]
-                        withSelf = HM.insert coord activated (swsChunks sws)
-                        withNbrs = foldl' (\m nc → HM.adjust activateChunk nc m)
-                                          withSelf nbrCoords
-                    writeIORef simStateRef $
-                        ss { ssWorlds = HM.insert pid
-                                          (sws { swsChunks = withNbrs })
-                                          (ssWorlds ss) }
+                sz  = chunkSize * chunkSize
+                -- Re-seed from the authoritative post-edit tiles. Build on
+                -- the existing sim chunk if present, else create one (an
+                -- edit can land before the sim has loaded that chunk).
+                base = case HM.lookup coord (swsChunks sws) of
+                    Just scs → scs { scsFluid       = fluidMap
+                                   , scsTerrain     = terrainMap
+                                   , scsGenFluid    = fluidMap
+                                   , scsSettleTicks = 24
+                                   }
+                    Nothing  → SimChunkState
+                        { scsFluid       = fluidMap
+                        , scsTerrain     = terrainMap
+                        , scsGenFluid    = fluidMap
+                        , scsSettleTicks = 24
+                        , scsActive      = False
+                        , scsActiveFluid = V.replicate sz Nothing
+                        , scsEquilTicks  = 0
+                        , scsSideDeco    = VU.replicate sz 0
+                        }
+                -- Force a fresh activation so the volume grid is rebuilt
+                -- from the NEW fluid: activateChunk no-ops on an already-
+                -- active chunk, so clear the flag first. Without this the
+                -- edited chunk kept the new snapshot but never flowed (#60).
+                activated = activateChunk (base { scsActive = False })
+                -- Activate the 4 cardinal neighbours too so dammed water can
+                -- spill across the chunk seam (reconcileSeams needs both
+                -- sides active). HM.adjust is a no-op for unloaded
+                -- neighbours; activateChunk is idempotent for active ones.
+                ChunkCoord cx cy = coord
+                nbrCoords = [ ChunkCoord (cx + 1) cy, ChunkCoord (cx - 1) cy
+                            , ChunkCoord cx (cy + 1), ChunkCoord cx (cy - 1) ]
+                withSelf = HM.insert coord activated (swsChunks sws)
+                withNbrs = foldl' (\m nc → HM.adjust activateChunk nc m)
+                                  withSelf nbrCoords
+            writeIORef simStateRef $
+                ss { ssWorlds = HM.insert pid
+                                  (sws { swsChunks = withNbrs })
+                                  (ssWorlds ss) }
 
         SimSetTickRate rate →
             writeIORef simStateRef $ ss { ssTickRate = rate }

--- a/src/Sim/Thread.hs
+++ b/src/Sim/Thread.hs
@@ -144,10 +144,20 @@ handleSimCommand env logger simStateRef cmd = do
             logDebug logger CatWorld $ "Sim: world activated " <> tshow pid
 
         SimDeactivateWorld pid → do
-            -- Drop ONLY this world's sim state; others keep running (#55/#61).
+            -- Hidden: stop ticking but KEEP the chunks so a later show can
+            -- resume them (ChunkLoading won't re-emit SimChunkLoaded for
+            -- already-loaded coords, so dropping them here would leave the
+            -- re-shown world's sim inert). Other worlds untouched (#55).
+            writeIORef simStateRef $
+                ss { ssWorlds = HM.adjust (\sws → sws { swsActive = False })
+                                          pid (ssWorlds ss) }
+            logDebug logger CatWorld $ "Sim: world deactivated " <> tshow pid
+
+        SimDropWorld pid → do
+            -- Destroyed: discard this world's sim state entirely (#61).
             writeIORef simStateRef $
                 ss { ssWorlds = HM.delete pid (ssWorlds ss) }
-            logDebug logger CatWorld $ "Sim: world deactivated " <> tshow pid
+            logDebug logger CatWorld $ "Sim: world dropped " <> tshow pid
 
         SimChunkLoaded pid coord fluidMap terrainMap → do
             let sz = chunkSize * chunkSize

--- a/src/Sim/Thread.hs
+++ b/src/Sim/Thread.hs
@@ -21,11 +21,13 @@ import Engine.Core.Log (logInfo, logDebug, logError, logWarn, LogCategory(..)
                         , LoggerState)
 import qualified Engine.Core.Queue as Q
 import World.Chunk.Types (ChunkCoord(..), LoadedChunk(..), chunkSize)
+import World.Page.Types (WorldPageId(..))
 import World.Fluid.Types (FluidCell(..), FluidType(..))
 import World.Command.Types (WorldCommand(..), FluidWriteback(..)
                            , FluidWritebackBatch(..))
 import Sim.Command.Types (SimCommand(..))
-import Sim.State.Types (SimState(..), SimChunkState(..), emptySimState)
+import Sim.State.Types (SimState(..), SimWorldState(..), SimChunkState(..)
+                       , emptySimState, emptySimWorldState)
 import Sim.Fluid.Types (ActiveFluidCell(..), fluidCellToActive, activeToFluidCell)
 import Sim.Fluid.Active (simulateActiveTick)
 
@@ -47,6 +49,12 @@ startSimThread env = do
             error "Sim thread start failure."
         )
     return $ ThreadState stateRef threadId doneVar
+
+-- | True when at least one world is active and holds chunks — i.e. there
+--   is simulation work to do this tick.
+anyLiveWorld ∷ SimState → Bool
+anyLiveWorld ss = any (\sws → swsActive sws ∧ not (HM.null (swsChunks sws)))
+                      (HM.elems (ssWorlds ss))
 
 simLoop ∷ EngineEnv → IORef ThreadControl → IORef SimState → IO ()
 simLoop env stateRef simStateRef = do
@@ -70,19 +78,22 @@ simLoop env stateRef simStateRef = do
 
                 ss ← readIORef simStateRef
 
-                if ssPaused ss ∨ HM.null (ssChunks ss)
-                                ∨ not (ssWorldActive ss)
+                if ssPaused ss ∨ not (anyLiveWorld ss)
                     then do
                         threadDelay (ssTickRate ss)
                         pure True
                     else do
-                        let ss'  = settleNewChunks ss
-                            ss'' = simulateActiveTick ss'
-                        emitDirtyFluids env ss'' Nothing
-                        let ss''' = ss'' { ssDirtyChunks = HS.empty }
-                        writeIORef simStateRef ss'''
+                        -- Tick every active world independently, emit each
+                        -- world's dirty fluids tagged with its page id, then
+                        -- clear the per-world dirty sets.
+                        let ticked = HM.map tickWorld (ssWorlds ss)
+                        forM_ (HM.toList ticked) $ \(pid, sws) →
+                            when (swsActive sws) $
+                                emitWorldDirtyFluids env pid sws Nothing
+                        let cleared = HM.map clearDirty ticked
+                        writeIORef simStateRef ss { ssWorlds = cleared }
 
-                        threadDelay (ssTickRate ss''')
+                        threadDelay (ssTickRate ss)
                         pure True
               )
               (\(e ∷ SomeException) → do
@@ -91,6 +102,15 @@ simLoop env stateRef simStateRef = do
                 pure False
               )
             when ok $ simLoop env stateRef simStateRef
+
+-- | Settle + simulate one world's chunks (a no-op for an inactive world).
+tickWorld ∷ SimWorldState → SimWorldState
+tickWorld sws
+    | not (swsActive sws) = sws
+    | otherwise           = simulateActiveTick (settleNewChunks sws)
+
+clearDirty ∷ SimWorldState → SimWorldState
+clearDirty sws = sws { swsDirtyChunks = HS.empty }
 
 processSimCommands ∷ EngineEnv → LoggerState → IORef SimState → IO ()
 processSimCommands env logger simStateRef = do
@@ -101,25 +121,35 @@ processSimCommands env logger simStateRef = do
             processSimCommands env logger simStateRef
         Nothing → return ()
 
+-- | Apply @f@ to one world's state, creating an empty entry if absent.
+modifyWorld ∷ WorldPageId → (SimWorldState → SimWorldState)
+            → SimState → SimState
+modifyWorld pid f ss =
+    let cur = HM.lookupDefault emptySimWorldState pid (ssWorlds ss)
+    in ss { ssWorlds = HM.insert pid (f cur) (ssWorlds ss) }
+
 handleSimCommand ∷ EngineEnv → LoggerState → IORef SimState → SimCommand → IO ()
 handleSimCommand env logger simStateRef cmd = do
     ss ← readIORef simStateRef
     case cmd of
-        SimActivateWorld → do
-            -- Re-trigger settle so existing chunks get simulated now that writeback is possible
-            let reSettled = HM.map (\scs →
-                    scs { scsSettleTicks = 24 }) (ssChunks ss)
+        SimActivateWorld pid → do
+            -- Re-trigger settle so this world's existing chunks get
+            -- simulated now that writeback is possible.
             writeIORef simStateRef $
-                ss { ssWorldActive = True
-                   , ssChunks = reSettled }
-            logDebug logger CatWorld "Sim: world activated"
+                modifyWorld pid (\sws → sws
+                    { swsActive = True
+                    , swsChunks = HM.map (\scs → scs { scsSettleTicks = 24 })
+                                         (swsChunks sws)
+                    }) ss
+            logDebug logger CatWorld $ "Sim: world activated " <> tshow pid
 
-        SimDeactivateWorld → do
-            writeIORef simStateRef $ emptySimState
-                { ssTickRate = ssTickRate ss }
-            logDebug logger CatWorld "Sim: world deactivated"
+        SimDeactivateWorld pid → do
+            -- Drop ONLY this world's sim state; others keep running (#55/#61).
+            writeIORef simStateRef $
+                ss { ssWorlds = HM.delete pid (ssWorlds ss) }
+            logDebug logger CatWorld $ "Sim: world deactivated " <> tshow pid
 
-        SimChunkLoaded coord fluidMap terrainMap → do
+        SimChunkLoaded pid coord fluidMap terrainMap → do
             let sz = chunkSize * chunkSize
                 scs = SimChunkState
                     { scsFluid       = fluidMap
@@ -132,14 +162,17 @@ handleSimCommand env logger simStateRef cmd = do
                     , scsSideDeco    = VU.replicate sz 0
                     }
             writeIORef simStateRef $
-                ss { ssChunks = HM.insert coord scs (ssChunks ss) }
+                modifyWorld pid (\sws →
+                    sws { swsChunks = HM.insert coord scs (swsChunks sws) }) ss
 
-        SimChunkUnloaded coord → do
+        SimChunkUnloaded pid coord → do
             writeIORef simStateRef $
-                ss { ssChunks = HM.delete coord (ssChunks ss) }
+                modifyWorld pid (\sws →
+                    sws { swsChunks = HM.delete coord (swsChunks sws) }) ss
 
-        SimTerrainModified coord mods → do
-            case HM.lookup coord (ssChunks ss) of
+        SimTerrainModified pid coord mods → do
+            let sws = HM.lookupDefault emptySimWorldState pid (ssWorlds ss)
+            case HM.lookup coord (swsChunks sws) of
                 Nothing → pure ()
                 Just scs → do
                     let terrV' = scsTerrain scs VU.// mods
@@ -156,10 +189,13 @@ handleSimCommand env logger simStateRef cmd = do
                         ChunkCoord cx cy = coord
                         nbrCoords = [ ChunkCoord (cx + 1) cy, ChunkCoord (cx - 1) cy
                                     , ChunkCoord cx (cy + 1), ChunkCoord cx (cy - 1) ]
-                        withSelf = HM.insert coord activated (ssChunks ss)
+                        withSelf = HM.insert coord activated (swsChunks sws)
                         withNbrs = foldl' (\m nc → HM.adjust activateChunk nc m)
                                           withSelf nbrCoords
-                    writeIORef simStateRef $ ss { ssChunks = withNbrs }
+                    writeIORef simStateRef $
+                        ss { ssWorlds = HM.insert pid
+                                          (sws { swsChunks = withNbrs })
+                                          (ssWorlds ss) }
 
         SimSetTickRate rate →
             writeIORef simStateRef $ ss { ssTickRate = rate }
@@ -174,67 +210,65 @@ handleSimCommand env logger simStateRef cmd = do
             -- No wsTilesRef re-sync needed: the world sends the FINAL
             -- fluid in SimChunkLoaded (the old post-load seal that this
             -- guarded against was removed), so scsFluid is already fresh.
-            -- Run sim ticks synchronously (no sleeping) until all chunks
-            -- are settled and inactive. Capped at maxIterations as a
-            -- safety net. Explicitly unpause — the dump path pauses the
-            -- sim before chunks load, but simulateActiveTick is a no-op
-            -- while paused, so the synchronous settle below would do
-            -- nothing.
+            -- Run sim ticks synchronously (no sleeping) for every world
+            -- until all its chunks are settled and inactive. Capped at
+            -- maxIterations as a safety net. Explicitly unpause — the dump
+            -- path pauses the sim before chunks load, but simulateActiveTick
+            -- is a no-op while paused, so the synchronous settle below would
+            -- do nothing.
             let maxIterations = 500 ∷ Int
-                ssUnpaused = ss { ssPaused = False }
-                ssSettled = fastSettleAll maxIterations ssUnpaused
+                settled = HM.map (fastSettleWorld maxIterations) (ssWorlds ss)
                 -- Mark every chunk dirty so the whole settled state is
                 -- emitted to the world thread.
-                allCoords = HS.fromList (HM.keys (ssChunks ssSettled))
-                ssDirty = ssSettled { ssDirtyChunks = allCoords
-                                    , ssPaused = True }
-            writeIORef simStateRef (ssDirty { ssDirtyChunks = HS.empty })
-            -- Emit to the world thread (sole writer) and WAIT for it to
-            -- apply before signalling done — the dump reads wsTilesRef
-            -- immediately after.
-            ack ← newEmptyMVar
-            emitDirtyFluids env ssDirty (Just ack)
-            takeMVar ack
+                dirtied = HM.map (\sws →
+                    sws { swsDirtyChunks = HS.fromList (HM.keys (swsChunks sws)) })
+                    settled
+            -- Persist the cleared (post-emit) state.
+            writeIORef simStateRef $
+                ss { ssWorlds = HM.map clearDirty dirtied, ssPaused = True }
+            -- Emit each world's batch and WAIT for the world thread to apply
+            -- it before signalling done — the dump reads wsTilesRef right
+            -- after. One ack per world (dump worlds are typically just one).
+            forM_ (HM.toList dirtied) $ \(pid, sws) → do
+                ack ← newEmptyMVar
+                emitWorldDirtyFluids env pid sws (Just ack)
+                takeMVar ack
             putMVar done ()
             logDebug logger CatWorld "Sim: fast-settled and paused"
 
--- | Run all sim ticks synchronously without sleeping. Stops when no
---   chunks have settle ticks remaining and no chunks are active, or
+tshow ∷ Show a ⇒ a → T.Text
+tshow = T.pack ∘ show
+
+-- | Run all sim ticks synchronously without sleeping for one world. Stops
+--   when no chunk has settle ticks remaining and no chunk is active, or
 --   when the iteration cap is reached.
-fastSettleAll ∷ Int → SimState → SimState
-fastSettleAll = go
+fastSettleWorld ∷ Int → SimWorldState → SimWorldState
+fastSettleWorld = go
   where
-    go 0 ss = ss
-    go n ss
-      | allDone ss = ss
-      | otherwise =
-          let ss'  = settleNewChunks ss
-              ss'' = simulateActiveTick ss'
-          in go (n - 1) ss''
+    go 0 sws = sws
+    go n sws
+      | allDone sws = sws
+      | otherwise   = go (n - 1) (simulateActiveTick (settleNewChunks sws))
 
-    allDone ss =
-        not (any (\scs → scsSettleTicks scs > 0) (ssChunks ss))
-        ∧ not (any scsActive (ssChunks ss))
+    allDone sws =
+        not (any (\scs → scsSettleTicks scs > 0) (swsChunks sws))
+        ∧ not (any scsActive (swsChunks sws))
 
--- | Tick down the per-chunk fast-settle countdown. A freshly loaded or
---   just-edited chunk starts with a non-zero 'scsSettleTicks';
---   'fastSettleAll' iterates until every chunk's countdown has reached 0
---   (and no chunk is active), which is how the synchronous settle knows
---   the world has quiesced. A no-op once all countdowns are 0.
---
---   Pure — shared by the live sim loop and the synchronous fast-settle.
---   (It used to also run the passive fluid pass, hence the old IO copy;
---   that pass was a no-op and has been removed.)
-settleNewChunks ∷ SimState → SimState
-settleNewChunks ss
-    | not (any (\scs → scsSettleTicks scs > 0) (ssChunks ss)) = ss
+-- | Tick down the per-chunk fast-settle countdown for one world. A freshly
+--   loaded or just-edited chunk starts with a non-zero 'scsSettleTicks';
+--   'fastSettleWorld' iterates until every chunk's countdown has reached 0
+--   (and no chunk is active), which is how the synchronous settle knows the
+--   world has quiesced. A no-op once all countdowns are 0.
+settleNewChunks ∷ SimWorldState → SimWorldState
+settleNewChunks sws
+    | not (any (\scs → scsSettleTicks scs > 0) (swsChunks sws)) = sws
     | otherwise =
         let decremented = HM.map (\scs →
                 if scsSettleTicks scs > 0
                     then scs { scsSettleTicks = scsSettleTicks scs - 1 }
                     else scs
-                ) (ssChunks ss)
-        in ss { ssChunks = decremented }
+                ) (swsChunks sws)
+        in sws { swsChunks = decremented }
 
 -- | Activate a passive chunk for volume-based simulation.
 activateChunk ∷ SimChunkState → SimChunkState
@@ -254,31 +288,17 @@ activateChunk scs
                , scsEquilTicks  = 0
                }
 
--- | Deactivate a chunk: bake active fluid back to passive FluidCells.
-deactivateChunk ∷ SimChunkState → SimChunkState
-deactivateChunk scs =
-    let terrV = scsTerrain scs
-        bakedFluid = V.imap (\idx mafc →
-            case mafc of
-                Nothing  → Nothing
-                Just afc → activeToFluidCell (terrV VU.! idx) afc
-            ) (scsActiveFluid scs)
-    in scs { scsActive      = False
-           , scsActiveFluid = V.replicate (V.length bakedFluid) Nothing
-           , scsFluid       = bakedFluid
-           , scsGenFluid    = bakedFluid
-           , scsEquilTicks  = 0
-           }
-
--- | Emit the dirty chunks' fluid results to the WORLD thread (the sole
---   writer of 'wsTilesRef') as a 'WorldApplyFluids' batch — the sim
---   never touches 'wsTilesRef' itself. With 'Just' ack, the world
---   signals it after applying (the synchronous fast-settle waits on it).
-emitDirtyFluids ∷ EngineEnv → SimState → Maybe (MVar ()) → IO ()
-emitDirtyFluids env ss mAck = do
-    let dirty = ssDirtyChunks ss
+-- | Emit one world's dirty chunks' fluid results to the WORLD thread (the
+--   sole writer of 'wsTilesRef') as a 'WorldApplyFluids' batch tagged with
+--   the world's page id, so the world thread applies it ONLY to that world
+--   (#59). The sim never touches 'wsTilesRef' itself. With 'Just' ack, the
+--   world signals it after applying (the synchronous fast-settle waits).
+emitWorldDirtyFluids ∷ EngineEnv → WorldPageId → SimWorldState
+                     → Maybe (MVar ()) → IO ()
+emitWorldDirtyFluids env pid sws mAck = do
+    let dirty = swsDirtyChunks sws
         writebacks = mapMaybe (\cc →
-            case HM.lookup cc (ssChunks ss) of
+            case HM.lookup cc (swsChunks sws) of
                 Nothing  → Nothing
                 Just scs →
                     let newFluid = if scsActive scs
@@ -300,7 +320,7 @@ emitDirtyFluids env ss mAck = do
             ) (HS.toList dirty)
     when (not (null writebacks) ∨ isJust mAck) $
         Q.writeQueue (worldQueue env)
-            (WorldApplyFluids (FluidWritebackBatch writebacks mAck))
+            (WorldApplyFluids (FluidWritebackBatch pid writebacks mAck))
 
 deriveFluidMap ∷ SimChunkState → V.Vector (Maybe FluidCell)
 deriveFluidMap scs =

--- a/src/World/Command/Types.hs
+++ b/src/World/Command/Types.hs
@@ -32,14 +32,18 @@ data FluidWriteback = FluidWriteback
     , fwSideDeco ∷ !(VU.Vector Word8)
     }
 
--- | A batch of fluid writebacks plus an optional ack 'MVar', signalled
---   once the world thread has applied the batch. Runtime ticks pass
---   'Nothing' (fire-and-forget); the dump's synchronous fast-settle
---   passes 'Just' and waits on it so the write lands before it reads.
-data FluidWritebackBatch = FluidWritebackBatch ![FluidWriteback] !(Maybe (MVar ()))
+-- | A batch of fluid writebacks for ONE world plus an optional ack
+--   'MVar', signalled once the world thread has applied the batch. The
+--   'WorldPageId' scopes the batch so the world thread applies it only to
+--   the world that produced it (not every visible world, #59). Runtime
+--   ticks pass 'Nothing' (fire-and-forget); the dump's synchronous
+--   fast-settle passes 'Just' and waits on it so the write lands before
+--   it reads.
+data FluidWritebackBatch =
+    FluidWritebackBatch !WorldPageId ![FluidWriteback] !(Maybe (MVar ()))
 instance Show FluidWritebackBatch where
-    show (FluidWritebackBatch ws _) =
-        "FluidWritebackBatch(" <> show (length ws) <> ")"
+    show (FluidWritebackBatch pid ws _) =
+        "FluidWritebackBatch(" <> show pid <> ", " <> show (length ws) <> ")"
 
 data WorldCommand
     = WorldInit WorldPageId Word64 Int Int

--- a/src/World/Page/Types.hs
+++ b/src/World/Page/Types.hs
@@ -1,9 +1,11 @@
-{-# LANGUAGE Strict, UnicodeSyntax #-}
+{-# LANGUAGE Strict, UnicodeSyntax, GeneralizedNewtypeDeriving, DerivingStrategies #-}
 module World.Page.Types
     ( WorldPageId(..)
     ) where
 
 import UPrelude
+import Data.Hashable (Hashable)
 
 newtype WorldPageId = WorldPageId Text
     deriving (Show, Eq, Ord)
+    deriving newtype (Hashable)

--- a/src/World/Thread/ChunkLoading.hs
+++ b/src/World/Thread/ChunkLoading.hs
@@ -127,12 +127,13 @@ updateChunkLoading env logger = do
                                 -- fluid + terrain (player edits matter).
                                 forM_ newChunks' $ \lc →
                                     Q.writeQueue (simQueue env) $
-                                        SimChunkLoaded (lcCoord lc)
+                                        SimChunkLoaded pageId (lcCoord lc)
                                             (lcFluidMap lc)
                                             (lcTerrainSurfaceMap lc)
                                 -- Notify sim thread of evicted chunks
                                 forM_ evicted $ \cc →
-                                    Q.writeQueue (simQueue env) (SimChunkUnloaded cc)
+                                    Q.writeQueue (simQueue env)
+                                        (SimChunkUnloaded pageId cc)
                                 writeIORef (wsQuadCacheRef worldState) Nothing
                                 writeIORef (wsZoomQuadCacheRef worldState) Nothing
                                 writeIORef (wsBgQuadCacheRef worldState) Nothing
@@ -227,7 +228,7 @@ drainInitQueues env logger = do
                         -- settle and never be simulated. (post-replay)
                         forM_ newChunks' $ \lc →
                             Q.writeQueue (simQueue env) $
-                                SimChunkLoaded (lcCoord lc)
+                                SimChunkLoaded pageId (lcCoord lc)
                                     (lcFluidMap lc)
                                     (lcTerrainSurfaceMap lc)
 

--- a/src/World/Thread/Command.hs
+++ b/src/World/Thread/Command.hs
@@ -160,23 +160,24 @@ handleWorldCommand env logger (WorldDestroy pageId)
 handleWorldCommand env _ (WorldApplyFluids batch)
   = handleApplyFluidsCommand env batch
 
--- | Sim → World: apply the sim's fluid writebacks to the visible
---   world's tile data. The world thread is the SOLE writer of
+-- | Sim → World: apply the sim's fluid writebacks to the ORIGINATING
+--   world's tile data, resolved by the batch's page id — not every
+--   visible world (that leaked one world's fluid sim into another that
+--   shared chunk coords, #59). The world thread is the SOLE writer of
 --   'wsTilesRef'; the sim only produces these batches. Acks the batch's
 --   MVar (if any) after applying — the dump's fast-settle waits on it.
 handleApplyFluidsCommand ∷ EngineEnv → FluidWritebackBatch → IO ()
-handleApplyFluidsCommand env (FluidWritebackBatch writebacks mAck) = do
+handleApplyFluidsCommand env (FluidWritebackBatch pageId writebacks mAck) = do
     when (not (null writebacks)) $ do
         mgr ← readIORef (worldManagerRef env)
-        forM_ (wmVisible mgr) $ \pageId →
-            case lookup pageId (wmWorlds mgr) of
-                Nothing → pure ()
-                Just ws → do
-                    atomicModifyIORef' (wsTilesRef ws) $ \wtd →
-                        (foldl' applyOneWriteback wtd writebacks, ())
-                    writeIORef (wsQuadCacheRef ws)     Nothing
-                    writeIORef (wsZoomQuadCacheRef ws) Nothing
-                    writeIORef (wsBgQuadCacheRef ws)   Nothing
+        case lookup pageId (wmWorlds mgr) of
+            Nothing → pure ()  -- world gone (destroyed/unloaded) — drop the batch
+            Just ws → do
+                atomicModifyIORef' (wsTilesRef ws) $ \wtd →
+                    (foldl' applyOneWriteback wtd writebacks, ())
+                writeIORef (wsQuadCacheRef ws)     Nothing
+                writeIORef (wsZoomQuadCacheRef ws) Nothing
+                writeIORef (wsBgQuadCacheRef ws)   Nothing
     forM_ mAck (`putMVar` ())
 
 -- | Overwrite one chunk's sim-owned fields (fluid + terrain surface +

--- a/src/World/Thread/Command/Basic.hs
+++ b/src/World/Thread/Command/Basic.hs
@@ -55,8 +55,9 @@ handleWorldDestroyCommand env logger pageId = do
 
     -- Tear down this world's simulation state too — destroy used to drop
     -- the page from wmWorlds/wmVisible while leaving its sim chunks behind
-    -- forever (#61). Per-world deactivate touches only this world's sim.
-    Q.writeQueue (simQueue env) (SimDeactivateWorld pageId)
+    -- forever (#61). SimDropWorld discards them (unlike hide, which keeps
+    -- them for a later re-show); only this world's sim is touched.
+    Q.writeQueue (simQueue env) (SimDropWorld pageId)
 
     -- Remove from visible list
     atomicModifyIORef' (worldManagerRef env) $ \mgr →

--- a/src/World/Thread/Command/Basic.hs
+++ b/src/World/Thread/Command/Basic.hs
@@ -13,6 +13,8 @@ import Data.IORef (readIORef, writeIORef, atomicModifyIORef')
 import Control.DeepSeq (force)
 import Control.Exception (evaluate)
 import Engine.Core.State (EngineEnv(..))
+import qualified Engine.Core.Queue as Q
+import Sim.Command.Types (SimCommand(..))
 import Engine.Core.Log (logInfo, logDebug, logError, logWarn
                        , LogCategory(..), LoggerState)
 import Engine.Graphics.Camera (Camera2D(..))
@@ -50,14 +52,19 @@ handleWorldSetCameraCommand env logger pageId x y = do
 handleWorldDestroyCommand ∷ EngineEnv → LoggerState → WorldPageId → IO ()
 handleWorldDestroyCommand env logger pageId = do
     logInfo logger CatWorld $ "Destroying world: " <> unWorldPageId pageId
-    
+
+    -- Tear down this world's simulation state too — destroy used to drop
+    -- the page from wmWorlds/wmVisible while leaving its sim chunks behind
+    -- forever (#61). Per-world deactivate touches only this world's sim.
+    Q.writeQueue (simQueue env) (SimDeactivateWorld pageId)
+
     -- Remove from visible list
     atomicModifyIORef' (worldManagerRef env) $ \mgr →
         (mgr { wmVisible = filter (/= pageId) (wmVisible mgr)
              , wmWorlds  = filter ((/= pageId) . fst) (wmWorlds mgr)
              }, ())
-    
+
     -- Clear world quads so renderer stops drawing the old world
     writeIORef (worldQuadsRef env) V.empty
-    
+
     logInfo logger CatWorld $ "World destroyed: " <> unWorldPageId pageId

--- a/src/World/Thread/Command/Edit.hs
+++ b/src/World/Thread/Command/Edit.hs
@@ -19,6 +19,7 @@ import qualified Data.Vector.Unboxed as VU
 import Data.IORef (readIORef, writeIORef, atomicModifyIORef')
 import qualified Engine.Core.Queue as Q
 import Engine.Core.State (EngineEnv(..))
+import Sim.Command.Types (SimCommand(..))
 import Unit.Command.Types (UnitCommand(..))
 import Engine.Core.Log (logDebug, logWarn, LogCategory(..), LoggerState)
 import World.Types
@@ -43,6 +44,19 @@ import World.Spoil.Types (SpoilPile(..), spoilCapacity, depositSpoil
                          , candidateVertices, promotableTiles
                          , debitPromotedTile, tileCornerVertices)
 import World.Thread.Helpers (unWorldPageId)
+
+-- | After a live terrain/fluid edit lands in the chunk, re-seed that
+--   chunk's sim state from the now-authoritative tiles by re-emitting
+--   'SimChunkLoaded'. Without this the sim keeps running against the
+--   pre-edit fluid/terrain and writes its stale result back over the
+--   edit (#60). Re-emitting replaces the sim chunk and re-settles it with
+--   the new maps; a no-op-ish for an inactive (hidden) world, which
+--   re-settles on show.
+syncEditToSim ∷ EngineEnv → WorldPageId → LoadedChunk → IO ()
+syncEditToSim env pageId lc =
+    Q.writeQueue (simQueue env) $
+        SimChunkLoaded pageId (lcCoord lc)
+            (lcFluidMap lc) (lcTerrainSurfaceMap lc)
 
 -- | Dig the top of the column at (gx, gy) down by 1 Z.
 --   Records the edit in the world's edit log so it survives chunk
@@ -89,6 +103,8 @@ handleWorldDeleteTileCommand env logger pageId gx gy = do
                             (insertChunk lc' w, ())
                         atomicModifyIORef' (wsEditsRef ws) $ \es →
                             (appendEdit coord edit es, ())
+                        -- Keep the sim's chunk in step with the new terrain.
+                        syncEditToSim env pageId lc'
                         -- Invalidate all three render caches so the next
                         -- tick rebuilds quads from the modified chunk.
                         writeIORef (wsQuadCacheRef ws)     Nothing
@@ -147,6 +163,7 @@ handleWorldAddTileCommand env logger pageId gx gy mat = do
                             (insertChunk lc' w, ())
                         atomicModifyIORef' (wsEditsRef ws) $ \es →
                             (appendEdit coord edit es, ())
+                        syncEditToSim env pageId lc'
                         writeIORef (wsQuadCacheRef ws)     Nothing
                         writeIORef (wsZoomQuadCacheRef ws) Nothing
                         writeIORef (wsBgQuadCacheRef ws)   Nothing
@@ -247,6 +264,11 @@ handleWorldSetSlopeCommand env logger pageId gx gy z bits = do
                             (insertChunk lc' w, ())
                         atomicModifyIORef' (wsEditsRef ws) $ \es →
                             (appendEdit coord edit es, ())
+                        -- No syncEditToSim here: a slope bitmask is pure
+                        -- walkability — it changes neither the surface
+                        -- elevation nor fluid the sim reads, so there is no
+                        -- stale sim state to refresh (#60), and re-seeding
+                        -- would needlessly reset an in-flight fluid sim.
                         writeIORef (wsQuadCacheRef ws)     Nothing
                         writeIORef (wsZoomQuadCacheRef ws) Nothing
                         writeIORef (wsBgQuadCacheRef ws)   Nothing
@@ -295,6 +317,7 @@ handleWorldSetCellCommand env logger pageId gx gy z mat = do
                             (insertChunk lc' w, ())
                         atomicModifyIORef' (wsEditsRef ws) $ \es →
                             (appendEdit coord edit es, ())
+                        syncEditToSim env pageId lc'
                         writeIORef (wsQuadCacheRef ws)     Nothing
                         writeIORef (wsZoomQuadCacheRef ws) Nothing
                         writeIORef (wsBgQuadCacheRef ws)   Nothing
@@ -597,6 +620,10 @@ handleWorldSetFluidTileCommand env logger pageId gx gy fluidType = do
                         (insertChunk lc' w, ())
                     atomicModifyIORef' (wsEditsRef ws) $ \es →
                         (appendEdit coord edit es, ())
+                    -- Re-seed the sim with the placed fluid so it flows /
+                    -- settles instead of being overwritten by stale sim
+                    -- output (#60).
+                    syncEditToSim env pageId lc'
                     writeIORef (wsQuadCacheRef ws)     Nothing
                     writeIORef (wsZoomQuadCacheRef ws) Nothing
                     writeIORef (wsBgQuadCacheRef ws)   Nothing

--- a/src/World/Thread/Command/Edit.hs
+++ b/src/World/Thread/Command/Edit.hs
@@ -46,16 +46,16 @@ import World.Spoil.Types (SpoilPile(..), spoilCapacity, depositSpoil
 import World.Thread.Helpers (unWorldPageId)
 
 -- | After a live terrain/fluid edit lands in the chunk, re-seed that
---   chunk's sim state from the now-authoritative tiles by re-emitting
---   'SimChunkLoaded'. Without this the sim keeps running against the
---   pre-edit fluid/terrain and writes its stale result back over the
---   edit (#60). Re-emitting replaces the sim chunk and re-settles it with
---   the new maps; a no-op-ish for an inactive (hidden) world, which
---   re-settles on show.
+--   chunk's sim state from the now-authoritative tiles AND activate it so
+--   the new fluid actually flows. Without the sync the sim runs against
+--   pre-edit fluid/terrain and writes its stale result back over the edit;
+--   without the activation (the old SimChunkLoaded path) the edited chunk
+--   kept the new snapshot but sat frozen because the volume sim only
+--   advances active chunks (#60).
 syncEditToSim ∷ EngineEnv → WorldPageId → LoadedChunk → IO ()
 syncEditToSim env pageId lc =
     Q.writeQueue (simQueue env) $
-        SimChunkLoaded pageId (lcCoord lc)
+        SimChunkEdited pageId (lcCoord lc)
             (lcFluidMap lc) (lcTerrainSurfaceMap lc)
 
 -- | Dig the top of the column at (gx, gy) down by 1 Z.

--- a/src/World/Thread/Command/UI.hs
+++ b/src/World/Thread/Command/UI.hs
@@ -62,20 +62,25 @@ handleWorldShowCommand env logger pageId = do
         logDebug logger CatWorld $
             "Visible worlds after show: " <> T.pack (show $ length $ wmVisible mgr)
 
-        -- Activate world in sim thread. The sim no longer holds the tile
-        -- ref — it emits WorldApplyFluids back to the world thread (the sole
-        -- writer of wsTilesRef) — so this is just an "is active" signal.
-        Q.writeQueue (simQueue env) SimActivateWorld
+        -- Activate this world in the sim thread. The sim no longer holds the
+        -- tile ref — it emits WorldApplyFluids back to the world thread (the
+        -- sole writer of wsTilesRef) — so this is just a per-world "is
+        -- active" signal.
+        Q.writeQueue (simQueue env) (SimActivateWorld pageId)
 
 handleWorldHideCommand ∷ EngineEnv → LoggerState → WorldPageId → IO ()
 handleWorldHideCommand env logger pageId = do
     logDebug logger CatWorld $ "Hiding world: " <> unWorldPageId pageId
 
-    atomicModifyIORef' (worldManagerRef env) $ \mgr →
-        (mgr { wmVisible = filter (/= pageId) (wmVisible mgr) }, ())
+    -- Only deactivate sim for a world that was actually visible. Hiding an
+    -- invalid / already-hidden page is a no-op for sim state, and hiding one
+    -- world never tears down the others' sim (per-world deactivate, #55).
+    wasVisible ← atomicModifyIORef' (worldManagerRef env) $ \mgr →
+        ( mgr { wmVisible = filter (/= pageId) (wmVisible mgr) }
+        , pageId `elem` wmVisible mgr )
 
-    -- Deactivate sim thread
-    Q.writeQueue (simQueue env) SimDeactivateWorld
+    when wasVisible $
+        Q.writeQueue (simQueue env) (SimDeactivateWorld pageId)
 
 handleWorldSetMapModeCommand ∷ EngineEnv → LoggerState → WorldPageId
     → ZoomMapMode → IO ()

--- a/test-headless/Test/Headless/Sim/Seam.hs
+++ b/test-headless/Test/Headless/Sim/Seam.hs
@@ -18,7 +18,7 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU
 import World.Chunk.Types (ChunkCoord(..), chunkSize)
 import World.Fluid.Types (FluidType(..))
-import Sim.State.Types (SimState(..), SimChunkState(..))
+import Sim.State.Types (SimWorldState(..), SimChunkState(..))
 import Sim.Fluid.Types (ActiveFluidCell(..), volumePerLevel, volumeToSurface)
 import Sim.Fluid.Active (simulateActiveTick)
 
@@ -38,38 +38,36 @@ mkChunk active = SimChunkState
     , scsSideDeco    = VU.replicate n 0
     }
 
-mkState ∷ [(ChunkCoord, SimChunkState)] → SimState
-mkState chunks = SimState
-    { ssChunks      = HM.fromList chunks
-    , ssTickRate    = 100000
-    , ssDirtyChunks = HS.empty
-    , ssPaused      = False
-    , ssWorldActive = True
+mkState ∷ [(ChunkCoord, SimChunkState)] → SimWorldState
+mkState chunks = SimWorldState
+    { swsChunks      = HM.fromList chunks
+    , swsDirtyChunks = HS.empty
+    , swsActive      = True
     }
 
 -- | Sum of active-fluid volume across all chunks.
-activeVolume ∷ SimState → Int
+activeVolume ∷ SimWorldState → Int
 activeVolume ss = sum
     [ fromIntegral (afcVolume afc)
-    | scs ← HM.elems (ssChunks ss)
+    | scs ← HM.elems (swsChunks ss)
     , Just afc ← V.toList (scsActiveFluid scs) ]
 
-allActive ∷ SimState → Bool
-allActive ss = all scsActive (HM.elems (ssChunks ss))
+allActive ∷ SimWorldState → Bool
+allActive ss = all scsActive (HM.elems (swsChunks ss))
 
-tick ∷ Int → SimState → SimState
+tick ∷ Int → SimWorldState → SimWorldState
 tick k ss = iterate simulateActiveTick ss !! k
 
 -- | Volume in one chunk (active grid).
-chunkVolume ∷ ChunkCoord → SimState → Int
-chunkVolume cc ss = case HM.lookup cc (ssChunks ss) of
+chunkVolume ∷ ChunkCoord → SimWorldState → Int
+chunkVolume cc ss = case HM.lookup cc (swsChunks ss) of
     Nothing  → 0
     Just scs → sum [ fromIntegral (afcVolume afc)
                    | Just afc ← V.toList (scsActiveFluid scs) ]
 
 -- | Water surface of the cell at (lx,ly) in a chunk (terrain z=0).
-surfAt ∷ ChunkCoord → Int → Int → SimState → Int
-surfAt cc lx ly ss = case HM.lookup cc (ssChunks ss) of
+surfAt ∷ ChunkCoord → Int → Int → SimWorldState → Int
+surfAt cc lx ly ss = case HM.lookup cc (swsChunks ss) of
     Nothing  → 0
     Just scs → case scsActiveFluid scs V.! (ly * chunkSize + lx) of
         Nothing  → 0


### PR DESCRIPTION
Part of epic #101. **Group B** — global simulation state → per-world. Stacked on #109 (group A); review/merge that first, then this rebases onto master.

Strategy: **(a) per-world data model** (chosen with the maintainer) — preserves multi-world rather than enforcing a single-world invariant.

## Data model
- `SimState` now holds `ssWorlds :: HashMap WorldPageId SimWorldState`. Each world owns its own chunk map, dirty set and active flag; `ssTickRate` and the engine-level `ssPaused` stay global. `simulateActiveTick` / settle / fast-settle operate on one `SimWorldState`.
- `WorldPageId` gains a `Hashable` instance (newtype-derived).
- `SimCommand` world/chunk variants carry a `WorldPageId` (`SimActivateWorld`/`SimDeactivateWorld`/`SimChunkLoaded`/`SimChunkUnloaded`/`SimTerrainModified`). `SimDeactivateWorld` drops only that world's entry.
- `FluidWritebackBatch` carries a `WorldPageId`.

## Issues closed
- **#59** — `handleApplyFluidsCommand` applies a batch only to its originating world (was `forM_ wmVisible` → every visible world got the writeback). The sim loop ticks each active world independently and tags its writebacks with the page id. The two `SimChunkLoaded`/`SimChunkUnloaded` emit sites pass the chunk's world.
- **#55** — `world.hide` deactivates only the hidden world's sim, and only when it was actually visible; other worlds keep simulating.
- **#60** — terrain/fluid edit handlers (`delete`/`add`/`setCell`/`setFluidTile`) re-seed the affected chunk's sim state via `syncEditToSim` so the sim can't write stale fluid/terrain back over the edit. `setSlope` is intentionally skipped (pure walkability bits the sim never reads — documented inline).
- **#61** — `world.destroy` now sends `SimDeactivateWorld` for the page, so a destroyed world's sim chunks don't leak.

## Verification
Headless (port 9011), two overlapping arena worlds `a1`/`a2` (same chunk coords):
- **#59** — lava placed in `a1` (5,5) reads `"lava"` in a1, `null` in a2 (no cross-world leak).
- **#60** — that placed lava survives 2.5 s of live sim ticks (synced into the sim, not erased on the next writeback).
- **#55** — hiding `a2` leaves `a1`'s sim intact (a1's lava survives a hide→show cycle); hide is no longer a global teardown.
- **#61** — destroying `a1` leaves the engine and `a2` healthy.
- Single-world regression: dump seed 42 / w128 still yields fluid (713 tiles); `cabal test synarchy-test-headless` 298 examples, 0 failures (`Test.Headless.Sim.Seam` updated to the per-world `SimWorldState`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)