### PR TITLE
Fix #133: tag HUD info pushes so zoom-map chunk selection keeps entity selection

### DIFF
--- a/scripts/building_info_panel.lua
+++ b/scripts/building_info_panel.lua
@@ -131,8 +131,12 @@ end
 -----------------------------------------------------------
 -- Tile-info broadcast: defer to tile when one is clicked
 -----------------------------------------------------------
-function buildingInfoWatch.onSetInfoText(basic, advanced)
-    if basic and basic ~= "" then
+-- `kind` separates a zoomed-in TILE selection from a zoom-map CHUNK
+-- selection (they share this broadcast). Only a tile should steal the
+-- panel from a selected building; a chunk click leaves it intact
+-- (issue #133).
+function buildingInfoWatch.onSetInfoText(basic, advanced, kind)
+    if basic and basic ~= "" and kind == "tile" then
         buildingInfoWatch.tilePushed = true
         if building.getSelected() then
             building.deselect()

--- a/scripts/item_info_panel.lua
+++ b/scripts/item_info_panel.lua
@@ -105,8 +105,11 @@ function itemInfoWatch.update(dt)
 end
 
 -- Tile-info broadcast: defer to the tile when one is clicked.
-function itemInfoWatch.onSetInfoText(basic, advanced)
-    if basic and basic ~= "" then
+-- `kind` separates a zoomed-in TILE selection from a zoom-map CHUNK
+-- selection (shared broadcast). Only a tile steals the panel from a
+-- selected ground item; a chunk click leaves it intact (issue #133).
+function itemInfoWatch.onSetInfoText(basic, advanced, kind)
+    if basic and basic ~= "" and kind == "tile" then
         itemInfoWatch.tilePushed = true
         if item.getSelected() then
             item.deselect()

--- a/scripts/unit_info_panel.lua
+++ b/scripts/unit_info_panel.lua
@@ -266,8 +266,13 @@ end
 --
 -- An empty payload means "nothing selected" (e.g. clicking empty
 -- space, or our own clearWorldCursorSelect call). We ignore those.
-function unitInfoWatch.onSetInfoText(basic, advanced)
-    if basic and basic ~= "" then
+--
+-- `kind` distinguishes a real zoomed-in TILE selection from a zoom-map
+-- CHUNK selection — both ride this one broadcast. Only a "tile" should
+-- steal the panel from a unit; a chunk click must leave the unit
+-- selection intact (issue #133).
+function unitInfoWatch.onSetInfoText(basic, advanced, kind)
+    if basic and basic ~= "" and kind == "tile" then
         -- A tile is now the active selection. Two effects:
         --   1. If a unit was selected, defer to the tile and deselect.
         --   2. Mark the panel as owned by the tile-info path. The next

--- a/src/Engine/Scripting/Lua/Thread.hs
+++ b/src/Engine/Scripting/Lua/Thread.hs
@@ -580,8 +580,9 @@ processLuaMsg env ls stateRef msg = case msg of
     broadcastToModules ls "onInterrupt" [ScriptNumber (fromIntegral fid)]
   LuaWorldGenLog text →
     broadcastToModules ls "onWorldGenLog" [ScriptString text]
-  LuaHudLogInfo text1 text2 →
-    broadcastToModules ls "onSetInfoText" [ScriptString text1, ScriptString text2]
+  LuaHudLogInfo text1 text2 kind →
+    broadcastToModules ls "onSetInfoText"
+      [ScriptString text1, ScriptString text2, ScriptString kind]
   LuaHudLogWeatherInfo text →
     broadcastToModules ls "onSetWeatherInfo" [ScriptString text]
   LuaHudLogResourcesInfo text →

--- a/src/Engine/Scripting/Lua/Types.hs
+++ b/src/Engine/Scripting/Lua/Types.hs
@@ -135,7 +135,12 @@ data LuaMsg = LuaTextureLoaded TextureHandle AssetId
             | LuaDebugHide
             | LuaDebugToggle
             | LuaWorldGenLog Text
-            | LuaHudLogInfo Text Text
+            | LuaHudLogInfo Text Text Text
+              -- ^ HUD info-panel push: basic, advanced, and a SOURCE
+              -- kind ("tile" | "chunk"). The kind lets entity-info
+              -- watchers (unit/building/item panels) tell a real
+              -- zoomed-in tile selection apart from a zoom-map chunk
+              -- selection, which share this same broadcast (issue #133).
             | LuaHudLogWeatherInfo Text
             | LuaHudLogResourcesInfo Text
             | LuaWorldPreviewReady Int

--- a/src/World/Thread/Cursor.hs
+++ b/src/World/Thread/Cursor.hs
@@ -20,7 +20,7 @@ import World.Generate (generateLoadedChunk)
 import World.Generate.Types (isArenaParams)
 import World.Geology.Ore (chunkOreCounts)
 import World.Slope (patchEdgeStrata)
-import World.Thread.Helpers (sendHudInfo, sendHudWeatherInfo
+import World.Thread.Helpers (sendHudInfo, sendHudChunkInfo, sendHudWeatherInfo
                             , sendHudResourcesInfo)
 import World.Weather.Types (ClimateCoord(..), ClimateState(..), ClimateGrid(..)
                            , RegionClimate(..), SeasonalClimate(..)
@@ -221,7 +221,7 @@ sendChunkInfo env worldState mParams baseGX baseGY = do
             Just params → chunkWeatherInfo params cx cy
             Nothing → ""
 
-    sendHudInfo env basicLines advLines
+    sendHudChunkInfo env basicLines advLines
     sendHudWeatherInfo env weatherInfo
 
 -- * chunkWeatherInfo: format weather for a chunk's climate region

--- a/src/World/Thread/Helpers.hs
+++ b/src/World/Thread/Helpers.hs
@@ -2,6 +2,7 @@
 module World.Thread.Helpers
     ( sendGenLog
     , sendHudInfo
+    , sendHudChunkInfo
     , sendHudWeatherInfo
     , sendHudResourcesInfo
     , unWorldPageId
@@ -17,10 +18,24 @@ import World.Types (WorldPageId(..))
 sendGenLog ∷ EngineEnv → Text → IO ()
 sendGenLog env msg = Q.writeQueue (luaQueue env) (LuaWorldGenLog msg)
 
--- | Info message to lua's HUD
+-- | Info message to lua's HUD, tagged with its SOURCE kind so the
+--   entity-info watchers can tell a zoomed-in tile selection ("tile")
+--   apart from a zoom-map chunk selection ("chunk") — both ride this
+--   one broadcast (issue #133).
+sendHudInfoKind ∷ EngineEnv → Text → Text → Text → IO ()
+sendHudInfoKind env kind msgbas msgadv = Q.writeQueue (luaQueue env)
+                                  (LuaHudLogInfo msgbas msgadv kind)
+
+-- | Tile (zoomed-in) info push. Also used for the blank-payload panel
+--   clear; a blank carries no selection so its kind is immaterial.
 sendHudInfo ∷ EngineEnv → Text → Text → IO ()
-sendHudInfo env msgbas msgadv = Q.writeQueue (luaQueue env)
-                                  (LuaHudLogInfo msgbas msgadv)
+sendHudInfo env = sendHudInfoKind env "tile"
+
+-- | Chunk (zoom-map) info push. Tagged "chunk" so unit/building/item
+--   watchers don't mistake it for a tile click and drop their
+--   zoomed-in selection (issue #133).
+sendHudChunkInfo ∷ EngineEnv → Text → Text → IO ()
+sendHudChunkInfo env = sendHudInfoKind env "chunk"
 
 -- | Send weather info to lua's HUD
 sendHudWeatherInfo ∷ EngineEnv → Text → IO ()

--- a/test-headless/Test/Headless/World/CursorInfo.hs
+++ b/test-headless/Test/Headless/World/CursorInfo.hs
@@ -72,7 +72,14 @@ resourceMsgs msgs = [t | LuaHudLogResourcesInfo t ← msgs]
 
 -- | Basic-tab text of every Basic/Advanced push, in order.
 infoBasics ∷ [LuaMsg] → [Text]
-infoBasics msgs = [b | LuaHudLogInfo b _ ← msgs]
+infoBasics msgs = [b | LuaHudLogInfo b _ _ ← msgs]
+
+-- | (Basic-tab text, source kind) of every Basic/Advanced push, in
+--   order. The kind ("tile" | "chunk") is what unit/building/item
+--   watchers gate on so a zoom-map chunk click doesn't drop their
+--   zoomed-in selection (issue #133).
+infoBasicKinds ∷ [LuaMsg] → [(Text, Text)]
+infoBasicKinds msgs = [(b, k) | LuaHudLogInfo b _ k ← msgs]
 
 -- | A fresh empty world (with climate-less gen params), registered as
 --   the sole visible page, Lua queue drained so the next
@@ -101,6 +108,25 @@ spec = beforeAll initEnv $ do
         -- Precondition for the #128 scenario: the dynamic Weather tab is
         -- non-empty (here "No climate data"), i.e. genuinely active.
         weatherMsgs msgs `shouldSatisfy` any (≢ "")
+
+    it "tags a chunk push 'chunk' and a tile push 'tile' (issue #133)" $ \env → do
+        ws ← freshVisibleWorld env
+        -- A zoom-map chunk selection must tag its Basic/Advanced push
+        -- "chunk", never "tile" — the unit/building/item watchers only
+        -- drop their zoomed-in selection on a "tile" push, so this is
+        -- what keeps a chunk click from clobbering that selection.
+        chunkMsgs ← selectChunk env ws
+        infoBasicKinds chunkMsgs `shouldSatisfy`
+            any (\(b, k) → T.isInfixOf "Chunk (" b ∧ k ≡ "chunk")
+        infoBasicKinds chunkMsgs `shouldSatisfy`
+            (not . any (\(_, k) → k ≡ "tile"))
+        -- A real zoomed-in tile selection tags its push "tile".
+        modifyIORef' (wsCursorRef ws)
+            (\c → c { worldSelectedTile = Just (8, 8, 1) })
+        pollCursorInfo env
+        tileMsgs ← drainLua env
+        infoBasicKinds tileMsgs `shouldSatisfy`
+            any (\(b, k) → T.isInfixOf "Tile (" b ∧ k ≡ "tile")
 
     it "tile selection clears the active Weather and Resources tabs" $ \env → do
         ws ← freshVisibleWorld env


### PR DESCRIPTION
## Summary
Fixes #133. Selecting a chunk in the zoom-map silently cleared the current unit / building / ground-item selection from the zoomed-in world state.

Chunk (zoom-map) and tile (zoomed-in) selections both pushed their Basic/Advanced text through the same `sendHudInfo` → `onSetInfoText` broadcast. The `unit_info_panel` / `building_info_panel` / `item_info_panel` watchers treat **any** non-empty `basic` text as "a tile was clicked" and call `unit.deselectAll()` / `building.deselect()` / `item.deselect()` — so a chunk click clobbered the entity selection.

## Fix
Tag each info push with its **source kind** (`"tile"` | `"chunk"`):
- `LuaHudLogInfo` gains a kind field; the broadcast carries it as a third arg to `onSetInfoText`.
- `World.Thread.Cursor.sendChunkInfo` routes through a new `sendHudChunkInfo` (`"chunk"`); tile and blank-clear pushes stay `"tile"`.
- The three entity watchers gate their deselect on `kind == "tile"`, so a chunk click leaves the entity selection intact.
- `ui_manager` and `tile_editor` ignore the extra arg (Lua tolerates it) — unchanged.

## Behavior (issue #133 scope)
Per the chosen scope, the shared HUD panel still shows one schema at a time. While an entity stays selected, its per-tick re-push keeps the panel on entity info and chunk info is suppressed — deselect the entity (ESC) to inspect chunks. The selection now **survives** the zoom round-trip, which is the bug this issue reports. Broader panel-display arbitration across zoom views remains epic #157.

## Testing
- Extended the `World.CursorInfo` headless spec with a kind-tag assertion (chunk push tagged `"chunk"` and never `"tile"`; tile push tagged `"tile"`).
- Verified end-to-end headless: with a unit selected, a `"chunk"` push keeps it selected; a `"tile"` push deselects it.
- Full headless suite green: **326 examples, 0 failures**; `test_audit.py` 25/25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)