### PR TITLE
Fix #106: reset registered modules to fresh state when absent from save

### DIFF
--- a/scripts/lib/save_modules.lua
+++ b/scripts/lib/save_modules.lua
@@ -9,9 +9,11 @@
 -- each module's deserializer with the matching blob.
 --
 -- Modules without persistent state don't need to register. Modules
--- registered without a blob in the saved data are skipped silently
--- (fresh state). Blobs whose name no longer matches a registered
--- module are skipped with a warn (def was removed between sessions).
+-- registered without a blob in the saved data have their deserializer
+-- invoked with a nil blob so they reset to fresh/default state (rather
+-- than keeping stale in-memory state). Blobs whose name no longer
+-- matches a registered module are skipped with a warn (def was removed
+-- between sessions).
 --
 -- Singleton via package.loaded so script reloads + multiple require()s
 -- share the same registry.
@@ -52,17 +54,29 @@ function saveModules.serializeAll()
 end
 
 -- Called from Haskell at load time. blobs is a table { name → string }
--- pulled out of the save file. Each registered module gets its blob
--- (or nil if absent). Unknown blob names are skipped with a warn.
+-- pulled out of the save file. We walk the REGISTRY (not just the
+-- blobs present in the save) so every registered module is restored:
+-- a module absent from the save is handed a nil blob, which its
+-- deserializer treats as fresh/default state. This is what makes the
+-- "missing blob → fresh state" contract hold even when the module
+-- already has live singleton state in memory from a prior load.
+-- Blob names with no matching registered module are reported with a
+-- warn (def was removed between sessions).
 function saveModules.deserializeAll(blobs)
-    if not blobs then return end
-    for name, blob in pairs(blobs) do
-        local fns = saveModules.registry[name]
-        if not fns then
+    blobs = blobs or {}
+    -- Warn about saved blobs that no longer map to a registered module.
+    for name in pairs(blobs) do
+        if not saveModules.registry[name] then
             engine.logWarn("saveModules: no registered module named '"
                 .. name .. "', blob skipped")
-        elseif fns.deserialize then
-            local ok, err = pcall(fns.deserialize, blob)
+        end
+    end
+    -- Restore every registered module. Absent blobs come through as nil
+    -- so the deserializer resets to fresh state instead of inheriting
+    -- whatever happened to be in memory.
+    for name, fns in pairs(saveModules.registry) do
+        if fns.deserialize then
+            local ok, err = pcall(fns.deserialize, blobs[name])
             if not ok then
                 engine.logWarn("saveModules: " .. name
                     .. " deserializer crashed: " .. tostring(err))


### PR DESCRIPTION
## Problem
`saveModules.deserializeAll(blobs)` only iterated the names present in the saved `blobs` table. A module that registered for save/load but whose blob was **absent** from the save never had its deserializer invoked, so it kept whatever singleton state happened to be in memory from a prior load. This violates the file-level contract (`save_modules.lua:11-14`): "missing blob → fresh state".

Repro (from the issue):
```lua
local p=require("scripts.pause")
p.prevTimeScale=7.5
require("scripts.lib.save_modules").deserializeAll({})
return tostring(p.prevTimeScale)   -- buggy: "7.5"
```

## Fix
Walk the **registry** rather than just the present blobs. Each registered module's deserializer is now called with `blobs[name]`, which is `nil` when the module is absent. All three real deserializers (`pause`, `unit_ai`, `building_spawn`) already treat a nil blob as a reset (`local restored = deserialize(blob) or {}`), so absent modules deterministically land in fresh/default state — no deserializer changes needed. Blob names with no matching registered module are still reported with a warn.

## Verification
Built the headless engine and ran against the real engine on port 9008:
- Issue repro now returns `1.0` (fresh default) instead of `7.5`.
- `serializeAll` → mutate → `deserializeAll` roundtrip still restores the saved value (set 5.0, mutate to 99, restore → 5).
- Unknown blob name (`{ghost="x"}`) logs `no registered module named 'ghost'` and does not crash.
- No engine errors; clean shutdown.

Also ran a standalone Lua test (luajit) exercising absent-module reset, present-blob restore, unknown-blob warn, nil-arg, and crashing-deserializer isolation — all pass.

`deserializeAll` is only invoked from `engine.loadSave` (`Engine.Scripting.Lua.API.Save.restoreLuaBlobs`), and the blobs table is always non-nil from the Haskell side, so resetting absent registered modules is exactly the right load-time behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)