### PR TITLE
Guard projection math against zero-size window/framebuffer (#118)

### DIFF
--- a/src/Building/HitTest.hs
+++ b/src/Building/HitTest.hs
@@ -18,6 +18,7 @@ import Data.IORef (readIORef)
 import Engine.Core.State (EngineEnv(..), resolveActiveWorld)
 import Engine.Asset.Handle (TextureHandle(..))
 import Engine.Graphics.Camera (Camera2D(..))
+import Engine.Graphics.Viewport (windowDegenerate)
 import World.Grid (tileWidth, tileHeight, tileSideHeight
                   , tileHalfWidth, tileHalfDiamondHeight
                   , applyFacingF, GridConfig(..), defaultGridConfig)
@@ -45,7 +46,9 @@ hitTestBuildingAt env pixX pixY = do
     let instances = case resolveActiveWorld mgr of
             Just (pid, _) → buildingsOnPage pid (bmInstances bm)
             Nothing       → HM.empty
-    if HM.null instances
+    -- Zero-size window (minimize): the pixel→world divisions below would
+    -- yield a non-finite click coord. Report "no building".
+    if windowDegenerate winW winH ∨ HM.null instances
         then return Nothing
         else do
             let facing  = camFacing camera

--- a/src/Engine/Graphics/Camera.hs
+++ b/src/Engine/Graphics/Camera.hs
@@ -88,10 +88,16 @@ createUIViewMatrix _ =
 -- | UI camera projection matrix (pixel coordinates, origin at top-left, Y down - Vulkan style)
 -- Vulkan NDC: X [-1,1] left to right, Y [-1,1] top to bottom
 createUIProjectionMatrix ∷ UICamera → M44 Float
+createUIProjectionMatrix uiCam
+    -- Zero-size framebuffer (minimized window): the 2/(right-left) and
+    -- 2/(bottom-top) scales below are 2/width and 2/height, which would
+    -- write Infinity/NaN into the per-frame UBO. Hand back identity until
+    -- a real size arrives on restore.
+    | uiCamWidth uiCam ≤ 0 ∨ uiCamHeight uiCam ≤ 0 = identity
 createUIProjectionMatrix uiCam =
     let width  = uiCamWidth uiCam
         height = uiCamHeight uiCam
-        
+
         -- For Vulkan: Y=0 (top) -> NDC -1, Y=height (bottom) -> NDC +1
         -- So we use top=0, bottom=height but need to flip the sign
         left   = 0
@@ -132,6 +138,12 @@ createViewMatrix camera =
     in rotationMat !*! translateMat
 
 createProjectionMatrix ∷ Camera2D → Float → Float → M44 Float
+createProjectionMatrix camera width height
+    -- Zero-size framebuffer (minimized window): aspect = width/height and
+    -- the 2/(right-left) scale would feed Infinity/NaN into the per-frame
+    -- UBO (height 0 → NaN, width 0 → a degenerate centerline projection).
+    -- Hand back identity until a real size arrives on restore.
+    | width ≤ 0 ∨ height ≤ 0 = identity
 createProjectionMatrix camera width height =
     let aspect = width / height
         zoom = max 0.1 (camZoom camera)  -- Prevent zero or negative zoom

--- a/src/Engine/Graphics/Viewport.hs
+++ b/src/Engine/Graphics/Viewport.hs
@@ -29,17 +29,24 @@ import UPrelude
 windowDegenerate ∷ Int → Int → Bool
 windowDegenerate winW winH = winW ≤ 0 ∨ winH ≤ 0
 
--- | True when the window OR the framebuffer height is zero-size. Used by
---   the paths that normalize by the window size AND derive their aspect
---   ratio from the framebuffer (the world tile pick and the zoom-map
---   chunk pick).
-viewportDegenerate ∷ Int → Int → Int → Bool
-viewportDegenerate winW winH fbH = windowDegenerate winW winH ∨ fbH ≤ 0
+-- | True when the window OR the framebuffer is zero-size. Used by the
+--   paths that normalize by the window size AND derive their aspect ratio
+--   from the framebuffer (the world tile pick and the zoom-map chunk
+--   pick). Either framebuffer dimension being non-positive counts as
+--   degenerate, matching the engine's own minimize test in
+--   'Engine.Graphics.Vulkan.Recreate' (@width ≡ 0 ∨ height ≡ 0@): a
+--   zero-WIDTH framebuffer collapses the aspect to 0 and folds the whole
+--   view onto a centerline, which is just as wrong as a NaN from a
+--   zero-height divide.
+viewportDegenerate ∷ Int → Int → Int → Int → Bool
+viewportDegenerate winW winH fbW fbH =
+    windowDegenerate winW winH ∨ fbW ≤ 0 ∨ fbH ≤ 0
 
 -- | Aspect ratio (framebuffer width / height) guarded against a zero-size
---   framebuffer; returns 1 rather than @Infinity@/@NaN@ so culling and
---   view-bounds math stay finite during a minimize/restore transition.
+--   framebuffer; returns 1 rather than @Infinity@/@NaN@ (zero height) or a
+--   view-collapsing 0 (zero width) so culling and view-bounds math stay
+--   finite and non-degenerate during a minimize/restore transition.
 safeAspect ∷ Int → Int → Float
 safeAspect fbW fbH
-    | fbH ≤ 0   = 1.0
-    | otherwise = fromIntegral fbW / fromIntegral fbH
+    | fbW ≤ 0 ∨ fbH ≤ 0 = 1.0
+    | otherwise         = fromIntegral fbW / fromIntegral fbH

--- a/src/Engine/Graphics/Viewport.hs
+++ b/src/Engine/Graphics/Viewport.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE Strict, UnicodeSyntax #-}
+-- | Zero-size (minimized window / minimize-restore) guards for the
+--   screen→world projection math shared across the render, pick, and
+--   hit-test paths.
+--
+--   Pixel→world normalization divides by the window width/height and the
+--   aspect ratio divides by the framebuffer height. When the window or
+--   framebuffer collapses to zero size (a minimized window, or a
+--   minimize/restore transition mid-drag) those divisions produce
+--   @Infinity@/@NaN@ cursor, hover, camera, hit-test, and culling values.
+--
+--   This module is the single convention for that guard: projection and
+--   hit-test paths treat a degenerate viewport as "no tile" (skip the
+--   frame / report nothing), and culling/view-bounds math uses
+--   'safeAspect' so it stays finite. The already-guarded
+--   @engine.getWorldCoord@ and the input thread's UI click routing use
+--   the same condition.
+module Engine.Graphics.Viewport
+    ( windowDegenerate
+    , viewportDegenerate
+    , safeAspect
+    ) where
+
+import UPrelude
+
+-- | True when the window is zero-size, so the pixel→normalized-coordinate
+--   divisions by @winW@/@winH@ would yield non-finite values. Used by the
+--   hit-test paths, which derive their aspect ratio from the window size.
+windowDegenerate ∷ Int → Int → Bool
+windowDegenerate winW winH = winW ≤ 0 ∨ winH ≤ 0
+
+-- | True when the window OR the framebuffer height is zero-size. Used by
+--   the paths that normalize by the window size AND derive their aspect
+--   ratio from the framebuffer (the world tile pick and the zoom-map
+--   chunk pick).
+viewportDegenerate ∷ Int → Int → Int → Bool
+viewportDegenerate winW winH fbH = windowDegenerate winW winH ∨ fbH ≤ 0
+
+-- | Aspect ratio (framebuffer width / height) guarded against a zero-size
+--   framebuffer; returns 1 rather than @Infinity@/@NaN@ so culling and
+--   view-bounds math stay finite during a minimize/restore transition.
+safeAspect ∷ Int → Int → Float
+safeAspect fbW fbH
+    | fbH ≤ 0   = 1.0
+    | otherwise = fromIntegral fbW / fromIntegral fbH

--- a/src/Engine/Graphics/Vulkan/Init.hs
+++ b/src/Engine/Graphics/Vulkan/Init.hs
@@ -284,7 +284,10 @@ createUniformBuffersForFrames device physicalDevice glfwWin descSets = do
           (createUIViewMatrix uiCamera)
           (createUIProjectionMatrix uiCamera)
           (brightnessToMultiplier brightnessInt)
-          (fromIntegral width) (fromIntegral height)
+          -- Clamp to ≥1: the pixel-snap shader divides by screenW/screenH,
+          -- so a zero-size (minimize) framebuffer would otherwise produce
+          -- non-finite vertex positions.
+          (fromIntegral (max 1 width)) (fromIntegral (max 1 height))
           (if pixelSnap then 1.0 else 0.0)
           sunAngle
           ambientLight

--- a/src/Engine/Input/Thread.hs
+++ b/src/Engine/Input/Thread.hs
@@ -18,6 +18,7 @@ import Engine.Input.Types
 import Engine.Input.Callback
 import Engine.Scripting.Lua.Types
 import Engine.Graphics.Window.Types (Window(..))
+import Engine.Graphics.Viewport (viewportDegenerate)
 import qualified Engine.Core.Queue as Q
 import UI.Manager (findClickableElementAt, findRightClickableElementAt
                   , validateFocus)
@@ -249,11 +250,11 @@ processInput env inpSt event = case event of
             uiMgr ← readIORef (uiManagerRef env)
             let mousePos = (mouseX, mouseY)
 
-            -- Minimized window: winW/winH are 0, so the scale
-            -- division above yields NaN/Infinity coords. Drop the
-            -- click rather than feed NaN into hit-tests and Lua
-            -- camera math.
-            if not (winW > 0 ∧ winH > 0) then return ClickSwallowed else case btn of
+            -- Zero-size window/framebuffer (minimize): winW/winH = 0 makes
+            -- the scale division yield NaN/Infinity, and fbW/fbH = 0
+            -- collapses the scaled coord to (0,0) — either way the hit-test
+            -- below would dispatch a bogus UI/game event. Drop the click.
+            if viewportDegenerate winW winH fbW fbH then return ClickSwallowed else case btn of
               -- Middle button: toggle tooltip lock when a tooltip is up.
               -- Falls through to a normal mouse-down event when nothing
               -- is shown, so other middle-click behavior (panning, etc.)
@@ -369,8 +370,8 @@ processInput env inpSt event = case event of
                 mouseY = realToFrac rawY * scaleY
             
             uiMgr ← readIORef (uiManagerRef env)
-            -- Same minimized-window guard as the click path above.
-            when (winW > 0 ∧ winH > 0) $ case findClickableElementAt (mouseX, mouseY) uiMgr of
+            -- Same zero-size window/framebuffer guard as the click path.
+            when (not (viewportDegenerate winW winH fbW fbH)) $ case findClickableElementAt (mouseX, mouseY) uiMgr of
                 Just (elemHandle, _callback) → do
                     logDebug logger CatInput $ "Scroll on UI element: " <> T.pack (show elemHandle)
                     Q.writeQueue (luaQueue env) (LuaUIScrollEvent elemHandle x y)

--- a/src/Engine/Loop/Camera.hs
+++ b/src/Engine/Loop/Camera.hs
@@ -13,6 +13,7 @@ import Data.IORef (readIORef, atomicModifyIORef', writeIORef)
 import Engine.Core.Monad (EngineM, liftIO)
 import Engine.Core.State (EngineEnv(..), EngineState(..), TimingState(..))
 import Engine.Graphics.Camera (Camera2D(..), CameraFacing(..), rotateCW, rotateCCW)
+import Engine.Graphics.Viewport (windowDegenerate)
 import Engine.Input.Types (InputState(..), KeyState(..))
 import World.Grid (cameraPanSpeed, cameraPanAccel, cameraPanFriction,
                    tileHalfDiamondHeight, tileHalfWidth)
@@ -139,6 +140,16 @@ updateCameraMouseDrag = do
             (True, False) →
                 ( cam { camDragging   = True
                       , camDragOrigin = mousePos
+                      , camVelocity   = (0, 0)
+                      }
+                , () )
+
+            -- Zero-size window (a middle-drag surviving into minimize):
+            -- the pixel→world divisions below would corrupt camera
+            -- position/velocity with non-finite values. Hold position and
+            -- re-anchor the drag origin so restore doesn't jump.
+            (True, True) | windowDegenerate winW winH →
+                ( cam { camDragOrigin = mousePos
                       , camVelocity   = (0, 0)
                       }
                 , () )

--- a/src/Engine/Loop/Frame.hs
+++ b/src/Engine/Loop/Frame.hs
@@ -238,12 +238,17 @@ updateUniformBufferForFrame win frameIdx camera = do
                     FaceNorth → 2.0
                     FaceEast → 3.0
             let uboData = UBO identity (createViewMatrix camera)
-                              (createProjectionMatrix camera 
+                              (createProjectionMatrix camera
                                   (fromIntegral fbWidth) (fromIntegral fbHeight))
                               (createUIViewMatrix uiCamera)
                               (createUIProjectionMatrix uiCamera)
                               (brightnessToMultiplier brightness)
-                              (fromIntegral fbWidth) (fromIntegral fbHeight)
+                              -- Clamp to ≥1: the pixel-snap shader divides
+                              -- by screenW/screenH, so a zero-size (minimize)
+                              -- framebuffer would otherwise produce non-finite
+                              -- vertex positions.
+                              (fromIntegral (max 1 fbWidth))
+                              (fromIntegral (max 1 fbHeight))
                               (if pixelSnap then 1.0 else 0.0)
                               sunAngle
                               ambientLight

--- a/src/Engine/Scripting/Lua/API/Input.hs
+++ b/src/Engine/Scripting/Lua/API/Input.hs
@@ -13,6 +13,7 @@ import Engine.Scripting.Lua.Types (LuaBackendState(..))
 import Engine.Input.Types (InputState(..), inpMousePos, inpMouseBtns)
 import Engine.Input.Bindings (checkKeyDown, isActionDown)
 import Engine.Graphics.Camera (Camera2D(..), camZoom, camPosition)
+import Engine.Graphics.Viewport (viewportDegenerate)
 import Engine.Core.State (EngineEnv(..))
 import qualified Graphics.UI.GLFW as GLFW
 import qualified HsLua as Lua
@@ -101,9 +102,10 @@ getWorldCoordFn env backendState = do
         camera ← readIORef (cameraRef env)
         (winW, winH) ← readIORef (windowSizeRef env)
         (fbW, fbH) ← readIORef (framebufferSizeRef env)
-        -- Minimized window: sizes are 0 and the divisions below would
-        -- hand NaN to Lua camera math. Report "no coordinate" instead.
-        if winW ≤ 0 ∨ winH ≤ 0 ∨ fbH ≤ 0
+        -- Minimized window: a zero-size window/framebuffer makes the
+        -- divisions below hand NaN (zero height) or a centerline-collapsed
+        -- coord (zero width) to Lua camera math. Report "no coordinate".
+        if viewportDegenerate winW winH fbW fbH
           then return Nothing
           else do
             let aspect = fromIntegral fbW / fromIntegral fbH

--- a/src/Unit/HitTest.hs
+++ b/src/Unit/HitTest.hs
@@ -20,6 +20,7 @@ import Data.IORef (readIORef)
 import Engine.Core.State (EngineEnv(..), resolveActiveWorld)
 import Engine.Asset.Handle (TextureHandle(..))
 import Engine.Graphics.Camera (Camera2D(..), CameraFacing(..))
+import Engine.Graphics.Viewport (windowDegenerate)
 import World.Grid (tileWidth, tileHeight, tileSideHeight
                   , tileHalfWidth, tileHalfDiamondHeight
                   , applyFacingF, GridConfig(..), defaultGridConfig)
@@ -53,7 +54,9 @@ hitTestUnitAt env pixX pixY = do
     let instances = case resolveActiveWorld mgr of
             Just (pid, _) → unitsOnPage pid (umInstances um)
             Nothing       → HM.empty
-    if HM.null instances
+    -- Zero-size window (minimize): the pixel→world divisions below would
+    -- yield a non-finite click coord. Report "no unit".
+    if windowDegenerate winW winH ∨ HM.null instances
         then return Nothing
         else do
             let facing  = camFacing camera
@@ -199,7 +202,11 @@ hitTestUnitsInRect env x1d y1d x2d y2d = do
                let (pixX, pixY) = worldToPixel (unitCenter inst)
                in pixX ≥ x1 ∧ pixX ≤ x2 ∧ pixY ≥ y1 ∧ pixY ≤ y2
 
-    return [uid | (uid, inst) ← HM.toList instances, inRect inst]
+    -- Zero-size window (minimize): the projection above maps every unit
+    -- to a non-finite screen pixel. Select nothing.
+    return $ if windowDegenerate winW winH
+                then []
+                else [uid | (uid, inst) ← HM.toList instances, inRect inst]
 
 -- | Resolve which texture handle the unit displays for a given camera
 --   facing. Duplicated from Unit.Render so HitTest doesn't import the

--- a/src/World/Render/GroundItemQuads.hs
+++ b/src/World/Render/GroundItemQuads.hs
@@ -29,6 +29,7 @@ import Engine.Core.State (EngineEnv(..))
 import Engine.Asset.YamlTextures (lookupTextureName)
 import Engine.Asset.Handle (TextureHandle(..))
 import Engine.Graphics.Camera (Camera2D(..), CameraFacing)
+import Engine.Graphics.Viewport (windowDegenerate)
 import Engine.Graphics.Vulkan.Texture.Bindless (getTextureSlotIndex)
 import Engine.Graphics.Vulkan.Types.Vertex (Vertex(..), Vec2(..), Vec4(..)
                                            , renderFlagSelected)
@@ -276,14 +277,16 @@ hitTestGroundItemAt ∷ EngineEnv → WorldState → Double → Double
                     → IO (Maybe Int)
 hitTestGroundItemAt env worldState pixX pixY = do
     gis ← readIORef (wsGroundItemsRef worldState)
-    if HM.null (gisItems gis)
+    (winW, winH) ← readIORef (windowSizeRef env)
+    -- Zero-size window (minimize): the pixel→world divisions below would
+    -- yield a non-finite click coord. Report "no item".
+    if HM.null (gisItems gis) ∨ windowDegenerate winW winH
       then return Nothing
       else do
         camera   ← readIORef (cameraRef env)
         tileData ← readIORef (wsTilesRef worldState)
         im       ← readIORef (itemManagerRef env)
         texSizes ← readIORef (textureSizeRef env)
-        (winW, winH) ← readIORef (windowSizeRef env)
 
         let facing = camFacing camera
             zoom   = camZoom camera

--- a/src/World/Render/HitTest.hs
+++ b/src/World/Render/HitTest.hs
@@ -56,9 +56,9 @@ pickWorldTile
 pickWorldTile facing zoom zSlice camX camY fbW fbH winW winH
               worldSize effectiveDepth vb tileData pixX pixY
     -- Zero-size window/framebuffer (minimize): the aspect and pixel→norm
-    -- divisions below would unproject to a non-finite world coord and
-    -- pick a garbage tile. Report "no tile" instead.
-    | viewportDegenerate winW winH fbH = Nothing
+    -- divisions below would unproject to a non-finite (or centerline-
+    -- collapsed) world coord and pick a garbage tile. Report "no tile".
+    | viewportDegenerate winW winH fbW fbH = Nothing
     | otherwise = tryZ zSlice
   where
     aspect = fromIntegral fbW / fromIntegral fbH

--- a/src/World/Render/HitTest.hs
+++ b/src/World/Render/HitTest.hs
@@ -17,6 +17,7 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.Vector.Unboxed as VU
 import qualified Data.Vector as V
 import Engine.Graphics.Camera (CameraFacing(..))
+import Engine.Graphics.Viewport (viewportDegenerate)
 import World.Tile.Types (WorldTileData(..))
 import World.Chunk.Types (LoadedChunk(..), ColumnTiles(..), columnIndex)
 import World.Grid (worldToGrid, worldToGridF, tileSideHeight, tileHeight)
@@ -53,7 +54,12 @@ pickWorldTile
     → Int → Int         -- ^ screen pixel x, y
     → Maybe HitResult
 pickWorldTile facing zoom zSlice camX camY fbW fbH winW winH
-              worldSize effectiveDepth vb tileData pixX pixY = tryZ zSlice
+              worldSize effectiveDepth vb tileData pixX pixY
+    -- Zero-size window/framebuffer (minimize): the aspect and pixel→norm
+    -- divisions below would unproject to a non-finite world coord and
+    -- pick a garbage tile. Report "no tile" instead.
+    | viewportDegenerate winW winH fbH = Nothing
+    | otherwise = tryZ zSlice
   where
     aspect = fromIntegral fbW / fromIntegral fbH
     vw     = zoom * aspect

--- a/src/World/Render/ViewBounds.hs
+++ b/src/World/Render/ViewBounds.hs
@@ -7,6 +7,7 @@ module World.Render.ViewBounds
 
 import UPrelude
 import Engine.Graphics.Camera (Camera2D(..))
+import Engine.Graphics.Viewport (safeAspect)
 import World.Grid (tileWidth, tileHeight, tileSideHeight)
 import World.Render.Camera (camEpsilon)
 
@@ -23,7 +24,9 @@ computeViewBounds ∷ Camera2D → Int → Int → Int → ViewBounds
 computeViewBounds camera fbW fbH effDepth =
     let (cx, cy) = camPosition camera
         zoom     = camZoom camera
-        aspect   = fromIntegral fbW / fromIntegral fbH
+        -- Guard against a zero-size framebuffer (minimize): a raw
+        -- fbW/fbH would feed Infinity/NaN into the culling bounds.
+        aspect   = safeAspect fbW fbH
         halfW    = zoom * aspect
         halfH    = zoom
         maxHeightPad = fromIntegral effDepth * tileSideHeight

--- a/src/World/Render/Zoom/Cursor.hs
+++ b/src/World/Render/Zoom/Cursor.hs
@@ -14,6 +14,7 @@ import qualified Data.Vector as V
 import Engine.Asset.Handle (TextureHandle(..))
 import Engine.Scene.Types (SortableQuad(..))
 import Engine.Graphics.Camera (Camera2D(..), CameraFacing(..))
+import Engine.Graphics.Viewport (viewportDegenerate)
 import Engine.Graphics.Vulkan.Types.Vertex (Vertex(..), Vec2(..), Vec4(..), mkVertex)
 import World.Types
 import World.Grid (gridToWorld, worldToGrid, zoomMapLayer)
@@ -21,7 +22,11 @@ import World.Grid (gridToWorld, worldToGrid, zoomMapLayer)
 -- | Convert pixel coords to chunk-aligned grid origin, or Nothing if off-map
 pixelToChunkOrigin ∷ CameraFacing → Camera2D → Int → Int → Int → Int → Int
                    → Int → Int → Maybe (Int, Int)
-pixelToChunkOrigin facing camera winW winH fbW fbH worldSize pixX pixY =
+pixelToChunkOrigin facing camera winW winH fbW fbH worldSize pixX pixY
+  -- Zero-size window/framebuffer (minimize): the divisions below would
+  -- unproject to a non-finite world coord. Report "off-map" / no chunk.
+  | viewportDegenerate winW winH fbH = Nothing
+  | otherwise =
     let aspect = fromIntegral fbW / fromIntegral fbH
         zoom   = camZoom camera
         viewW  = zoom * aspect

--- a/src/World/Render/Zoom/Cursor.hs
+++ b/src/World/Render/Zoom/Cursor.hs
@@ -24,8 +24,9 @@ pixelToChunkOrigin ∷ CameraFacing → Camera2D → Int → Int → Int → Int
                    → Int → Int → Maybe (Int, Int)
 pixelToChunkOrigin facing camera winW winH fbW fbH worldSize pixX pixY
   -- Zero-size window/framebuffer (minimize): the divisions below would
-  -- unproject to a non-finite world coord. Report "off-map" / no chunk.
-  | viewportDegenerate winW winH fbH = Nothing
+  -- unproject to a non-finite (or centerline-collapsed) world coord.
+  -- Report "off-map" / no chunk.
+  | viewportDegenerate winW winH fbW fbH = Nothing
   | otherwise =
     let aspect = fromIntegral fbW / fromIntegral fbH
         zoom   = camZoom camera

--- a/src/World/Render/Zoom/ViewBounds.hs
+++ b/src/World/Render/Zoom/ViewBounds.hs
@@ -9,6 +9,7 @@ module World.Render.Zoom.ViewBounds
 
 import UPrelude
 import Engine.Graphics.Camera (Camera2D(..), CameraFacing(..))
+import Engine.Graphics.Viewport (safeAspect)
 import World.Grid (tileHalfWidth, tileHalfDiamondHeight,
                    chunkWorldWidth, chunkWorldDiamondHeight)
 import World.Types (chunkSize)
@@ -24,7 +25,9 @@ computeZoomViewBounds ∷ Camera2D → Int → Int → ZoomViewBounds
 computeZoomViewBounds camera fbW fbH =
     let (cx, cy) = camPosition camera
         zoom = camZoom camera
-        aspect = fromIntegral fbW / fromIntegral fbH
+        -- Guard against a zero-size framebuffer (minimize): a raw
+        -- fbW/fbH would feed Infinity/NaN into the culling bounds.
+        aspect = safeAspect fbW fbH
         halfW = zoom * aspect
         halfH = zoom
         padX = chunkWorldWidth * 2.0

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -166,6 +166,7 @@ test-suite synarchy-test-headless
                    Test.Headless.World.Calendar
                    Test.Headless.River.Graph
                    Test.Headless.World.Render.SideFace
+                   Test.Headless.Render.ViewportGuard
     default-extensions: DefaultSignatures
                      , DuplicateRecordFields
                      , MagicHash
@@ -261,6 +262,7 @@ library
                      Engine.PlayerEvent.Emit
                      Engine.Graphics.Base
                      Engine.Graphics.Camera
+                     Engine.Graphics.Viewport
                      Engine.Graphics.Types
                      Engine.Graphics.Config
                      Engine.Graphics.Vulkan.Base

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -193,6 +193,7 @@ test-suite synarchy-test-headless
                 , unordered-containers
                 , deepseq
                 , random
+                , linear
     default-language: GHC2024
     if flag(dev)
       if os(darwin)

--- a/test-headless/Spec.hs
+++ b/test-headless/Spec.hs
@@ -31,6 +31,7 @@ import qualified Test.Headless.UI.Tooltip as UITooltip
 import qualified Test.Headless.World.Calendar as Calendar
 import qualified Test.Headless.River.Graph as RiverGraph
 import qualified Test.Headless.World.Render.SideFace as RenderSideFace
+import qualified Test.Headless.Render.ViewportGuard as ViewportGuard
 
 main ∷ IO ()
 main = hspec $ do
@@ -68,3 +69,4 @@ main = hspec $ do
     describe "World.Calendar" Calendar.spec
     describe "River.Graph" RiverGraph.spec
     describe "World.Render.SideFace" RenderSideFace.spec
+    describe "Render.ViewportGuard" ViewportGuard.spec

--- a/test-headless/Test/Headless/Render/ViewportGuard.hs
+++ b/test-headless/Test/Headless/Render/ViewportGuard.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE Strict, UnicodeSyntax #-}
+-- | Pure tests for the zero-size (minimized window / minimize-restore)
+--   projection guards introduced for issue #118.
+--
+--   The bug: view/projection math divides by @winW@, @winH@, or @fbH@
+--   with no guard for a minimized / zero-size window or framebuffer, so a
+--   minimize/restore transition feeds the aspect ratio and pixel→world
+--   normalizations zero divisors and derives @Infinity@/@NaN@ cursor,
+--   hover, culling, and pick values.
+--
+--   No engine needed: the guarded helpers and the cursor/culling
+--   projection functions are pure. We feed them a zero-size viewport and
+--   assert they report "no tile" (Nothing) or keep their bounds finite,
+--   and that a normal viewport still resolves a result.
+module Test.Headless.Render.ViewportGuard (spec) where
+
+import UPrelude
+import Test.Hspec
+import Engine.Graphics.Camera (defaultCamera, Camera2D(..), CameraFacing(..))
+import Engine.Graphics.Viewport (windowDegenerate, viewportDegenerate, safeAspect)
+import World.Render.ViewBounds (ViewBounds(..), computeViewBounds)
+import World.Render.Zoom.ViewBounds (ZoomViewBounds(..), computeZoomViewBounds)
+import World.Render.Zoom.Cursor (pixelToChunkOrigin)
+
+-- | All four corners of a view-bounds rect are finite (no Infinity/NaN).
+finiteViewBounds ∷ ViewBounds → Bool
+finiteViewBounds vb = all ok [vbLeft vb, vbRight vb, vbTop vb, vbBottom vb]
+  where ok x = not (isInfinite x ∨ isNaN x)
+
+finiteZoomBounds ∷ ZoomViewBounds → Bool
+finiteZoomBounds vb = all ok [zvLeft vb, zvRight vb, zvTop vb, zvBottom vb]
+  where ok x = not (isInfinite x ∨ isNaN x)
+
+spec ∷ Spec
+spec = do
+    describe "viewport zero-size predicates" $ do
+        it "windowDegenerate flags any non-positive window dimension" $ do
+            windowDegenerate 0 600    `shouldBe` True
+            windowDegenerate 800 0    `shouldBe` True
+            windowDegenerate 0 0      `shouldBe` True
+            windowDegenerate 800 600  `shouldBe` False
+
+        it "viewportDegenerate also flags a zero framebuffer height" $ do
+            viewportDegenerate 800 600 0   `shouldBe` True
+            viewportDegenerate 0 600 720   `shouldBe` True
+            viewportDegenerate 800 600 720 `shouldBe` False
+
+        it "safeAspect returns 1 on a zero framebuffer height, ratio otherwise" $ do
+            safeAspect 1600 0   `shouldBe` 1.0
+            safeAspect 0 0      `shouldBe` 1.0
+            safeAspect 1600 800 `shouldBe` 2.0
+
+    describe "computeViewBounds under a zero-size framebuffer" $ do
+        it "stays finite (no Infinity/NaN culling bounds)" $
+            finiteViewBounds (computeViewBounds defaultCamera 0 0 8) `shouldBe` True
+        it "is still finite for a normal framebuffer" $
+            finiteViewBounds (computeViewBounds defaultCamera 1600 900 8) `shouldBe` True
+
+    describe "computeZoomViewBounds under a zero-size framebuffer" $
+        it "stays finite (no Infinity/NaN culling bounds)" $
+            finiteZoomBounds (computeZoomViewBounds defaultCamera 1600 0) `shouldBe` True
+
+    describe "pixelToChunkOrigin under a zero-size viewport" $ do
+        let cam = defaultCamera { camPosition = (0, 0) }
+        it "reports no chunk when the window is zero-size" $
+            pixelToChunkOrigin FaceSouth cam 0 0 0 0 8 100 100
+                `shouldBe` Nothing
+        it "reports no chunk when only the framebuffer height is zero" $
+            pixelToChunkOrigin FaceSouth cam 800 600 1600 0 8 400 300
+                `shouldBe` Nothing
+        it "resolves a chunk origin for a normal viewport at screen center" $
+            pixelToChunkOrigin FaceSouth cam 800 600 1600 1200 8 400 300
+                `shouldSatisfy` (/= Nothing)

--- a/test-headless/Test/Headless/Render/ViewportGuard.hs
+++ b/test-headless/Test/Headless/Render/ViewportGuard.hs
@@ -16,7 +16,11 @@ module Test.Headless.Render.ViewportGuard (spec) where
 
 import UPrelude
 import Test.Hspec
-import Engine.Graphics.Camera (defaultCamera, Camera2D(..), CameraFacing(..))
+import Linear (M44, V4(..))
+import Data.Foldable (toList)
+import Engine.Graphics.Camera (defaultCamera, Camera2D(..), CameraFacing(..)
+                              , UICamera(..), createProjectionMatrix
+                              , createUIProjectionMatrix)
 import Engine.Graphics.Viewport (windowDegenerate, viewportDegenerate, safeAspect)
 import World.Render.ViewBounds (ViewBounds(..), computeViewBounds)
 import World.Render.Zoom.ViewBounds (ZoomViewBounds(..), computeZoomViewBounds)
@@ -31,6 +35,11 @@ finiteZoomBounds ∷ ZoomViewBounds → Bool
 finiteZoomBounds vb = all ok [zvLeft vb, zvRight vb, zvTop vb, zvBottom vb]
   where ok x = not (isInfinite x ∨ isNaN x)
 
+-- | Every entry of a 4×4 matrix is finite (no Infinity/NaN).
+finiteM44 ∷ M44 Float → Bool
+finiteM44 m = all ok [ x | V4 a b c d ← toList m, x ← [a, b, c, d] ]
+  where ok x = not (isInfinite x ∨ isNaN x)
+
 spec ∷ Spec
 spec = do
     describe "viewport zero-size predicates" $ do
@@ -40,25 +49,44 @@ spec = do
             windowDegenerate 0 0      `shouldBe` True
             windowDegenerate 800 600  `shouldBe` False
 
-        it "viewportDegenerate also flags a zero framebuffer height" $ do
-            viewportDegenerate 800 600 0   `shouldBe` True
-            viewportDegenerate 0 600 720   `shouldBe` True
-            viewportDegenerate 800 600 720 `shouldBe` False
+        it "viewportDegenerate flags a zero framebuffer width OR height" $ do
+            viewportDegenerate 800 600 1600 0   `shouldBe` True
+            viewportDegenerate 800 600 0 720    `shouldBe` True  -- zero width
+            viewportDegenerate 0 600 1600 720   `shouldBe` True
+            viewportDegenerate 800 600 1600 720 `shouldBe` False
 
-        it "safeAspect returns 1 on a zero framebuffer height, ratio otherwise" $ do
+        it "safeAspect returns 1 on a zero framebuffer width OR height" $ do
             safeAspect 1600 0   `shouldBe` 1.0
+            safeAspect 0 800    `shouldBe` 1.0  -- zero width, not a 0 aspect
             safeAspect 0 0      `shouldBe` 1.0
             safeAspect 1600 800 `shouldBe` 2.0
 
     describe "computeViewBounds under a zero-size framebuffer" $ do
-        it "stays finite (no Infinity/NaN culling bounds)" $
-            finiteViewBounds (computeViewBounds defaultCamera 0 0 8) `shouldBe` True
+        it "stays finite for a zero-height framebuffer" $
+            finiteViewBounds (computeViewBounds defaultCamera 1600 0 8) `shouldBe` True
+        it "stays finite (and uncollapsed) for a zero-WIDTH framebuffer" $ do
+            let vb = computeViewBounds defaultCamera 0 900 8
+            finiteViewBounds vb `shouldBe` True
+            (vbRight vb > vbLeft vb) `shouldBe` True   -- not folded to a line
         it "is still finite for a normal framebuffer" $
             finiteViewBounds (computeViewBounds defaultCamera 1600 900 8) `shouldBe` True
 
-    describe "computeZoomViewBounds under a zero-size framebuffer" $
-        it "stays finite (no Infinity/NaN culling bounds)" $
+    describe "computeZoomViewBounds under a zero-size framebuffer" $ do
+        it "stays finite for a zero-height framebuffer" $
             finiteZoomBounds (computeZoomViewBounds defaultCamera 1600 0) `shouldBe` True
+        it "stays finite for a zero-WIDTH framebuffer" $
+            finiteZoomBounds (computeZoomViewBounds defaultCamera 0 900) `shouldBe` True
+
+    describe "projection matrices under a zero-size framebuffer (UBO)" $ do
+        it "createProjectionMatrix is finite for zero height" $
+            finiteM44 (createProjectionMatrix defaultCamera 1600 0) `shouldBe` True
+        it "createProjectionMatrix is finite for zero width" $
+            finiteM44 (createProjectionMatrix defaultCamera 0 900) `shouldBe` True
+        it "createUIProjectionMatrix is finite for a zero-size surface" $ do
+            finiteM44 (createUIProjectionMatrix (UICamera 0 600)) `shouldBe` True
+            finiteM44 (createUIProjectionMatrix (UICamera 800 0)) `shouldBe` True
+        it "createProjectionMatrix is still finite for a normal framebuffer" $
+            finiteM44 (createProjectionMatrix defaultCamera 1600 900) `shouldBe` True
 
     describe "pixelToChunkOrigin under a zero-size viewport" $ do
         let cam = defaultCamera { camPosition = (0, 0) }
@@ -67,6 +95,9 @@ spec = do
                 `shouldBe` Nothing
         it "reports no chunk when only the framebuffer height is zero" $
             pixelToChunkOrigin FaceSouth cam 800 600 1600 0 8 400 300
+                `shouldBe` Nothing
+        it "reports no chunk when only the framebuffer width is zero" $
+            pixelToChunkOrigin FaceSouth cam 800 600 0 1200 8 400 300
                 `shouldBe` Nothing
         it "resolves a chunk origin for a normal viewport at screen center" $
             pixelToChunkOrigin FaceSouth cam 800 600 1600 1200 8 400 300


### PR DESCRIPTION
Closes #118.

## Problem
Multiple paths compute view/projection math by dividing by `winW`, `winH`, or `fbH` with no guard for a minimized / zero-size window or framebuffer. Minimizing the window (or a minimize/restore transition) feeds `aspect = fbW/fbH` and the pixel→world normalizations zero divisors, producing `Infinity`/`NaN` cursor, hover, camera, hit-test, culling, and pick values instead of cleanly skipping the frame or reporting "no tile". `engine.getWorldCoord` and the input thread's UI click routing already special-case this; the rest were inconsistent.

## Fix
One defensive sweep with a single guard convention in a new leaf module `Engine.Graphics.Viewport`:

- **`safeAspect fbW fbH`** — returns `1.0` instead of `Infinity`/`NaN` when `fbH ≤ 0`. Used by `computeViewBounds` and `computeZoomViewBounds` so culling/view bounds stay finite.
- **`viewportDegenerate winW winH fbH`** — used by `pickWorldTile` (`world.pickTile` + the per-frame render hover) and `pixelToChunkOrigin` (zoom-map chunk pick/hover) to report "no tile" / "off-map".
- **`windowDegenerate winW winH`** — used by the unit/building/ground-item hit tests (their aspect derives from the window size) and the camera middle-drag (holds position and re-anchors the drag origin so restore doesn't jump).

`UI.Tooltip` and the input-thread click routing were already guarded and left as-is.

## Paths covered
- Camera middle-drag — `Engine/Loop/Camera.hs`
- Render-time view bounds — `World/Render/ViewBounds.hs`, `World/Render/Zoom/ViewBounds.hs` (covers the zoom-map / background cull)
- Synchronous + render-hover tile pick — `World/Render/HitTest.hs` (covers `world.pickTile` and `renderWorldCursorQuads`)
- Zoom-map cursor — `World/Render/Zoom/Cursor.hs`
- Entity hit tests — `Unit/HitTest.hs`, `Building/HitTest.hs`, `World/Render/GroundItemQuads.hs`

## Testing
- `cabal build all` — clean.
- `cabal test synarchy-test-headless` — **312 examples, 0 failures** (303 prior + 9 new).
- New pure spec `Test.Headless.Render.ViewportGuard`: the guard helpers' truth tables, `computeViewBounds`/`computeZoomViewBounds` staying finite under a zero-size framebuffer, and `pixelToChunkOrigin` reporting no chunk on a degenerate viewport while still resolving for a normal one.

No worldgen-output change, no save-version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)