### PR TITLE
Fix #198: scope build-tool visibility to the active world

### DIFF
--- a/scripts/build_tool.lua
+++ b/scripts/build_tool.lua
@@ -100,17 +100,12 @@ end
 -- Visibility helpers
 -----------------------------------------------------------
 
--- Parse building.list() into an array of placed building ids. Same
--- shape used by building_spawn.lua's getAllBuildingIds — duplicated
--- here to avoid a cross-module require for one regex.
+-- Active-world placed building ids. building.list() is global across
+-- every live world page, so buildings on hidden/off-world pages used to
+-- pollute this world's build-menu visibility (#198). building.getActiveIds()
+-- is scoped to the active page, matching unit.getAllIds.
 local function getAllBuildingIds()
-    local s = building.list()
-    if not s or s == "No buildings placed" then return {} end
-    local ids = {}
-    for id in s:gmatch("id=(%d+)") do
-        table.insert(ids, tonumber(id))
-    end
-    return ids
+    return building.getActiveIds() or {}
 end
 
 -- Computes which defs the player should currently see in the build

--- a/src/Engine/Scripting/Lua/API.hs
+++ b/src/Engine/Scripting/Lua/API.hs
@@ -372,6 +372,7 @@ registerLuaAPI lst env backendState = Lua.runWith lst $ do
   registerLuaFunction "getInfo"             (buildingGetInfoFn env)
   registerLuaFunction "getActivity"         (buildingGetActivityFn env)
   registerLuaFunction "list"                (buildingListFn env)
+  registerLuaFunction "getActiveIds"        (buildingGetActiveIdsFn env)
   registerLuaFunction "listDefs"            (buildingListDefsFn env)
   registerLuaFunction "hitTestAt"           (buildingHitTestAtFn env)
   registerLuaFunction "select"              (buildingSelectFn env)

--- a/src/Engine/Scripting/Lua/API/Buildings.hs
+++ b/src/Engine/Scripting/Lua/API/Buildings.hs
@@ -10,6 +10,7 @@ module Engine.Scripting.Lua.API.Buildings
     , buildingGetInfoFn
     , buildingGetActivityFn
     , buildingListFn
+    , buildingGetActiveIdsFn
     , buildingListDefsFn
     , buildingHitTestAtFn
     , buildingSelectFn
@@ -749,6 +750,26 @@ buildingListFn env = do
                 <> ", " <> T.pack (show (biGridZ inst)) <> ")"
             ) entries
     Lua.pushstring (TE.encodeUtf8 (T.pack result))
+    return 1
+
+-- | building.getActiveIds() — Lua array of every live building's integer
+--   id, scoped to the ACTIVE world page. The world-scoping boundary for
+--   per-tick iteration so a building in another live world never leaks
+--   into the current one (#198), mirroring unit.getAllIds (#78). Empty
+--   when no world is active. Scripts should prefer this over parsing the
+--   global, page-agnostic building.list when they iterate gameplay.
+buildingGetActiveIdsFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+buildingGetActiveIdsFn env = do
+    ids ← Lua.liftIO $ do
+        bm ← readIORef (buildingManagerRef env)
+        mActive ← activeWorldPage env
+        pure $ case mActive of
+            Just (pid, _) → HM.keys (buildingsOnPage pid (bmInstances bm))
+            Nothing       → []
+    Lua.newtable
+    forM_ (zip [1 ∷ Int ..] ids) $ \(i, bid) → do
+        Lua.pushinteger (fromIntegral (unBuildingId bid))
+        Lua.rawseti (-2) (fromIntegral i)
     return 1
 
 -- | building.listDefs() — Lua array of tables, one per registered


### PR DESCRIPTION
## Summary
`build_tool.visibleDefs()` computed the build menu's visibility from `building.list()`, which enumerates **every** building in the global `BuildingManager` with no world-page filter. Buildings placed on hidden/off-world pages could therefore hide or unlock build options in the currently active world (#198).

## Fix
- Add `building.getActiveIds()` — a page-scoped accessor that returns building ids on the **active** world page, mirroring the existing `unit.getAllIds()` (#78). It uses the same `buildingsOnPage`/`activeWorldPage` filter already relied on by `building.select` / `getSelected` / `canPlaceAt` / `spawn` (#76), so it cannot diverge from the rest of the world-scoping boundary.
- `build_tool.lua`'s `getAllBuildingIds()` now calls `building.getActiveIds()` instead of regex-parsing the global `building.list()` string.

Purely additive on the engine side; the Lua change is a one-function swap.

## Verification
- `cabal build all` clean.
- Headless probe: `building.getActiveIds()` is registered, returns `{}` when no world is active, and returns the active world's building (`n=1`) after a clean spawn. It agrees with the canonical `building.getSelected` page filter in every state probed.
- `cabal test synarchy-test-headless`: **319 examples, 0 failures**.

## Notes
This is one of a cluster of issues (#196, #197, #198) sharing the root cause that `building.list()` is page-agnostic while `unit.getAllIds()` is scoped. This PR fixes only the build-tool visibility path (#198); the new `building.getActiveIds()` accessor is reusable by the `building_spawn`/`unit_ai` fixes for #196/#197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)