### PR TITLE
Clear mine-tool anchor on Exit to Menu (#102)

### DIFF
--- a/scripts/pause_menu.lua
+++ b/scripts/pause_menu.lua
@@ -285,6 +285,9 @@ function pauseMenu.onExitToMenu()
     -- Clear transient build-tool placement so an armed action can't carry
     -- into the next world (#82).
     pcall(function() require("scripts.build_tool").exitPlacement() end)
+    -- Clear any pending mine-tool anchor so the next world's first click
+    -- doesn't commit a rectangle from a stale origin (#102).
+    pcall(function() require("scripts.mine_tool").cancel() end)
     if worldManager.currentWorld then
         world.hide(worldManager.currentWorld)
     end


### PR DESCRIPTION
Fixes #102.

## Problem
`pauseMenu.onExitToMenu()` clears the build-tool placement state (#82) but never clears the mine-tool anchor. The mine tool keeps its first-click anchor in the `scripts.mine_tool` singleton, cleared only via `mineTool.cancel()` (right-click / Escape / tool-mode change). Leaving the world via Exit to Menu left a pending anchor alive, so the next world's first mine click committed a rectangle from the stale origin to the new hover tile.

## Fix
Mirror the existing build-tool clear: add a `pcall(function() require("scripts.mine_tool").cancel() end)` in `onExitToMenu`. `cancel()` nils the Lua anchor and clears the world-side anchor, and is safe to call with no hud/world (it short-circuits).

## Verification (headless)
Reproduced the issue's repro against the fix:
- After `onExitToMenu()` with a pending `anchor={1,1}`, `mineTool.anchor` is now `nil` (was `"1,1"`).
- In a fresh world, a single mine click commits `0` designations — no stale 11×11 rectangle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)