### PR TITLE
Gate debug anim panel on the debug overlay being active

### DIFF
--- a/scripts/debug_anim_panel.lua
+++ b/scripts/debug_anim_panel.lua
@@ -282,7 +282,11 @@ end
 -----------------------------------------------------------
 
 function panel.tryClaimClick(button, x, y)
-    if not panel.visible then return false end
+    -- Also gate on the overlay here, not just in update(): the panel
+    -- ticks at 0.1s while F8 toggles the overlay off immediately, so a
+    -- quick click in that gap would otherwise be swallowed by the stale
+    -- panel while debug mode is already off.
+    if not panel.visible or not debugOverlay.isVisible() then return false end
     if button ~= MOUSE_LEFT then return false end
 
     -- onMouseDown delivers WINDOW pixels; our rects are in

--- a/scripts/debug_anim_panel.lua
+++ b/scripts/debug_anim_panel.lua
@@ -23,6 +23,7 @@
 
 local label = require("scripts.ui.label")
 local scale = require("scripts.ui.scale")
+local debugOverlay = require("scripts.debug")
 
 local panel = package.loaded["scripts.debug_anim_panel"] or {}
 package.loaded["scripts.debug_anim_panel"] = panel
@@ -334,8 +335,13 @@ function panel.update(dt)
     local sel = unit.getSelected() or {}
     local uid = sel[1]
 
-    if not uid then
+    -- This is a debug tool: only present it when the debug overlay (F8)
+    -- is active. Otherwise the menu would pop on every unit selection in
+    -- normal play. Reset activeUid so it rebuilds cleanly if the overlay
+    -- is toggled back on while the same unit is still selected.
+    if not uid or not debugOverlay.isVisible() then
         if panel.visible then hide() end
+        panel.activeUid = nil
         return
     end
 


### PR DESCRIPTION
## Problem

The animation testing menu (`debug_anim_panel.lua`) appeared in-game whenever a unit was selected — even during normal play with the debug layer off. The panel is a debug tool and should only show when the debug overlay (toggled with F8, the same layer that draws the FPS counter) is active.

## Cause

`panel.update()` only checked that a unit was selected before calling `show(uid)`. It never checked the debug overlay's state, so the menu popped on every selection.

## Fix

- Require the `scripts.debug` module (the debug overlay singleton).
- Gate the show path on `debugOverlay.isVisible()`: when no unit is selected **or** the overlay is off, hide the panel and clear `activeUid` so it rebuilds cleanly if the overlay is toggled back on while the same unit stays selected.

The panel still triggers off unit selection (correct behavior) — it now additionally requires the debug layer to be active.

## Testing

- Lua syntax verified (`luajit -bl` / `luac -p`).
- Lua-only change, no engine rebuild required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)