### PR TITLE
Group C (epic #101): per-world units and buildings

### DIFF
--- a/src/Building/Command/Types.hs
+++ b/src/Building/Command/Types.hs
@@ -5,10 +5,13 @@ module Building.Command.Types
 
 import UPrelude
 import Building.Types (BuildingId(..))
+import World.Page.Types (WorldPageId(..))
 
 data BuildingCommand
-    = BuildingSpawn !BuildingId !Text !Int !Int !Int
-        -- ^ pre-allocated id, defName, anchor gx, gy, gz.
+    = BuildingSpawn !BuildingId !Text !Int !Int !Int !WorldPageId
+        -- ^ pre-allocated id, defName, anchor gx, gy, gz, owning world
+        --   page (stamped from the active world so the building is
+        --   world-scoped, #76).
         --   Placement validation is the caller's responsibility — the
         --   handler trusts these coords. (We do this in the Lua API:
         --   spawn checks canPlaceAt before enqueuing.)

--- a/src/Building/HitTest.hs
+++ b/src/Building/HitTest.hs
@@ -15,7 +15,7 @@ module Building.HitTest
 import UPrelude
 import qualified Data.HashMap.Strict as HM
 import Data.IORef (readIORef)
-import Engine.Core.State (EngineEnv(..))
+import Engine.Core.State (EngineEnv(..), resolveActiveWorld)
 import Engine.Asset.Handle (TextureHandle(..))
 import Engine.Graphics.Camera (Camera2D(..))
 import World.Grid (tileWidth, tileHeight, tileSideHeight
@@ -38,8 +38,13 @@ hitTestBuildingAt env pixX pixY = do
     camera   ← readIORef (cameraRef env)
     (winW, winH) ← readIORef (windowSizeRef env)
     texSizes ← readIORef (textureSizeRef env)
+    mgr      ← readIORef (worldManagerRef env)
 
-    let instances = bmInstances bm
+    -- Only the active world's buildings are clickable (#76) — matches the
+    -- render scoping; a hidden world's building must not win the hit-test.
+    let instances = case resolveActiveWorld mgr of
+            Just (pid, _) → buildingsOnPage pid (bmInstances bm)
+            Nothing       → HM.empty
     if HM.null instances
         then return Nothing
         else do

--- a/src/Building/Render.hs
+++ b/src/Building/Render.hs
@@ -6,6 +6,7 @@ module Building.Render
 
 import UPrelude
 import qualified Data.HashMap.Strict as HM
+import qualified Data.HashSet as HS
 import qualified Data.Map.Strict as Map
 import qualified Data.Vector as V
 import Data.IORef (readIORef)
@@ -23,6 +24,7 @@ import World.Grid (tileWidth, tileHeight, tileSideHeight
                   , worldLayer, GridConfig(..), defaultGridConfig)
 import Unit.Direction (Direction(..))
 import Unit.Types (Animation(..))
+import World.State.Types (wmVisible)
 import Building.Types
 
 baseTileW ∷ Float
@@ -88,7 +90,11 @@ pickBuildingFrame now inst def =
 renderBuildingQuads ∷ EngineEnv → CameraFacing → Int → Int → Float → IO (V.Vector SortableQuad)
 renderBuildingQuads env facing zSlice effDepth tileAlpha = do
     bm ← readIORef (buildingManagerRef env)
-    let instances = bmInstances bm
+    -- Render only the visible worlds' buildings — buildings are
+    -- world-scoped so a hidden world's must not draw here (#76).
+    mgr ← readIORef (worldManagerRef env)
+    let visiblePages = HS.fromList (wmVisible mgr)
+        instances = buildingsOnPages visiblePages (bmInstances bm)
         defs      = bmDefs bm
         selected  = bmSelected bm
     if HM.null instances

--- a/src/Building/Thread/Command.hs
+++ b/src/Building/Thread/Command.hs
@@ -28,7 +28,7 @@ processAllBuildingCommands env = do
         Nothing → return ()
 
 handleBuildingCommand ∷ EngineEnv → BuildingCommand → IO ()
-handleBuildingCommand env (BuildingSpawn bid defName gx gy gz) = do
+handleBuildingCommand env (BuildingSpawn bid defName gx gy gz pageId) = do
     bm ← readIORef (buildingManagerRef env)
     case HM.lookup defName (bmDefs bm) of
         Nothing → do
@@ -40,6 +40,7 @@ handleBuildingCommand env (BuildingSpawn bid defName gx gy gz) = do
             now ← readIORef (gameTimeRef env)
             let inst = BuildingInstance
                     { biDefName   = defName
+                    , biPage      = pageId
                     , biTexture   = bdTexture def
                     , biAnchorX   = gx
                     , biAnchorY   = gy

--- a/src/Building/Types.hs
+++ b/src/Building/Types.hs
@@ -10,6 +10,8 @@ module Building.Types
     , nextBuildingId
     , currentActivity
     , materialsSatisfied
+    , buildingsOnPage
+    , buildingsOnPages
     ) where
 
 import UPrelude
@@ -17,9 +19,11 @@ import GHC.Generics (Generic)
 import Data.Hashable (Hashable)
 import Data.Serialize (Serialize)
 import qualified Data.HashMap.Strict as HM
+import qualified Data.HashSet as HS
 import qualified Data.Map.Strict as Map
 import qualified Data.Vector as V
 import Engine.Asset.Handle (TextureHandle(..))
+import World.Page.Types (WorldPageId(..))
 import Unit.Direction (Direction(..))
 import Unit.Types (Animation(..))
 import Item.Types (ItemInstance)
@@ -87,6 +91,11 @@ data BuildingDef = BuildingDef
 -- | A placed building. anchor = bottom-left corner of the footprint.
 data BuildingInstance = BuildingInstance
     { biDefName    ∷ !Text
+    , biPage       ∷ !WorldPageId
+      -- ^ which world this building belongs to. Runtime-only (not
+      --   serialized — a save holds one world; loaded buildings are
+      --   stamped with the load target page). Scopes placement/render so
+      --   a building in one world never blocks or draws in another (#76).
     , biTexture    ∷ !TextureHandle      -- ^ copied from def
     , biAnchorX    ∷ !Int                -- ^ tile coords (footprint origin)
     , biAnchorY    ∷ !Int
@@ -160,6 +169,20 @@ nextBuildingId ∷ BuildingManager → (BuildingId, BuildingManager)
 nextBuildingId bm =
     let bid = BuildingId (bmNextId bm)
     in (bid, bm { bmNextId = bmNextId bm + 1 })
+
+-- | Buildings belonging to one specific world page (active-world
+--   placement / occupancy scoping, #76).
+buildingsOnPage ∷ WorldPageId
+                → HM.HashMap BuildingId BuildingInstance
+                → HM.HashMap BuildingId BuildingInstance
+buildingsOnPage pid = HM.filter (\bi → biPage bi ≡ pid)
+
+-- | Buildings belonging to any of the given world pages (the visible set,
+--   for rendering).
+buildingsOnPages ∷ HS.HashSet WorldPageId
+                 → HM.HashMap BuildingId BuildingInstance
+                 → HM.HashMap BuildingId BuildingInstance
+buildingsOnPages pages = HM.filter (\bi → HS.member (biPage bi) pages)
 
 -- | Pure derivation of activity. Two modes:
 --

--- a/src/Engine/Scripting/Lua/API/Buildings.hs
+++ b/src/Engine/Scripting/Lua/API/Buildings.hs
@@ -830,12 +830,14 @@ buildingSelectFn env = do
     case idArg of
         Just n → do
             let bid = BuildingId (fromIntegral n)
+            mActive ← Lua.liftIO $ activeWorldPage env
             Lua.liftIO $ atomicModifyIORef' (buildingManagerRef env) $ \bm →
-                -- Only select if the id actually exists; otherwise leave
-                -- the previous selection alone.
-                if HM.member bid (bmInstances bm)
-                then (bm { bmSelected = Just bid }, ())
-                else (bm, ())
+                -- Only select a building of the ACTIVE world (#76) that
+                -- still exists; otherwise leave the previous selection.
+                case (mActive, HM.lookup bid (bmInstances bm)) of
+                    (Just (pid, _), Just bi) | biPage bi ≡ pid →
+                        (bm { bmSelected = Just bid }, ())
+                    _ → (bm, ())
         Nothing → pure ()
     return 0
 
@@ -852,8 +854,12 @@ buildingGetSelectedFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 buildingGetSelectedFn env = do
     mBid ← Lua.liftIO $ do
         bm ← readIORef (buildingManagerRef env)
+        mActive ← activeWorldPage env
         pure $ case bmSelected bm of
-            Just bid | HM.member bid (bmInstances bm) → Just bid
+            Just bid
+                | Just bi      ← HM.lookup bid (bmInstances bm)
+                , Just (pid,_) ← mActive
+                , biPage bi ≡ pid → Just bid
             _ → Nothing
     case mBid of
         Just (BuildingId n) → do

--- a/src/Engine/Scripting/Lua/API/Buildings.hs
+++ b/src/Engine/Scripting/Lua/API/Buildings.hs
@@ -39,7 +39,7 @@ import qualified HsLua as Lua
 import Control.Monad (foldM, forM_)
 import Data.IORef (readIORef, atomicModifyIORef', writeIORef)
 import Data.Time.Clock.POSIX (getPOSIXTime)
-import Engine.Core.State (EngineEnv(..))
+import Engine.Core.State (EngineEnv(..), activeWorldPage)
 import Engine.Core.Log (LogCategory(..), logInfo, logDebug, logWarn)
 import Engine.Scripting.Lua.Types (LuaBackendState(..), LuaToEngineMsg(..))
 import Engine.Scripting.Lua.API.YamlTextures (loadAndRegister)
@@ -177,13 +177,17 @@ buildingSpawnFn env = do
                 gy      = fromIntegral y
             mBid ← Lua.liftIO $ do
                 bm ← readIORef (buildingManagerRef env)
-                case HM.lookup defName (bmDefs bm) of
-                    Nothing  → pure Nothing
-                    Just def → do
+                mActive ← activeWorldPage env
+                case (HM.lookup defName (bmDefs bm), mActive) of
+                    (Just def, Just (pid, _)) → do
                         mWtd ← snapshotVisibleWorldTiles env
                         case mWtd of
                             Nothing  → pure Nothing
-                            Just wtd → case canPlaceAt bm wtd def gx gy of
+                            -- Occupancy scoped to the active world (#76).
+                            Just wtd → case canPlaceAt
+                                    (bm { bmInstances =
+                                            buildingsOnPage pid (bmInstances bm) })
+                                    wtd def gx gy of
                                 NotPlaceable _ → pure Nothing
                                 Placeable → do
                                     let gz = floorZAt wtd gx gy
@@ -192,8 +196,9 @@ buildingSpawnFn env = do
                                                 let (bid', bm'') = nextBuildingId bm'
                                                 in (bm'', bid')
                                     Q.writeQueue (buildingQueue env) $
-                                        BuildingSpawn bid defName gx gy gz
+                                        BuildingSpawn bid defName gx gy gz pid
                                     pure (Just bid)
+                    _ → pure Nothing
             case mBid of
                 Just (BuildingId n) → do
                     Lua.pushinteger (fromIntegral n)
@@ -235,13 +240,21 @@ buildingCanPlaceAtFn env = do
                 gy      = fromIntegral y
             result ← Lua.liftIO $ do
                 bm ← readIORef (buildingManagerRef env)
-                case HM.lookup defName (bmDefs bm) of
-                    Nothing  → pure (NotPlaceable "unknown building")
-                    Just def → do
+                mActive ← activeWorldPage env
+                -- Occupancy is checked only against the ACTIVE world's
+                -- buildings — a building in another world must not block
+                -- placement here (#76).
+                case (HM.lookup defName (bmDefs bm), mActive) of
+                    (Nothing, _) → pure (NotPlaceable "unknown building")
+                    (_, Nothing) → pure (NotPlaceable "no active world")
+                    (Just def, Just (pid, _)) → do
                         mWtd ← snapshotVisibleWorldTiles env
                         case mWtd of
                             Nothing  → pure (NotPlaceable "no world loaded")
-                            Just wtd → pure (canPlaceAt bm wtd def gx gy)
+                            Just wtd → pure (canPlaceAt
+                                (bm { bmInstances =
+                                        buildingsOnPage pid (bmInstances bm) })
+                                wtd def gx gy)
             case result of
                 Placeable → do
                     Lua.pushboolean True

--- a/src/Engine/Scripting/Lua/API/Units.hs
+++ b/src/Engine/Scripting/Lua/API/Units.hs
@@ -104,7 +104,7 @@ import Data.IORef (readIORef, atomicModifyIORef')
 import Data.Maybe (fromMaybe)
 import qualified Data.List as L
 import qualified System.Random as Random
-import Engine.Core.State (EngineEnv(..), activeWorldState)
+import Engine.Core.State (EngineEnv(..), activeWorldState, activeWorldPage)
 import Infection.Types (InfectionDef(..), lookupInfection)
 import Engine.Core.Log (LogCategory(..), logInfo, logDebug, logWarn)
 import Engine.Scripting.Lua.Types (LuaBackendState(..), LuaToEngineMsg(..))
@@ -433,9 +433,18 @@ unitSpawnFn env = do
             result ← Lua.liftIO $ do
                 -- Check def exists
                 um ← readIORef (unitManagerRef env)
-                case HM.lookup name (umDefs um) of
-                    Nothing → return (-1)
-                    Just _ → do
+                -- Resolve the world the unit will belong to (the active
+                -- world). A unit needs a world to live in, so reject the
+                -- spawn when none is active (#78).
+                mActive ← activeWorldPage env
+                case (HM.lookup name (umDefs um), mActive) of
+                    (Nothing, _) → return (-1)
+                    (_, Nothing) → do
+                        logger ← readIORef (loggerRef env)
+                        logWarn logger CatAsset
+                            "unit.spawn: no active world to spawn into"
+                        return (-1)
+                    (Just _, Just (pageId, _)) → do
                         -- Resolve Z
                         gz ← case zArg of
                             Just n  → return (fromIntegral n)
@@ -459,9 +468,10 @@ unitSpawnFn env = do
                             let (uid', um'') = nextUnitId um'
                             in (um'', uid')
 
-                        -- Enqueue spawn command
+                        -- Enqueue spawn command, stamped with the active
+                        -- world so the unit is world-scoped (#78).
                         Q.writeQueue (unitQueue env) $
-                            UnitSpawn uid name gx gy gz factionId
+                            UnitSpawn uid name gx gy gz factionId pageId
 
                         return (fromIntegral (unUnitId uid) ∷ Int)
 
@@ -2263,11 +2273,20 @@ unitGetActivityFn env = do
 -- | unit.getAllIds() — return a Lua array of every live unit's
 --   integer id. Useful for per-tick iteration in scripts that don't
 --   want to parse the human-readable string from unit.list.
+-- | Instances of the ACTIVE world only — the world-scoping boundary for
+--   listing / selection so a unit in another world never leaks into the
+--   current one (#78). Empty when no world is active.
+activeUnits ∷ EngineEnv → IO (HM.HashMap UnitId UnitInstance)
+activeUnits env = do
+    um ← readIORef (unitManagerRef env)
+    mActive ← activeWorldPage env
+    pure $ case mActive of
+        Just (pid, _) → unitsOnPage pid (umInstances um)
+        Nothing       → HM.empty
+
 unitGetAllIdsFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 unitGetAllIdsFn env = do
-    ids ← Lua.liftIO $ do
-        um ← readIORef (unitManagerRef env)
-        pure (HM.keys (umInstances um))
+    ids ← Lua.liftIO $ HM.keys <$> activeUnits env
     Lua.newtable
     forM_ (zip [1 ∷ Int ..] ids) $ \(i, uid) → do
         Lua.pushinteger (fromIntegral (unUnitId uid))

--- a/src/Unit/Command/Types.hs
+++ b/src/Unit/Command/Types.hs
@@ -6,10 +6,13 @@ module Unit.Command.Types
 import UPrelude
 import Unit.Types (UnitId(..))
 import Unit.Sim.Types (Pose(..))
+import World.Page.Types (WorldPageId(..))
 
 data UnitCommand
-    = UnitSpawn !UnitId !Text !Float !Float !Int !Text
-        -- ^ pre-allocated ID, defName, gridX, gridY, gridZ, factionId.
+    = UnitSpawn !UnitId !Text !Float !Float !Int !Text !WorldPageId
+        -- ^ pre-allocated ID, defName, gridX, gridY, gridZ, factionId,
+        --   owning world page (stamped from the active world at spawn so
+        --   the unit is world-scoped, #78).
         --   factionId is the spawn-time-only faction tag (no def-level
         --   default); "player" for player-controlled units, "wildlife"
         --   for everything else. Used by the combat layer for

--- a/src/Unit/HitTest.hs
+++ b/src/Unit/HitTest.hs
@@ -17,7 +17,7 @@ import UPrelude
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as Map
 import Data.IORef (readIORef)
-import Engine.Core.State (EngineEnv(..))
+import Engine.Core.State (EngineEnv(..), resolveActiveWorld)
 import Engine.Asset.Handle (TextureHandle(..))
 import Engine.Graphics.Camera (Camera2D(..), CameraFacing(..))
 import World.Grid (tileWidth, tileHeight, tileSideHeight
@@ -47,8 +47,12 @@ hitTestUnitAt env pixX pixY = do
     camera   ← readIORef (cameraRef env)
     (winW, winH) ← readIORef (windowSizeRef env)
     texSizes ← readIORef (textureSizeRef env)
+    mgr      ← readIORef (worldManagerRef env)
 
-    let instances = umInstances um
+    -- Only the active world's units are clickable (#78).
+    let instances = case resolveActiveWorld mgr of
+            Just (pid, _) → unitsOnPage pid (umInstances um)
+            Nothing       → HM.empty
     if HM.null instances
         then return Nothing
         else do

--- a/src/Unit/Render.hs
+++ b/src/Unit/Render.hs
@@ -25,6 +25,7 @@ import Engine.Graphics.Vulkan.Texture.Bindless (getTextureSlotIndex)
 import World.Grid (tileWidth, tileHeight, tileSideHeight
                   , tileHalfWidth, tileHalfDiamondHeight
                   , worldLayer, applyFacing, GridConfig(..), defaultGridConfig)
+import World.State.Types (wmVisible)
 import Unit.Types
 import Unit.Direction (Direction(..), dirIndex, indexToDir, mirrorDir)
 
@@ -150,7 +151,11 @@ pickFrame now cam inst def
 renderUnitQuads ∷ EngineEnv → CameraFacing → Int → Int → Float → IO (V.Vector SortableQuad)
 renderUnitQuads env facing zSlice effDepth tileAlpha = do
     um ← readIORef (unitManagerRef env)
-    let instances = umInstances um
+    -- Render only units of the VISIBLE worlds — units are world-scoped, so
+    -- a hidden world's units must not draw over the active one (#78).
+    mgr ← readIORef (worldManagerRef env)
+    let visiblePages = HS.fromList (wmVisible mgr)
+        instances = unitsOnPages visiblePages (umInstances um)
         defs      = umDefs um
         selected  = umSelected um
     if HM.null instances

--- a/src/Unit/Selection.hs
+++ b/src/Unit/Selection.hs
@@ -20,15 +20,26 @@ import UPrelude
 import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
 import Data.IORef (readIORef, atomicModifyIORef')
-import Engine.Core.State (EngineEnv(..))
-import Unit.Types (UnitManager(..), UnitId(..))
+import Engine.Core.State (EngineEnv(..), activeWorldPage)
+import World.Page.Types (WorldPageId(..))
+import Unit.Types (UnitManager(..), UnitInstance(..), UnitId(..))
+
+-- | True when @uid@ is a live instance belonging to the active world —
+--   the selection world-scoping predicate (#78). A unit in another world
+--   can neither be selected nor reported as selected.
+onActivePage ∷ Maybe WorldPageId → UnitManager → UnitId → Bool
+onActivePage mPage um uid = case (mPage, HM.lookup uid (umInstances um)) of
+    (Just pid, Just inst) → uiPage inst ≡ pid
+    _                     → False
 
 -- | Set the selection to exactly one unit, replacing any previous selection.
---   No-op if the unit doesn't exist.
+--   No-op if the unit doesn't exist or belongs to another world.
 selectUnit ∷ EngineEnv → UnitId → IO Bool
-selectUnit env uid =
+selectUnit env uid = do
+    mActive ← activeWorldPage env
+    let mPage = fst <$> mActive
     atomicModifyIORef' (unitManagerRef env) $ \um →
-        if HM.member uid (umInstances um)
+        if onActivePage mPage um uid
         then (um { umSelected = HS.singleton uid }, True)
         else (um, False)
 
@@ -45,20 +56,26 @@ clearSelection env =
         (um { umSelected = HS.empty }, ())
 
 -- | Replace the selection with a specific set. Filters out any IDs that
---   don't currently have a live unit instance.
+--   don't currently have a live unit instance in the active world.
 setSelection ∷ EngineEnv → HS.HashSet UnitId → IO ()
-setSelection env new =
+setSelection env new = do
+    mActive ← activeWorldPage env
+    let mPage = fst <$> mActive
     atomicModifyIORef' (unitManagerRef env) $ \um →
-        let live = HS.filter (`HM.member` umInstances um) new
+        let live = HS.filter (onActivePage mPage um) new
         in (um { umSelected = live }, ())
 
 isSelected ∷ EngineEnv → UnitId → IO Bool
 isSelected env uid = do
     um ← readIORef (unitManagerRef env)
-    pure (HS.member uid (umSelected um))
+    mActive ← activeWorldPage env
+    pure (HS.member uid (umSelected um) ∧ onActivePage (fst <$> mActive) um uid)
 
--- | Returns the current selection, filtered to only live unit IDs.
+-- | Returns the current selection, filtered to live units of the active
+--   world (selection is global state; reads are world-scoped, #78).
 getSelected ∷ EngineEnv → IO (HS.HashSet UnitId)
 getSelected env = do
     um ← readIORef (unitManagerRef env)
-    pure (HS.filter (`HM.member` umInstances um) (umSelected um))
+    mActive ← activeWorldPage env
+    let mPage = fst <$> mActive
+    pure (HS.filter (onActivePage mPage um) (umSelected um))

--- a/src/Unit/Thread/Command.hs
+++ b/src/Unit/Thread/Command.hs
@@ -45,7 +45,7 @@ processAllUnitCommands env utsRef = do
         Nothing → return ()
 
 handleUnitCommand ∷ EngineEnv → IORef UnitThreadState → UnitCommand → IO ()
-handleUnitCommand env utsRef (UnitSpawn uid defName gx gy gz factionId) = do
+handleUnitCommand env utsRef (UnitSpawn uid defName gx gy gz factionId pageId) = do
     um ← readIORef (unitManagerRef env)
     case HM.lookup defName (umDefs um) of
         Nothing → do
@@ -131,6 +131,7 @@ handleUnitCommand env utsRef (UnitSpawn uid defName gx gy gz factionId) = do
                                           taggedInventory
             let inst = UnitInstance
                     { uiDefName    = defName
+                    , uiPage       = pageId
                     , uiTexture    = udTexture def
                     , uiDirSprites = udDirSprites def
                     , uiBaseWidth  = udBaseWidth def

--- a/src/Unit/Types.hs
+++ b/src/Unit/Types.hs
@@ -15,6 +15,8 @@ module Unit.Types
     , UnitId(..)
     , emptyUnitManager
     , nextUnitId
+    , unitsOnPages
+    , unitsOnPage
     ) where
 
 import UPrelude
@@ -28,6 +30,7 @@ import qualified Data.Vector as V
 import Engine.Asset.Handle (TextureHandle(..))
 import Item.Types (ItemInstance(..))
 import Unit.Direction (Direction(..))
+import World.Page.Types (WorldPageId(..))
 
 -- | A single animation: per-direction frame sequences.
 --
@@ -390,6 +393,11 @@ data UnitDef = UnitDef
 --   Engine is agnostic to player vs NPC — Lua drives behavior.
 data UnitInstance = UnitInstance
     { uiDefName    ∷ !Text           -- ^ which UnitDef this came from
+    , uiPage       ∷ !WorldPageId
+      -- ^ which world this unit belongs to. Runtime-only (not serialized
+      --   — a save holds one world; loaded units are stamped with the
+      --   load target page). Scopes queries/selection/render/hit-test so a
+      --   unit spawned in one world never leaks into another (#78).
     , uiTexture    ∷ !TextureHandle  -- ^ current display texture (fallback)
     , uiDirSprites ∷ !(Map.Map Direction TextureHandle)
       -- ^ copied from UnitDef at spawn time
@@ -562,3 +570,16 @@ nextUnitId ∷ UnitManager → (UnitId, UnitManager)
 nextUnitId um =
     let uid = UnitId (umNextId um)
     in (uid, um { umNextId = umNextId um + 1 })
+
+-- | Instances belonging to any of the given world pages — the
+--   world-scoping filter for render (the visible set) and queries.
+unitsOnPages ∷ HS.HashSet WorldPageId
+             → HM.HashMap UnitId UnitInstance
+             → HM.HashMap UnitId UnitInstance
+unitsOnPages pages = HM.filter (\inst → HS.member (uiPage inst) pages)
+
+-- | Instances belonging to one specific world page (the active world).
+unitsOnPage ∷ WorldPageId
+            → HM.HashMap UnitId UnitInstance
+            → HM.HashMap UnitId UnitInstance
+unitsOnPage pid = HM.filter (\inst → uiPage inst ≡ pid)

--- a/src/World/Save/Types.hs
+++ b/src/World/Save/Types.hs
@@ -21,6 +21,7 @@ import GHC.Generics (Generic)
 import qualified Data.HashMap.Strict as HM
 import Structure.Palette (TexPalette)
 import World.Generate.Types (WorldGenParams(..))
+import World.Page.Types (WorldPageId(..))
 import World.Render.Zoom.Types (ZoomMapMode(..))
 import World.Tool.Types (ToolMode(..))
 import World.Edit.Types (WorldEdits)
@@ -277,11 +278,15 @@ toBuildingInstanceSnapshot bi = BuildingInstanceSnapshot
 --
 --   Returns (manager, [orphan BuildingId]) so the caller can log
 --   the dropped entries.
-fromBuildingSnapshot ∷ HM.HashMap Text BuildingDef → BuildingSnapshot
+--   @page@ is the world the buildings load into (the load target); every
+--   restored building is stamped with it so the runtime world scoping
+--   holds after a load (#76).
+fromBuildingSnapshot ∷ WorldPageId → HM.HashMap Text BuildingDef
+                     → BuildingSnapshot
                      → (BuildingManager, [BuildingId])
-fromBuildingSnapshot defs snap =
+fromBuildingSnapshot page defs snap =
     let pairs = HM.toList (bsnInstances snap)
-        resolved = [ (bid, fromBuildingInstanceSnapshot d snap')
+        resolved = [ (bid, fromBuildingInstanceSnapshot page d snap')
                    | (bid, snap') ← pairs
                    , Just d ← [HM.lookup (bisDefName snap') defs]
                    ]
@@ -297,10 +302,11 @@ fromBuildingSnapshot defs snap =
                 }
     in (bm, orphans)
 
-fromBuildingInstanceSnapshot ∷ BuildingDef → BuildingInstanceSnapshot
-                             → BuildingInstance
-fromBuildingInstanceSnapshot def s = BuildingInstance
+fromBuildingInstanceSnapshot ∷ WorldPageId → BuildingDef
+                             → BuildingInstanceSnapshot → BuildingInstance
+fromBuildingInstanceSnapshot page def s = BuildingInstance
     { biDefName        = bisDefName s
+    , biPage           = page             -- runtime world scoping (#76)
     , biTexture        = bdTexture def    -- re-resolved
     , biAnchorX        = bisAnchorX s
     , biAnchorY        = bisAnchorY s
@@ -410,11 +416,14 @@ toUnitInstanceSnapshot ui = UnitInstanceSnapshot
 -- | Restore a UnitManager from a snapshot. Like buildings: instances
 --   whose def is no longer registered get dropped with the orphan
 --   list returned for caller logging. `umSelected` resets to empty.
-fromUnitSnapshot ∷ HM.HashMap Text UnitDef → UnitSnapshot
+--   @page@ is the world the units are loaded into (always the load
+--   target, "main_world"); every restored unit is stamped with it so the
+--   runtime-only world scoping holds after a load (#78).
+fromUnitSnapshot ∷ WorldPageId → HM.HashMap Text UnitDef → UnitSnapshot
                  → (UnitManager, [UnitId])
-fromUnitSnapshot defs snap =
+fromUnitSnapshot page defs snap =
     let pairs = HM.toList (usnInstances snap)
-        resolved = [ (uid, fromUnitInstanceSnapshot d s)
+        resolved = [ (uid, fromUnitInstanceSnapshot page d s)
                    | (uid, s) ← pairs
                    , Just d ← [HM.lookup (uisDefName s) defs]
                    ]
@@ -430,9 +439,11 @@ fromUnitSnapshot defs snap =
                 }
     in (um, orphans)
 
-fromUnitInstanceSnapshot ∷ UnitDef → UnitInstanceSnapshot → UnitInstance
-fromUnitInstanceSnapshot def s = UnitInstance
+fromUnitInstanceSnapshot ∷ WorldPageId → UnitDef → UnitInstanceSnapshot
+                         → UnitInstance
+fromUnitInstanceSnapshot page def s = UnitInstance
     { uiDefName     = uisDefName s
+    , uiPage        = page                -- runtime world scoping (#78)
     , uiTexture     = udTexture def       -- re-resolved
     , uiDirSprites  = udDirSprites def    -- re-resolved
     , uiBaseWidth   = uisBaseWidth s

--- a/src/World/Save/Types.hs
+++ b/src/World/Save/Types.hs
@@ -30,9 +30,9 @@ import World.Spoil.Types (SpoilPiles)
 import Item.Ground (GroundItems)
 import Engine.Graphics.Camera (CameraFacing(..))
 import Building.Types (BuildingId(..), BuildingInstance(..), BuildingDef(..)
-                      , BuildingManager(..))
+                      , BuildingManager(..), buildingsOnPage)
 import Unit.Types (UnitId(..), UnitInstance(..), UnitDef(..), UnitManager(..)
-                  , StatModifier(..), Wound(..), Scar(..))
+                  , StatModifier(..), Wound(..), Scar(..), unitsOnPage)
 import Unit.Direction (Direction(..))
 import Unit.Sim.Types (UnitSimState(..), UnitThreadState(..))
 import Item.Types (ItemInstance(..))
@@ -245,12 +245,15 @@ data BuildingInstanceSnapshot = BuildingInstanceSnapshot
     , bisStorage           ∷ ![ItemInstance]
     } deriving (Show, Serialize, Generic)
 
--- | Build a snapshot from a live BuildingManager. Strips `bmDefs`
---   (regenerated from YAML on next boot, always in memory at load
---   time) and `bmSelected` (resets to Nothing).
-toBuildingSnapshot ∷ BuildingManager → BuildingSnapshot
-toBuildingSnapshot bm = BuildingSnapshot
-    { bsnInstances = HM.map toBuildingInstanceSnapshot (bmInstances bm)
+-- | Build a snapshot from a live BuildingManager, restricted to the world
+--   being saved (@page@). The manager is global across worlds, so an
+--   unfiltered snapshot would serialize other worlds' buildings and stamp
+--   them onto the load target (#76). Strips `bmDefs` (regenerated from
+--   YAML on next boot) and `bmSelected` (resets to Nothing).
+toBuildingSnapshot ∷ WorldPageId → BuildingManager → BuildingSnapshot
+toBuildingSnapshot page bm = BuildingSnapshot
+    { bsnInstances = HM.map toBuildingInstanceSnapshot
+                            (buildingsOnPage page (bmInstances bm))
     , bsnNextId    = bmNextId bm
     }
 
@@ -378,9 +381,14 @@ data UnitInstanceSnapshot = UnitInstanceSnapshot
       --   from body_mass; ticked down by Combat.Wounds bleeding.
     } deriving (Show, Serialize, Generic)
 
-toUnitSnapshot ∷ UnitManager → UnitSnapshot
-toUnitSnapshot um = UnitSnapshot
-    { usnInstances = HM.map toUnitInstanceSnapshot (umInstances um)
+-- | Build a snapshot from a live UnitManager, restricted to the world
+--   being saved (@page@). The manager is global across worlds, so an
+--   unfiltered snapshot would serialize other worlds' units and stamp
+--   them onto the load target (#78).
+toUnitSnapshot ∷ WorldPageId → UnitManager → UnitSnapshot
+toUnitSnapshot page um = UnitSnapshot
+    { usnInstances = HM.map toUnitInstanceSnapshot
+                            (unitsOnPage page (umInstances um))
     , usnNextId    = umNextId um
     }
 

--- a/src/World/Thread/Command/Save.hs
+++ b/src/World/Thread/Command/Save.hs
@@ -330,7 +330,7 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
     do
         currentBm ← readIORef (buildingManagerRef env)
         let (restored, orphans) =
-                fromBuildingSnapshot (bmDefs currentBm) (sdBuildings saveData)
+                fromBuildingSnapshot pageId (bmDefs currentBm) (sdBuildings saveData)
         writeIORef (buildingManagerRef env) restored
         forM_ orphans $ \bid →
             logWarn logger CatWorld $
@@ -365,7 +365,7 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
     do
         currentUm ← readIORef (unitManagerRef env)
         let (restoredUm, orphanUnits) =
-                fromUnitSnapshot (umDefs currentUm) (sdUnits saveData)
+                fromUnitSnapshot pageId (umDefs currentUm) (sdUnits saveData)
             liveUids = HM.keysSet (umInstances restoredUm)
             -- Drop sim states whose owning unit was orphaned.
             simStates' = HM.filterWithKey (\uid _ → uid `HS.member` liveUids)

--- a/src/World/Thread/Command/Save.hs
+++ b/src/World/Thread/Command/Save.hs
@@ -39,7 +39,7 @@ import World.Save.Types (toBuildingSnapshot, fromBuildingSnapshot
 import World.Edit.Apply (replayEdits)
 import World.Mine.Apply (applyDigSlopes)
 import Building.Types (BuildingManager(..), unBuildingId)
-import Unit.Types (UnitManager(..), unUnitId)
+import Unit.Types (UnitManager(..), unUnitId, unitsOnPage)
 import Unit.Sim.Types (UnitThreadState(..))
 import World.Weather (initEarlyClimate, formatWeather, defaultClimateParams)
 import World.Thread.Helpers (sendGenLog, unWorldPageId)
@@ -92,12 +92,17 @@ handleWorldSaveCommand env logger pageId saveName timestampTxt luaBlobs = do
             texPalette ← readIORef (texPaletteRef env)
             -- v4 (Phase 3) additions
             bm        ← readIORef (buildingManagerRef env)
-            let buildings = toBuildingSnapshot bm
+            -- Snapshot only THIS world's buildings/units — the managers are
+            -- global across worlds (#76/#78).
+            let buildings = toBuildingSnapshot pageId bm
             -- v5 (Phase 4) additions
             um        ← readIORef (unitManagerRef env)
             uts       ← readIORef (utsRef env)
-            let units     = toUnitSnapshot um
-                simStates = utsSimStates uts
+            let units     = toUnitSnapshot pageId um
+                -- Keep only the saved world's units' sim states.
+                savedUids = HM.keysSet (unitsOnPage pageId (umInstances um))
+                simStates = HM.filterWithKey (\uid _ → uid `HS.member` savedUids)
+                                             (utsSimStates uts)
 
             case mParams of
                 Nothing →

--- a/test-headless/Test/Headless/Combat/Severing.hs
+++ b/test-headless/Test/Headless/Combat/Severing.hs
@@ -10,6 +10,7 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as Map
 import Engine.Asset.Handle (TextureHandle(..))
 import Unit.Types
+import World.Page.Types (WorldPageId(..))
 import Unit.Direction (Direction(..))
 import Combat.Wounds (propagateSevering)
 
@@ -40,7 +41,8 @@ def = UnitDef
 
 inst ∷ [Wound] → UnitInstance
 inst ws = UnitInstance
-    { uiDefName = "t", uiTexture = TextureHandle 0, uiDirSprites = Map.empty
+    { uiDefName = "t", uiPage = WorldPageId "test"
+    , uiTexture = TextureHandle 0, uiDirSprites = Map.empty
     , uiBaseWidth = 0, uiGridX = 0, uiGridY = 0, uiGridZ = 0, uiRealZ = 0
     , uiFacing = DirS, uiCurrentAnim = "", uiAnimStart = 0, uiAnimReverse = False
     , uiActivity = "idle", uiPose = "standing", uiAnimStride = 1

--- a/test-headless/Test/Headless/Combat/Wounds.hs
+++ b/test-headless/Test/Headless/Combat/Wounds.hs
@@ -12,6 +12,7 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as Map
 import Engine.Asset.Handle (TextureHandle(..))
 import Unit.Types
+import World.Page.Types (WorldPageId(..))
 import Unit.Direction (Direction(..))
 import Combat.Wounds (tickOneUnit)
 import Infection.Types (InfectionManager(..), InfectionDef(..)
@@ -55,7 +56,8 @@ def = UnitDef
 -- bleed can't kill it mid-test (we're testing infection, not death).
 inst ∷ [Wound] → UnitInstance
 inst ws = UnitInstance
-    { uiDefName = "t", uiTexture = TextureHandle 0, uiDirSprites = Map.empty
+    { uiDefName = "t", uiPage = WorldPageId "test"
+    , uiTexture = TextureHandle 0, uiDirSprites = Map.empty
     , uiBaseWidth = 0, uiGridX = 0, uiGridY = 0, uiGridZ = 0, uiRealZ = 0
     , uiFacing = DirS, uiCurrentAnim = "", uiAnimStart = 0, uiAnimReverse = False
     , uiActivity = "idle", uiPose = "standing", uiAnimStride = 1

--- a/test-headless/Test/Headless/Unit/Render/PickFrame.hs
+++ b/test-headless/Test/Headless/Unit/Render/PickFrame.hs
@@ -14,6 +14,7 @@ import Engine.Graphics.Camera (CameraFacing(..))
 import Unit.Direction (Direction(..))
 import Unit.Render (pickFrame, screenDirOf)
 import Unit.Types
+import World.Page.Types (WorldPageId(..))
 
 -- | A texture handle by integer ID, for readable test assertions.
 h ∷ Int → TextureHandle
@@ -56,6 +57,7 @@ mkDef anims = UnitDef
 mkInst ∷ Text → Double → UnitInstance
 mkInst animName start = UnitInstance
     { uiDefName     = "test-unit"
+    , uiPage        = WorldPageId "test"
     , uiTexture     = h 0
     , uiDirSprites  = Map.fromList [(DirS, h 1)]
     , uiBaseWidth   = 0


### PR DESCRIPTION
Part of epic #101. **Group C** — global unit/building state → per-world. Stacked on #112 (group B), which is stacked on #109 (group A). Review/merge bottom-up.

Strategy: **(a) per-world data model**, implemented with a **runtime-only** page field so there is **no save-schema change / version bump** — a save holds a single world, and loaded instances are stamped with the load target page (`main_world`).

## Units (#78)
- `UnitInstance` gains `uiPage`, stamped at spawn from the active world (`unit.spawn` rejects when no world is active) and on load from the load target page. `UnitSpawn` command carries the page.
- World-scoped boundary reads: `unit.getAllIds` and the whole selection module (`select`/`getSelected`/`isSelected`/`setSelection`) see only the active world's units; `Unit.Render` draws only visible worlds'; `Unit.HitTest` hits only the active world. Internal combat/movement is untouched (keyed by uid).
- Helpers `unitsOnPage` / `unitsOnPages` in `Unit.Types`.

## Buildings (#76)
- `BuildingInstance` gains `biPage`, stamped at spawn / load. `BuildingSpawn` command carries the page.
- `building.canPlaceAt` and `building.spawn` check occupancy only against the active world's buildings; `Building.Render` draws only visible worlds'.
- Helpers `buildingsOnPage` / `buildingsOnPages` in `Building.Types`.

## Verification
Headless (port 9011):
- **#78** — acolyte spawned in `w1` (uid 1): after switching to a fresh `w2`, `getAllIds` `{}`, `select(1)` `false`, `getSelected` `{}`; back in `w1`, `getAllIds` `[1]` and `select(1)` `true`.
- **#76** — portal placed in `b1`: a fresh `b2` reports `canPlaceAt` `true` (no leak); `b1` reports `false` at the occupied `(0,0)` and `true` at a free `(10,10)` (scoping still blocks within the world).
- `cabal test synarchy-test-headless`: 298 examples, 0 failures (3 test `UnitInstance` literals updated with `uiPage`).

## Note on save format
No `currentSaveVersion` bump: `uiPage`/`biPage` are runtime-only and reconstructed on load. A save still round-trips at the existing version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)