### PR TITLE
Fix #213: remove dead arm in soilFromClimate hot+dry desert branch

### DIFF
--- a/src/World/Geology/Erosion.hs
+++ b/src/World/Geology/Erosion.hs
@@ -396,8 +396,7 @@ soilFromClimate temp precip humid snow _srcMat roll
 
     -- Hot + dry desert → transitional
     | temp > blur 25.0 ∧ precip < blur 0.3 =
-        if precip < blur 0.08 then 55          -- sand (hyper-arid)
-        else if precip < blur 0.15 then 55    -- sand (arid)
+        if precip < blur 0.15 then 55          -- sand (arid)
         else if precip < blur 0.2  then 54    -- loamy sand
         else if precip < blur 0.25 then 53    -- sandy loam
         else 52                                -- sandy clay loam


### PR DESCRIPTION
## Summary

Closes #213.

The hot+dry desert branch of `World.Geology.Erosion.soilFromClimate` had two threshold arms returning the **same** material (`55`, sand):

```haskell
if precip < blur 0.08 then 55          -- sand (hyper-arid)
else if precip < blur 0.15 then 55    -- sand (arid)
```

Because `blur` shifts every threshold by the same per-tile roll, any `precip` falling into the first arm (`< blur 0.08`) also satisfies the second (`< blur 0.15`), so the second arm was unreachable dead code.

Per maintainer decision, this collapses the two into a single arm rather than introducing a distinct hyper-arid material:

```haskell
if precip < blur 0.15 then 55          -- sand (arid)
```

## Behavior / testing

- **Provably output-identical** for every input (both arms returned `55`), so worldgen output is byte-identical — baselines do not move and **no `currentSaveVersion` bump** is needed.
- `cabal build lib:synarchy` — clean (352/352).
- `cabal test synarchy-test-headless --match "Geology"` — 6/6 pass.
- `cabal test synarchy-test-headless --match "Soil"` — 12/12 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)