### PR TITLE
Fix #142: close item-contents popup on zoom transitions

### DIFF
--- a/scripts/hud.lua
+++ b/scripts/hud.lua
@@ -628,6 +628,12 @@ function hud.onScroll(dx, dy)
     local zoomFadeStart = camera.getZoomFadeStart()
     local zoomFadeEnd = camera.getZoomFadeEnd()
     local oldView = hud.currentView
+    -- The item-contents popup is mounted on hud.world_page, so hiding
+    -- that page on a zoom transition only takes it off-view; its logical
+    -- state stays open and can reappear stale when the world page comes
+    -- back. Tear it down on every transition, alongside the info-panel
+    -- clear, so it never survives a view change (#142).
+    local itemContentsPanel = require("scripts.item_contents_panel")
     if zoom > zoomFadeEnd then
         if oldView ~= "zoomed_out" and hud.zoom_page and hud.world_page then
             UI.showPage(hud.zoom_page)
@@ -635,6 +641,7 @@ function hud.onScroll(dx, dy)
             hud.currentView = "zoomed_out"
             -- Clear info panel on zoom transition
             infoPanel.clear()
+            itemContentsPanel.closeIfOpen()
         end
     elseif zoom < zoomFadeStart then
         if oldView ~= "zoomed_in" and hud.zoom_page and hud.world_page then
@@ -643,6 +650,7 @@ function hud.onScroll(dx, dy)
             hud.currentView = "zoomed_in"
             -- Clear info panel on zoom transition
             infoPanel.clear()
+            itemContentsPanel.closeIfOpen()
         end
     else
         if oldView == "zoomed_in" and hud.world_page then
@@ -653,6 +661,7 @@ function hud.onScroll(dx, dy)
         hud.currentView = "none"
         -- In the fade zone, clear the info panel
         infoPanel.clear()
+        itemContentsPanel.closeIfOpen()
     end
 end
 


### PR DESCRIPTION
## Summary
Fixes #142. The unit-carried item-contents popup is mounted on `hud.world_page`. `hud.onScroll()` hid that page on zoom transitions but never closed the popup, so its logical state (`itemContentsPanel.state.open`) stayed `true` and could reappear stale when the world page came back.

This adds `itemContentsPanel.closeIfOpen()` at each `onScroll` transition, alongside the existing `infoPanel.clear()` — the same teardown already done on `hud.hide()` for #100. `closeIfOpen()` is idempotent and cheap (early-returns when not open), so calling it in the fade-zone branch per-tick is harmless. The `require` is `package.loaded`-cached.

## Testing
Lua-only change. Added a focused luajit harness that loads the real `item_contents_panel` and `hud` modules under stubbed engine globals, forces the popup open, and drives `hud.onScroll` across each zoom transition:
- `zoomed_in -> zoomed_out` closes the popup ✅
- `zoomed_in -> fade zone` closes the popup ✅
- `zoomed_out -> zoomed_in` leaves it closed ✅
- idempotent close ✅

Verified the harness **fails** without the fix (3 failures) and **passes** with it. `luac -p` / `luajit` syntax-check clean.

The popup itself is GUI (not headless-verifiable in pixels), but the logical open/closed state that drives the stale-reappearance is exactly what's tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)