### PR TITLE
Fix #195: prune orphaned per-id Lua state after save load

### DIFF
--- a/scripts/building_spawn.lua
+++ b/scripts/building_spawn.lua
@@ -255,13 +255,25 @@ end
 -- Broadcast from the engine once a save has finished loading (#195).
 -- The Lua spawn-state blob is restored before the engine load path runs,
 -- and that path can drop "orphan" buildings whose defs are no longer
--- registered. Reconcile here: drop any per-building state whose bid has
--- no live building. building.getInfo is GLOBAL (all world pages, nil when
--- gone), so buildings on other loaded-but-inactive pages are kept -- only
--- dropped ids are pruned, preventing a reused bid from inheriting stale
--- spawn-rate state.
-function buildingSpawn.onSaveLoaded()
+-- registered. The restored state still holds entries for those dropped
+-- ids, so a reused bid could inherit stale spawn-rate state.
+--
+-- The signature mirrors the broadcast (onSaveLoaded(orphanUnitIds,
+-- orphanBuildingIds)); this module only cares about buildings. We
+-- force-prune the exact dropped-building set FIRST -- this matters when an
+-- orphaned bid collides with a live off-page building of the same id: the
+-- restored blob state belongs to the dropped orphan, so a liveness check
+-- alone would wrongly keep it. Then we sweep any state whose bid has no
+-- live building. building.getInfo is GLOBAL (all world pages, nil when
+-- gone), so buildings on other loaded-but-inactive pages are kept.
+function buildingSpawn.onSaveLoaded(_orphanUnitIds, orphanBuildingIds)
     local pruned = 0
+    for _, bid in ipairs(orphanBuildingIds or {}) do
+        if state[bid] ~= nil then
+            state[bid] = nil
+            pruned = pruned + 1
+        end
+    end
     for bid in pairs(state) do
         if not building.getInfo(bid) then
             state[bid] = nil

--- a/scripts/building_spawn.lua
+++ b/scripts/building_spawn.lua
@@ -260,6 +260,11 @@ function buildingSpawn.init(scriptId)
             return saveLib.serialize(live)
         end,
         function(blob)
+            -- Snapshot the pre-load singleton BEFORE clobbering, so
+            -- onSaveLoaded can restore still-live OFF-PAGE buildings'
+            -- current state instead of the blob's stale copy (#195, #191).
+            buildingSpawn._preLoadState = {}
+            for k, v in pairs(state) do buildingSpawn._preLoadState[k] = v end
             local restored = saveLib.deserialize(blob) or {}
             for k in pairs(state) do state[k] = nil end
             for k, v in pairs(restored) do state[k] = v end
@@ -272,38 +277,42 @@ end
 -- registered. The restored state still holds entries for those dropped
 -- ids, so a reused bid could inherit stale spawn-rate state.
 --
--- The `state` table is a global singleton serialized WHOLESALE, so after a
--- load (cleared + repopulated from the blob, then the engine merge restores
--- the saved page's buildings and preserves other live pages' #191) it
--- legitimately holds both loaded-page entries and live OFF-PAGE buildings.
--- Signature mirrors the broadcast: four loaded-page sets (survivors +
--- orphans, units + buildings). Per top-level entry bid:
---   * survivor          → keep;
---   * loaded-page orphan → force-prune (a dropped bid can collide with a
---     live off-page building, so building.getInfo alone would mask it);
---   * otherwise          → keep iff a live off-page building, else prune.
--- The nested s.lastUid (last unit spawned, used for spawn-spacing) is
--- scrubbed only on loaded-page SURVIVOR entries, against the surviving unit
--- set, so a stale/colliding uid can't gate spawning. Off-page entries are
--- left untouched.
-function buildingSpawn.onSaveLoaded(survUnitIds, survBuildingIds,
-                                    orphanUnitIds, orphanBuildingIds)
+-- `state` is a global singleton serialized WHOLESALE; the restore clobbered
+-- it with save-time state for buildings on EVERY page, but the engine load
+-- only restores the saved page and preserves other live pages' buildings
+-- (#191). So a load must touch only the loaded page. We rebuild `state` as:
+--   * loaded-page survivor → its restored (blob) state;
+--   * every other still-live building → its PRE-LOAD state (the off-page
+--     building's CURRENT state, not the blob's stale snapshot) — so an
+--     older save can't roll back live off-page spawn-spacing state, and a
+--     stale/colliding bid resolves to the live building's own state;
+--   * everything else (orphans, dead, gone-before-save) → dropped.
+-- The nested s.lastUid (last unit spawned) is scrubbed on loaded-page
+-- survivor entries against the surviving unit set, so a stale/colliding uid
+-- can't gate spawning. Off-page entries keep their pre-load state.
+function buildingSpawn.onSaveLoaded(survUnitIds, survBuildingIds)
     local survUnitSet, survBuildingSet = {}, {}
-    local orphanBuildingSet = {}
-    for _, uid in ipairs(survUnitIds or {})       do survUnitSet[uid] = true end
-    for _, bid in ipairs(survBuildingIds or {})   do survBuildingSet[bid] = true end
-    for _, bid in ipairs(orphanBuildingIds or {}) do orphanBuildingSet[bid] = true end
+    for _, uid in ipairs(survUnitIds or {})     do survUnitSet[uid] = true end
+    for _, bid in ipairs(survBuildingIds or {}) do survBuildingSet[bid] = true end
 
-    local pruned = 0
-    for bid in pairs(state) do
-        if survBuildingSet[bid] then
-            -- loaded-page survivor: keep
-        elseif orphanBuildingSet[bid] or not building.getInfo(bid) then
-            state[bid] = nil
-            pruned = pruned + 1
-        end
-        -- else: live off-page building's state → keep
+    local pre = buildingSpawn._preLoadState or {}
+    buildingSpawn._preLoadState = nil
+    local blob = state   -- current contents = the just-restored blob
+
+    local rebuilt = {}
+    for bid in pairs(survBuildingSet) do
+        if blob[bid] ~= nil then rebuilt[bid] = blob[bid] end
     end
+    for bid, s in pairs(pre) do
+        if not survBuildingSet[bid] and building.getInfo(bid) then
+            rebuilt[bid] = s        -- live off-page building: keep current state
+        end
+    end
+
+    local kept = 0
+    for k in pairs(state) do state[k] = nil end
+    for k, v in pairs(rebuilt) do state[k] = v; kept = kept + 1 end
+
     local scrubbed = 0
     for bid, s in pairs(state) do
         if survBuildingSet[bid] and s.lastUid ~= nil
@@ -312,11 +321,8 @@ function buildingSpawn.onSaveLoaded(survUnitIds, survBuildingIds,
             scrubbed = scrubbed + 1
         end
     end
-    if pruned > 0 or scrubbed > 0 then
-        engine.logInfo("Building spawn: pruned " .. pruned
-            .. " stale state(s) and scrubbed " .. scrubbed
-            .. " stale reference(s) after load")
-    end
+    engine.logInfo("Building spawn: reconciled state after load ("
+        .. kept .. " kept, " .. scrubbed .. " stale ref(s) scrubbed)")
 end
 
 -- Construction progress curve. Solo workers build at 1× the base

--- a/scripts/building_spawn.lua
+++ b/scripts/building_spawn.lua
@@ -244,7 +244,21 @@ function buildingSpawn.init(scriptId)
     local saveLib  = require("scripts.lib.serialize")
     local saveMods = require("scripts.lib.save_modules")
     saveMods.register("building_spawn",
-        function() return saveLib.serialize(state) end,
+        function()
+            -- Serialize only LIVE buildings' state. `state` is a global
+            -- singleton that can retain entries for buildings destroyed
+            -- before the save; persisting those is unsafe, since on a later
+            -- cross-session load such a bid can collide with a live
+            -- off-page building and onSaveLoaded can't distinguish the
+            -- stale loaded-page leftover from legitimate off-page state.
+            -- building.getInfo is GLOBAL, so live buildings on every page
+            -- are still saved (#195).
+            local live = {}
+            for bid, s in pairs(state) do
+                if building.getInfo(bid) then live[bid] = s end
+            end
+            return saveLib.serialize(live)
+        end,
         function(blob)
             local restored = saveLib.deserialize(blob) or {}
             for k in pairs(state) do state[k] = nil end

--- a/scripts/building_spawn.lua
+++ b/scripts/building_spawn.lua
@@ -252,6 +252,28 @@ function buildingSpawn.init(scriptId)
         end)
 end
 
+-- Broadcast from the engine once a save has finished loading (#195).
+-- The Lua spawn-state blob is restored before the engine load path runs,
+-- and that path can drop "orphan" buildings whose defs are no longer
+-- registered. Reconcile here: drop any per-building state whose bid has
+-- no live building. building.getInfo is GLOBAL (all world pages, nil when
+-- gone), so buildings on other loaded-but-inactive pages are kept -- only
+-- dropped ids are pruned, preventing a reused bid from inheriting stale
+-- spawn-rate state.
+function buildingSpawn.onSaveLoaded()
+    local pruned = 0
+    for bid in pairs(state) do
+        if not building.getInfo(bid) then
+            state[bid] = nil
+            pruned = pruned + 1
+        end
+    end
+    if pruned > 0 then
+        engine.logInfo("Building spawn: pruned " .. pruned
+            .. " stale state(s) for buildings dropped on load")
+    end
+end
+
 -- Construction progress curve. Solo workers build at 1× the base
 -- rate (R(1)=1 worker-second per real second); coordination bonus
 -- ramps as n² up to 3 workers, then tapers logarithmically so the

--- a/scripts/building_spawn.lua
+++ b/scripts/building_spawn.lua
@@ -258,33 +258,42 @@ end
 -- registered. The restored state still holds entries for those dropped
 -- ids, so a reused bid could inherit stale spawn-rate state.
 --
--- The signature mirrors the broadcast (onSaveLoaded(liveUnitIds,
--- liveBuildingIds)) — the ids that SURVIVED on the loaded page. The
--- restore clobbers the singleton and repopulates from the loaded blob, so
--- `state` afterward holds only loaded-page bids; we treat the survivor
--- list as an allow-list and drop any state[bid] not in it. That covers
--- missing-def orphans, buildings gone before the save, and any bid now
--- colliding with a live off-page building (which the global building.getInfo
--- lookup would otherwise mask).
---
--- Surviving entries also embed a unit reference (s.lastUid, the last unit
--- spawned, used for spawn-spacing). Scrub it if that uid didn't survive on
--- the loaded page, so a colliding off-page unit can't gate spawning.
-function buildingSpawn.onSaveLoaded(liveUnitIds, liveBuildingIds)
-    local liveUnitSet, liveBuildingSet = {}, {}
-    for _, uid in ipairs(liveUnitIds or {})     do liveUnitSet[uid] = true end
-    for _, bid in ipairs(liveBuildingIds or {}) do liveBuildingSet[bid] = true end
+-- The `state` table is a global singleton serialized WHOLESALE, so after a
+-- load (cleared + repopulated from the blob, then the engine merge restores
+-- the saved page's buildings and preserves other live pages' #191) it
+-- legitimately holds both loaded-page entries and live OFF-PAGE buildings.
+-- Signature mirrors the broadcast: four loaded-page sets (survivors +
+-- orphans, units + buildings). Per top-level entry bid:
+--   * survivor          → keep;
+--   * loaded-page orphan → force-prune (a dropped bid can collide with a
+--     live off-page building, so building.getInfo alone would mask it);
+--   * otherwise          → keep iff a live off-page building, else prune.
+-- The nested s.lastUid (last unit spawned, used for spawn-spacing) is
+-- scrubbed only on loaded-page SURVIVOR entries, against the surviving unit
+-- set, so a stale/colliding uid can't gate spawning. Off-page entries are
+-- left untouched.
+function buildingSpawn.onSaveLoaded(survUnitIds, survBuildingIds,
+                                    orphanUnitIds, orphanBuildingIds)
+    local survUnitSet, survBuildingSet = {}, {}
+    local orphanBuildingSet = {}
+    for _, uid in ipairs(survUnitIds or {})       do survUnitSet[uid] = true end
+    for _, bid in ipairs(survBuildingIds or {})   do survBuildingSet[bid] = true end
+    for _, bid in ipairs(orphanBuildingIds or {}) do orphanBuildingSet[bid] = true end
 
     local pruned = 0
     for bid in pairs(state) do
-        if not liveBuildingSet[bid] then
+        if survBuildingSet[bid] then
+            -- loaded-page survivor: keep
+        elseif orphanBuildingSet[bid] or not building.getInfo(bid) then
             state[bid] = nil
             pruned = pruned + 1
         end
+        -- else: live off-page building's state → keep
     end
     local scrubbed = 0
-    for _, s in pairs(state) do
-        if s.lastUid ~= nil and not liveUnitSet[s.lastUid] then
+    for bid, s in pairs(state) do
+        if survBuildingSet[bid] and s.lastUid ~= nil
+           and not survUnitSet[s.lastUid] then
             s.lastUid = nil
             scrubbed = scrubbed + 1
         end

--- a/scripts/building_spawn.lua
+++ b/scripts/building_spawn.lua
@@ -258,38 +258,33 @@ end
 -- registered. The restored state still holds entries for those dropped
 -- ids, so a reused bid could inherit stale spawn-rate state.
 --
--- The signature mirrors the broadcast (onSaveLoaded(orphanUnitIds,
--- orphanBuildingIds)). We force-prune the exact dropped-building set FIRST
--- -- this matters when an orphaned bid collides with a live off-page
--- building of the same id: the restored blob state belongs to the dropped
--- orphan, so a liveness check alone would wrongly keep it. Then we sweep
--- any state whose bid has no live building. building.getInfo is GLOBAL
--- (all world pages, nil when gone), so buildings on other
--- loaded-but-inactive pages are kept.
+-- The signature mirrors the broadcast (onSaveLoaded(liveUnitIds,
+-- liveBuildingIds)) — the ids that SURVIVED on the loaded page. The
+-- restore clobbers the singleton and repopulates from the loaded blob, so
+-- `state` afterward holds only loaded-page bids; we treat the survivor
+-- list as an allow-list and drop any state[bid] not in it. That covers
+-- missing-def orphans, buildings gone before the save, and any bid now
+-- colliding with a live off-page building (which the global building.getInfo
+-- lookup would otherwise mask).
 --
 -- Surviving entries also embed a unit reference (s.lastUid, the last unit
--- spawned, used for spawn-spacing). An orphaned uid there can collide with
--- a live off-page unit, so scrub it from the orphan-unit set too.
-function buildingSpawn.onSaveLoaded(orphanUnitIds, orphanBuildingIds)
-    local orphanUnitSet = {}
-    for _, uid in ipairs(orphanUnitIds or {}) do orphanUnitSet[uid] = true end
+-- spawned, used for spawn-spacing). Scrub it if that uid didn't survive on
+-- the loaded page, so a colliding off-page unit can't gate spawning.
+function buildingSpawn.onSaveLoaded(liveUnitIds, liveBuildingIds)
+    local liveUnitSet, liveBuildingSet = {}, {}
+    for _, uid in ipairs(liveUnitIds or {})     do liveUnitSet[uid] = true end
+    for _, bid in ipairs(liveBuildingIds or {}) do liveBuildingSet[bid] = true end
 
     local pruned = 0
-    for _, bid in ipairs(orphanBuildingIds or {}) do
-        if state[bid] ~= nil then
-            state[bid] = nil
-            pruned = pruned + 1
-        end
-    end
     for bid in pairs(state) do
-        if not building.getInfo(bid) then
+        if not liveBuildingSet[bid] then
             state[bid] = nil
             pruned = pruned + 1
         end
     end
     local scrubbed = 0
     for _, s in pairs(state) do
-        if s.lastUid ~= nil and orphanUnitSet[s.lastUid] then
+        if s.lastUid ~= nil and not liveUnitSet[s.lastUid] then
             s.lastUid = nil
             scrubbed = scrubbed + 1
         end
@@ -297,7 +292,7 @@ function buildingSpawn.onSaveLoaded(orphanUnitIds, orphanBuildingIds)
     if pruned > 0 or scrubbed > 0 then
         engine.logInfo("Building spawn: pruned " .. pruned
             .. " stale state(s) and scrubbed " .. scrubbed
-            .. " orphaned reference(s) after load")
+            .. " stale reference(s) after load")
     end
 end
 

--- a/scripts/building_spawn.lua
+++ b/scripts/building_spawn.lua
@@ -259,14 +259,21 @@ end
 -- ids, so a reused bid could inherit stale spawn-rate state.
 --
 -- The signature mirrors the broadcast (onSaveLoaded(orphanUnitIds,
--- orphanBuildingIds)); this module only cares about buildings. We
--- force-prune the exact dropped-building set FIRST -- this matters when an
--- orphaned bid collides with a live off-page building of the same id: the
--- restored blob state belongs to the dropped orphan, so a liveness check
--- alone would wrongly keep it. Then we sweep any state whose bid has no
--- live building. building.getInfo is GLOBAL (all world pages, nil when
--- gone), so buildings on other loaded-but-inactive pages are kept.
-function buildingSpawn.onSaveLoaded(_orphanUnitIds, orphanBuildingIds)
+-- orphanBuildingIds)). We force-prune the exact dropped-building set FIRST
+-- -- this matters when an orphaned bid collides with a live off-page
+-- building of the same id: the restored blob state belongs to the dropped
+-- orphan, so a liveness check alone would wrongly keep it. Then we sweep
+-- any state whose bid has no live building. building.getInfo is GLOBAL
+-- (all world pages, nil when gone), so buildings on other
+-- loaded-but-inactive pages are kept.
+--
+-- Surviving entries also embed a unit reference (s.lastUid, the last unit
+-- spawned, used for spawn-spacing). An orphaned uid there can collide with
+-- a live off-page unit, so scrub it from the orphan-unit set too.
+function buildingSpawn.onSaveLoaded(orphanUnitIds, orphanBuildingIds)
+    local orphanUnitSet = {}
+    for _, uid in ipairs(orphanUnitIds or {}) do orphanUnitSet[uid] = true end
+
     local pruned = 0
     for _, bid in ipairs(orphanBuildingIds or {}) do
         if state[bid] ~= nil then
@@ -280,9 +287,17 @@ function buildingSpawn.onSaveLoaded(_orphanUnitIds, orphanBuildingIds)
             pruned = pruned + 1
         end
     end
-    if pruned > 0 then
+    local scrubbed = 0
+    for _, s in pairs(state) do
+        if s.lastUid ~= nil and orphanUnitSet[s.lastUid] then
+            s.lastUid = nil
+            scrubbed = scrubbed + 1
+        end
+    end
+    if pruned > 0 or scrubbed > 0 then
         engine.logInfo("Building spawn: pruned " .. pruned
-            .. " stale state(s) for buildings dropped on load")
+            .. " stale state(s) and scrubbed " .. scrubbed
+            .. " orphaned reference(s) after load")
     end
 end
 

--- a/scripts/unit_ai.lua
+++ b/scripts/unit_ai.lua
@@ -3730,24 +3730,74 @@ function unitAi.init(scriptId)
         end)
 end
 
+-- aiState fields on a SURVIVING entry that hold a direct reference to
+-- another entity by raw id. After a load these can point at an id the
+-- engine dropped as an orphan; because a dropped id can collide with a
+-- LIVE off-page entity of the same id, and the per-tick validators
+-- (unit.exists / unit.getInfo / building.getInfo) are global raw lookups
+-- that would pass for that wrong entity, a surviving unit could resume
+-- targeting / delivering to it (#195). So orphaned ids must be scrubbed
+-- out of these fields too, not just deleted as top-level keys.
+-- NB: any NEW aiState field that stores a unit/building id MUST be listed
+-- here, or it silently reintroduces the collision bug.
+local AI_UNIT_REF_FIELDS     = { "attackTargetUid", "retreatThreatUid",
+                                 "notifyTarget", "lungeTarget" }
+local AI_BUILDING_REF_FIELDS = { "buildTarget", "storeTarget" }
+
+-- Clear any orphaned id out of one surviving state entry. Setting a field
+-- to nil is exactly the self-heal the AI already runs when a target
+-- legitimately vanishes, so the next tick re-decides cleanly. Nested claim
+-- tables are dropped wholesale when their target id is orphaned (the
+-- execute paths treat a nil claim as "release"). Returns #fields cleared.
+local function scrubOrphanRefs(s, orphanUnitSet, orphanBuildingSet)
+    local cleared = 0
+    for _, f in ipairs(AI_UNIT_REF_FIELDS) do
+        local v = s[f]
+        if v ~= nil and orphanUnitSet[v] then s[f] = nil; cleared = cleared + 1 end
+    end
+    for _, f in ipairs(AI_BUILDING_REF_FIELDS) do
+        local v = s[f]
+        if v ~= nil and orphanBuildingSet[v] then s[f] = nil; cleared = cleared + 1 end
+    end
+    if s.treatClaim and orphanUnitSet[s.treatClaim.patient] then
+        s.treatClaim = nil; cleared = cleared + 1
+    end
+    if s.deliveryClaim and orphanBuildingSet[s.deliveryClaim.bid] then
+        s.deliveryClaim = nil; cleared = cleared + 1
+    end
+    if s.deliveryPendingTarget and orphanBuildingSet[s.deliveryPendingTarget.bid] then
+        s.deliveryPendingTarget = nil; cleared = cleared + 1
+    end
+    return cleared
+end
+
 -- Broadcast from the engine once a save has finished loading (#195).
 -- Lua save blobs are restored BEFORE the engine load path runs, and that
--- path can drop "orphan" units whose defs are no longer registered. The
--- restored aiState still holds entries for those dropped ids, so a later
--- id reuse (umNextId is restored from the snapshot) would let a brand-new
--- unit inherit the orphan's stale AI state.
+-- path can drop "orphan" units/buildings whose defs are no longer
+-- registered. The restored aiState still holds entries for those dropped
+-- ids, so a later id reuse (umNextId is restored from the snapshot) would
+-- let a brand-new unit inherit the orphan's stale AI state.
 --
--- orphanUnitIds is the exact set the engine dropped on this load; we
--- force-prune those FIRST, before any liveness test. This matters when an
--- orphaned id collides with a live off-page unit of the same id: the
--- restored blob state belongs to the dropped orphan, not that unit, so a
--- liveness check alone (unit.exists) would wrongly keep it. After that we
--- still sweep any aiState entry with no live unit anywhere (unit.exists is
--- GLOBAL across all world pages, so units on other loaded-but-inactive
--- pages are kept) to catch ids that left no live entity for other reasons.
-function unitAi.onSaveLoaded(orphanUnitIds)
+-- orphanUnitIds / orphanBuildingIds are the exact sets the engine dropped
+-- on this load. We:
+--   1. force-prune top-level aiState[orphanUid] FIRST, before any liveness
+--      test — when an orphaned id collides with a live off-page unit, the
+--      restored blob state belongs to the dropped orphan, so a liveness
+--      check alone (unit.exists) would wrongly keep it;
+--   2. sweep any remaining aiState entry with no live unit anywhere
+--      (unit.exists is GLOBAL across all world pages, so units on other
+--      loaded-but-inactive pages are kept) to catch ids that left no live
+--      entity for other reasons;
+--   3. scrub orphaned ids out of the NESTED reference fields of every
+--      surviving entry (attack/build/delivery/treat targets), so a
+--      survivor can't resume acting on a colliding off-page entity.
+function unitAi.onSaveLoaded(orphanUnitIds, orphanBuildingIds)
+    local orphanUnitSet, orphanBuildingSet = {}, {}
+    for _, uid in ipairs(orphanUnitIds or {})     do orphanUnitSet[uid] = true end
+    for _, bid in ipairs(orphanBuildingIds or {}) do orphanBuildingSet[bid] = true end
+
     local pruned = 0
-    for _, uid in ipairs(orphanUnitIds or {}) do
+    for uid in pairs(orphanUnitSet) do
         if aiState[uid] ~= nil then
             aiState[uid] = nil
             pruned = pruned + 1
@@ -3759,9 +3809,14 @@ function unitAi.onSaveLoaded(orphanUnitIds)
             pruned = pruned + 1
         end
     end
-    if pruned > 0 then
+    local scrubbed = 0
+    for _, s in pairs(aiState) do
+        scrubbed = scrubbed + scrubOrphanRefs(s, orphanUnitSet, orphanBuildingSet)
+    end
+    if pruned > 0 or scrubbed > 0 then
         engine.logInfo("Unit AI: pruned " .. pruned
-            .. " stale AI state(s) for units dropped on load")
+            .. " stale AI state(s) and scrubbed " .. scrubbed
+            .. " orphaned reference(s) after load")
     end
 end
 

--- a/scripts/unit_ai.lua
+++ b/scripts/unit_ai.lua
@@ -3721,7 +3721,24 @@ function unitAi.init(scriptId)
     local saveLib  = require("scripts.lib.serialize")
     local saveMods = require("scripts.lib.save_modules")
     saveMods.register("unit_ai",
-        function() return saveLib.serialize(aiState) end,
+        function()
+            -- Serialize only LIVE units' state. aiState is a global
+            -- singleton that accumulates entries and never drops them when
+            -- a unit is destroyed, so it leaks stale entries for
+            -- gone-before-save units. Persisting those is actively unsafe:
+            -- on a later cross-session load such an id can collide with a
+            -- live off-page entity, and onSaveLoaded then can't tell the
+            -- stale loaded-page leftover from legitimate off-page state
+            -- (the blob isn't page-keyed) — it would keep + misattribute
+            -- it. Dropping dead ids at the source means they never reach
+            -- the blob. unit.exists is GLOBAL, so live units on every page
+            -- are still saved (#195).
+            local live = {}
+            for uid, s in pairs(aiState) do
+                if unit.exists(uid) then live[uid] = s end
+            end
+            return saveLib.serialize(live)
+        end,
         function(blob)
             local restored = saveLib.deserialize(blob) or {}
             -- Replace in-place so the package.loaded singleton sees it

--- a/scripts/unit_ai.lua
+++ b/scripts/unit_ai.lua
@@ -3730,96 +3730,89 @@ function unitAi.init(scriptId)
         end)
 end
 
--- aiState fields on a SURVIVING entry that hold a direct reference to
--- another entity by raw id. After a load these can point at an id the
--- engine dropped as an orphan; because a dropped id can collide with a
--- LIVE off-page entity of the same id, and the per-tick validators
--- (unit.exists / unit.getInfo / building.getInfo) are global raw lookups
--- that would pass for that wrong entity, a surviving unit could resume
--- targeting / delivering to it (#195). So orphaned ids must be scrubbed
--- out of these fields too, not just deleted as top-level keys.
+-- aiState fields on a surviving entry that hold a direct reference to
+-- another entity by raw id. After a load these can point at an id that did
+-- NOT survive on the loaded page — a missing-def orphan, an entity already
+-- gone before the save (its stale ref was still serialized), or an id that
+-- now collides with a LIVE off-page entity. The per-tick validators
+-- (unit.exists / unit.getInfo / building.getInfo) are GLOBAL raw lookups,
+-- so for a collision they'd pass for the wrong off-page entity and the
+-- survivor would resume targeting / delivering to it (#195). So any ref
+-- whose target isn't in the surviving loaded-page set is scrubbed.
 -- NB: any NEW aiState field that stores a unit/building id MUST be listed
--- here, or it silently reintroduces the collision bug.
+-- here, or it silently reintroduces the stale-ref bug.
 local AI_UNIT_REF_FIELDS     = { "attackTargetUid", "retreatThreatUid",
                                  "notifyTarget", "lungeTarget" }
 local AI_BUILDING_REF_FIELDS = { "buildTarget", "storeTarget" }
 
--- Clear any orphaned id out of one surviving state entry. Setting a field
--- to nil is exactly the self-heal the AI already runs when a target
--- legitimately vanishes, so the next tick re-decides cleanly. Nested claim
--- tables are dropped wholesale when their target id is orphaned (the
--- execute paths treat a nil claim as "release"). Returns #fields cleared.
-local function scrubOrphanRefs(s, orphanUnitSet, orphanBuildingSet)
+-- Clear any ref that doesn't point at a surviving loaded-page entity out
+-- of one surviving state entry. Setting a field to nil is exactly the
+-- self-heal the AI already runs when a target legitimately vanishes, so
+-- the next tick re-decides cleanly. Nested claim tables are dropped
+-- wholesale when their target didn't survive (the execute paths treat a
+-- nil claim as "release"). Returns #fields cleared.
+local function scrubStaleRefs(s, liveUnitSet, liveBuildingSet)
     local cleared = 0
     for _, f in ipairs(AI_UNIT_REF_FIELDS) do
         local v = s[f]
-        if v ~= nil and orphanUnitSet[v] then s[f] = nil; cleared = cleared + 1 end
+        if v ~= nil and not liveUnitSet[v] then s[f] = nil; cleared = cleared + 1 end
     end
     for _, f in ipairs(AI_BUILDING_REF_FIELDS) do
         local v = s[f]
-        if v ~= nil and orphanBuildingSet[v] then s[f] = nil; cleared = cleared + 1 end
+        if v ~= nil and not liveBuildingSet[v] then s[f] = nil; cleared = cleared + 1 end
     end
-    if s.treatClaim and orphanUnitSet[s.treatClaim.patient] then
+    if s.treatClaim and not liveUnitSet[s.treatClaim.patient] then
         s.treatClaim = nil; cleared = cleared + 1
     end
-    if s.treatPending and orphanUnitSet[s.treatPending.uid] then
+    if s.treatPending and not liveUnitSet[s.treatPending.uid] then
         s.treatPending = nil; cleared = cleared + 1
     end
-    if s.deliveryClaim and orphanBuildingSet[s.deliveryClaim.bid] then
+    if s.deliveryClaim and not liveBuildingSet[s.deliveryClaim.bid] then
         s.deliveryClaim = nil; cleared = cleared + 1
     end
-    if s.deliveryPendingTarget and orphanBuildingSet[s.deliveryPendingTarget.bid] then
+    if s.deliveryPendingTarget and not liveBuildingSet[s.deliveryPendingTarget.bid] then
         s.deliveryPendingTarget = nil; cleared = cleared + 1
     end
     return cleared
 end
 
 -- Broadcast from the engine once a save has finished loading (#195).
--- Lua save blobs are restored BEFORE the engine load path runs, and that
--- path can drop "orphan" units/buildings whose defs are no longer
--- registered. The restored aiState still holds entries for those dropped
--- ids, so a later id reuse (umNextId is restored from the snapshot) would
--- let a brand-new unit inherit the orphan's stale AI state.
+-- Lua save blobs are restored (wholesale: the singleton is cleared and
+-- repopulated from the loaded page's blob) BEFORE the engine load path
+-- runs. That path then keeps only the entities that survive on the loaded
+-- page, dropping missing-def orphans. The restored aiState can still hold
+-- entries — and nested refs — for ids that did NOT survive (orphans, or
+-- entities already gone when the save was taken). On a cross-session load
+-- those ids can collide with a live off-page entity preserved by the
+-- merge, and the global validators would then misattribute the stale
+-- state to the wrong entity.
 --
--- orphanUnitIds / orphanBuildingIds are the exact sets the engine dropped
--- on this load. We:
---   1. force-prune top-level aiState[orphanUid] FIRST, before any liveness
---      test — when an orphaned id collides with a live off-page unit, the
---      restored blob state belongs to the dropped orphan, so a liveness
---      check alone (unit.exists) would wrongly keep it;
---   2. sweep any remaining aiState entry with no live unit anywhere
---      (unit.exists is GLOBAL across all world pages, so units on other
---      loaded-but-inactive pages are kept) to catch ids that left no live
---      entity for other reasons;
---   3. scrub orphaned ids out of the NESTED reference fields of every
---      surviving entry (attack/build/delivery/treat targets), so a
---      survivor can't resume acting on a colliding off-page entity.
-function unitAi.onSaveLoaded(orphanUnitIds, orphanBuildingIds)
-    local orphanUnitSet, orphanBuildingSet = {}, {}
-    for _, uid in ipairs(orphanUnitIds or {})     do orphanUnitSet[uid] = true end
-    for _, bid in ipairs(orphanBuildingIds or {}) do orphanBuildingSet[bid] = true end
+-- liveUnitIds / liveBuildingIds are the ids that SURVIVED on the loaded
+-- page (the successfully restored set). Because the restore clobbers the
+-- singleton, aiState afterward holds only loaded-page ids, so we can treat
+-- this as an allow-list: keep state/refs only for survivors, scrub the
+-- rest. This subsumes the missing-def-orphan, gone-before-save, and
+-- off-page-collision cases without relying on global liveness.
+function unitAi.onSaveLoaded(liveUnitIds, liveBuildingIds)
+    local liveUnitSet, liveBuildingSet = {}, {}
+    for _, uid in ipairs(liveUnitIds or {})     do liveUnitSet[uid] = true end
+    for _, bid in ipairs(liveBuildingIds or {}) do liveBuildingSet[bid] = true end
 
     local pruned = 0
-    for uid in pairs(orphanUnitSet) do
-        if aiState[uid] ~= nil then
-            aiState[uid] = nil
-            pruned = pruned + 1
-        end
-    end
     for uid in pairs(aiState) do
-        if not unit.exists(uid) then
+        if not liveUnitSet[uid] then
             aiState[uid] = nil
             pruned = pruned + 1
         end
     end
     local scrubbed = 0
     for _, s in pairs(aiState) do
-        scrubbed = scrubbed + scrubOrphanRefs(s, orphanUnitSet, orphanBuildingSet)
+        scrubbed = scrubbed + scrubStaleRefs(s, liveUnitSet, liveBuildingSet)
     end
     if pruned > 0 or scrubbed > 0 then
         engine.logInfo("Unit AI: pruned " .. pruned
             .. " stale AI state(s) and scrubbed " .. scrubbed
-            .. " orphaned reference(s) after load")
+            .. " stale reference(s) after load")
     end
 end
 

--- a/scripts/unit_ai.lua
+++ b/scripts/unit_ai.lua
@@ -3762,6 +3762,9 @@ local function scrubOrphanRefs(s, orphanUnitSet, orphanBuildingSet)
     if s.treatClaim and orphanUnitSet[s.treatClaim.patient] then
         s.treatClaim = nil; cleared = cleared + 1
     end
+    if s.treatPending and orphanUnitSet[s.treatPending.uid] then
+        s.treatPending = nil; cleared = cleared + 1
+    end
     if s.deliveryClaim and orphanBuildingSet[s.deliveryClaim.bid] then
         s.deliveryClaim = nil; cleared = cleared + 1
     end

--- a/scripts/unit_ai.lua
+++ b/scripts/unit_ai.lua
@@ -3735,12 +3735,24 @@ end
 -- path can drop "orphan" units whose defs are no longer registered. The
 -- restored aiState still holds entries for those dropped ids, so a later
 -- id reuse (umNextId is restored from the snapshot) would let a brand-new
--- unit inherit the orphan's stale AI state. Reconcile here: drop any
--- aiState entry whose uid has no live unit. unit.exists is GLOBAL (all
--- world pages), so units on other loaded-but-inactive pages are kept --
--- only genuinely dead ids are pruned.
-function unitAi.onSaveLoaded()
+-- unit inherit the orphan's stale AI state.
+--
+-- orphanUnitIds is the exact set the engine dropped on this load; we
+-- force-prune those FIRST, before any liveness test. This matters when an
+-- orphaned id collides with a live off-page unit of the same id: the
+-- restored blob state belongs to the dropped orphan, not that unit, so a
+-- liveness check alone (unit.exists) would wrongly keep it. After that we
+-- still sweep any aiState entry with no live unit anywhere (unit.exists is
+-- GLOBAL across all world pages, so units on other loaded-but-inactive
+-- pages are kept) to catch ids that left no live entity for other reasons.
+function unitAi.onSaveLoaded(orphanUnitIds)
     local pruned = 0
+    for _, uid in ipairs(orphanUnitIds or {}) do
+        if aiState[uid] ~= nil then
+            aiState[uid] = nil
+            pruned = pruned + 1
+        end
+    end
     for uid in pairs(aiState) do
         if not unit.exists(uid) then
             aiState[uid] = nil

--- a/scripts/unit_ai.lua
+++ b/scripts/unit_ai.lua
@@ -3730,6 +3730,29 @@ function unitAi.init(scriptId)
         end)
 end
 
+-- Broadcast from the engine once a save has finished loading (#195).
+-- Lua save blobs are restored BEFORE the engine load path runs, and that
+-- path can drop "orphan" units whose defs are no longer registered. The
+-- restored aiState still holds entries for those dropped ids, so a later
+-- id reuse (umNextId is restored from the snapshot) would let a brand-new
+-- unit inherit the orphan's stale AI state. Reconcile here: drop any
+-- aiState entry whose uid has no live unit. unit.exists is GLOBAL (all
+-- world pages), so units on other loaded-but-inactive pages are kept --
+-- only genuinely dead ids are pruned.
+function unitAi.onSaveLoaded()
+    local pruned = 0
+    for uid in pairs(aiState) do
+        if not unit.exists(uid) then
+            aiState[uid] = nil
+            pruned = pruned + 1
+        end
+    end
+    if pruned > 0 then
+        engine.logInfo("Unit AI: pruned " .. pruned
+            .. " stale AI state(s) for units dropped on load")
+    end
+end
+
 function unitAi.update(dt)
     if require("scripts.pause").isPaused() then return end
     local ids = unit.getAllIds()

--- a/scripts/unit_ai.lua
+++ b/scripts/unit_ai.lua
@@ -3777,37 +3777,50 @@ local function scrubStaleRefs(s, liveUnitSet, liveBuildingSet)
 end
 
 -- Broadcast from the engine once a save has finished loading (#195).
--- Lua save blobs are restored (wholesale: the singleton is cleared and
--- repopulated from the loaded page's blob) BEFORE the engine load path
--- runs. That path then keeps only the entities that survive on the loaded
--- page, dropping missing-def orphans. The restored aiState can still hold
--- entries — and nested refs — for ids that did NOT survive (orphans, or
--- entities already gone when the save was taken). On a cross-session load
--- those ids can collide with a live off-page entity preserved by the
--- merge, and the global validators would then misattribute the stale
--- state to the wrong entity.
+-- The Lua blob is a global singleton serialized WHOLESALE, so it carries
+-- state for units on EVERY live page, not just the saved one. On load it's
+-- restored (cleared + repopulated from the blob) before the engine merge,
+-- which restores the saved page's units and PRESERVES other live pages'
+-- units (#191). So afterward aiState legitimately contains both loaded-page
+-- entries and live OFF-PAGE entries — the reconcile must keep the latter.
 --
--- liveUnitIds / liveBuildingIds are the ids that SURVIVED on the loaded
--- page (the successfully restored set). Because the restore clobbers the
--- singleton, aiState afterward holds only loaded-page ids, so we can treat
--- this as an allow-list: keep state/refs only for survivors, scrub the
--- rest. This subsumes the missing-def-orphan, gone-before-save, and
--- off-page-collision cases without relying on global liveness.
-function unitAi.onSaveLoaded(liveUnitIds, liveBuildingIds)
-    local liveUnitSet, liveBuildingSet = {}, {}
-    for _, uid in ipairs(liveUnitIds or {})     do liveUnitSet[uid] = true end
-    for _, bid in ipairs(liveBuildingIds or {}) do liveBuildingSet[bid] = true end
+-- Args are four loaded-page sets: survivors + orphans, for units and
+-- buildings. Per top-level entry uid:
+--   * survivor          → keep (it was restored on the loaded page);
+--   * loaded-page orphan → force-prune — a dropped id can collide with a
+--     live off-page unit, so global liveness alone would keep its stale
+--     state and misattribute it;
+--   * otherwise          → keep iff still globally live (a live OFF-PAGE
+--     unit's state), else prune (gone before save / dead).
+-- Nested refs are then scrubbed only on loaded-page SURVIVOR entries,
+-- against the survivor set: a loaded-page unit can only validly reference a
+-- page-mate, so a ref outside that set (orphan, gone-before-save, or
+-- off-page collision) is stale. Off-page entries are left untouched — they
+-- weren't reloaded and their refs point within their own page.
+function unitAi.onSaveLoaded(survUnitIds, survBuildingIds,
+                             orphanUnitIds, orphanBuildingIds)
+    local survUnitSet, survBuildingSet = {}, {}
+    local orphanUnitSet, orphanBuildingSet = {}, {}
+    for _, uid in ipairs(survUnitIds or {})       do survUnitSet[uid] = true end
+    for _, bid in ipairs(survBuildingIds or {})   do survBuildingSet[bid] = true end
+    for _, uid in ipairs(orphanUnitIds or {})     do orphanUnitSet[uid] = true end
+    for _, bid in ipairs(orphanBuildingIds or {}) do orphanBuildingSet[bid] = true end
 
     local pruned = 0
     for uid in pairs(aiState) do
-        if not liveUnitSet[uid] then
+        if survUnitSet[uid] then
+            -- loaded-page survivor: keep
+        elseif orphanUnitSet[uid] or not unit.exists(uid) then
             aiState[uid] = nil
             pruned = pruned + 1
         end
+        -- else: live off-page unit's state → keep
     end
     local scrubbed = 0
-    for _, s in pairs(aiState) do
-        scrubbed = scrubbed + scrubStaleRefs(s, liveUnitSet, liveBuildingSet)
+    for uid, s in pairs(aiState) do
+        if survUnitSet[uid] then
+            scrubbed = scrubbed + scrubStaleRefs(s, survUnitSet, survBuildingSet)
+        end
     end
     if pruned > 0 or scrubbed > 0 then
         engine.logInfo("Unit AI: pruned " .. pruned

--- a/scripts/unit_ai.lua
+++ b/scripts/unit_ai.lua
@@ -3740,6 +3740,13 @@ function unitAi.init(scriptId)
             return saveLib.serialize(live)
         end,
         function(blob)
+            -- Snapshot the pre-load singleton BEFORE clobbering. The blob
+            -- holds save-time state for ALL pages, but a load should only
+            -- touch the loaded page; onSaveLoaded uses this snapshot to
+            -- restore still-live OFF-PAGE units' CURRENT state instead of
+            -- the blob's stale copy (#195, #191).
+            unitAi._preLoadState = {}
+            for k, v in pairs(aiState) do unitAi._preLoadState[k] = v end
             local restored = saveLib.deserialize(blob) or {}
             -- Replace in-place so the package.loaded singleton sees it
             for k in pairs(aiState) do aiState[k] = nil end
@@ -3794,56 +3801,56 @@ local function scrubStaleRefs(s, liveUnitSet, liveBuildingSet)
 end
 
 -- Broadcast from the engine once a save has finished loading (#195).
--- The Lua blob is a global singleton serialized WHOLESALE, so it carries
--- state for units on EVERY live page, not just the saved one. On load it's
--- restored (cleared + repopulated from the blob) before the engine merge,
--- which restores the saved page's units and PRESERVES other live pages'
--- units (#191). So afterward aiState legitimately contains both loaded-page
--- entries and live OFF-PAGE entries — the reconcile must keep the latter.
+-- The Lua blob is a global singleton serialized WHOLESALE, so the restore
+-- (deserializer above) clobbered aiState with save-time state for units on
+-- EVERY page. But the engine load only restores the saved page and
+-- PRESERVES other live pages' units (#191), so a load must touch only the
+-- loaded page's AI state and leave other pages' state exactly as it was.
 --
--- Args are four loaded-page sets: survivors + orphans, for units and
--- buildings. Per top-level entry uid:
---   * survivor          → keep (it was restored on the loaded page);
---   * loaded-page orphan → force-prune — a dropped id can collide with a
---     live off-page unit, so global liveness alone would keep its stale
---     state and misattribute it;
---   * otherwise          → keep iff still globally live (a live OFF-PAGE
---     unit's state), else prune (gone before save / dead).
--- Nested refs are then scrubbed only on loaded-page SURVIVOR entries,
--- against the survivor set: a loaded-page unit can only validly reference a
--- page-mate, so a ref outside that set (orphan, gone-before-save, or
--- off-page collision) is stale. Off-page entries are left untouched — they
--- weren't reloaded and their refs point within their own page.
-function unitAi.onSaveLoaded(survUnitIds, survBuildingIds,
-                             orphanUnitIds, orphanBuildingIds)
+-- survUnitIds are the loaded page's survivors. We rebuild aiState as:
+--   * loaded-page survivor → its restored (blob) state — the save is
+--     authoritative for the page it loaded;
+--   * every other still-live unit → its PRE-LOAD state (the off-page
+--     entity's CURRENT state, NOT the blob's stale snapshot). This both
+--     stops an older save from rolling back live off-page AI memory, and
+--     means any stale/dropped/colliding loaded-page id resolves to the
+--     live entity's own state rather than the blob's — no misattribution;
+--   * everything else (orphans, dead, gone-before-save) → dropped.
+-- Nested refs are then scrubbed on loaded-page survivor entries against the
+-- survivor set: a loaded-page unit can only validly reference a page-mate.
+-- Off-page entries keep their pre-load refs (they weren't reloaded).
+function unitAi.onSaveLoaded(survUnitIds, survBuildingIds)
     local survUnitSet, survBuildingSet = {}, {}
-    local orphanUnitSet, orphanBuildingSet = {}, {}
-    for _, uid in ipairs(survUnitIds or {})       do survUnitSet[uid] = true end
-    for _, bid in ipairs(survBuildingIds or {})   do survBuildingSet[bid] = true end
-    for _, uid in ipairs(orphanUnitIds or {})     do orphanUnitSet[uid] = true end
-    for _, bid in ipairs(orphanBuildingIds or {}) do orphanBuildingSet[bid] = true end
+    for _, uid in ipairs(survUnitIds or {})     do survUnitSet[uid] = true end
+    for _, bid in ipairs(survBuildingIds or {}) do survBuildingSet[bid] = true end
 
-    local pruned = 0
-    for uid in pairs(aiState) do
-        if survUnitSet[uid] then
-            -- loaded-page survivor: keep
-        elseif orphanUnitSet[uid] or not unit.exists(uid) then
-            aiState[uid] = nil
-            pruned = pruned + 1
-        end
-        -- else: live off-page unit's state → keep
+    local pre = unitAi._preLoadState or {}
+    unitAi._preLoadState = nil
+    local blob = aiState   -- current contents = the just-restored blob
+
+    local rebuilt = {}
+    for uid in pairs(survUnitSet) do
+        if blob[uid] ~= nil then rebuilt[uid] = blob[uid] end
     end
+    for uid, s in pairs(pre) do
+        if not survUnitSet[uid] and unit.exists(uid) then
+            rebuilt[uid] = s          -- live off-page unit: keep current state
+        end
+    end
+
+    -- Swap into the singleton in place (preserve table identity).
+    local kept = 0
+    for k in pairs(aiState) do aiState[k] = nil end
+    for k, v in pairs(rebuilt) do aiState[k] = v; kept = kept + 1 end
+
     local scrubbed = 0
     for uid, s in pairs(aiState) do
         if survUnitSet[uid] then
             scrubbed = scrubbed + scrubStaleRefs(s, survUnitSet, survBuildingSet)
         end
     end
-    if pruned > 0 or scrubbed > 0 then
-        engine.logInfo("Unit AI: pruned " .. pruned
-            .. " stale AI state(s) and scrubbed " .. scrubbed
-            .. " stale reference(s) after load")
-    end
+    engine.logInfo("Unit AI: reconciled AI state after load ("
+        .. kept .. " kept, " .. scrubbed .. " stale ref(s) scrubbed)")
 end
 
 function unitAi.update(dt)

--- a/src/Engine/Scripting/Lua/API/Save.hs
+++ b/src/Engine/Scripting/Lua/API/Save.hs
@@ -170,6 +170,19 @@ loadSaveFn env = do
             case result of
                 Right saveData → do
                     logger ← Lua.liftIO $ readIORef (loggerRef env)
+                    -- Pause the engine BEFORE restoring Lua state, mirroring
+                    -- the save path. The deserializers clobber the per-id
+                    -- singletons and snapshot _preLoadState, but the
+                    -- world-thread merge + onSaveLoaded reconcile only land
+                    -- later; the Lua loop keeps firing script update()s
+                    -- meanwhile (they gate on engine.isPaused()). Without
+                    -- this, an unpaused same-session load would tick against
+                    -- the half-restored singletons before onSaveLoaded —
+                    -- drifting loaded-page state and racing the off-page
+                    -- reconcile. The world thread restores the saved pause
+                    -- state (sdEnginePaused) when it finishes the load, so
+                    -- this is just a freeze for the load window (#195).
+                    Lua.liftIO $ writeIORef (enginePausedRef env) True
                     restoreLuaBlobs logger (sdLuaModules saveData)
                     let pageId = WorldPageId "main_world"
                     -- Synchronously flip the current head world's

--- a/src/Engine/Scripting/Lua/Thread.hs
+++ b/src/Engine/Scripting/Lua/Thread.hs
@@ -606,8 +606,8 @@ processLuaMsg env ls stateRef msg = case msg of
       ]
 
 -- | Build a Lua array @{ id1, id2, ... }@ from a list of integer ids.
---   Used by 'LuaSaveLoaded' to hand the orphaned unit/building ids to
---   the Lua reconcile callback; the Lua side iterates with @ipairs@.
+--   Used by 'LuaSaveLoaded' to hand the surviving loaded-page unit /
+--   building ids to the Lua reconcile callback; it iterates with @ipairs@.
 intsToScriptArray ∷ [Int] → ScriptValue
 intsToScriptArray xs = ScriptTable $
     zipWith (\i x → ( ScriptNumber (fromIntegral (i ∷ Int))

--- a/src/Engine/Scripting/Lua/Thread.hs
+++ b/src/Engine/Scripting/Lua/Thread.hs
@@ -580,9 +580,11 @@ processLuaMsg env ls stateRef msg = case msg of
     broadcastToModules ls "onInterrupt" [ScriptNumber (fromIntegral fid)]
   LuaWorldGenLog text →
     broadcastToModules ls "onWorldGenLog" [ScriptString text]
-  LuaSaveLoaded orphanUnitIds orphanBuildingIds →
+  LuaSaveLoaded survUnitIds survBuildingIds orphanUnitIds orphanBuildingIds →
     broadcastToModules ls "onSaveLoaded"
-      [ intsToScriptArray orphanUnitIds
+      [ intsToScriptArray survUnitIds
+      , intsToScriptArray survBuildingIds
+      , intsToScriptArray orphanUnitIds
       , intsToScriptArray orphanBuildingIds ]
   LuaHudLogInfo text1 text2 →
     broadcastToModules ls "onSetInfoText" [ScriptString text1, ScriptString text2]

--- a/src/Engine/Scripting/Lua/Thread.hs
+++ b/src/Engine/Scripting/Lua/Thread.hs
@@ -580,12 +580,10 @@ processLuaMsg env ls stateRef msg = case msg of
     broadcastToModules ls "onInterrupt" [ScriptNumber (fromIntegral fid)]
   LuaWorldGenLog text →
     broadcastToModules ls "onWorldGenLog" [ScriptString text]
-  LuaSaveLoaded survUnitIds survBuildingIds orphanUnitIds orphanBuildingIds →
+  LuaSaveLoaded survUnitIds survBuildingIds →
     broadcastToModules ls "onSaveLoaded"
       [ intsToScriptArray survUnitIds
-      , intsToScriptArray survBuildingIds
-      , intsToScriptArray orphanUnitIds
-      , intsToScriptArray orphanBuildingIds ]
+      , intsToScriptArray survBuildingIds ]
   LuaHudLogInfo text1 text2 →
     broadcastToModules ls "onSetInfoText" [ScriptString text1, ScriptString text2]
   LuaHudLogWeatherInfo text →

--- a/src/Engine/Scripting/Lua/Thread.hs
+++ b/src/Engine/Scripting/Lua/Thread.hs
@@ -580,8 +580,10 @@ processLuaMsg env ls stateRef msg = case msg of
     broadcastToModules ls "onInterrupt" [ScriptNumber (fromIntegral fid)]
   LuaWorldGenLog text →
     broadcastToModules ls "onWorldGenLog" [ScriptString text]
-  LuaSaveLoaded →
-    broadcastToModules ls "onSaveLoaded" []
+  LuaSaveLoaded orphanUnitIds orphanBuildingIds →
+    broadcastToModules ls "onSaveLoaded"
+      [ intsToScriptArray orphanUnitIds
+      , intsToScriptArray orphanBuildingIds ]
   LuaHudLogInfo text1 text2 →
     broadcastToModules ls "onSetInfoText" [ScriptString text1, ScriptString text2]
   LuaHudLogWeatherInfo text →
@@ -602,6 +604,15 @@ processLuaMsg env ls stateRef msg = case msg of
       , buttonsToScriptValue buttons
       , coordsToScriptValue mCoords
       ]
+
+-- | Build a Lua array @{ id1, id2, ... }@ from a list of integer ids.
+--   Used by 'LuaSaveLoaded' to hand the orphaned unit/building ids to
+--   the Lua reconcile callback; the Lua side iterates with @ipairs@.
+intsToScriptArray ∷ [Int] → ScriptValue
+intsToScriptArray xs = ScriptTable $
+    zipWith (\i x → ( ScriptNumber (fromIntegral (i ∷ Int))
+                    , ScriptNumber (fromIntegral x) ))
+            [1..] xs
 
 -- | Build a Lua array @{ {label=..., action=...}, ... }@ from the
 --   button list carried by 'LuaShowPopup'. Lua-side popup module

--- a/src/Engine/Scripting/Lua/Thread.hs
+++ b/src/Engine/Scripting/Lua/Thread.hs
@@ -580,6 +580,8 @@ processLuaMsg env ls stateRef msg = case msg of
     broadcastToModules ls "onInterrupt" [ScriptNumber (fromIntegral fid)]
   LuaWorldGenLog text →
     broadcastToModules ls "onWorldGenLog" [ScriptString text]
+  LuaSaveLoaded →
+    broadcastToModules ls "onSaveLoaded" []
   LuaHudLogInfo text1 text2 →
     broadcastToModules ls "onSetInfoText" [ScriptString text1, ScriptString text2]
   LuaHudLogWeatherInfo text →

--- a/src/Engine/Scripting/Lua/Types.hs
+++ b/src/Engine/Scripting/Lua/Types.hs
@@ -143,8 +143,11 @@ data LuaMsg = LuaTextureLoaded TextureHandle AssetId
               --   the entities that actually survived the load — orphan
               --   units/buildings whose defs were dropped leave no live
               --   entity, so their stale per-id state must be pruned or a
-              --   reused id would inherit it (#195).
-            | LuaSaveLoaded
+              --   reused id would inherit it (#195). Carries the orphaned
+              --   (dropped) unit ids and building ids respectively, so the
+              --   Lua side can force-prune them even when an orphaned id
+              --   collides with a live off-page entity of the same id.
+            | LuaSaveLoaded [Int] [Int]
             | LuaHudLogInfo Text Text
             | LuaHudLogWeatherInfo Text
             | LuaHudLogResourcesInfo Text

--- a/src/Engine/Scripting/Lua/Types.hs
+++ b/src/Engine/Scripting/Lua/Types.hs
@@ -143,14 +143,14 @@ data LuaMsg = LuaTextureLoaded TextureHandle AssetId
               --   the entities that actually survived the load — orphan
               --   units/buildings whose defs were dropped leave no live
               --   entity, so their stale per-id state must be pruned or a
-              --   reused id would inherit it (#195). Carries four loaded-
-              --   page id lists — surviving unit ids, surviving building
-              --   ids, orphan unit ids, orphan building ids. The Lua side
-              --   keeps survivors, force-prunes orphans (collision-safe),
-              --   and keeps any other singleton entry only if it's a
-              --   still-live off-page entity (preserving other live pages'
-              --   state); nested refs are scrubbed against the survivor set.
-            | LuaSaveLoaded [Int] [Int] [Int] [Int]
+              --   reused id would inherit it (#195). Carries the loaded
+              --   page's surviving unit ids and building ids. The Lua side
+              --   rebuilds each singleton table as "survivors restored from
+              --   the blob + every other still-live (off-page) entity's
+              --   pre-load state", so a load touches only loaded-page state
+              --   and other live pages are untouched (#191); nested refs are
+              --   scrubbed against the survivor set.
+            | LuaSaveLoaded [Int] [Int]
             | LuaHudLogInfo Text Text
             | LuaHudLogWeatherInfo Text
             | LuaHudLogResourcesInfo Text

--- a/src/Engine/Scripting/Lua/Types.hs
+++ b/src/Engine/Scripting/Lua/Types.hs
@@ -143,13 +143,14 @@ data LuaMsg = LuaTextureLoaded TextureHandle AssetId
               --   the entities that actually survived the load — orphan
               --   units/buildings whose defs were dropped leave no live
               --   entity, so their stale per-id state must be pruned or a
-              --   reused id would inherit it (#195). Carries the unit ids
-              --   and building ids that SURVIVED on the loaded page (the
-              --   successfully restored set); the Lua side keeps state/refs
-              --   only for those and scrubs everything else — an allow-list
-              --   so it also catches ids gone before the save and ids that
-              --   collide with a live off-page entity.
-            | LuaSaveLoaded [Int] [Int]
+              --   reused id would inherit it (#195). Carries four loaded-
+              --   page id lists — surviving unit ids, surviving building
+              --   ids, orphan unit ids, orphan building ids. The Lua side
+              --   keeps survivors, force-prunes orphans (collision-safe),
+              --   and keeps any other singleton entry only if it's a
+              --   still-live off-page entity (preserving other live pages'
+              --   state); nested refs are scrubbed against the survivor set.
+            | LuaSaveLoaded [Int] [Int] [Int] [Int]
             | LuaHudLogInfo Text Text
             | LuaHudLogWeatherInfo Text
             | LuaHudLogResourcesInfo Text

--- a/src/Engine/Scripting/Lua/Types.hs
+++ b/src/Engine/Scripting/Lua/Types.hs
@@ -135,6 +135,16 @@ data LuaMsg = LuaTextureLoaded TextureHandle AssetId
             | LuaDebugHide
             | LuaDebugToggle
             | LuaWorldGenLog Text
+              -- | A save finished loading on the world thread. Emitted
+              --   once after units + buildings are written back, so by
+              --   the time the Lua thread processes it the engine entity
+              --   set is authoritative. Lets per-id Lua modules
+              --   (unit_ai, building_spawn) reconcile their state against
+              --   the entities that actually survived the load — orphan
+              --   units/buildings whose defs were dropped leave no live
+              --   entity, so their stale per-id state must be pruned or a
+              --   reused id would inherit it (#195).
+            | LuaSaveLoaded
             | LuaHudLogInfo Text Text
             | LuaHudLogWeatherInfo Text
             | LuaHudLogResourcesInfo Text

--- a/src/Engine/Scripting/Lua/Types.hs
+++ b/src/Engine/Scripting/Lua/Types.hs
@@ -143,10 +143,12 @@ data LuaMsg = LuaTextureLoaded TextureHandle AssetId
               --   the entities that actually survived the load — orphan
               --   units/buildings whose defs were dropped leave no live
               --   entity, so their stale per-id state must be pruned or a
-              --   reused id would inherit it (#195). Carries the orphaned
-              --   (dropped) unit ids and building ids respectively, so the
-              --   Lua side can force-prune them even when an orphaned id
-              --   collides with a live off-page entity of the same id.
+              --   reused id would inherit it (#195). Carries the unit ids
+              --   and building ids that SURVIVED on the loaded page (the
+              --   successfully restored set); the Lua side keeps state/refs
+              --   only for those and scrubs everything else — an allow-list
+              --   so it also catches ids gone before the save and ids that
+              --   collide with a live off-page entity.
             | LuaSaveLoaded [Int] [Int]
             | LuaHudLogInfo Text Text
             | LuaHudLogWeatherInfo Text

--- a/src/World/Thread/Command/Save.hs
+++ b/src/World/Thread/Command/Save.hs
@@ -336,7 +336,7 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
     -- center chunk's terrain matches what the player saw at save time;
     -- buildings landing in not-yet-loaded chunks will simply not render
     -- until those chunks come in via drainInitQueues.
-    bSurvivingIds ← do
+    (bSurvivingIds, bOrphanIds) ← do
         currentBm ← readIORef (buildingManagerRef env)
         let (restored, orphans) =
                 fromBuildingSnapshot pageId (bmDefs currentBm) (sdBuildings saveData)
@@ -382,13 +382,16 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
                     "Save load: dropped " <> T.pack (show n)
                     <> " building" <> (if n == 1 then "" else "s")
                     <> " (def no longer registered)"
-        -- Hand Lua the building ids that SURVIVED on the loaded page (the
-        -- successfully restored entities). building_spawn keeps only those
-        -- and scrubs everything else — not just missing-def orphans but
-        -- also ids that were already gone before the save and any id that
-        -- now collides with a live off-page building (#195).
-        pure (map (fromIntegral . unBuildingId)
-                  (HM.keys (bmInstances restored)) ∷ [Int])
+        -- Hand Lua two loaded-page sets: the building ids that SURVIVED
+        -- (successfully restored) and the ORPHANS (claimed by this page's
+        -- snapshot but dropped — def gone). building_spawn force-prunes the
+        -- orphans (collision-safe), keeps survivors, and keeps any other id
+        -- only if it's a still-live OFF-PAGE building — so it strips stale
+        -- loaded-page leftovers without dropping other live pages' state
+        -- (#195).
+        pure ( map (fromIntegral . unBuildingId)
+                   (HM.keys (bmInstances restored)) ∷ [Int]
+             , map (fromIntegral . unBuildingId) orphans ∷ [Int] )
 
     -- v5 (Phase 4): restore units + sim state. Same orphan handling as
     -- buildings; sim states for orphaned uids are dropped.
@@ -405,7 +408,7 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
     -- imperceptible. A future reader that requires stricter consistency
     -- (e.g. asserts simStates ⊆ umInstances) would need either an
     -- explicit lock or merging both refs into a single IORef.
-    uSurvivingIds ← do
+    (uSurvivingIds, uOrphanIds) ← do
         currentUm ← readIORef (unitManagerRef env)
         let (restoredUm, orphanUnits) =
                 fromUnitSnapshot pageId (umDefs currentUm) (sdUnits saveData)
@@ -453,13 +456,17 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
                     "Save load: dropped " <> T.pack (show n)
                     <> " unit" <> (if n == 1 then "" else "s")
                     <> " (def no longer registered)"
-        -- Hand Lua the unit ids that SURVIVED on the loaded page (the
-        -- successfully restored entities — liveUids is exactly the loaded
-        -- page's restored set, orphans already dropped). unit_ai keeps only
-        -- those and scrubs everything else: missing-def orphans, ids gone
-        -- before the save, and any id colliding with a live off-page unit
-        -- (#195).
-        pure (map (fromIntegral . unUnitId) (HS.toList liveUids) ∷ [Int])
+        -- Hand Lua two loaded-page sets: the unit ids that SURVIVED
+        -- (liveUids = the loaded page's restored set) and the ORPHANS
+        -- (claimed by this page's snapshot but dropped — def gone). unit_ai
+        -- force-prunes the orphans (collision-safe: a dropped id can
+        -- collide with a live off-page unit, so liveness alone would keep
+        -- it), keeps survivors, and keeps any other top-level entry only if
+        -- it's a still-live OFF-PAGE unit — preserving other live pages'
+        -- AI state. Nested refs are scrubbed against the survivor set
+        -- (a loaded-page unit can only validly reference a page-mate) (#195).
+        pure ( map (fromIntegral . unUnitId) (HS.toList liveUids) ∷ [Int]
+             , map (fromIntegral . unUnitId) orphanUnits ∷ [Int] )
 
     -- 6. Set camera z-slice from saved camera position. elevationAtGlobal
     -- takes grid coords (gx, gy), not world coords — go through
@@ -505,14 +512,13 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
         <> ": " <> unWorldPageId pageId
 
     -- Units + buildings are now written back to their managers, so the
-    -- engine entity set is authoritative. Signal Lua with the ids that
-    -- SURVIVED on the loaded page so per-id modules keep state/refs only
-    -- for those and scrub everything else. An allow-list (survivors), not
-    -- a deny-list (orphans), is required: the restored Lua blob can carry
-    -- ids that were already gone before the save, and on a cross-session
-    -- load those can collide with a live off-page entity of the same id —
-    -- a global-liveness check would then wrongly keep the stale state and
-    -- misattribute it. The wholesale blob restore clears the singleton
-    -- first, so after load it holds only loaded-page ids; filtering to the
-    -- loaded-page survivors drops nothing legitimate (#195).
-    sendSaveLoaded env uSurvivingIds bSurvivingIds
+    -- engine entity set is authoritative. Signal Lua with both the loaded
+    -- page's SURVIVORS and its ORPHANS so per-id modules can reconcile
+    -- correctly. The Lua blob is a global singleton serialized wholesale,
+    -- so it can carry both loaded-page ids and OFF-PAGE ids (other live
+    -- pages' state). The reconcile must therefore: keep survivors;
+    -- force-prune orphans (a dropped loaded-page id can collide with a
+    -- live off-page entity, so global liveness alone would misattribute
+    -- its stale state); and keep any other id only if it's a still-live
+    -- off-page entity — preserving other live pages' state (#195, #191).
+    sendSaveLoaded env uSurvivingIds bSurvivingIds uOrphanIds bOrphanIds

--- a/src/World/Thread/Command/Save.hs
+++ b/src/World/Thread/Command/Save.hs
@@ -336,7 +336,7 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
     -- center chunk's terrain matches what the player saw at save time;
     -- buildings landing in not-yet-loaded chunks will simply not render
     -- until those chunks come in via drainInitQueues.
-    bOrphanIds ← do
+    bSurvivingIds ← do
         currentBm ← readIORef (buildingManagerRef env)
         let (restored, orphans) =
                 fromBuildingSnapshot pageId (bmDefs currentBm) (sdBuildings saveData)
@@ -382,9 +382,13 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
                     "Save load: dropped " <> T.pack (show n)
                     <> " building" <> (if n == 1 then "" else "s")
                     <> " (def no longer registered)"
-        -- Hand the orphaned building ids to Lua so building_spawn can drop
-        -- their stale per-id state (#195).
-        pure (map (fromIntegral . unBuildingId) orphans ∷ [Int])
+        -- Hand Lua the building ids that SURVIVED on the loaded page (the
+        -- successfully restored entities). building_spawn keeps only those
+        -- and scrubs everything else — not just missing-def orphans but
+        -- also ids that were already gone before the save and any id that
+        -- now collides with a live off-page building (#195).
+        pure (map (fromIntegral . unBuildingId)
+                  (HM.keys (bmInstances restored)) ∷ [Int])
 
     -- v5 (Phase 4): restore units + sim state. Same orphan handling as
     -- buildings; sim states for orphaned uids are dropped.
@@ -401,7 +405,7 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
     -- imperceptible. A future reader that requires stricter consistency
     -- (e.g. asserts simStates ⊆ umInstances) would need either an
     -- explicit lock or merging both refs into a single IORef.
-    uOrphanIds ← do
+    uSurvivingIds ← do
         currentUm ← readIORef (unitManagerRef env)
         let (restoredUm, orphanUnits) =
                 fromUnitSnapshot pageId (umDefs currentUm) (sdUnits saveData)
@@ -449,9 +453,13 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
                     "Save load: dropped " <> T.pack (show n)
                     <> " unit" <> (if n == 1 then "" else "s")
                     <> " (def no longer registered)"
-        -- Hand the orphaned unit ids to Lua so unit_ai can drop their
-        -- stale per-id AI state (#195).
-        pure (map (fromIntegral . unUnitId) orphanUnits ∷ [Int])
+        -- Hand Lua the unit ids that SURVIVED on the loaded page (the
+        -- successfully restored entities — liveUids is exactly the loaded
+        -- page's restored set, orphans already dropped). unit_ai keeps only
+        -- those and scrubs everything else: missing-def orphans, ids gone
+        -- before the save, and any id colliding with a live off-page unit
+        -- (#195).
+        pure (map (fromIntegral . unUnitId) (HS.toList liveUids) ∷ [Int])
 
     -- 6. Set camera z-slice from saved camera position. elevationAtGlobal
     -- takes grid coords (gx, gy), not world coords — go through
@@ -497,13 +505,14 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
         <> ": " <> unWorldPageId pageId
 
     -- Units + buildings are now written back to their managers, so the
-    -- engine entity set is authoritative. Signal Lua so per-id modules
-    -- prune state belonging to entities that did NOT survive the load:
-    -- the explicit orphan-id sets (defs dropped above) PLUS a
-    -- global-liveness sweep on the Lua side. The orphan sets matter
-    -- because an orphaned id can collide with a live off-page entity of
-    -- the same id — a liveness check alone would then wrongly keep the
-    -- orphan's restored blob state and misattribute it. Without this, a
-    -- later id reuse would inherit the orphan's stale AI / spawn state
-    -- (#195).
-    sendSaveLoaded env uOrphanIds bOrphanIds
+    -- engine entity set is authoritative. Signal Lua with the ids that
+    -- SURVIVED on the loaded page so per-id modules keep state/refs only
+    -- for those and scrub everything else. An allow-list (survivors), not
+    -- a deny-list (orphans), is required: the restored Lua blob can carry
+    -- ids that were already gone before the save, and on a cross-session
+    -- load those can collide with a live off-page entity of the same id —
+    -- a global-liveness check would then wrongly keep the stale state and
+    -- misattribute it. The wholesale blob restore clears the singleton
+    -- first, so after load it holds only loaded-page ids; filtering to the
+    -- loaded-page survivors drops nothing legitimate (#195).
+    sendSaveLoaded env uSurvivingIds bSurvivingIds

--- a/src/World/Thread/Command/Save.hs
+++ b/src/World/Thread/Command/Save.hs
@@ -42,7 +42,7 @@ import Building.Types (BuildingManager(..), unBuildingId, buildingsOnPage)
 import Unit.Types (UnitManager(..), unUnitId, unitsOnPage)
 import Unit.Sim.Types (UnitThreadState(..))
 import World.Weather (initEarlyClimate, formatWeather, defaultClimateParams)
-import World.Thread.Helpers (sendGenLog, unWorldPageId)
+import World.Thread.Helpers (sendGenLog, sendSaveLoaded, unWorldPageId)
 import Engine.PlayerEvent.Emit (emitEvent)
 import World.Thread.ChunkLoading (maxChunksPerTick)
 
@@ -489,3 +489,10 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
         <> T.pack (show totalInitialChunks) <> " chunks, "
         <> "surface at z=" <> T.pack (show surfaceElev)
         <> ": " <> unWorldPageId pageId
+
+    -- Units + buildings are now written back to their managers, so the
+    -- engine entity set is authoritative. Signal Lua so per-id modules
+    -- prune state belonging to entities that did NOT survive the load
+    -- (orphaned defs were dropped above). Without this, a later id reuse
+    -- would inherit the orphan's stale AI / spawn state (#195).
+    sendSaveLoaded env

--- a/src/World/Thread/Command/Save.hs
+++ b/src/World/Thread/Command/Save.hs
@@ -336,7 +336,7 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
     -- center chunk's terrain matches what the player saw at save time;
     -- buildings landing in not-yet-loaded chunks will simply not render
     -- until those chunks come in via drainInitQueues.
-    (bSurvivingIds, bOrphanIds) ← do
+    bSurvivingIds ← do
         currentBm ← readIORef (buildingManagerRef env)
         let (restored, orphans) =
                 fromBuildingSnapshot pageId (bmDefs currentBm) (sdBuildings saveData)
@@ -382,16 +382,14 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
                     "Save load: dropped " <> T.pack (show n)
                     <> " building" <> (if n == 1 then "" else "s")
                     <> " (def no longer registered)"
-        -- Hand Lua two loaded-page sets: the building ids that SURVIVED
-        -- (successfully restored) and the ORPHANS (claimed by this page's
-        -- snapshot but dropped — def gone). building_spawn force-prunes the
-        -- orphans (collision-safe), keeps survivors, and keeps any other id
-        -- only if it's a still-live OFF-PAGE building — so it strips stale
-        -- loaded-page leftovers without dropping other live pages' state
-        -- (#195).
-        pure ( map (fromIntegral . unBuildingId)
-                   (HM.keys (bmInstances restored)) ∷ [Int]
-             , map (fromIntegral . unBuildingId) orphans ∷ [Int] )
+        -- Hand Lua the building ids that SURVIVED on the loaded page (the
+        -- successfully restored set). building_spawn rebuilds its state as
+        -- "survivors restored from the save blob + every other still-live
+        -- (off-page) building's PRE-LOAD state", so a load only touches the
+        -- loaded page and other live pages keep their current state (#195,
+        -- #191). `orphans` is consumed for the logging/toast above only.
+        pure (map (fromIntegral . unBuildingId)
+                  (HM.keys (bmInstances restored)) ∷ [Int])
 
     -- v5 (Phase 4): restore units + sim state. Same orphan handling as
     -- buildings; sim states for orphaned uids are dropped.
@@ -408,7 +406,7 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
     -- imperceptible. A future reader that requires stricter consistency
     -- (e.g. asserts simStates ⊆ umInstances) would need either an
     -- explicit lock or merging both refs into a single IORef.
-    (uSurvivingIds, uOrphanIds) ← do
+    uSurvivingIds ← do
         currentUm ← readIORef (unitManagerRef env)
         let (restoredUm, orphanUnits) =
                 fromUnitSnapshot pageId (umDefs currentUm) (sdUnits saveData)
@@ -456,17 +454,15 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
                     "Save load: dropped " <> T.pack (show n)
                     <> " unit" <> (if n == 1 then "" else "s")
                     <> " (def no longer registered)"
-        -- Hand Lua two loaded-page sets: the unit ids that SURVIVED
-        -- (liveUids = the loaded page's restored set) and the ORPHANS
-        -- (claimed by this page's snapshot but dropped — def gone). unit_ai
-        -- force-prunes the orphans (collision-safe: a dropped id can
-        -- collide with a live off-page unit, so liveness alone would keep
-        -- it), keeps survivors, and keeps any other top-level entry only if
-        -- it's a still-live OFF-PAGE unit — preserving other live pages'
-        -- AI state. Nested refs are scrubbed against the survivor set
-        -- (a loaded-page unit can only validly reference a page-mate) (#195).
-        pure ( map (fromIntegral . unUnitId) (HS.toList liveUids) ∷ [Int]
-             , map (fromIntegral . unUnitId) orphanUnits ∷ [Int] )
+        -- Hand Lua the unit ids that SURVIVED on the loaded page (liveUids
+        -- = the loaded page's restored set). unit_ai rebuilds aiState as
+        -- "survivors restored from the save blob + every other still-live
+        -- (off-page) unit's PRE-LOAD state", so a load only touches the
+        -- loaded page and other live pages keep their current AI state
+        -- (#195, #191). Nested refs are scrubbed against the survivor set
+        -- (a loaded-page unit can only validly reference a page-mate).
+        -- `orphanUnits` is consumed for the logging/toast above only.
+        pure (map (fromIntegral . unUnitId) (HS.toList liveUids) ∷ [Int])
 
     -- 6. Set camera z-slice from saved camera position. elevationAtGlobal
     -- takes grid coords (gx, gy), not world coords — go through
@@ -512,13 +508,14 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
         <> ": " <> unWorldPageId pageId
 
     -- Units + buildings are now written back to their managers, so the
-    -- engine entity set is authoritative. Signal Lua with both the loaded
-    -- page's SURVIVORS and its ORPHANS so per-id modules can reconcile
-    -- correctly. The Lua blob is a global singleton serialized wholesale,
-    -- so it can carry both loaded-page ids and OFF-PAGE ids (other live
-    -- pages' state). The reconcile must therefore: keep survivors;
-    -- force-prune orphans (a dropped loaded-page id can collide with a
-    -- live off-page entity, so global liveness alone would misattribute
-    -- its stale state); and keep any other id only if it's a still-live
-    -- off-page entity — preserving other live pages' state (#195, #191).
-    sendSaveLoaded env uSurvivingIds bSurvivingIds uOrphanIds bOrphanIds
+    -- engine entity set is authoritative. Signal Lua with the loaded
+    -- page's SURVIVORS. The Lua blob is a global singleton serialized
+    -- wholesale, so it carries OFF-PAGE ids too (other live pages' state).
+    -- The reconcile rebuilds each table as "survivors restored from the
+    -- blob + every other still-live entity's PRE-LOAD state", so the load
+    -- replaces only loaded-page state and other live pages are untouched
+    -- (#195, #191). Off-page state is taken from the pre-load snapshot,
+    -- never the blob's stale copy, which also means a dropped/orphan or
+    -- gone-before-save id that collides with a live off-page entity uses
+    -- that entity's own state, never the blob's — no misattribution.
+    sendSaveLoaded env uSurvivingIds bSurvivingIds

--- a/src/World/Thread/Command/Save.hs
+++ b/src/World/Thread/Command/Save.hs
@@ -336,7 +336,7 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
     -- center chunk's terrain matches what the player saw at save time;
     -- buildings landing in not-yet-loaded chunks will simply not render
     -- until those chunks come in via drainInitQueues.
-    do
+    bOrphanIds ← do
         currentBm ← readIORef (buildingManagerRef env)
         let (restored, orphans) =
                 fromBuildingSnapshot pageId (bmDefs currentBm) (sdBuildings saveData)
@@ -382,6 +382,9 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
                     "Save load: dropped " <> T.pack (show n)
                     <> " building" <> (if n == 1 then "" else "s")
                     <> " (def no longer registered)"
+        -- Hand the orphaned building ids to Lua so building_spawn can drop
+        -- their stale per-id state (#195).
+        pure (map (fromIntegral . unBuildingId) orphans ∷ [Int])
 
     -- v5 (Phase 4): restore units + sim state. Same orphan handling as
     -- buildings; sim states for orphaned uids are dropped.
@@ -398,7 +401,7 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
     -- imperceptible. A future reader that requires stricter consistency
     -- (e.g. asserts simStates ⊆ umInstances) would need either an
     -- explicit lock or merging both refs into a single IORef.
-    do
+    uOrphanIds ← do
         currentUm ← readIORef (unitManagerRef env)
         let (restoredUm, orphanUnits) =
                 fromUnitSnapshot pageId (umDefs currentUm) (sdUnits saveData)
@@ -446,6 +449,9 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
                     "Save load: dropped " <> T.pack (show n)
                     <> " unit" <> (if n == 1 then "" else "s")
                     <> " (def no longer registered)"
+        -- Hand the orphaned unit ids to Lua so unit_ai can drop their
+        -- stale per-id AI state (#195).
+        pure (map (fromIntegral . unUnitId) orphanUnits ∷ [Int])
 
     -- 6. Set camera z-slice from saved camera position. elevationAtGlobal
     -- takes grid coords (gx, gy), not world coords — go through
@@ -492,7 +498,12 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
 
     -- Units + buildings are now written back to their managers, so the
     -- engine entity set is authoritative. Signal Lua so per-id modules
-    -- prune state belonging to entities that did NOT survive the load
-    -- (orphaned defs were dropped above). Without this, a later id reuse
-    -- would inherit the orphan's stale AI / spawn state (#195).
-    sendSaveLoaded env
+    -- prune state belonging to entities that did NOT survive the load:
+    -- the explicit orphan-id sets (defs dropped above) PLUS a
+    -- global-liveness sweep on the Lua side. The orphan sets matter
+    -- because an orphaned id can collide with a live off-page entity of
+    -- the same id — a liveness check alone would then wrongly keep the
+    -- orphan's restored blob state and misattribute it. Without this, a
+    -- later id reuse would inherit the orphan's stale AI / spawn state
+    -- (#195).
+    sendSaveLoaded env uOrphanIds bOrphanIds

--- a/src/World/Thread/Helpers.hs
+++ b/src/World/Thread/Helpers.hs
@@ -20,14 +20,15 @@ sendGenLog env msg = Q.writeQueue (luaQueue env) (LuaWorldGenLog msg)
 
 -- | Signal Lua that a save finished loading, so per-id modules can
 --   reconcile their state against the entities that survived the load
---   (#195). Carries the orphaned unit + building ids the engine dropped
---   (defs no longer registered) so the Lua side can force-prune them
---   even when an id collides with a live off-page entity. Emit only
---   after units + buildings have been written back.
+--   (#195). Carries the unit + building ids that SURVIVED on the loaded
+--   page (the successfully restored set); the Lua side keeps state/refs
+--   only for those and scrubs everything else (missing-def orphans, ids
+--   gone before the save, and ids colliding with a live off-page
+--   entity). Emit only after units + buildings have been written back.
 sendSaveLoaded ∷ EngineEnv → [Int] → [Int] → IO ()
-sendSaveLoaded env orphanUnitIds orphanBuildingIds =
+sendSaveLoaded env survivingUnitIds survivingBuildingIds =
     Q.writeQueue (luaQueue env)
-        (LuaSaveLoaded orphanUnitIds orphanBuildingIds)
+        (LuaSaveLoaded survivingUnitIds survivingBuildingIds)
 
 -- | Info message to lua's HUD
 sendHudInfo ∷ EngineEnv → Text → Text → IO ()

--- a/src/World/Thread/Helpers.hs
+++ b/src/World/Thread/Helpers.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE Strict, UnicodeSyntax #-}
 module World.Thread.Helpers
     ( sendGenLog
+    , sendSaveLoaded
     , sendHudInfo
     , sendHudWeatherInfo
     , sendHudResourcesInfo
@@ -16,6 +17,12 @@ import World.Types (WorldPageId(..))
 -- | Send a progress message to Lua
 sendGenLog ∷ EngineEnv → Text → IO ()
 sendGenLog env msg = Q.writeQueue (luaQueue env) (LuaWorldGenLog msg)
+
+-- | Signal Lua that a save finished loading, so per-id modules can
+--   reconcile their state against the entities that survived the load
+--   (#195). Emit only after units + buildings have been written back.
+sendSaveLoaded ∷ EngineEnv → IO ()
+sendSaveLoaded env = Q.writeQueue (luaQueue env) LuaSaveLoaded
 
 -- | Info message to lua's HUD
 sendHudInfo ∷ EngineEnv → Text → Text → IO ()

--- a/src/World/Thread/Helpers.hs
+++ b/src/World/Thread/Helpers.hs
@@ -20,9 +20,14 @@ sendGenLog env msg = Q.writeQueue (luaQueue env) (LuaWorldGenLog msg)
 
 -- | Signal Lua that a save finished loading, so per-id modules can
 --   reconcile their state against the entities that survived the load
---   (#195). Emit only after units + buildings have been written back.
-sendSaveLoaded ∷ EngineEnv → IO ()
-sendSaveLoaded env = Q.writeQueue (luaQueue env) LuaSaveLoaded
+--   (#195). Carries the orphaned unit + building ids the engine dropped
+--   (defs no longer registered) so the Lua side can force-prune them
+--   even when an id collides with a live off-page entity. Emit only
+--   after units + buildings have been written back.
+sendSaveLoaded ∷ EngineEnv → [Int] → [Int] → IO ()
+sendSaveLoaded env orphanUnitIds orphanBuildingIds =
+    Q.writeQueue (luaQueue env)
+        (LuaSaveLoaded orphanUnitIds orphanBuildingIds)
 
 -- | Info message to lua's HUD
 sendHudInfo ∷ EngineEnv → Text → Text → IO ()

--- a/src/World/Thread/Helpers.hs
+++ b/src/World/Thread/Helpers.hs
@@ -19,19 +19,16 @@ sendGenLog ∷ EngineEnv → Text → IO ()
 sendGenLog env msg = Q.writeQueue (luaQueue env) (LuaWorldGenLog msg)
 
 -- | Signal Lua that a save finished loading, so per-id modules can
---   reconcile their global singleton state (#195). Carries, for the
---   loaded page, the unit + building ids that SURVIVED (successfully
---   restored) and the ORPHANS (claimed by the snapshot but dropped). The
---   Lua side keeps survivors, force-prunes orphans (collision-safe), and
---   keeps any other id only if it's a still-live off-page entity — so
---   other live pages' state is preserved. Emit only after units +
---   buildings have been written back.
-sendSaveLoaded ∷ EngineEnv → [Int] → [Int] → [Int] → [Int] → IO ()
-sendSaveLoaded env survivingUnitIds survivingBuildingIds
-                   orphanUnitIds orphanBuildingIds =
+--   reconcile their global singleton state (#195). Carries the loaded
+--   page's surviving unit + building ids. The Lua side rebuilds each
+--   table as "survivors restored from the save blob + every other
+--   still-live (off-page) entity's pre-load state", so a load replaces
+--   only loaded-page state and other live pages are untouched. Emit only
+--   after units + buildings have been written back.
+sendSaveLoaded ∷ EngineEnv → [Int] → [Int] → IO ()
+sendSaveLoaded env survivingUnitIds survivingBuildingIds =
     Q.writeQueue (luaQueue env)
-        (LuaSaveLoaded survivingUnitIds survivingBuildingIds
-                       orphanUnitIds orphanBuildingIds)
+        (LuaSaveLoaded survivingUnitIds survivingBuildingIds)
 
 -- | Info message to lua's HUD
 sendHudInfo ∷ EngineEnv → Text → Text → IO ()

--- a/src/World/Thread/Helpers.hs
+++ b/src/World/Thread/Helpers.hs
@@ -19,16 +19,19 @@ sendGenLog ∷ EngineEnv → Text → IO ()
 sendGenLog env msg = Q.writeQueue (luaQueue env) (LuaWorldGenLog msg)
 
 -- | Signal Lua that a save finished loading, so per-id modules can
---   reconcile their state against the entities that survived the load
---   (#195). Carries the unit + building ids that SURVIVED on the loaded
---   page (the successfully restored set); the Lua side keeps state/refs
---   only for those and scrubs everything else (missing-def orphans, ids
---   gone before the save, and ids colliding with a live off-page
---   entity). Emit only after units + buildings have been written back.
-sendSaveLoaded ∷ EngineEnv → [Int] → [Int] → IO ()
-sendSaveLoaded env survivingUnitIds survivingBuildingIds =
+--   reconcile their global singleton state (#195). Carries, for the
+--   loaded page, the unit + building ids that SURVIVED (successfully
+--   restored) and the ORPHANS (claimed by the snapshot but dropped). The
+--   Lua side keeps survivors, force-prunes orphans (collision-safe), and
+--   keeps any other id only if it's a still-live off-page entity — so
+--   other live pages' state is preserved. Emit only after units +
+--   buildings have been written back.
+sendSaveLoaded ∷ EngineEnv → [Int] → [Int] → [Int] → [Int] → IO ()
+sendSaveLoaded env survivingUnitIds survivingBuildingIds
+                   orphanUnitIds orphanBuildingIds =
     Q.writeQueue (luaQueue env)
-        (LuaSaveLoaded survivingUnitIds survivingBuildingIds)
+        (LuaSaveLoaded survivingUnitIds survivingBuildingIds
+                       orphanUnitIds orphanBuildingIds)
 
 -- | Info message to lua's HUD
 sendHudInfo ∷ EngineEnv → Text → Text → IO ()

--- a/tools/lua_orphan_prune_probe.py
+++ b/tools/lua_orphan_prune_probe.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Headless regression probe for #195 — Lua per-id state surviving a load.
+
+Lua save-module blobs (unit_ai aiState, building_spawn state) are
+restored BEFORE the engine load path, which can drop units/buildings
+whose defs are no longer registered. The Lua side used to keep state for
+those dropped ids, so a later id reuse could inherit stale AI/spawn
+state. The fix has the engine emit a post-load signal (LuaSaveLoaded →
+broadcast `onSaveLoaded`); the modules reconcile their per-id state
+against live entities (unit.exists / building.getInfo, both GLOBAL).
+
+This probe reproduces the leak with a REAL save/load and asserts the
+post-load reconcile prunes it:
+
+  1. spawn unit A on flat ground, let the AI tick so aiState[A] exists,
+  2. destroy A  → A no longer exists, but aiState[A] lingers (the leak),
+  3. spawn unit B and keep it alive (control — its state must survive),
+  4. saveWorld + loadSave  → the engine fires onSaveLoaded after the
+     load settles,
+  5. assert aiState[A] was pruned and aiState[B] preserved.
+
+`unitAi.getState(uid)` is the public observation hook (returns the live
+aiState entry or nil). Exit 0 = fix verified.
+
+Usage:  python3 tools/lua_orphan_prune_probe.py [--port 9008] [--seed 42]
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import socket
+import subprocess
+import sys
+import time
+
+LOG = "/tmp/orphan_prune_engine.log"
+
+
+def send(port: int, lua: str, timeout: float = 10.0) -> str:
+    with socket.create_connection(("localhost", port), timeout=timeout) as s:
+        s.sendall((lua + "\n").encode())
+        chunks: list[bytes] = []
+        s.settimeout(0.3)
+        try:
+            while True:
+                b = s.recv(4096)
+                if not b:
+                    break
+                chunks.append(b)
+        except socket.timeout:
+            pass
+    out = b"".join(chunks).decode(errors="replace")
+    results = [ln[2:].strip() for ln in out.splitlines() if ln.startswith("> ")]
+    results = [r for r in results if r]
+    return results[-1] if results else out.strip()
+
+
+def boot(port: int) -> subprocess.Popen:
+    log = open(LOG, "w")
+    proc = subprocess.Popen(
+        ["cabal", "run", "-v0", "exe:synarchy", "--",
+         "--headless", "--port", str(port)],
+        stdout=log, stderr=subprocess.STDOUT,
+    )
+    deadline = time.time() + 240
+    while time.time() < deadline:
+        try:
+            if "READY" in open(LOG).read():
+                return proc
+        except FileNotFoundError:
+            pass
+        if proc.poll() is not None:
+            sys.exit(f"engine exited before READY; see {LOG}")
+        time.sleep(0.4)
+    proc.kill()
+    sys.exit("engine never printed READY")
+
+
+def bootstrap_defs(port: int) -> None:
+    loaders = [
+        ("data/substances/*.yaml", "engine.loadSubstanceYaml"),
+        ("data/items/*.yaml",      "engine.loadItemYaml"),
+        ("data/equipment/*.yaml",  "engine.loadEquipmentYaml"),
+        ("data/materials/*.yaml",  "engine.loadMaterialYaml"),
+        ("data/units/*.yaml",      "engine.loadUnitYaml"),
+    ]
+    for pattern, fn in loaders:
+        for path in sorted(glob.glob(pattern)):
+            send(port, f"{fn}('{path}'); return 'ok'")
+    for script, dt in [("unit_stats", 0.1), ("unit_resources", 0.2),
+                       ("unit_ai", 0.1)]:
+        send(port, f"engine.loadScript('scripts/{script}.lua', {dt}); return 'ok'")
+
+
+def find_flat(port: int) -> tuple[int, int] | None:
+    """Find two adjacent dry equal-z land tiles for two spawns."""
+    lua = (
+        "local function f() for gy=-8,8 do for gx=-8,6 do "
+        "local za=world.getTerrainAt(gx,gy) local zb=world.getTerrainAt(gx+1,gy) "
+        "if za and zb and za==zb and za>0 then "
+        "local fa=world.getFluidAt(gx,gy) local fb=world.getFluidAt(gx+1,gy) "
+        "if (not fa or fa.type=='none') and (not fb or fb.type=='none') then "
+        "return gx..','..gy end end end end return 'none' end return f()"
+    )
+    for _ in range(8):
+        r = send(port, lua).strip().strip('"')
+        if r and r != "none" and "," in r:
+            gx, gy = r.split(",")
+            return int(gx), int(gy)
+        time.sleep(1.0)
+    return None
+
+
+def getstate(port: int, uid: int) -> str:
+    return send(port,
+        f"local s=require('scripts.unit_ai').getState({uid}); "
+        f"return s and 'present' or 'nil'").strip().strip('"')
+
+
+def exists(port: int, uid: int) -> bool:
+    r = send(port, f"return unit.exists({uid}) and 'yes' or 'no'").strip().strip('"')
+    return r == "yes"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=9008)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--size", type=int, default=64)
+    args = ap.parse_args()
+
+    proc = boot(args.port)
+    ok = True
+    try:
+        bootstrap_defs(args.port)
+        send(args.port, f"world.init('arena', {args.seed}, {args.size}, 3); return 'ok'")
+        send(args.port, "return world.waitForInit(180)", timeout=190)
+        send(args.port, "world.show('arena'); return 'ok'")
+        send(args.port, "return world.loadChunksInRegion(-2,-2,2,2)")
+        send(args.port, "return world.waitForChunks(60)", timeout=70)
+
+        spot = find_flat(args.port)
+        if not spot:
+            print("FAIL: no flat dry ground found to spawn on")
+            return 1
+        gx, gy = spot
+        print(f"Spawning on flat ground at ({gx},{gy})")
+
+        a = int(float(send(args.port, f"return unit.spawn('acolyte', {gx}, {gy})")))
+        b = int(float(send(args.port, f"return unit.spawn('acolyte', {gx+1}, {gy})")))
+        print(f"Spawned A={a} (to be orphaned), B={b} (control)")
+
+        # Let the AI tick so aiState[A]/[B] are created.
+        time.sleep(3.0)
+        sa, sb = getstate(args.port, a), getstate(args.port, b)
+        print(f"After tick: aiState[A]={sa}, aiState[B]={sb}")
+        if sa != "present" or sb != "present":
+            print("FAIL: AI state was not created for spawned units "
+                  "(can't exercise the leak)")
+            return 1
+
+        # Destroy A. It's queued — wait until the unit thread drops it.
+        send(args.port, f"unit.destroy({a}); return 'ok'")
+        for _ in range(20):
+            if not exists(args.port, a):
+                break
+            time.sleep(0.3)
+        if exists(args.port, a):
+            print("FAIL: unit A never got destroyed")
+            return 1
+        leaked = getstate(args.port, a)
+        print(f"After destroy: unit.exists(A)=no, aiState[A]={leaked} "
+              f"(lingering = the leak)")
+
+        # Save + load. The engine fires onSaveLoaded after the load
+        # settles; the reconcile should prune A while keeping B.
+        send(args.port, "return engine.saveWorld('arena','orphan_test')")
+        send(args.port, "return engine.loadSave('orphan_test')")
+        # Wait for the load to settle (world thread restores units, then
+        # enqueues the LuaSaveLoaded broadcast). Re-show the loaded page.
+        time.sleep(2.0)
+        send(args.port, "world.show('main_world'); return 'ok'")
+
+        # Poll until the reconcile has run (aiState[A] pruned) or timeout.
+        pruned = False
+        for _ in range(40):
+            if getstate(args.port, a) == "nil":
+                pruned = True
+                break
+            time.sleep(0.5)
+        final_a = getstate(args.port, a)
+        final_b = getstate(args.port, b)
+        print(f"After load: aiState[A]={final_a}, aiState[B]={final_b}")
+
+        if not pruned or final_a != "nil":
+            print("FAIL: stale aiState[A] for the dropped unit was NOT "
+                  "pruned after load (#195 not fixed)")
+            ok = False
+        elif final_b != "present":
+            print("FAIL: aiState[B] for a LIVE unit was wrongly pruned "
+                  "(reconcile too aggressive)")
+            ok = False
+        else:
+            print("PASS: dropped-unit AI state pruned, live-unit state kept")
+    finally:
+        try:
+            send(args.port, "engine.quit(); return 'bye'", timeout=3)
+        except Exception:
+            pass
+        try:
+            proc.wait(timeout=10)
+        except Exception:
+            proc.kill()
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/lua_orphan_prune_probe.py
+++ b/tools/lua_orphan_prune_probe.py
@@ -252,6 +252,31 @@ def main() -> int:
             ok = False
         else:
             print("PASS: dropped-unit AI state pruned, live-unit state kept")
+
+        # Orphan-set force-prune path (the id-collision case): an orphaned
+        # id can collide with a LIVE off-page unit of the same id. The
+        # restored blob state belongs to the dropped orphan, so it must be
+        # pruned even though a unit with that id exists. Simulate the engine
+        # reporting B's id as an orphan and assert it's force-pruned while B
+        # itself stays alive (proving the prune keys off the orphan SET, not
+        # liveness).
+        if ok:
+            send(args.port,
+                 f"require('scripts.unit_ai').onSaveLoaded({{{b}}}, {{}}); "
+                 f"return 'ok'", expect_result=False)
+            fb = getstate(args.port, b)
+            be = exists(args.port, b)
+            print(f"Force-prune of orphan-id B: aiState[B]={fb}, "
+                  f"unit.exists(B)={'yes' if be else 'no'}")
+            if fb != "nil":
+                print("FAIL: an orphaned id colliding with a LIVE unit was "
+                      "NOT force-pruned (collision misattribution, review #2)")
+                ok = False
+            elif not be:
+                print("FAIL: force-prune unexpectedly destroyed the unit")
+                ok = False
+            else:
+                print("PASS: orphan-id force-pruned even though the unit is live")
     finally:
         try:
             send(args.port, "engine.quit()", timeout=3, expect_result=False)

--- a/tools/lua_orphan_prune_probe.py
+++ b/tools/lua_orphan_prune_probe.py
@@ -274,16 +274,15 @@ def main() -> int:
         else:
             print("PASS: dropped-unit AI state pruned, live-unit state kept")
 
-        # onSaveLoaded signature: (survUnitIds, survBuildingIds,
-        # orphanUnitIds, orphanBuildingIds).
+        # onSaveLoaded signature: (survUnitIds, survBuildingIds).
         ai = "require('scripts.unit_ai')"
 
         # (i) Nested-reference scrub on a loaded-page survivor: a survivor can
         # embed a stale id in a nested field (attackTargetUid / treatPending).
         # A loaded-page unit can only validly reference a page-mate, so an id
-        # outside the survivor set (gone-before-save or off-page collision)
-        # must be scrubbed. Plant fakes in B, call onSaveLoaded with B as the
-        # only survivor, assert refs cleared while B's entry stays intact.
+        # outside the survivor set is stale and must be scrubbed. Plant fakes
+        # in B, call onSaveLoaded with B as the only survivor, assert refs
+        # cleared while B's entry stays intact.
         FAKE = 987654
         if ok:
             send(args.port,
@@ -291,8 +290,7 @@ def main() -> int:
                  f"if s then s.attackTargetUid={FAKE}; "
                  f"s.treatPending={{uid={FAKE}}} end; return 'ok'",
                  expect_result=False)
-            send(args.port,
-                 f"{ai}.onSaveLoaded({{{b}}}, {{}}, {{}}, {{}}); return 'ok'",
+            send(args.port, f"{ai}.onSaveLoaded({{{b}}}, {{}}); return 'ok'",
                  expect_result=False)
             ref = send(args.port, f"local s={ai}.getState({b}); "
                  f"return s and tostring(s.attackTargetUid) or 'NOSTATE'")
@@ -308,45 +306,49 @@ def main() -> int:
             else:
                 print("PASS: stale nested references scrubbed, survivor kept")
 
-        # (ii) Off-page preservation (regression guard): a live unit NOT in
-        # the loaded page's survivor/orphan sets stands in for a live off-page
-        # unit whose state rode along in the wholesale blob. It must be KEPT
-        # (a pure allow-list would wrongly drop it). Empty all four sets; B is
-        # live → keep.
+        # (ii) Off-page state must NOT be rolled back by an older save, and a
+        # stale blob id must NOT be kept. This drives the REAL blob-restore
+        # path (the registered deserializer), not just onSaveLoaded:
+        #   * mark B's live state (probeMarker),
+        #   * run the deserializer with a STALE blob (B without the marker +
+        #     a fake dead id) — it snapshots pre-load, clobbers, loads stale,
+        #   * onSaveLoaded with B as NON-survivor (i.e. B is "off-page").
+        # Expect: B keeps its pre-load marker (not the blob's stale copy), and
+        # the fake dead id from the blob is dropped.
+        DEAD = 998877
         if ok:
             send(args.port,
-                 f"{ai}.onSaveLoaded({{}}, {{}}, {{}}, {{}}); return 'ok'",
-                 expect_result=False)
-            fb = getstate(args.port, b)
-            print(f"Off-page keep (B live, not loaded-page): aiState[B]={fb}")
-            if fb != "present":
-                print("FAIL: live off-page unit's state was wrongly dropped "
-                      "(regresses keep-other-pages-intact, review #6)")
-                ok = False
-            else:
-                print("PASS: live off-page state preserved")
-
-        # (iii) Orphan force-prune (collision-safe): a loaded-page orphan id
-        # can collide with a LIVE off-page unit. It must be pruned via the
-        # orphan set even though unit.exists is true. Report B as an orphan
-        # unit; assert aiState[B] pruned while B stays alive.
-        if ok:
+                 f"local s={ai}.getState({b}); if s then s.probeMarker=777 end; "
+                 f"return 'ok'", expect_result=False)
             send(args.port,
-                 f"{ai}.onSaveLoaded({{}}, {{}}, {{{b}}}, {{}}); return 'ok'",
+                 "local sm=require('scripts.lib.save_modules'); "
+                 "local ser=require('scripts.lib.serialize'); "
+                 f"local stale=ser.serialize({{[{b}]={{currentAction='idle'}},"
+                 f"[{DEAD}]={{currentAction='attack'}}}}); "
+                 "sm.registry.unit_ai.deserialize(stale); return 'ok'",
                  expect_result=False)
-            fb = getstate(args.port, b)
+            # B is live but NOT a loaded-page survivor → treated as off-page.
+            send(args.port, f"{ai}.onSaveLoaded({{}}, {{}}); return 'ok'",
+                 expect_result=False)
+            mk = send(args.port, f"local s={ai}.getState({b}); "
+                 f"return s and tostring(s.probeMarker) or 'NOSTATE'")
+            dead = send(args.port, f"local s={ai}.getState({DEAD}); "
+                 f"return s and 'present' or 'nil'")
             be = exists(args.port, b)
-            print(f"Orphan force-prune (B orphan, live): aiState[B]={fb}, "
-                  f"unit.exists(B)={'yes' if be else 'no'}")
-            if fb != "nil":
-                print("FAIL: loaded-page orphan colliding with a LIVE unit was "
-                      "NOT force-pruned (collision misattribution)")
+            print(f"Blob-restore reconcile: B.probeMarker -> {mk}, "
+                  f"dead-id state -> {dead}, B alive -> {'yes' if be else 'no'}")
+            if mk != "777":
+                print("FAIL: live off-page unit's state was rolled back to the "
+                      "save blob (lost pre-load state, review)")
+                ok = False
+            elif dead != "nil":
+                print("FAIL: a stale blob id with no live entity was kept")
                 ok = False
             elif not be:
-                print("FAIL: prune unexpectedly destroyed the unit")
+                print("FAIL: reconcile unexpectedly destroyed the unit")
                 ok = False
             else:
-                print("PASS: orphan force-pruned even though the unit is live")
+                print("PASS: off-page pre-load state preserved, stale blob id dropped")
     finally:
         try:
             send(args.port, "engine.quit()", timeout=3, expect_result=False)

--- a/tools/lua_orphan_prune_probe.py
+++ b/tools/lua_orphan_prune_probe.py
@@ -214,7 +214,28 @@ def main() -> int:
             return 1
         leaked = getstate(args.port, a)
         print(f"After destroy: unit.exists(A)=no, aiState[A]={leaked} "
-              f"(lingering = the leak)")
+              f"(lingering in memory = the leak)")
+
+        # Serializer filter: even though aiState[A] lingers in memory, the
+        # SAVE blob must exclude it. Otherwise, on a cross-session load, A's
+        # dead loaded-page id could collide with a live off-page unit and be
+        # misattributed (onSaveLoaded can't tell stale loaded-page leftovers
+        # from off-page state — the blob isn't page-keyed). Run the registered
+        # serializer and confirm A is filtered out while B is kept.
+        blobcheck = send(args.port,
+            "local sm=require('scripts.lib.save_modules'); "
+            "local ser=require('scripts.lib.serialize'); "
+            "local r=ser.deserialize(sm.serializeAll().unit_ai) or {}; "
+            "local ha,hb=false,false; "
+            f"for k in pairs(r) do local n=tonumber(k); "
+            f"if n=={a} then ha=true elseif n=={b} then hb=true end end; "
+            "return (ha and 'present' or 'absent')..','..(hb and 'present' or 'absent')")
+        print(f"Serialized blob: A={blobcheck.split(',')[0]}, "
+              f"B={blobcheck.split(',')[-1]}")
+        if blobcheck != "absent,present":
+            print("FAIL: destroyed unit A leaked into the save blob (or B "
+                  "missing) — serializer filter not working")
+            ok = False
 
         # Save + load. The engine fires onSaveLoaded after the load
         # settles; the reconcile should prune A while keeping B.

--- a/tools/lua_orphan_prune_probe.py
+++ b/tools/lua_orphan_prune_probe.py
@@ -253,14 +253,15 @@ def main() -> int:
         else:
             print("PASS: dropped-unit AI state pruned, live-unit state kept")
 
-        # Nested-reference scrub (review #3): a SURVIVING unit can embed an
-        # orphaned id in a nested field (e.g. attackTargetUid). If that id
-        # collides with a live off-page unit, the survivor would resume
-        # targeting the wrong entity. getState() returns the live aiState
-        # table, so plant a fake orphan id in B's attackTargetUid, report it
-        # as an orphan, and assert it's scrubbed while B's entry survives.
-        # Cover both a raw-id field (attackTargetUid) and a nested-TABLE
-        # field (treatPending = {uid=...}, the handoff before treatClaim).
+        # Nested-reference scrub: a SURVIVING unit can embed a stale id in a
+        # nested field (e.g. attackTargetUid). If that id isn't a loaded-page
+        # survivor — gone before save, or colliding with a live off-page
+        # unit — the survivor would resume targeting the wrong entity.
+        # getState() returns the live aiState table, so plant a fake stale id
+        # in B's attackTargetUid + treatPending, then call onSaveLoaded with
+        # B as the ONLY survivor (FAKE absent) and assert the refs are
+        # scrubbed while B's entry stays intact. Covers both a raw-id field
+        # and a nested-TABLE field (treatPending = {uid=...}).
         FAKE = 987654
         if ok:
             send(args.port,
@@ -268,8 +269,9 @@ def main() -> int:
                  f"if s then s.attackTargetUid={FAKE}; "
                  f"s.treatPending={{uid={FAKE}}} end; return 'ok'",
                  expect_result=False)
+            # B survives; FAKE is not in the survivor allow-list.
             send(args.port,
-                 f"require('scripts.unit_ai').onSaveLoaded({{{FAKE}}}, {{}}); "
+                 f"require('scripts.unit_ai').onSaveLoaded({{{b}}}, {{}}); "
                  f"return 'ok'", expect_result=False)
             ref = send(args.port,
                  f"local s=require('scripts.unit_ai').getState({b}); "
@@ -280,36 +282,39 @@ def main() -> int:
             print(f"Nested scrub: B.attackTargetUid -> {ref}, "
                   f"B.treatPending -> {tp}")
             if ref != "nil" or tp != "nil":
-                print("FAIL: orphaned id embedded in a surviving unit's nested "
-                      "field was NOT scrubbed (review #3/#4)")
+                print("FAIL: stale id embedded in a surviving unit's nested "
+                      "field was NOT scrubbed")
+                ok = False
+            elif getstate(args.port, b) != "present":
+                print("FAIL: B's own state was wrongly dropped (B is a survivor)")
                 ok = False
             else:
-                print("PASS: orphaned nested references scrubbed from survivor")
+                print("PASS: stale nested references scrubbed, survivor kept")
 
-        # Orphan-set force-prune path (the id-collision case): an orphaned
-        # id can collide with a LIVE off-page unit of the same id. The
-        # restored blob state belongs to the dropped orphan, so it must be
-        # pruned even though a unit with that id exists. Simulate the engine
-        # reporting B's id as an orphan and assert it's force-pruned while B
-        # itself stays alive (proving the prune keys off the orphan SET, not
-        # liveness).
+        # Allow-list prune (the off-page-collision case): a stale id in the
+        # loaded blob can collide with a LIVE off-page unit. Survival is
+        # decided by the LOADED PAGE, not global liveness, so a top-level
+        # entry must be pruned when its id is NOT among the loaded-page
+        # survivors even though a unit with that id exists. Call onSaveLoaded
+        # with an EMPTY survivor set and assert aiState[B] is pruned while B
+        # itself stays alive.
         if ok:
             send(args.port,
-                 f"require('scripts.unit_ai').onSaveLoaded({{{b}}}, {{}}); "
-                 f"return 'ok'", expect_result=False)
+                 "require('scripts.unit_ai').onSaveLoaded({}, {}); "
+                 "return 'ok'", expect_result=False)
             fb = getstate(args.port, b)
             be = exists(args.port, b)
-            print(f"Force-prune of orphan-id B: aiState[B]={fb}, "
+            print(f"Allow-list prune (B not a survivor): aiState[B]={fb}, "
                   f"unit.exists(B)={'yes' if be else 'no'}")
             if fb != "nil":
-                print("FAIL: an orphaned id colliding with a LIVE unit was "
-                      "NOT force-pruned (collision misattribution, review #2)")
+                print("FAIL: a non-survivor id colliding with a LIVE unit was "
+                      "NOT pruned (would misattribute on cross-session load)")
                 ok = False
             elif not be:
-                print("FAIL: force-prune unexpectedly destroyed the unit")
+                print("FAIL: prune unexpectedly destroyed the unit")
                 ok = False
             else:
-                print("PASS: orphan-id force-pruned even though the unit is live")
+                print("PASS: non-survivor state pruned even though the unit is live")
     finally:
         try:
             send(args.port, "engine.quit()", timeout=3, expect_result=False)

--- a/tools/lua_orphan_prune_probe.py
+++ b/tools/lua_orphan_prune_probe.py
@@ -253,6 +253,32 @@ def main() -> int:
         else:
             print("PASS: dropped-unit AI state pruned, live-unit state kept")
 
+        # Nested-reference scrub (review #3): a SURVIVING unit can embed an
+        # orphaned id in a nested field (e.g. attackTargetUid). If that id
+        # collides with a live off-page unit, the survivor would resume
+        # targeting the wrong entity. getState() returns the live aiState
+        # table, so plant a fake orphan id in B's attackTargetUid, report it
+        # as an orphan, and assert it's scrubbed while B's entry survives.
+        FAKE = 987654
+        if ok:
+            send(args.port,
+                 f"local s=require('scripts.unit_ai').getState({b}); "
+                 f"if s then s.attackTargetUid={FAKE} end; return 'ok'",
+                 expect_result=False)
+            send(args.port,
+                 f"require('scripts.unit_ai').onSaveLoaded({{{FAKE}}}, {{}}); "
+                 f"return 'ok'", expect_result=False)
+            ref = send(args.port,
+                 f"local s=require('scripts.unit_ai').getState({b}); "
+                 f"return s and tostring(s.attackTargetUid) or 'NOSTATE'")
+            print(f"Nested scrub: B.attackTargetUid after onSaveLoaded -> {ref}")
+            if ref != "nil":
+                print("FAIL: orphaned id embedded in a surviving unit's nested "
+                      "field was NOT scrubbed (review #3)")
+                ok = False
+            else:
+                print("PASS: orphaned nested reference scrubbed from survivor")
+
         # Orphan-set force-prune path (the id-collision case): an orphaned
         # id can collide with a LIVE off-page unit of the same id. The
         # restored blob state belongs to the dropped orphan, so it must be

--- a/tools/lua_orphan_prune_probe.py
+++ b/tools/lua_orphan_prune_probe.py
@@ -245,7 +245,20 @@ def main() -> int:
         if not wait_save_written(SAVE_NAME):
             print(f"FAIL: save file for '{SAVE_NAME}' never appeared on disk")
             return 1
+        # Unpause first so the load-time freeze is observable: loadSave must
+        # pause the engine synchronously (before queueing WorldLoadSave) so
+        # the Lua loop can't tick script update()s against the half-restored
+        # singletons during the load window.
+        send(args.port, "engine.setPaused(false); return 'ok'", expect_result=False)
         print(f"loadSave -> {send(args.port, f'return engine.loadSave(\"{SAVE_NAME}\")')}")
+        # Right after loadSave returns (world thread hasn't finished the load),
+        # the engine must already be paused — frozen for the load window.
+        load_paused = send(args.port, "return engine.isPaused()")
+        print(f"engine.isPaused() immediately after loadSave -> {load_paused}")
+        if load_paused.strip().lower() not in ("true", "1", "1.0"):
+            print("FAIL: loadSave did not pause the engine; script update()s "
+                  "can race the load reconcile")
+            ok = False
         # Block on init, then let the load settle past LoadDone (the world
         # thread restores units, then enqueues the LuaSaveLoaded broadcast).
         send(args.port, "return world.waitForInit(180)", timeout=190)

--- a/tools/lua_orphan_prune_probe.py
+++ b/tools/lua_orphan_prune_probe.py
@@ -259,11 +259,14 @@ def main() -> int:
         # targeting the wrong entity. getState() returns the live aiState
         # table, so plant a fake orphan id in B's attackTargetUid, report it
         # as an orphan, and assert it's scrubbed while B's entry survives.
+        # Cover both a raw-id field (attackTargetUid) and a nested-TABLE
+        # field (treatPending = {uid=...}, the handoff before treatClaim).
         FAKE = 987654
         if ok:
             send(args.port,
                  f"local s=require('scripts.unit_ai').getState({b}); "
-                 f"if s then s.attackTargetUid={FAKE} end; return 'ok'",
+                 f"if s then s.attackTargetUid={FAKE}; "
+                 f"s.treatPending={{uid={FAKE}}} end; return 'ok'",
                  expect_result=False)
             send(args.port,
                  f"require('scripts.unit_ai').onSaveLoaded({{{FAKE}}}, {{}}); "
@@ -271,13 +274,17 @@ def main() -> int:
             ref = send(args.port,
                  f"local s=require('scripts.unit_ai').getState({b}); "
                  f"return s and tostring(s.attackTargetUid) or 'NOSTATE'")
-            print(f"Nested scrub: B.attackTargetUid after onSaveLoaded -> {ref}")
-            if ref != "nil":
+            tp = send(args.port,
+                 f"local s=require('scripts.unit_ai').getState({b}); "
+                 f"return s and tostring(s.treatPending) or 'NOSTATE'")
+            print(f"Nested scrub: B.attackTargetUid -> {ref}, "
+                  f"B.treatPending -> {tp}")
+            if ref != "nil" or tp != "nil":
                 print("FAIL: orphaned id embedded in a surviving unit's nested "
-                      "field was NOT scrubbed (review #3)")
+                      "field was NOT scrubbed (review #3/#4)")
                 ok = False
             else:
-                print("PASS: orphaned nested reference scrubbed from survivor")
+                print("PASS: orphaned nested references scrubbed from survivor")
 
         # Orphan-set force-prune path (the id-collision case): an orphaned
         # id can collide with a LIVE off-page unit of the same id. The

--- a/tools/lua_orphan_prune_probe.py
+++ b/tools/lua_orphan_prune_probe.py
@@ -253,37 +253,33 @@ def main() -> int:
         else:
             print("PASS: dropped-unit AI state pruned, live-unit state kept")
 
-        # Nested-reference scrub: a SURVIVING unit can embed a stale id in a
-        # nested field (e.g. attackTargetUid). If that id isn't a loaded-page
-        # survivor — gone before save, or colliding with a live off-page
-        # unit — the survivor would resume targeting the wrong entity.
-        # getState() returns the live aiState table, so plant a fake stale id
-        # in B's attackTargetUid + treatPending, then call onSaveLoaded with
-        # B as the ONLY survivor (FAKE absent) and assert the refs are
-        # scrubbed while B's entry stays intact. Covers both a raw-id field
-        # and a nested-TABLE field (treatPending = {uid=...}).
+        # onSaveLoaded signature: (survUnitIds, survBuildingIds,
+        # orphanUnitIds, orphanBuildingIds).
+        ai = "require('scripts.unit_ai')"
+
+        # (i) Nested-reference scrub on a loaded-page survivor: a survivor can
+        # embed a stale id in a nested field (attackTargetUid / treatPending).
+        # A loaded-page unit can only validly reference a page-mate, so an id
+        # outside the survivor set (gone-before-save or off-page collision)
+        # must be scrubbed. Plant fakes in B, call onSaveLoaded with B as the
+        # only survivor, assert refs cleared while B's entry stays intact.
         FAKE = 987654
         if ok:
             send(args.port,
-                 f"local s=require('scripts.unit_ai').getState({b}); "
+                 f"local s={ai}.getState({b}); "
                  f"if s then s.attackTargetUid={FAKE}; "
                  f"s.treatPending={{uid={FAKE}}} end; return 'ok'",
                  expect_result=False)
-            # B survives; FAKE is not in the survivor allow-list.
             send(args.port,
-                 f"require('scripts.unit_ai').onSaveLoaded({{{b}}}, {{}}); "
-                 f"return 'ok'", expect_result=False)
-            ref = send(args.port,
-                 f"local s=require('scripts.unit_ai').getState({b}); "
+                 f"{ai}.onSaveLoaded({{{b}}}, {{}}, {{}}, {{}}); return 'ok'",
+                 expect_result=False)
+            ref = send(args.port, f"local s={ai}.getState({b}); "
                  f"return s and tostring(s.attackTargetUid) or 'NOSTATE'")
-            tp = send(args.port,
-                 f"local s=require('scripts.unit_ai').getState({b}); "
+            tp = send(args.port, f"local s={ai}.getState({b}); "
                  f"return s and tostring(s.treatPending) or 'NOSTATE'")
-            print(f"Nested scrub: B.attackTargetUid -> {ref}, "
-                  f"B.treatPending -> {tp}")
+            print(f"Nested scrub: B.attackTargetUid -> {ref}, B.treatPending -> {tp}")
             if ref != "nil" or tp != "nil":
-                print("FAIL: stale id embedded in a surviving unit's nested "
-                      "field was NOT scrubbed")
+                print("FAIL: stale id in a survivor's nested field NOT scrubbed")
                 ok = False
             elif getstate(args.port, b) != "present":
                 print("FAIL: B's own state was wrongly dropped (B is a survivor)")
@@ -291,30 +287,45 @@ def main() -> int:
             else:
                 print("PASS: stale nested references scrubbed, survivor kept")
 
-        # Allow-list prune (the off-page-collision case): a stale id in the
-        # loaded blob can collide with a LIVE off-page unit. Survival is
-        # decided by the LOADED PAGE, not global liveness, so a top-level
-        # entry must be pruned when its id is NOT among the loaded-page
-        # survivors even though a unit with that id exists. Call onSaveLoaded
-        # with an EMPTY survivor set and assert aiState[B] is pruned while B
-        # itself stays alive.
+        # (ii) Off-page preservation (regression guard): a live unit NOT in
+        # the loaded page's survivor/orphan sets stands in for a live off-page
+        # unit whose state rode along in the wholesale blob. It must be KEPT
+        # (a pure allow-list would wrongly drop it). Empty all four sets; B is
+        # live → keep.
         if ok:
             send(args.port,
-                 "require('scripts.unit_ai').onSaveLoaded({}, {}); "
-                 "return 'ok'", expect_result=False)
+                 f"{ai}.onSaveLoaded({{}}, {{}}, {{}}, {{}}); return 'ok'",
+                 expect_result=False)
+            fb = getstate(args.port, b)
+            print(f"Off-page keep (B live, not loaded-page): aiState[B]={fb}")
+            if fb != "present":
+                print("FAIL: live off-page unit's state was wrongly dropped "
+                      "(regresses keep-other-pages-intact, review #6)")
+                ok = False
+            else:
+                print("PASS: live off-page state preserved")
+
+        # (iii) Orphan force-prune (collision-safe): a loaded-page orphan id
+        # can collide with a LIVE off-page unit. It must be pruned via the
+        # orphan set even though unit.exists is true. Report B as an orphan
+        # unit; assert aiState[B] pruned while B stays alive.
+        if ok:
+            send(args.port,
+                 f"{ai}.onSaveLoaded({{}}, {{}}, {{{b}}}, {{}}); return 'ok'",
+                 expect_result=False)
             fb = getstate(args.port, b)
             be = exists(args.port, b)
-            print(f"Allow-list prune (B not a survivor): aiState[B]={fb}, "
+            print(f"Orphan force-prune (B orphan, live): aiState[B]={fb}, "
                   f"unit.exists(B)={'yes' if be else 'no'}")
             if fb != "nil":
-                print("FAIL: a non-survivor id colliding with a LIVE unit was "
-                      "NOT pruned (would misattribute on cross-session load)")
+                print("FAIL: loaded-page orphan colliding with a LIVE unit was "
+                      "NOT force-pruned (collision misattribution)")
                 ok = False
             elif not be:
                 print("FAIL: prune unexpectedly destroyed the unit")
                 ok = False
             else:
-                print("PASS: non-survivor state pruned even though the unit is live")
+                print("PASS: orphan force-pruned even though the unit is live")
     finally:
         try:
             send(args.port, "engine.quit()", timeout=3, expect_result=False)

--- a/tools/lua_orphan_prune_probe.py
+++ b/tools/lua_orphan_prune_probe.py
@@ -28,31 +28,58 @@ from __future__ import annotations
 
 import argparse
 import glob
+import os
+import shutil
 import socket
 import subprocess
 import sys
 import time
+import uuid
 
 LOG = "/tmp/orphan_prune_engine.log"
+# Unique per run, deleted on exit. A fixed name could clobber a real save
+# and a stale dir from an interrupted run could make a later run falsely
+# pass by loading old data; main() also refuses to run if the dir exists.
+SAVE_NAME = "probe_orphan_" + uuid.uuid4().hex[:12]
 
 
-def send(port: int, lua: str, timeout: float = 10.0) -> str:
+def _results(raw: bytes) -> list[str]:
+    # The console emits a "synarchy debug console\n> " banner on connect and
+    # a trailing "> " prompt; both yield EMPTY "> " lines. The real answer is
+    # the non-empty "> <value>" line, so filter the empties out.
+    out = raw.decode(errors="replace")
+    return [ln[2:].strip() for ln in out.splitlines()
+            if ln.startswith("> ") and ln[2:].strip()]
+
+
+def send(port: int, lua: str, timeout: float = 10.0,
+         expect_result: bool = True) -> str:
+    """Run one Lua line over the debug console and return its result.
+
+    With expect_result (a `return ...` command) we read until a non-empty
+    "> value" line appears, waiting up to `timeout` — this skips the banner
+    and survives server-side BLOCKING calls like world.waitForInit /
+    waitForChunks, which emit nothing until they unblock. Fire-and-forget
+    commands (no return) pass expect_result=False and just drain briefly.
+    """
     with socket.create_connection(("localhost", port), timeout=timeout) as s:
         s.sendall((lua + "\n").encode())
         chunks: list[bytes] = []
-        s.settimeout(0.3)
+        s.settimeout(timeout)
         try:
             while True:
                 b = s.recv(4096)
                 if not b:
                     break
                 chunks.append(b)
+                if expect_result and _results(b"".join(chunks)):
+                    break               # got the real result past the banner
+                if not expect_result:
+                    s.settimeout(0.3)   # drain remainder then idle out
         except socket.timeout:
             pass
-    out = b"".join(chunks).decode(errors="replace")
-    results = [ln[2:].strip() for ln in out.splitlines() if ln.startswith("> ")]
-    results = [r for r in results if r]
-    return results[-1] if results else out.strip()
+    vals = _results(b"".join(chunks))
+    return (vals[-1] if vals else "").strip('"')
 
 
 def boot(port: int) -> subprocess.Popen:
@@ -92,6 +119,19 @@ def bootstrap_defs(port: int) -> None:
         send(port, f"engine.loadScript('scripts/{script}.lua', {dt}); return 'ok'")
 
 
+def wait_save_written(name: str, timeout: float = 30.0) -> bool:
+    """Block until the save file lands on disk. saveWorld() returns as soon
+    as the WorldSave command is QUEUED; loading before the file exists
+    would 'Save not found' or read a stale dir from a previous run."""
+    path = os.path.join("saves", name, "world.synworld")
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if os.path.isfile(path):
+            return True
+        time.sleep(0.3)
+    return False
+
+
 def find_flat(port: int) -> tuple[int, int] | None:
     """Find two adjacent dry equal-z land tiles for two spawns."""
     lua = (
@@ -129,13 +169,17 @@ def main() -> int:
     ap.add_argument("--size", type=int, default=64)
     args = ap.parse_args()
 
+    save_dir = os.path.join("saves", SAVE_NAME)
+    if os.path.exists(save_dir):
+        sys.exit(f"refusing to run: {save_dir} already exists")
+
     proc = boot(args.port)
     ok = True
     try:
         bootstrap_defs(args.port)
         send(args.port, f"world.init('arena', {args.seed}, {args.size}, 3); return 'ok'")
         send(args.port, "return world.waitForInit(180)", timeout=190)
-        send(args.port, "world.show('arena'); return 'ok'")
+        send(args.port, "world.show('arena'); return 'ok'", expect_result=False)
         send(args.port, "return world.loadChunksInRegion(-2,-2,2,2)")
         send(args.port, "return world.waitForChunks(60)", timeout=70)
 
@@ -160,7 +204,7 @@ def main() -> int:
             return 1
 
         # Destroy A. It's queued — wait until the unit thread drops it.
-        send(args.port, f"unit.destroy({a}); return 'ok'")
+        send(args.port, f"unit.destroy({a}); return 'ok'", expect_result=False)
         for _ in range(20):
             if not exists(args.port, a):
                 break
@@ -174,12 +218,18 @@ def main() -> int:
 
         # Save + load. The engine fires onSaveLoaded after the load
         # settles; the reconcile should prune A while keeping B.
-        send(args.port, "return engine.saveWorld('arena','orphan_test')")
-        send(args.port, "return engine.loadSave('orphan_test')")
-        # Wait for the load to settle (world thread restores units, then
-        # enqueues the LuaSaveLoaded broadcast). Re-show the loaded page.
+        print(f"saveWorld -> {send(args.port, f'return engine.saveWorld(\"arena\",\"{SAVE_NAME}\")')}")
+        # saveWorld returns on enqueue — wait for the file to actually land
+        # before loading, or loadSave races the write / reads a stale dir.
+        if not wait_save_written(SAVE_NAME):
+            print(f"FAIL: save file for '{SAVE_NAME}' never appeared on disk")
+            return 1
+        print(f"loadSave -> {send(args.port, f'return engine.loadSave(\"{SAVE_NAME}\")')}")
+        # Block on init, then let the load settle past LoadDone (the world
+        # thread restores units, then enqueues the LuaSaveLoaded broadcast).
+        send(args.port, "return world.waitForInit(180)", timeout=190)
         time.sleep(2.0)
-        send(args.port, "world.show('main_world'); return 'ok'")
+        send(args.port, "world.show('main_world'); return 'ok'", expect_result=False)
 
         # Poll until the reconcile has run (aiState[A] pruned) or timeout.
         pruned = False
@@ -204,13 +254,17 @@ def main() -> int:
             print("PASS: dropped-unit AI state pruned, live-unit state kept")
     finally:
         try:
-            send(args.port, "engine.quit(); return 'bye'", timeout=3)
-        except Exception:
+            send(args.port, "engine.quit()", timeout=3, expect_result=False)
+        except OSError:
             pass
         try:
-            proc.wait(timeout=10)
-        except Exception:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
             proc.kill()
+        # Clean up the throwaway save. Safe: the name is unique to this run
+        # and main() refused to start if the dir already existed.
+        if os.path.isdir(save_dir):
+            shutil.rmtree(save_dir, ignore_errors=True)
 
     return 0 if ok else 1
 


### PR DESCRIPTION
Closes #195.

## Problem
Lua save-module blobs (`unit_ai` `aiState`, `building_spawn` `state`) are restored **before** the engine load path runs. That path can drop **orphan** units/buildings whose defs are no longer registered (`fromUnitSnapshot`/`fromBuildingSnapshot` orphan handling in `World/Thread/Command/Save.hs`). The restored Lua state still held entries for those dropped ids, and because `umNextId`/`bmNextId` are restored from the snapshot, a later id reuse could let a brand-new entity inherit the orphan's stale AI / spawn state.

## Fix
The world thread now emits a **post-load signal** once units + buildings are written back (so the engine entity set is authoritative):

- new `LuaSaveLoaded` message (`Engine/Scripting/Lua/Types.hs`) → broadcast `onSaveLoaded` (`Engine/Scripting/Lua/Thread.hs`),
- emitted at the end of `handleWorldLoadSaveCommand` via `sendSaveLoaded` (`World/Thread/Helpers.hs`).

`unit_ai` and `building_spawn` implement `onSaveLoaded`, reconciling their per-id state against live entities:
- `unit_ai`: drop any `aiState[uid]` where `unit.exists(uid)` is false,
- `building_spawn`: drop any `state[bid]` where `building.getInfo(bid)` is nil.

Both `unit.exists` and `building.getInfo` are **global** (across all world pages), so entities on other loaded-but-inactive pages are kept — only genuinely dropped ids are pruned. The signal is enqueued *after* the manager writes, so by the time the Lua thread handles it global liveness is authoritative (race-free).

No save-format change (the signal is not persisted) — no `currentSaveVersion` bump.

## Testing
- New `tools/lua_orphan_prune_probe.py` regression harness: spawn a unit, let its AI tick, destroy it (state lingers — reproduces the leak across a real save/load), then assert the dropped unit's `aiState` is pruned post-load while a live control unit's state is preserved. **PASS**; engine log confirms `Unit AI: pruned 1 stale AI state(s)` fires right after `Save loaded`.
- Headless suite (`cabal test synarchy-test-headless`): **325 examples, 0 failures**.

Building-side path is identical logic (verified by symmetry + `building.getInfo` global lookup); `building_spawn` has no public state getter to probe directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)