### PR TITLE
Fix #175: clear ground-item selection on hud.hide() and zoom transitions

### DIFF
--- a/scripts/hud.lua
+++ b/scripts/hud.lua
@@ -698,7 +698,20 @@ end
 
 -- Wheel hook (no UI element under cursor, no shift). Reconcile immediately
 -- so a transition the wheel itself crosses doesn't wait for the next tick.
+--
+-- Gated on hud.visible, same as hud.update()/hud.onMouseDown(): uiManager
+-- still routes game scrolls here in the plain "test_arena" loading/builder
+-- state, where the HUD is hidden (hud.show() only runs for the
+-- "test_arena_view"/"world_view" gameplay states). Without the gate, a
+-- scroll there would run reconcileView()'s item.deselect() against
+-- activeWorld behind the hidden HUD — the very wrong-world clear this
+-- change moves engine-side for the hide path (#175). The per-tick driver
+-- in hud.update() is gated the same way, so reconcile only ever runs while
+-- the HUD owns the view.
 function hud.onScroll(dx, dy)
+    if not hud.visible then
+        return
+    end
     hud.reconcileView()
 end
 

--- a/scripts/hud.lua
+++ b/scripts/hud.lua
@@ -547,6 +547,13 @@ function hud.hide()
     --   * item-contents popup (#100)
     --   * per-unit log overlay (#104)
     --   * cargo inventory popup (#99)
+    -- Ground-item selection (#175) is NOT cleared here: it lives in the
+    -- per-world cursor (wsCursorRef) and a Lua deselect resolves through
+    -- activeWorld, which head-falls-back to a different registered world
+    -- once this page leaves wmVisible — so it could clear the wrong
+    -- world. The world thread clears it deterministically in
+    -- handleWorldHideCommand, keyed on the exact page being hidden (which
+    -- worldView.hide()/testArena.hide() issue just before this runs).
     pcall(function() require("scripts.event_log").hide() end)
     pcall(function() require("scripts.combat_log").hide() end)
     pcall(function() require("scripts.injury_log_panel").hide() end)
@@ -625,46 +632,74 @@ end
 -- manage hud (zoom transitions)
 -----------------------------------------------------------
 
-function hud.onScroll(dx, dy)
+-- Reconcile the HUD view (zoomed_in / zoomed_out / none) with the camera's
+-- actual zoom band, doing the page swap + per-transition teardown exactly
+-- when the band genuinely changes.
+--
+-- This is driven both from hud.update() (every tick) and hud.onScroll()
+-- (the wheel hook). The wheel hook alone is NOT enough: worldView.onScroll
+-- only imparts zoom *velocity*, and the camera crosses the band later in
+-- Engine.Loop.Camera.updateCameraZoom. If the final wheel event carries
+-- enough momentum to coast across the band with no further scroll event,
+-- a wheel-timed teardown never fires. Running it per-tick off the real
+-- zoom closes that gap (#175). It also keeps hud.currentView authoritative
+-- so the HUD page never lags the camera.
+--
+-- Teardown on each real transition:
+--   * infoPanel.clear() — the shared HUD info panel.
+--   * item-contents popup (#142): mounted on hud.world_page, so hiding
+--     the page only takes it off-view; its logical state stays open and
+--     could reappear stale. closeIfOpen() tears it down.
+--   * ground-item selection (#175): per-world cursor state the item
+--     watcher (item_info_panel.update) keeps polling and would use to
+--     repopulate the panel. item.deselect() clears the active world's
+--     selection — and here the world is still the visible/active one, so
+--     activeWorld resolves correctly (unlike the menu-hide path, which is
+--     handled engine-side in handleWorldHideCommand).
+function hud.reconcileView()
     local zoom = camera.getZoom()
     local zoomFadeStart = camera.getZoomFadeStart()
     local zoomFadeEnd = camera.getZoomFadeEnd()
-    local oldView = hud.currentView
-    -- The item-contents popup is mounted on hud.world_page, so hiding
-    -- that page on a zoom transition only takes it off-view; its logical
-    -- state stays open and can reappear stale when the world page comes
-    -- back. Tear it down on every transition, alongside the info-panel
-    -- clear, so it never survives a view change (#142).
-    local itemContentsPanel = require("scripts.item_contents_panel")
+
+    local newView
     if zoom > zoomFadeEnd then
-        if oldView ~= "zoomed_out" and hud.zoom_page and hud.world_page then
-            UI.showPage(hud.zoom_page)
-            UI.hidePage(hud.world_page)
-            hud.currentView = "zoomed_out"
-            -- Clear info panel on zoom transition
-            infoPanel.clear()
-            itemContentsPanel.closeIfOpen()
-        end
+        newView = "zoomed_out"
     elseif zoom < zoomFadeStart then
-        if oldView ~= "zoomed_in" and hud.zoom_page and hud.world_page then
-            UI.showPage(hud.world_page)
-            UI.hidePage(hud.zoom_page)
-            hud.currentView = "zoomed_in"
-            -- Clear info panel on zoom transition
-            infoPanel.clear()
-            itemContentsPanel.closeIfOpen()
-        end
+        newView = "zoomed_in"
     else
+        newView = "none"
+    end
+
+    local oldView = hud.currentView
+    if newView == oldView then return end
+
+    -- Page swaps are guarded on page existence (pages don't exist before
+    -- createUI / in headless); the teardown below runs on every real
+    -- transition regardless, so selection/info never survive a band change.
+    if newView == "zoomed_out" then
+        if hud.zoom_page then UI.showPage(hud.zoom_page) end
+        if hud.world_page then UI.hidePage(hud.world_page) end
+    elseif newView == "zoomed_in" then
+        if hud.world_page then UI.showPage(hud.world_page) end
+        if hud.zoom_page then UI.hidePage(hud.zoom_page) end
+    else -- "none": in the fade band, hide whichever view page was up
         if oldView == "zoomed_in" and hud.world_page then
             UI.hidePage(hud.world_page)
         elseif oldView == "zoomed_out" and hud.zoom_page then
             UI.hidePage(hud.zoom_page)
         end
-        hud.currentView = "none"
-        -- In the fade zone, clear the info panel
-        infoPanel.clear()
-        itemContentsPanel.closeIfOpen()
     end
+    hud.currentView = newView
+
+    infoPanel.clear()
+    require("scripts.item_contents_panel").closeIfOpen()
+    item.deselect()
+end
+
+-- Wheel hook (no UI element under cursor, no shift). Reconcile immediately
+-- so a transition the wheel itself crosses doesn't wait for the next tick.
+function hud.onScroll(dx, dy)
+    hud.reconcileView()
 end
 
 -----------------------------------------------------------
@@ -680,6 +715,11 @@ function hud.update(dt)
     if not hud.visible then
         return
     end
+    -- Reconcile the view band against the camera's actual zoom every tick.
+    -- The camera crosses the band in the engine camera loop, which the
+    -- wheel-timed onScroll can miss when momentum coasts past the band
+    -- (#175). Idempotent: returns immediately when the band is unchanged.
+    hud.reconcileView()
     local mx, my = engine.getMousePosition()
     if mx and my then
         if hud.currentView == "zoomed_out" then

--- a/src/World/Thread/Command/UI.hs
+++ b/src/World/Thread/Command/UI.hs
@@ -79,6 +79,20 @@ handleWorldHideCommand env logger pageId = do
         ( mgr { wmVisible = filter (/= pageId) (wmVisible mgr) }
         , pageId `elem` wmVisible mgr )
 
+    -- Clear this page's ground-item cursor selection on hide. Selection is
+    -- per-world (wsCursorRef), but the Lua-side deselect resolves through
+    -- activeWorld, which head-falls-back to another registered world once
+    -- this page leaves wmVisible — so a Lua deselect could clear the wrong
+    -- world and leave this one's selection live to repopulate the HUD when
+    -- it's shown again (#175). Doing it here, keyed on the exact pageId
+    -- being hidden, is race-free and always targets the right world.
+    mgr ← readIORef (worldManagerRef env)
+    case lookup pageId (wmWorlds mgr) of
+        Just worldState →
+            atomicModifyIORef' (wsCursorRef worldState) $ \cs →
+                (cs { selectedGroundItem = Nothing }, ())
+        Nothing → pure ()
+
     when wasVisible $
         Q.writeQueue (simQueue env) (SimDeactivateWorld pageId)
 


### PR DESCRIPTION
## Summary
Fixes #175. Ground-item selection survived leaving the zoomed-in gameplay context (zoom out, or a menu transition), so the shared HUD info panel could repopulate with stale item info on later ticks — the item watcher keeps polling `item.getSelected()`.

Selection lives in **per-world** engine cursor state (`wsCursorRef.selectedGroundItem`), not a HUD page. There are two distinct triggers, each fixed at the right layer:

### Menu transition (world hide) — engine-side
`world.hide()` queues `WorldHide` async. A Lua `item.deselect()` in `hud.hide()` resolves through `activeWorld`, which **head-falls-back to a different registered world** once the page leaves `wmVisible` (`resolveActiveWorld`) — so in a multi-world session it could clear the *wrong* world and leave the hidden page's selection live. Instead, clear it in `handleWorldHideCommand`, keyed on the exact `pageId` being hidden: race-free, always the right world.

### Zoom-band change — Lua, driven by the actual band
`worldView.onScroll` only imparts zoom *velocity*; the camera crosses the band later in the camera loop, so a wheel-timed teardown misses a momentum-only crossing. The transition is factored into `hud.reconcileView()` and called **every tick** from `hud.update()` (plus immediately from the `onScroll` wheel hook). It runs the page swap + teardown (`infoPanel.clear`, item-contents popup #142, `item.deselect`) only on a real band change, and keeps `hud.currentView` authoritative so the HUD page never lags the camera. The deselect here is safe because the world is still active/visible.

## Addresses review findings
- **Finding 1** (onScroll is wheel-timed, misses momentum crossings) → now driven per-tick by the real band via `reconcileView()`.
- **Finding 2** (`hud.hide()` deselect could clear the wrong world via `activeWorld` head-fallback) → moved engine-side, keyed on the exact hidden `pageId`.

## Testing
Headless against the freshly built worktree binary:
- `world.hide()` clears the exact hidden page's selection (`gid → nil` across hide/show).
- A same-band `reconcileView()` does **not** clear (no spurious clears); a real `zoomed_in → zoomed_out` reconcile clears and flips `currentView`.
- hspec headless suite: **325 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)