### PR TITLE
Fix #182: gate gameplay key handlers when a menu/overlay is open

### DIFF
--- a/scripts/init.lua
+++ b/scripts/init.lua
@@ -766,6 +766,18 @@ function game.onMouseUp(button, x, y, downRoute)
 end
 
 function game.onKeyDown(key)
+    -- Don't run gameplay key handlers while a menu/overlay is up (#182).
+    -- Menus and overlays don't establish UI focus, so the input thread
+    -- stays in the generic game-keydown path and broadcasts every key to
+    -- all Lua modules — including this one. Gate here on the active view
+    -- so menu-open presses (Space pause-toggle, L log-toggle, build/mine
+    -- Escape, selection-clear, etc.) can't reach the world underneath.
+    -- Menu-level Escape still works: it's handled by uiManager.onUIEscape
+    -- on a separate broadcast that this gate doesn't touch.
+    if not require("scripts.ui_manager").isGameplayInputActive() then
+        return
+    end
+
     -- Space toggles pause first — works regardless of tool mode or
     -- selection state, and shouldn't be eaten by a tool's local
     -- handler.

--- a/scripts/ui_manager.lua
+++ b/scripts/ui_manager.lua
@@ -1,5 +1,14 @@
 -- UI Manager - coordinates all UI pages
-local uiManager = {}
+--
+-- Singleton via package.loaded so a require() (e.g. game.onKeyDown's
+-- isGameplayInputActive gate, #182) sees the SAME instance the engine
+-- loadScript'd and broadcasts to. engine.loadScript uses dofile, which
+-- does not populate package.loaded; without this self-registration a
+-- require would re-execute the file as a fresh module (currentMenu reset
+-- to "main") with its own disconnected state. Init loadScripts this
+-- module last, so the dofile instance is the live one require resolves.
+local uiManager = package.loaded["scripts.ui_manager"] or {}
+package.loaded["scripts.ui_manager"] = uiManager
 
 local boxTextures = require("scripts.ui.box_textures")
 local boxTexSet = nil
@@ -1502,6 +1511,25 @@ end
 -----------------------------------------------------------
 -- Key Input Forwarding
 -----------------------------------------------------------
+
+-- True only when the player is in a gameplay view with no blocking
+-- menu/overlay on top. Gameplay key handlers (init.lua game.onKeyDown)
+-- gate on this (#182): ordinary menus/overlays don't take UI focus, so
+-- the input thread can't divert keys away from gameplay for us — keys
+-- still broadcast to every Lua module. currentMenu is the authoritative
+-- view, and the pause menu is an overlay shown while currentMenu stays
+-- world_view/test_arena_view, so it has to be checked explicitly.
+-- Menu-level keys (e.g. Escape closing a menu) are unaffected: they go
+-- through uiManager.onUIEscape, a separate broadcast.
+function uiManager.isGameplayInputActive()
+    if currentMenu ~= "world_view" and currentMenu ~= "test_arena_view" then
+        return false
+    end
+    if pauseMenu and pauseMenu.visible then
+        return false
+    end
+    return true
+end
 
 function uiManager.onKeyDown(key)
     if key == "F7" then


### PR DESCRIPTION
Closes #182.

## Problem
Gameplay `onKeyDown` handlers still ran while an ordinary menu/settings overlay was open if no text-input widget had UI focus. Menu buttons/toggles/sliders never establish focus, so the input thread stayed in the generic `(GameInputMode, Nothing)` path (`src/Engine/Input/Thread.hs:177-190`) and broadcast every key to all Lua modules — including `game.onKeyDown` in `scripts/init.lua`. Menu-open presses could therefore toggle pause (`Space`), toggle the log (`L`), cancel build/mine placement, or clear selection on the world underneath.

## Fix
- Add `uiManager.isGameplayInputActive()` — true only in a gameplay view (`world_view` / `test_arena_view`) with no pause-menu overlay up. The settings overlay switches `currentMenu` to `"settings"`; the pause menu is an overlay shown while `currentMenu` stays on the gameplay view, so both cases are covered.
- `game.onKeyDown` early-returns when it's false.
- Make `ui_manager.lua` a `package.loaded` singleton so `game.onKeyDown`'s `require()` resolves the **same** instance the engine `loadScript`'d and broadcasts to. `engine.loadScript` uses `dofile`, which doesn't populate `package.loaded`; without self-registration the `require` would re-execute the file as a fresh module (resetting `currentMenu` to `"main"`) and the gate would block gameplay keys permanently. Mirrors the existing `pause.lua` / `popup.lua` singleton pattern.

## What is intentionally unaffected
- **Menu-level Escape** still works — it's handled by `uiManager.onUIEscape` on a separate broadcast this gate doesn't touch (settings → back, world_view → open pause menu, etc.).
- **In-world transient popups** (cargo inventory, item-contents, context menu) stay reachable: they keep `currentMenu` on the gameplay view, so their Escape handling in `game.onKeyDown` still runs.
- The mouse equivalent (blank menu clicks reaching gameplay) is a separate issue (#154) and is not touched here.
- Debug overlay key handling (debug.lua) is left to #148/#151/#152.

## Testing
- `luajit -bl` syntax check on both files — clean.
- Standalone luajit harness modeling the exact `dofile`(broadcast) + `require`(gate) singleton split: proves `require` returns the same instance and the predicate returns the correct value across all states (main / settings overlay / world_view / world_view+pause / test_arena_view / save_browser).
- Real engine boot (headless): `package.loaded["scripts.ui_manager"]` is set, `isGameplayInputActive` resolves and returns the correct default (`false` outside a gameplay view); no Lua errors during script load; clean shutdown.

⚠️ The end-to-end interaction (open a menu in-game, press a gameplay key, confirm the world is untouched) is GUI-only — menus/the loading screen don't run headless — so a quick in-game visual confirmation is worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)