### PR TITLE
Fix #107: shell quit/exit actually quit the game

### DIFF
--- a/scripts/shell.lua
+++ b/scripts/shell.lua
@@ -382,6 +382,7 @@ end
 
 function shell.cmdQuit()
     engine.logDebug("Quit requested from shell")
+    engine.quit()
 end
 
 function shell.rebuildHistoryDisplay()


### PR DESCRIPTION
## Summary
`quit`/`exit` are advertised in the debug shell's `help`, and the dispatcher routes them to `shell.cmdQuit()` — but that function only logged a debug message, so the command recorded `OK` and did nothing (issue #107).

Per the user's decision, `quit`/`exit` should shut down the game. `shell.cmdQuit()` now calls `engine.quit()`, the same path used by the pause menu, main menu, and `ui_manager`.

## Change
```lua
function shell.cmdQuit()
    engine.logDebug("Quit requested from shell")
    engine.quit()
end
```

Lua-only change; no rebuild required (`engine.quit` is registered in `Engine/Scripting/Lua/API.hs`).

## Testing
Ran the already-built binary with the worktree as cwd (so the modified `scripts/shell.lua` loads), headless on port 9107:

- Before: repro `require("scripts.shell").cmdQuit(); return "still-alive"` returned `"still-alive"`.
- After: calling `shell.cmdQuit()` shuts the engine down — the process exits and the log shows `Headless engine shutting down...`.

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)