### PR TITLE
Fix #108: settings Revert restores saved tooltip dwell/hint values

### DIFF
--- a/scripts/settings/data.lua
+++ b/scripts/settings/data.lua
@@ -18,6 +18,12 @@ data.tooltipDwellMin = 0
 data.tooltipDwellMax = 1000
 data.tooltipHintDelayMin = 0
 data.tooltipHintDelayMax = 1000
+-- Snapshots of the last saved tooltip values, used by revert().
+-- These (like savedBrightness) capture the saved state because dwell/hint
+-- are live-previewed to the engine, so getTooltipDwellMs()/getTooltipHintDelayMs()
+-- return the just-edited values, not what we should revert to.
+data.savedTooltipDwellMs = nil
+data.savedTooltipHintDelayMs = nil
 
 -- Standard resolutions
 data.resolutions = {
@@ -138,8 +144,10 @@ function data.loadDefaults()
     data.current.tooltipDwellMs = engine.getTooltipDwellMs() or 400
     data.current.tooltipHintDelayMs = engine.getTooltipHintDelayMs() or 400
 
-    -- Snapshot brightness for revert
+    -- Snapshot brightness/tooltip values for revert
     data.savedBrightness = data.current.brightness
+    data.savedTooltipDwellMs = data.current.tooltipDwellMs
+    data.savedTooltipHintDelayMs = data.current.tooltipHintDelayMs
 
     -- Push all values to engine via individual setters
     engine.setResolution(data.current.width, data.current.height)
@@ -240,6 +248,8 @@ function data.reload()
     data.current.tooltipDwellMs = engine.getTooltipDwellMs() or 400
     data.current.tooltipHintDelayMs = engine.getTooltipHintDelayMs() or 400
     data.savedBrightness = data.current.brightness
+    data.savedTooltipDwellMs = data.current.tooltipDwellMs
+    data.savedTooltipHintDelayMs = data.current.tooltipHintDelayMs
 end
 
 -----------------------------------------------------------
@@ -387,6 +397,11 @@ function data.save(widgetValues)
     engine.logInfo("Saving settings...")
     local result = data.apply(widgetValues)
     engine.saveVideoConfig()
+    -- Refresh revert snapshots so a later revert restores these saved values,
+    -- not the pre-save ones.
+    data.savedBrightness = data.current.brightness
+    data.savedTooltipDwellMs = data.current.tooltipDwellMs
+    data.savedTooltipHintDelayMs = data.current.tooltipHintDelayMs
     engine.logInfo("Settings saved.")
     return result
 end
@@ -425,12 +440,12 @@ function data.revert()
         engine.setTextureFilter(savedTextureFilter)
     end
 
-    local savedDwell = engine.getTooltipDwellMs() or 400
+    local savedDwell = data.savedTooltipDwellMs or 400
     if data.current.tooltipDwellMs ~= savedDwell then
         engine.setTooltipDwellMs(savedDwell)
     end
 
-    local savedHintDelay = engine.getTooltipHintDelayMs() or 400
+    local savedHintDelay = data.savedTooltipHintDelayMs or 400
     if data.current.tooltipHintDelayMs ~= savedHintDelay then
         engine.setTooltipHintDelayMs(savedHintDelay)
     end
@@ -442,7 +457,7 @@ function data.revert()
     data.current.vsync         = vs
     data.current.frameLimit    = frameLimit
     data.current.msaa          = msaa or 1
-    data.current.brightness    = savedBrightness
+    data.current.brightness    = revertBrightness
     data.current.pixelSnap     = savedPixelSnap
     data.current.textureFilter = savedTextureFilter
     data.current.tooltipDwellMs = savedDwell

--- a/tools/test_settings_revert.lua
+++ b/tools/test_settings_revert.lua
@@ -1,0 +1,96 @@
+-- Offline regression harness for issue #108: settings Revert/Back must
+-- restore the LAST SAVED tooltip dwell / hint-delay values, not the
+-- just-edited runtime values.
+--
+-- Dwell/hint are live-previewed straight to the engine, so the pre-fix
+-- revert() read them back via engine.getTooltipDwellMs()/...HintDelayMs()
+-- and wrote the edited value back to itself (a no-op revert). The fix
+-- snapshots the saved values (mirroring savedBrightness) and restores
+-- those.
+--
+-- Run from repo root:  luajit tools/test_settings_revert.lua
+-- PASS = revert restores saved values. FAIL = pre-fix self-revert.
+
+package.path = "./scripts/?.lua;" .. package.path
+
+local state = {
+  dwell = 400, hint = 400, brightness = 100,
+  w = 1920, h = 1080, wm = "windowed", uiScale = 1.0, vs = true,
+  frameLimit = 60, msaa = 1, pixelSnap = false, textureFilter = "nearest",
+}
+
+engine = {}
+function engine.logInfo() end
+function engine.logWarn() end
+function engine.logDebug() end
+function engine.getTooltipDwellMs() return state.dwell end
+function engine.setTooltipDwellMs(v) state.dwell = v end
+function engine.getTooltipHintDelayMs() return state.hint end
+function engine.setTooltipHintDelayMs(v) state.hint = v end
+function engine.setBrightness(v) state.brightness = v end
+function engine.getVideoConfig()
+  return state.w, state.h, state.wm, state.uiScale, state.vs,
+         state.frameLimit, state.msaa, state.brightness,
+         state.pixelSnap, state.textureFilter
+end
+function engine.saveVideoConfig() end
+function engine.setResolution() end
+function engine.setWindowMode() end
+function engine.setUIScale() end
+function engine.setVSync() end
+function engine.setFrameLimit() end
+function engine.setMSAA() end
+function engine.setPixelSnap() end
+function engine.setTextureFilter() end
+
+local data = require("settings.data")
+
+local failures = 0
+local function check(label, got, want)
+  if got ~= want then
+    print(string.format("FAIL %-42s got=%s want=%s",
+      label, tostring(got), tostring(want)))
+    failures = failures + 1
+  else
+    print(string.format("PASS %-42s = %s", label, tostring(got)))
+  end
+end
+
+-- Open settings (reload snapshots saved state) and edit + revert dwell.
+data.reload()
+local oldDwell = state.dwell
+data.current.tooltipDwellMs = oldDwell + 123
+engine.setTooltipDwellMs(oldDwell + 123)        -- live preview
+data.revert()
+check("dwell restored to saved", engine.getTooltipDwellMs(), oldDwell)
+
+-- Same for hint delay.
+data.reload()
+local oldHint = state.hint
+data.current.tooltipHintDelayMs = oldHint + 77
+engine.setTooltipHintDelayMs(oldHint + 77)
+data.revert()
+check("hint delay restored to saved", engine.getTooltipHintDelayMs(), oldHint)
+
+-- Save then edit then revert: revert must target the freshly SAVED value.
+data.reload()
+data.resetPending()
+data.apply({ tooltipDwellMs = 500 })
+data.save({})
+data.apply({ tooltipDwellMs = 600 })
+data.revert()
+check("save-then-revert targets saved value", engine.getTooltipDwellMs(), 500)
+
+-- Revert must leave data.current.brightness defined (not nil).
+data.reload()
+data.revert()
+check("current.brightness defined after revert",
+  data.current.brightness, state.brightness)
+
+print("")
+if failures == 0 then
+  print("ALL PASS")
+else
+  print(failures .. " FAILURE(S)")
+end
+os.exit(failures == 0 and 0 or 1)


### PR DESCRIPTION
Closes #108.

## Problem
`data.revert()` (settings Back/Revert) read the tooltip dwell and hint-delay back from the engine via `engine.getTooltipDwellMs()` / `getTooltipHintDelayMs()`, then wrote those same values back. Because both settings are **live-previewed** straight to the engine on every slider change, the getters return the just-edited values — so revert restored the value to itself, a no-op.

Repro from the issue (now fixed):
```lua
local data=require("scripts.settings.data")
local old=engine.getTooltipDwellMs()
data.current.tooltipDwellMs=old+123
engine.setTooltipDwellMs(old+123)
data.revert()
return tostring(old).."|"..tostring(engine.getTooltipDwellMs())  -- was "400|523", now "400|400"
```

## Fix
Mirror the existing `savedBrightness` snapshot pattern for the two tooltip values:
- Add `data.savedTooltipDwellMs` / `data.savedTooltipHintDelayMs`.
- Snapshot them in `loadDefaults()`, `reload()` (menu open) and `save()`.
- `revert()` restores from those snapshots instead of re-reading the live engine state.

Refreshing the snapshots in `save()` (brightness included) also makes a revert **after** a save target the freshly saved value rather than the pre-save one.

Also fixes an adjacent typo in `revert()`: the trailing assignment used a bare global `savedBrightness` (nil) instead of the local `revertBrightness`, which left `data.current.brightness = nil` after a revert.

## Testing
Added `tools/test_settings_revert.lua`, an offline luajit harness (matching the `test_rest_freeze.lua` / `test_mule_sourcing.lua` convention) that stubs the engine API and exercises revert. It reproduces the exact issue values (523/477) on the unpatched code and passes on this branch:

```
$ luajit tools/test_settings_revert.lua
PASS dwell restored to saved                    = 400
PASS hint delay restored to saved               = 400
PASS save-then-revert targets saved value       = 500
PASS current.brightness defined after revert    = 100
ALL PASS
```

Lua-only change; no engine rebuild required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)