### PR TITLE
Fix #178: clear building/item selection on unit context-menu Info

### DIFF
--- a/scripts/init.lua
+++ b/scripts/init.lua
@@ -428,6 +428,12 @@ function game.onMouseDown(button, x, y)
                     { label = "Info",
                       callback = function()
                           unit.select(targetUid)
+                          -- Mirror the left-click unit-selection path:
+                          -- selecting a unit takes over the info panel,
+                          -- so clear any building/item selection to keep
+                          -- the shared HUD panel from flickering schemas.
+                          building.deselect()
+                          item.deselect()
                       end },
                 }
                 -- Filter selection down to player-commandable


### PR DESCRIPTION
## Summary
Right-clicking a unit and choosing **Info** only called `unit.select(targetUid)`. Unlike the main left-click unit-selection path, it did not first clear building or ground-item selection, so conflicting selection domains could remain active together and the shared HUD info panel could flicker between schemas.

This mirrors the existing left-click cleanup (`init.lua:320-324`) in the context-menu Info callback: after `unit.select(...)`, call `building.deselect()` and `item.deselect()`.

## Repro (before fix)
1. Select a building or a ground item so its HUD info is active.
2. Right-click a unit and choose **Info**.
3. The unit becomes selected without clearing the building/item selection.

## Change
- `scripts/init.lua` — Info callback now clears building/item selection, matching normal unit selection.

## Verification
- Lua-only change; `scripts/init.lua` compiles cleanly (luajit bytecode check).
- `building.deselect` / `item.deselect` are registered engine API functions (`Engine/Scripting/Lua/API.hs:378,447`) already used by the left-click path in the same function.
- The right-click → Info flow is GUI-only and not exercisable headless (the loading screen that wires `onMouseDown` doesn't run headless), so no automated test covers it; the change is a 2-call addition replicating established behavior.

Fixes #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)