### PR TITLE
Consume right-clicks on ordinary clickable UI controls (#184)

### DIFF
--- a/src/Engine/Input/Thread.hs
+++ b/src/Engine/Input/Thread.hs
@@ -311,9 +311,20 @@ processInput env inpSt event = case event of
                                 logDebug logger CatUI $
                                     "UI element right-clicked: " <> callback
                                 return ClickUI
-                            Nothing → do
-                                Q.writeQueue lq (LuaMouseDownEvent btn x y)
-                                return ClickGame
+                            -- No right-click handler under the cursor. If
+                            -- an ordinary clickable control is still there,
+                            -- consume the click so it can't fall through to
+                            -- gameplay (mirrors the left-click blocking
+                            -- semantics); only truly empty UI space routes
+                            -- the right-click to the world.
+                            Nothing → case findClickableElementAt mousePos uiMgr' of
+                                Just _ → do
+                                    logDebug logger CatUI
+                                        "Right-click consumed by clickable UI element (no handler)"
+                                    return ClickUI
+                                Nothing → do
+                                    Q.writeQueue lq (LuaMouseDownEvent btn x y)
+                                    return ClickGame
 
                       _ → do
                         Q.writeQueue lq (LuaMouseDownEvent btn x y)


### PR DESCRIPTION
Fixes #184.

## Problem
The input thread routes left clicks through `findClickableElementAt` (which blocks gameplay for any clickable control) but routes right clicks only through `findRightClickableElementAt`, which requires both `ueClickable` and `ueOnRightClick`. A normal clickable control with only a left-click handler is therefore treated as if no UI element were under the cursor, so a right-click falls through to gameplay and can open world context menus or issue hidden-world actions behind the UI.

## Fix
In the `MouseButton'2` branch of `processInput` (`src/Engine/Input/Thread.hs`), when `findRightClickableElementAt` finds no handler, fall back to `findClickableElementAt`. If an ordinary clickable control is under the cursor, consume the click (`ClickUI`, no Lua event dispatched). Only truly empty UI space still routes the right-click to the world (`LuaMouseDownEvent` → `ClickGame`).

This mirrors the existing left-click blocking semantics and uses the already-imported pure helper. Elements that do define `ueOnRightClick` continue to dispatch their right-click callback exactly as before.

## Testing
- `cabal build exe:synarchy` compiles cleanly (rebuilds `Engine.Input.Thread`).
- Behavioral note: the routing decision is embedded in IO (queue writes / IORef reads); the routing helpers are pure and the change adds a single fallback branch. The dedicated `Engine.Input.Thread` hspec lives in the graphical test suite, not run headless here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)