### PR TITLE
Fix #194: clear unit_resources per-uid caches on save-load

### DIFF
--- a/scripts/unit_resources.lua
+++ b/scripts/unit_resources.lua
@@ -359,6 +359,24 @@ end
 -----------------------------------------------------------
 function unitResources.init(scriptId)
     engine.logInfo("Unit resources tick initializing...")
+    -- Save hook: this module keeps two uid-keyed caches —
+    -- `unitAlertState` (starvation/dehydration warning debounce) and
+    -- `droppedSlots` (one-shot disabled-hand drop suppression). Both
+    -- are transient debounce state with nothing worth persisting, so
+    -- we register NO serializer (no blob is written into the save).
+    -- The deserializer is what matters: a load replaces unitManagerRef
+    -- from the snapshot and can rewind umNextId, so the same uid can be
+    -- reused by a different unit. Clearing the caches on every load
+    -- (deserializeAll invokes registered deserializers with a nil blob
+    -- when no blob is present) prevents stale suppression state from
+    -- attaching to a reused id. We clear IN-PLACE because the tables
+    -- are upvalues captured by checkSurvivalAlerts / emitDeathAlert /
+    -- dropDisabledHandWeapons; reassigning would orphan those closures.
+    local saveMods = require("scripts.lib.save_modules")
+    saveMods.register("unit_resources", nil, function(_blob)
+        for k in pairs(unitAlertState) do unitAlertState[k] = nil end
+        for k in pairs(droppedSlots)   do droppedSlots[k]   = nil end
+    end)
 end
 
 -----------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes #194. `scripts/unit_resources.lua` kept two uid-keyed caches with no load/reset hook:
- `unitAlertState` — starvation/dehydration warning debounce
- `droppedSlots` — one-shot disabled-hand drop suppression

A save load replaces `unitManagerRef` from the `UnitSnapshot` and can rewind `umNextId`, so an id from the pre-load world can be reused by a different loaded unit, which then inherits stale suppression state (a starving unit whose warning is silently debounced, or a unit that never re-drops a disabled-hand weapon).

## Fix
Register the module with `scripts.lib.save_modules` in `unitResources.init`. The load path (`restoreLuaBlobs` → `deserializeAll`) walks the registry and invokes every registered deserializer — including with a `nil` blob when no blob is present — so the caches are cleared on **every** load.

- These caches are transient debounce state with nothing worth persisting, so **no serializer** is registered (no blob is written into the save).
- The deserializer clears **in-place** (`for k in pairs(t) do t[k]=nil end`) because both tables are upvalues captured by `checkSurvivalAlerts` / `emitDeathAlert` / `dropDisabledHandWeapons`; reassigning would orphan those closures. This matches the existing pattern in `unit_ai` / `building_spawn`.

## Testing
Lua-only change; verified headless (running the built binary with the worktree as cwd):
1. `unit_resources` registers with `save_modules` (`registry.unit_resources` present).
2. `deserializeAll({})` runs without error.
3. With both caches populated, invoking the registered deserializer empties them (`before=true cleared=true`), confirmed by upvalue inspection of the live closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)