### PR TITLE
Fix #189: weigh actual ItemInstance in depositToCargo capacity check

### DIFF
--- a/src/Engine/Scripting/Lua/API/Units.hs
+++ b/src/Engine/Scripting/Lua/API/Units.hs
@@ -1752,22 +1752,26 @@ unitDepositToCargoFn env = do
             let uid     = UnitId (fromIntegral nU)
                 bid     = BuildingId (fromIntegral nB)
                 defName = TE.decodeUtf8 nameBS
-            -- Capacity pre-check: read-only snapshot.
+            -- Capacity pre-check: read-only snapshot. Weighs the ACTUAL
+            -- ItemInstance that will be popped below (the first match in
+            -- the unit's inventory) via itemTotalWeight, so fill and
+            -- nested contents are counted — the same recursive measure
+            -- used for the items already in storage. A filled container
+            -- or stocked kit can be kilograms heavier than its def mean,
+            -- so checking idWeight here would let it overfill the cargo.
             okFits ← Lua.liftIO $ do
                 bm      ← readIORef (buildingManagerRef env)
                 itemMgr ← readIORef (itemManagerRef env)
+                um      ← readIORef (unitManagerRef env)
                 pure $ fromMaybe False $ do
-                    inst    ← HM.lookup bid (bmInstances bm)
-                    def     ← HM.lookup (biDefName inst) (bmDefs bm)
-                    itemDef ← lookupItemDef defName itemMgr
+                    inst       ← HM.lookup bid (bmInstances bm)
+                    def        ← HM.lookup (biDefName inst) (bmDefs bm)
+                    u          ← HM.lookup uid (umInstances um)
+                    (item, _)  ← popFirstByName defName (uiInventory u)
                     let cap     = bdStorageCapacity def
                         current = sum (map (itemTotalWeight itemMgr)
                                            (biStorage inst))
-                    -- Pre-check uses the def MEAN; the actual item
-                    -- popped below carries its instance weight, so a
-                    -- rolled-heavy instance can overshoot by a hair —
-                    -- acceptable for storage.
-                    pure (cap > 0 ∧ current + idWeight itemDef <= cap)
+                    pure (cap > 0 ∧ current + itemTotalWeight itemMgr item <= cap)
             if not okFits then do
                 Lua.pushboolean False
                 return 1

--- a/tools/cargo_capacity_probe.py
+++ b/tools/cargo_capacity_probe.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Headless probe for issue #189: depositToCargo capacity check must weigh
+the actual ItemInstance (fill + nested contents), not the def base weight.
+
+Setup: flat arena, one unit, one cargo_hold_S (capacity 200 kg). Repeatedly
+give the unit a FULL 2 L steel canteen (real instance weight ~2.2 kg, def base
+weight ~0.2 kg) and deposit it. The pre-check that uses base weight (the bug)
+keeps accepting deposits until real stored weight overshoots capacity; a
+pre-check that uses the real instance weight (the fix) stops at <= capacity.
+
+PASS  = final stored weight <= capacity (fix).
+FAIL  = final stored weight  > capacity (bug overfilled the cargo).
+"""
+from __future__ import annotations
+import glob, json, socket, subprocess, sys, time
+
+PORT = 9009
+LOG = "/tmp/cargo_capacity_probe_engine.log"
+
+
+def send(lua: str, timeout: float = 10.0) -> str:
+    with socket.create_connection(("localhost", PORT), timeout=timeout) as s:
+        s.sendall((lua + "\n").encode())
+        chunks, = ([],)
+        s.settimeout(0.4)
+        try:
+            while True:
+                b = s.recv(4096)
+                if not b:
+                    break
+                chunks.append(b)
+        except socket.timeout:
+            pass
+    out = b"".join(chunks).decode(errors="replace")
+    res = [ln[2:].strip() for ln in out.splitlines() if ln.startswith("> ")]
+    res = [r for r in res if r]
+    return res[-1] if res else out.strip()
+
+
+def num(lua: str):
+    r = send(lua)
+    try:
+        return float(r)
+    except (TypeError, ValueError):
+        return None
+
+
+def boot() -> subprocess.Popen:
+    log = open(LOG, "w")
+    proc = subprocess.Popen(
+        ["cabal", "run", "-v0", "exe:synarchy", "--",
+         "--headless", "--port", str(PORT)],
+        stdout=log, stderr=subprocess.STDOUT,
+    )
+    deadline = time.time() + 240
+    while time.time() < deadline:
+        try:
+            if "READY" in open(LOG).read():
+                return proc
+        except FileNotFoundError:
+            pass
+        if proc.poll() is not None:
+            sys.exit(f"engine exited before READY; see {LOG}")
+        time.sleep(0.4)
+    proc.kill()
+    sys.exit("engine never printed READY")
+
+
+def bootstrap():
+    loaders = [
+        ("data/substances/*.yaml", "engine.loadSubstanceYaml"),
+        ("data/items/*.yaml",      "engine.loadItemYaml"),
+        ("data/equipment/*.yaml",  "engine.loadEquipmentYaml"),
+        ("data/materials/*.yaml",  "engine.loadMaterialYaml"),
+        ("data/units/*.yaml",      "engine.loadUnitYaml"),
+        ("data/buildings/*.yaml",  "engine.loadBuildingYaml"),
+    ]
+    for pattern, fn in loaders:
+        for path in sorted(glob.glob(pattern)):
+            send(f"{fn}('{path}'); return 'ok'")
+    send("pcall(function() require('scripts.unit_ai').update=function() end end); "
+         "return 'ai-off'")
+    send("require('scripts.movement_arena'); return 'ok'")
+
+
+def main() -> int:
+    proc = boot()
+    try:
+        bootstrap()
+        course = json.loads(send(
+            "return require('scripts.movement_arena').buildCourse('flat')"))
+        sx, sy = int(course["sx"]), int(course["sy"])
+        # wait for the arena centre chunk to load
+        for _ in range(40):
+            r = send("return world.getChunkInfo(0,0)")
+            try:
+                if json.loads(r).get("loaded"):
+                    break
+            except Exception:
+                pass
+            time.sleep(0.25)
+
+        uid = int(num(f"return unit.spawn('acolyte', {sx}, {sy})"))
+        bid = num(f"return building.spawn('cargo_hold_S', {sx+2}, {sy})")
+        if bid is None:
+            print("FAIL: could not spawn cargo_hold_S")
+            return 2
+        bid = int(bid)
+        # wait for the queued BuildingSpawn to materialise
+        cap = None
+        for _ in range(40):
+            cap = num(f"return building.getStorageCapacity({bid})")
+            if cap and cap > 0:
+                break
+            time.sleep(0.25)
+        if not cap:
+            print("FAIL: cargo building never became queryable")
+            return 2
+
+        DEF = "canteen_steel_2l"
+        accepted = 0
+        for _ in range(200):
+            send(f"unit.addItem({uid}, '{DEF}', 2); return 'ok'")  # full 2 L
+            ok = send(f"return unit.depositToCargo({uid}, {bid}, '{DEF}')")
+            if ok.lower() == "true":
+                accepted += 1
+            else:
+                # remove the rejected canteen so it can't accumulate weight
+                send(f"unit.removeItem({uid}, '{DEF}'); return 'ok'")
+                break
+
+        stored = num(f"return building.getStorageWeight({bid})")
+        print(f"capacity      = {cap:.2f} kg")
+        print(f"canteens kept = {accepted}  (each full = ~2.2 kg real / ~0.2 kg base)")
+        print(f"stored weight = {stored:.2f} kg")
+
+        overfilled = stored is not None and stored > cap + 1e-3
+        if overfilled:
+            print(f"\nFAIL: cargo overfilled — stored {stored:.2f} > capacity {cap:.2f}")
+            print("      (base-weight pre-check let heavy instances slip past)")
+            return 1
+        print(f"\nPASS: stored {stored:.2f} kg <= capacity {cap:.2f} kg "
+              "(instance weight respected)")
+        return 0
+    finally:
+        try:
+            send("engine.quit(); return 'bye'", timeout=3)
+        except Exception:
+            pass
+        time.sleep(1)
+        if proc.poll() is None:
+            proc.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
`unit.depositToCargo` capacity-checked the building's remaining storage against the item definition's **base** weight (`idWeight itemDef`), while items already in storage are summed with `itemTotalWeight` — which recursively includes container fill and nested contents. A filled canteen or stocked kit (kilograms heavier than its def mean) could therefore pass the pre-check and overfill the cargo beyond `bdStorageCapacity`.

Fixes #189.

## Fix
The pre-check now peeks the first matching `ItemInstance` in the unit's inventory (the exact one the deposit will pop) and weighs it with the same `itemTotalWeight` measure used for the stored items. The check is now exact and consistent with how stored mass is accounted everywhere else.

`src/Engine/Scripting/Lua/API/Units.hs` — `unitDepositToCargoFn` pre-check.

## Verification
Added `tools/cargo_capacity_probe.py` — a headless regression guard:
- flat arena, one unit, one `cargo_hold_S` (capacity 200 kg);
- repeatedly gives the unit a full 2 L steel canteen (~2.2 kg real / ~0.2 kg base) and deposits it until rejected;
- asserts the cargo's stored weight never exceeds its capacity.

Result on this branch:
```
capacity      = 200.00 kg
canteens kept = 90  (each full = ~2.2 kg real / ~0.2 kg base)
stored weight = 198.00 kg
PASS: stored 198.00 kg <= capacity 200.00 kg (instance weight respected)
```

The loop stops one canteen earlier than the buggy code would (90 vs 91), precisely because the pre-check now counts 2.2 kg instead of 0.2 kg. Pre-fix the same probe overfills to ~200.2 kg.

## Scope note
This addresses only the capacity-accounting bug in #189. The separate rollback-on-failure data-loss race across the cross-manager transfer APIs is tracked in #190 and is left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)