### PR TITLE
Fix #197: scope unit_ai building target finders to the active world

### DIFF
--- a/scripts/unit_ai.lua
+++ b/scripts/unit_ai.lua
@@ -1996,11 +1996,14 @@ local function remainingUnclaimedNeed(bid, matType, need, delivered, excludeUid)
 end
 
 local function findDeliveryTarget(uid, fromX, fromY, params)
-    local listStr = building.list()
-    if not listStr or listStr == "No buildings placed" then return nil end
+    -- Active-world buildings only — building.list() is global across every
+    -- live world page, so off-world buildings used to leak in as delivery
+    -- targets (#197). building.getActiveIds() is page-scoped, matching the
+    -- active-world unit.getAllIds the actors come from.
+    local ids = building.getActiveIds()
+    if not ids or #ids == 0 then return nil end
     local best, bestD = nil, params.deliver_scan_range
-    for id in listStr:gmatch("id=(%d+)") do
-        local bid = tonumber(id)
+    for _, bid in ipairs(ids) do
         if bid and building.getActivity(bid) == "appearing"
            and not building.areMaterialsSatisfied(bid) then
             local need      = building.getMaterialNeed(bid) or {}
@@ -2233,11 +2236,11 @@ end
 -- at least one more item (current weight < capacity). Returns
 -- {bid, gridX, gridY, tileW, tileH, distance} or nil.
 local function findStorageTarget(fromX, fromY, maxRange)
-    local listStr = building.list()
-    if not listStr or listStr == "No buildings placed" then return nil end
+    -- Active-world buildings only (#197); see findDeliveryTarget.
+    local ids = building.getActiveIds()
+    if not ids or #ids == 0 then return nil end
     local best, bestD = nil, maxRange
-    for id in listStr:gmatch("id=(%d+)") do
-        local bid = tonumber(id)
+    for _, bid in ipairs(ids) do
         if bid and building.getActivity(bid) == "built" then
             local cap = building.getStorageCapacity(bid)
             local used = building.getStorageWeight(bid) or 0
@@ -2361,14 +2364,14 @@ end
 
 -- Returns {bid, gridX, gridY, tileW, tileH, distance} for the
 -- nearest Appearing building with bdBuildWork > 0 within maxRange,
--- or nil. Uses building.list() / getActivity / getBuildRequired /
+-- or nil. Uses building.getActiveIds() / getActivity / getBuildRequired /
 -- getInfo — all cheap on a small N of placed buildings.
 local function findNearestUnbuilt(fromX, fromY, maxRange)
-    local listStr = building.list()
-    if not listStr or listStr == "No buildings placed" then return nil end
+    -- Active-world buildings only (#197); see findDeliveryTarget.
+    local ids = building.getActiveIds()
+    if not ids or #ids == 0 then return nil end
     local best, bestD = nil, maxRange
-    for id in listStr:gmatch("id=(%d+)") do
-        local bid = tonumber(id)
+    for _, bid in ipairs(ids) do
         if bid then
             local activity = building.getActivity(bid)
             local required = building.getBuildRequired(bid)


### PR DESCRIPTION
## Summary
`scripts/unit_ai.lua`'s building-target finders selected candidates by parsing `building.list()`, which enumerates **all** buildings in the global `BuildingManager` with no world-page filter. The actors driving these finders come from `unit.getAllIds()`, which **is** active-page scoped — so active-world units could target hidden/off-world buildings for delivery, storage, and nearby-build work (cross-world leakage).

## Fix
Switch all three finders from `building.list()` to `building.getActiveIds()` — the page-scoped accessor added for #198 (build_tool), itself mirroring `unit.getAllIds` (#78). Targeting now only considers buildings on the actors' own world page.

- `findDeliveryTarget` (`unit_ai.lua:1998`)
- `findStorageTarget` (`unit_ai.lua:2235`)
- `findNearestUnbuilt` (`unit_ai.lua:2366`)

The loop bodies are otherwise unchanged (same `getActivity`/`getInfo`/`getMaterialNeed` resolution per `bid`).

Lua-only change; no engine code touched.

## Verification (headless)
With one `cargo_hold_S` placed on each of two arena pages:
- active page's `building.getActiveIds()` → **1** (only its own building), while global `building.list()` → **2**
- switching the active page tracks correctly (active = wa → 1, active = wb → 1)
- `unit_ai` loads clean; no Lua errors in the engine log

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)