### PR TITLE
Fix #100: item-contents popup guards missing container + closes on hud.hide

### DIFF
--- a/scripts/hud.lua
+++ b/scripts/hud.lua
@@ -544,11 +544,13 @@ function hud.hide()
     --   * event/combat/injury log panels (#84)
     --   * notification popups (#85)
     --   * right-click context menus (#86)
+    --   * item-contents popup (#100)
     pcall(function() require("scripts.event_log").hide() end)
     pcall(function() require("scripts.combat_log").hide() end)
     pcall(function() require("scripts.injury_log_panel").hide() end)
     pcall(function() require("scripts.popup").dismissAll() end)
     pcall(function() require("scripts.ui.context_menu").hide() end)
+    pcall(function() require("scripts.item_contents_panel").closeIfOpen() end)
 
     engine.logDebug("HUD hidden")
 end

--- a/scripts/item_contents_panel.lua
+++ b/scripts/item_contents_panel.lua
@@ -413,13 +413,16 @@ end
 
 function itemContentsPanel.openFor(uid, defName, mx, my)
     if not uid or not defName then return end
+    -- A new request always tears down the prior popup first (singleton),
+    -- so a stale/invalid request never leaves an earlier container's
+    -- popup on screen. Close BEFORE the existence guard below.
+    itemContentsPanel.closeIfOpen()
     -- Don't open for a container that doesn't exist: the unit holds no
     -- inventory item matching defName. unit.getItemContents returns nil
     -- in that case; an existing-but-empty container returns a table, so
     -- this only rejects genuinely missing containers (the popup still
     -- opens and shows "(empty)" for a real, empty kit).
     if not unit.getItemContents(uid, defName) then return end
-    itemContentsPanel.closeIfOpen()
     local s = itemContentsPanel.state
     s.open    = true
     s.uid     = uid

--- a/scripts/item_contents_panel.lua
+++ b/scripts/item_contents_panel.lua
@@ -413,6 +413,12 @@ end
 
 function itemContentsPanel.openFor(uid, defName, mx, my)
     if not uid or not defName then return end
+    -- Don't open for a container that doesn't exist: the unit holds no
+    -- inventory item matching defName. unit.getItemContents returns nil
+    -- in that case; an existing-but-empty container returns a table, so
+    -- this only rejects genuinely missing containers (the popup still
+    -- opens and shows "(empty)" for a real, empty kit).
+    if not unit.getItemContents(uid, defName) then return end
     itemContentsPanel.closeIfOpen()
     local s = itemContentsPanel.state
     s.open    = true


### PR DESCRIPTION
Closes #100.

## Problem
`itemContentsPanel.openFor(uid, defName, ...)` never verified the requested container exists — it unconditionally set `open=true` and built a layout, so the popup could open for a nonexistent container and show an empty box. Separately, `hud.hide()` never closed the popup, so its singleton `state.open`/`state.uid` survived gameplay teardown and could leak into later screens.

## Fix
1. **Guard `openFor`** with `unit.getItemContents(uid, defName)`. The engine returns `nil` when the unit holds no item matching `defName` (a genuinely missing container) but an empty *table* when the container exists yet holds nothing. So this rejects only missing containers — a real, empty kit still opens and shows `(empty)`.
2. **Close on teardown** — `hud.hide()` now calls `itemContentsPanel.closeIfOpen()` alongside the other HUD-owned overlays (event/combat/injury logs, popups, context menus).

> Scope note: the cargo-inventory popup has the analogous `hud.hide()` gap; that's tracked separately in #141 and left untouched here.

## Verification (headless, port 9100)
Followed the issue repro plus the positive case:

| Case | Before | After |
|------|--------|-------|
| `openFor` for nonexistent container | `isOpen=true` (bug) | `isOpen=false` ✅ |
| `openFor` for real empty container | n/a | `isOpen=true` ✅ (preserved) |
| `hud.hide()` with panel open | `true \| uid=1` (bug) | `isOpen=false, uid=nil` ✅ |

Lua-only change — no worldgen/save-format impact. Engine boots and loads the scripts cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)