### PR TITLE
Fix #110: clear armed preview on debug_anim_panel shutdown

### DIFF
--- a/scripts/debug_anim_panel.lua
+++ b/scripts/debug_anim_panel.lua
@@ -352,6 +352,10 @@ function panel.update(dt)
 end
 
 function panel.shutdown()
+    -- Clear any armed preview first so the affected unit is unfrozen and
+    -- un-force-looped — otherwise unloading the panel mid-preview leaves
+    -- the unit stuck (frozen + force-looped) with no way to recover.
+    disarm()
     destroyPage()
     engine.logInfo("DebugAnimPanel: shut down")
 end


### PR DESCRIPTION
## Summary
`debug_anim_panel.shutdown()` deleted the panel page but never called `disarm()`. If the panel was unloaded (`engine.killScript`) while an animation was armed, the previewed unit was left **frozen** (`unit.setFrozen`) and **force-looped** (`unit.setForceLoop`) with no way to recover — `moveTo` was silently ignored until the unit was manually unfrozen.

Fixes #110.

## Fix
Call `disarm()` at the top of `panel.shutdown()` (before `destroyPage()`), matching what `hide()` already does. `disarm()` unfreezes / un-force-loops `panel.armedUid` and clears the preview state. It is a no-op when nothing is armed.

## Testing
Reproduced the issue headless against the worktree scripts (engine binary from main repo, cwd = worktree):

1. Spawn an acolyte, set `armedUid`/`armedAnim`, freeze + force-loop, call `panel.shutdown()`.
2. Issue `unit.moveTo(1,4,0,2.0)`.

With the fix the unit moves toward the goal after shutdown (`1.05,-2.51` → `3.19,-0.69` heading to `(4,0)`), confirming it was unfrozen. Before the fix the unit stayed put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)