### PR TITLE
Re-drop weapons re-equipped into a disabled hand (#193)

### DIFF
--- a/scripts/unit_resources.lua
+++ b/scripts/unit_resources.lua
@@ -256,15 +256,6 @@ local function unitCoords(info)
     return math.floor(info.gridX or 0), math.floor(info.gridY or 0)
 end
 
--- uid:slot we've already emptied by a disabling injury (drop a maimed
--- hand's weapon exactly once). Declared here so emitDeathAlert can clear
--- it on death; populated by dropDisabledHandWeapons below.
-local droppedSlots = {}
-local function clearDropState(uid)
-    droppedSlots[uid .. ":left_hand"]  = nil
-    droppedSlots[uid .. ":right_hand"] = nil
-end
-
 -- `channel` is optional: pass "injury" for a WOUND-caused death (it also
 -- lands in the injury/medical log). Pure survival deaths (starvation /
 -- thirst) omit it and stay event-only — they aren't injuries.
@@ -290,7 +281,6 @@ local function emitDeathAlert(uid, cause, channel)
     -- the same uid (engine reassigns ids on destroy/spawn) doesn't
     -- inherit stale state.
     unitAlertState[uid] = nil
-    clearDropState(uid)
 end
 
 local function emitWarningAlert(uid, info, msg)
@@ -743,8 +733,16 @@ end
 -----------------------------------------------------------
 local GRIP_DISABLERS = { hand = true, palm = true, forearm = true, arm = true }
 local HAND_SLOT = { ["l_"] = "left_hand", ["r_"] = "right_hand" }
--- (droppedSlots + clearDropState are declared above emitDeathAlert.)
 
+-- Drop the weapon held in any grip slot that a disabling wound has
+-- maimed. This runs every injury tick and is self-correcting: the drop
+-- only fires when a weapon is actually present (dropEquipmentToGround
+-- returns false on an empty slot, and reads/writes the same unit
+-- instance the loadout query does), so an emptied hand no-ops on
+-- subsequent ticks. A weapon re-equipped into the still-disabled slot
+-- later is dropped again — there is no one-shot guard to suppress it
+-- (issue #193: a stale per-slot flag used to let a re-equipped weapon
+-- stay in a severed hand forever).
 local function dropDisabledHandWeapons(uid)
     local ws = unit.getWounds(uid)
     if type(ws) ~= "table" then return end
@@ -756,27 +754,21 @@ local function dropDisabledHandWeapons(uid)
             local disabling = GRIP_DISABLERS[tokn]
                 and (w.kind == "severed"
                      or (w.kind == "fracture" and (w.severity or 0) >= 0.85))
-            local key = uid .. ":" .. slot
-            if disabling and not droppedSlots[key] then
+            if disabling then
                 local lo   = equipment.getLoadout(uid)
                 local held = lo and lo[slot]
-                if held then
-                    if unit.dropEquipmentToGround(uid, slot) then
-                        droppedSlots[key] = true
-                        local info = unit.getInfo(uid)
-                        if info then
-                            local gx, gy = unitCoords(info)
-                            local msg = unitLabel(info) .. " drops "
-                                .. (held.displayName or held.defName or "a weapon")
-                            if gx and gy then
-                                engine.emitEventForUnit("unit_event", msg, uid, gx, gy)
-                            else
-                                engine.emitEventForUnit("unit_event", msg, uid)
-                            end
+                if held and unit.dropEquipmentToGround(uid, slot) then
+                    local info = unit.getInfo(uid)
+                    if info then
+                        local gx, gy = unitCoords(info)
+                        local msg = unitLabel(info) .. " drops "
+                            .. (held.displayName or held.defName or "a weapon")
+                        if gx and gy then
+                            engine.emitEventForUnit("unit_event", msg, uid, gx, gy)
+                        else
+                            engine.emitEventForUnit("unit_event", msg, uid)
                         end
                     end
-                else
-                    droppedSlots[key] = true          -- nothing to drop; stop rechecking
                 end
             end
         end

--- a/tools/disarm_probe.py
+++ b/tools/disarm_probe.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Headless probe for issue #193: disabled-hand auto-drop must re-fire.
+
+A weapon held in a severed/maimed grip slot should be auto-dropped on
+the injury tick. The bug: a one-shot guard dropped it exactly once, so a
+weapon RE-EQUIPPED into the same still-disabled hand afterward was never
+dropped again. This probe verifies BOTH the first drop and the re-drop.
+"""
+from __future__ import annotations
+import glob, socket, subprocess, sys, time
+
+PORT = 9193
+LOG = "/tmp/disarm_probe_engine.log"
+
+
+def send(lua: str, timeout: float = 10.0) -> str:
+    with socket.create_connection(("localhost", PORT), timeout=timeout) as s:
+        s.sendall((lua + "\n").encode())
+        chunks = []
+        s.settimeout(0.3)
+        try:
+            while True:
+                b = s.recv(4096)
+                if not b:
+                    break
+                chunks.append(b)
+        except socket.timeout:
+            pass
+    out = b"".join(chunks).decode(errors="replace")
+    results = [ln[2:].strip() for ln in out.splitlines() if ln.startswith("> ")]
+    results = [r for r in results if r]
+    return results[-1] if results else out.strip()
+
+
+def boot() -> subprocess.Popen:
+    log = open(LOG, "w")
+    proc = subprocess.Popen(
+        ["cabal", "run", "-v0", "exe:synarchy", "--", "--headless", "--port", str(PORT)],
+        stdout=log, stderr=subprocess.STDOUT,
+    )
+    deadline = time.time() + 240
+    while time.time() < deadline:
+        try:
+            if "READY" in open(LOG).read():
+                return proc
+        except FileNotFoundError:
+            pass
+        if proc.poll() is not None:
+            sys.exit(f"engine exited before READY; see {LOG}")
+        time.sleep(0.4)
+    proc.kill()
+    sys.exit("engine never printed READY")
+
+
+def bootstrap():
+    loaders = [
+        ("data/substances/*.yaml", "engine.loadSubstanceYaml"),
+        ("data/items/*.yaml",      "engine.loadItemYaml"),
+        ("data/equipment/*.yaml",  "engine.loadEquipmentYaml"),
+        ("data/materials/*.yaml",  "engine.loadMaterialYaml"),
+        ("data/units/*.yaml",      "engine.loadUnitYaml"),
+    ]
+    for pattern, fn in loaders:
+        for path in sorted(glob.glob(pattern)):
+            send(f"{fn}('{path}'); return 'ok'")
+    for script, dt in [("unit_stats", 0.1), ("unit_resources", 0.2), ("unit_ai", 0.1)]:
+        send(f"engine.loadScript('scripts/{script}.lua', {dt}); return 'ok'")
+
+
+def find_flat():
+    lua = (
+        "local function f() for gy=-8,8 do for gx=-8,8 do "
+        "local z=world.getTerrainAt(gx,gy) local fl=world.getFluidAt(gx,gy) "
+        "if z and not fl then return gx..','..gy..','..z end end end return 'none' end return f()"
+    )
+    for _ in range(8):
+        res = send(lua).strip('"')
+        if res and res != "none" and res.count(",") == 2:
+            return tuple(int(v) for v in res.split(","))
+        time.sleep(0.75)
+    return None
+
+
+def held_right(uid: int) -> str:
+    r = send(f"local lo=equipment.getLoadout({uid}); local h=lo and lo['right_hand']; "
+             f"return h and (h.defName or 'yes') or 'EMPTY'")
+    return r.strip('"')
+
+
+def main() -> int:
+    proc = boot()
+    try:
+        bootstrap()
+        send("world.init('arena', 42, 64, 3); return 'ok'")
+        send("return world.waitForInit(180)", timeout=190)
+        send("world.show('arena'); return 'ok'")
+        send("return world.loadChunksInRegion(-1,-1,1,1)")
+        send("return world.waitForChunks(120)", timeout=125)
+
+        flat = find_flat()
+        if not flat:
+            print("FAIL: no flat dry ground", file=sys.stderr); return 2
+        gx, gy, z = flat
+        uid = int(float(send(f"return unit.spawn('acolyte', {gx}, {gy})")))
+        print(f"spawned acolyte #{uid} at ({gx},{gy}) z={z}")
+        time.sleep(1.0)
+
+        def arm():
+            send(f"unit.addItem({uid}, 'steel_dagger'); return 'ok'")
+            return send(f"return equipment.equip({uid}, 'right_hand', 'steel_dagger')").strip()
+
+        def ground_daggers():
+            r = send("local n=0; for _,it in ipairs(item.listGround() or {}) do "
+                     "if (it.defName or '')=='steel_dagger' then n=n+1 end end; return n")
+            try:
+                return int(float(r))
+            except ValueError:
+                return -1
+
+        def wait_empty(timeout=8.0):
+            """Poll until right_hand is empty (the weapon got dropped)."""
+            deadline = time.time() + timeout
+            while time.time() < deadline:
+                if held_right(uid) == "EMPTY":
+                    return True
+                time.sleep(0.3)
+            return False
+
+        base_ground = ground_daggers()
+        print(f"ground daggers (baseline): {base_ground}")
+
+        # Phase 1: equip a dagger, sever the hand, expect the first drop.
+        eq1 = arm()
+        print(f"phase1: equip()={eq1}, right_hand = {held_right(uid)}")
+        send(f"return unit.injure({uid}, 'r_hand', 'severed', 1.0)")
+        print("phase1: severed r_hand")
+        p1 = wait_empty()
+        g1 = ground_daggers()
+        print(f"  first drop: right_hand empty={p1}, ground daggers={g1}")
+        p1 = p1 and g1 == base_ground + 1
+
+        # Phase 2: re-equip into the SAME still-severed hand. equip() must
+        # succeed (the engine doesn't block equipping a maimed hand), and
+        # the next injury tick must drop it AGAIN — the #193 fix. With the
+        # old one-shot guard, equip()==true but the dagger stays held and
+        # the ground count never increments a second time.
+        eq2 = arm()
+        print(f"phase2: equip()={eq2}")
+        if eq2 != "true":
+            print("INCONCLUSIVE: re-equip into severed hand was rejected "
+                  f"(equip returned {eq2}); can't exercise the re-drop path",
+                  file=sys.stderr)
+            return 3
+        p2 = wait_empty()
+        g2 = ground_daggers()
+        print(f"  re-drop: right_hand empty={p2}, ground daggers={g2}")
+        p2 = p2 and g2 == base_ground + 2
+
+        print("\n--- result ---")
+        print(f"  first drop : {'PASS' if p1 else 'FAIL'}")
+        print(f"  re-drop    : {'PASS' if p2 else 'FAIL'}  (issue #193)")
+        return 0 if (p1 and p2) else 1
+    finally:
+        try:
+            send("engine.quit()", timeout=2)
+        except OSError:
+            pass
+        time.sleep(1)
+        if proc.poll() is None:
+            proc.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #193.

## Problem
`dropDisabledHandWeapons()` (`scripts/unit_resources.lua`) guarded each `(uid, slot)` with a one-shot `droppedSlots` flag that only cleared on death. Since `equipment.equip()` does not block a maimed grip slot, a weapon re-equipped into a severed/fractured hand after the first auto-drop was never dropped again — the flag suppressed every future drop in that slot until the unit died.

## Fix
Remove the one-shot guard entirely. The drop is naturally idempotent:
- `dropEquipmentToGround` returns false on an empty slot and mutates the **same** unit instance that `equipment.getLoadout` reads, so an emptied hand no-ops on subsequent ticks.
- A weapon re-equipped into the still-disabled slot is dropped again on the next injury tick.
- The "drops X" event is gated on a *successful* drop, so there is no event spam.

Also removes the now-dead `clearDropState()` and its death-path call.

## Testing
Added `tools/disarm_probe.py` (headless regression probe). It equips a dagger into a hand, severs it, asserts the first drop, then re-equips into the **still-severed** hand and asserts the re-drop, verifying via ground-item conservation:

```
ground daggers (baseline): 0
phase1: equip()=true, right_hand = steel_dagger
phase1: severed r_hand
  first drop: right_hand empty=True, ground daggers=1
phase2: equip()=true
  re-drop: right_hand empty=True, ground daggers=2
--- result ---
  first drop : PASS
  re-drop    : PASS  (issue #193)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)