### PR TITLE
Fix #191: merge restored page into global managers on load

### DIFF
--- a/src/World/Thread/Command/Save.hs
+++ b/src/World/Thread/Command/Save.hs
@@ -345,12 +345,29 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
             -- pages' buildings intact — a wholesale write dropped them.
             offPage = HM.difference (bmInstances currentBm)
                                     (buildingsOnPage pageId (bmInstances currentBm))
+            -- An off-page id that collides with a restored (loaded-page)
+            -- id can't share the global map: the loaded save wins and the
+            -- off-page building is dropped. Unreachable in normal play
+            -- (one global id counter per session keeps live ids disjoint);
+            -- only a cross-session load of an *older* save can hit it.
+            -- Logged below so it's diagnosable, not silent. Full
+            -- resolution needs re-keying (breaks Lua per-id blobs) — that
+            -- lands with epic #214 / #218.
+            collidingB = HM.intersection offPage (bmInstances restored)
             merged  = restored
                 { bmInstances = HM.union (bmInstances restored) offPage
                 -- Don't let the saved counter reuse an off-page id.
                 , bmNextId    = max (bmNextId restored) (bmNextId currentBm)
                 }
         writeIORef (buildingManagerRef env) merged
+        case HM.size collidingB of
+            0 → pure ()
+            n → logWarn logger CatWorld $
+                    "Save load: " <> T.pack (show n)
+                    <> " off-page building id(s) collided with the loaded "
+                    <> "page and were dropped (ids: "
+                    <> T.pack (show (map unBuildingId (HM.keys collidingB)))
+                    <> ") — see #214"
         forM_ orphans $ \bid →
             logWarn logger CatWorld $
                 "Save load: dropping building id="
@@ -395,6 +412,10 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
             offPageU    = HM.difference (umInstances currentUm)
                                         (unitsOnPage pageId (umInstances currentUm))
             offPageUids = HM.keysSet offPageU
+            -- Same collision caveat as buildings above: a colliding
+            -- off-page unit id loses to the loaded save and is dropped
+            -- (logged below). Cross-session-old-save only; resolved by #214.
+            collidingU  = HM.intersection offPageU (umInstances restoredUm)
             mergedUm    = restoredUm
                 { umInstances = HM.union (umInstances restoredUm) offPageU
                 -- Don't let the saved counter reuse an off-page id.
@@ -406,6 +427,14 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
             let keptSim = HM.filterWithKey (\uid _ → uid `HS.member` offPageUids)
                                            (utsSimStates old)
             in (UnitThreadState { utsSimStates = HM.union simStates' keptSim }, ())
+        case HM.size collidingU of
+            0 → pure ()
+            n → logWarn logger CatWorld $
+                    "Save load: " <> T.pack (show n)
+                    <> " off-page unit id(s) collided with the loaded "
+                    <> "page and were dropped (ids: "
+                    <> T.pack (show (map unUnitId (HM.keys collidingU)))
+                    <> ") — see #214"
         forM_ orphanUnits $ \uid →
             logWarn logger CatWorld $
                 "Save load: dropping unit id="

--- a/src/World/Thread/Command/Save.hs
+++ b/src/World/Thread/Command/Save.hs
@@ -38,7 +38,7 @@ import World.Save.Types (toBuildingSnapshot, fromBuildingSnapshot
                         , toUnitSnapshot, fromUnitSnapshot)
 import World.Edit.Apply (replayEdits)
 import World.Mine.Apply (applyDigSlopes)
-import Building.Types (BuildingManager(..), unBuildingId)
+import Building.Types (BuildingManager(..), unBuildingId, buildingsOnPage)
 import Unit.Types (UnitManager(..), unUnitId, unitsOnPage)
 import Unit.Sim.Types (UnitThreadState(..))
 import World.Weather (initEarlyClimate, formatWeather, defaultClimateParams)
@@ -340,7 +340,17 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
         currentBm ← readIORef (buildingManagerRef env)
         let (restored, orphans) =
                 fromBuildingSnapshot pageId (bmDefs currentBm) (sdBuildings saveData)
-        writeIORef (buildingManagerRef env) restored
+            -- #191: the snapshot owns only THIS page. Replace just this
+            -- page's slice of the global manager and keep other live
+            -- pages' buildings intact — a wholesale write dropped them.
+            offPage = HM.difference (bmInstances currentBm)
+                                    (buildingsOnPage pageId (bmInstances currentBm))
+            merged  = restored
+                { bmInstances = HM.union (bmInstances restored) offPage
+                -- Don't let the saved counter reuse an off-page id.
+                , bmNextId    = max (bmNextId restored) (bmNextId currentBm)
+                }
+        writeIORef (buildingManagerRef env) merged
         forM_ orphans $ \bid →
             logWarn logger CatWorld $
                 "Save load: dropping building id="
@@ -379,9 +389,23 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
             -- Drop sim states whose owning unit was orphaned.
             simStates' = HM.filterWithKey (\uid _ → uid `HS.member` liveUids)
                                           (sdUnitSimStates saveData)
-        writeIORef (unitManagerRef env) restoredUm
-        atomicModifyIORef' (utsRef env) $ \_ →
-            (UnitThreadState { utsSimStates = simStates' }, ())
+            -- #191: keep units (and their sim states) belonging to OTHER
+            -- live pages; replace only this page's slice of the global
+            -- manager. A wholesale write dropped off-page units.
+            offPageU    = HM.difference (umInstances currentUm)
+                                        (unitsOnPage pageId (umInstances currentUm))
+            offPageUids = HM.keysSet offPageU
+            mergedUm    = restoredUm
+                { umInstances = HM.union (umInstances restoredUm) offPageU
+                -- Don't let the saved counter reuse an off-page id.
+                , umNextId    = max (umNextId restoredUm) (umNextId currentUm)
+                }
+        writeIORef (unitManagerRef env) mergedUm
+        atomicModifyIORef' (utsRef env) $ \old →
+            -- Preserve off-page units' sim states; replace this page's.
+            let keptSim = HM.filterWithKey (\uid _ → uid `HS.member` offPageUids)
+                                           (utsSimStates old)
+            in (UnitThreadState { utsSimStates = HM.union simStates' keptSim }, ())
         forM_ orphanUnits $ \uid →
             logWarn logger CatWorld $
                 "Save load: dropping unit id="


### PR DESCRIPTION
## Summary
Closes #191. Loading a save into `main_world` was wiping units/buildings from any **other** live world page.

The entity managers (`buildingManagerRef`, `unitManagerRef`, `utsRef`) are **global across all pages**, but a save snapshots only the active page. The load handler wrote those page-scoped snapshots back **wholesale**:

```haskell
writeIORef (buildingManagerRef env) restored
writeIORef (unitManagerRef env) restoredUm
atomicModifyIORef' (utsRef env) $ \_ -> (UnitThreadState { utsSimStates = simStates' }, ())
```

so any secondary page (e.g. `test_arena`) lost all its entities while its `wmWorlds` entry survived.

## Fix
The load now replaces **only the loaded page's slice** of each global manager and leaves other pages intact (`src/World/Thread/Command/Save.hs`):
- Buildings/units: union the restored page's instances with the off-page instances (`HM.difference` vs the existing `buildingsOnPage`/`unitsOnPage` helpers); `nextId = max(saved, current)` so the saved counter can't reuse a live off-page id.
- Sim states: keep off-page units' sim states instead of replacing `utsSimStates` wholesale.

Load-side only — **no save-schema change, no version bump**.

### Residual note
A *saved* id colliding with a *live off-page* id can't be fully resolved without re-keying (which would break Lua per-id blobs, see #195). The `max` guard prevents any *future* collision, and the case is unreachable today (secondary worlds are unused in normal play). Full resolution is the all-worlds-save epic.

## Scope / tracking
Standalone fix under epic **#214** (single save persists all world pages). The general "merge across *all* saved pages" case lands with **#218**; this PR is the immediate data-loss stop.

## Verification
Headless repro: load defs, `world.init('main_world',...)` + a live `world.initArena('test_arena')`, spawn a unit on each page, `engine.saveWorld('main_world',...)` then `engine.loadSave(...)`.

```
before save -> main: YES  arena: YES
save: "saved"   load: "queued"
AFTER LOAD -> main: YES  arena: YES
RESULT: PASS (test_arena unit survived the load)
```

Engine log confirms the load actually executed (`Save:174 Loading save into world: main_world`) with no orphan drops. `lib:synarchy` + `exe:synarchy` build clean (prod profile). No save/load hspec specs exist; save/load is verified via headless probes per project convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)