### PR TITLE
Consume ground-item clicks in info mode so tile-info doesn't run (#173)

### DIFF
--- a/scripts/hud.lua
+++ b/scripts/hud.lua
@@ -585,6 +585,14 @@ function hud.onMouseDown(button_num, mx, my)
                and building.getSelected() then
                 return
             end
+            -- Same rule for ground items: game.onMouseDown already
+            -- settled the item selection (item.select), and the item
+            -- watcher owns the panel + expects tile-info pushes to
+            -- deselect it. Consume the click here so tile-info doesn't
+            -- race-clobber the item info on the same click (#173).
+            if item and item.getSelected and item.getSelected() then
+                return
+            end
             -- Tile-info popup only fires in info-tool mode. In other
             -- tools, a click that misses a unit just clears any active
             -- selection (game.onMouseDown already did that) and is


### PR DESCRIPTION
Fixes #173.

## Problem
`hud.onMouseDown` early-returns when a unit or building was selected by the earlier `game.onMouseDown` broadcast (`scripts/init.lua` settles `unit.select`/`building.select`/`item.select` synchronously before HUD handlers run), but it never checked `item.getSelected()`. In `info` tool mode, a left-click on a ground item therefore still ran `world.setWorldCursorSelect(...)`, triggering tile selection / tile info on the same click.

This is a real ownership conflict, not a benign duplicate: the item watcher (`scripts/item_info_panel.lua`) owns the shared HUD panel and explicitly expects a tile-info push to take over the panel and deselect the item.

## Fix
Add the matching `item.getSelected()` guard alongside the existing unit/building guards in `hud.onMouseDown`, so a ground-item click consumes the click and the tile-info path doesn't run. `item` is in the same Lua sandbox global table as `unit`/`building` (`Engine.Scripting.Lua.API.Shell`), and the check is defensive (`item and item.getSelected and ...`).

## Testing
Lua-only change (no Haskell rebuild). `hud.lua` passes a luajit syntax check. The affected path is GUI click-routing in info mode and isn't meaningfully headless-testable; the fix mirrors the established, working unit/building guard pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)