### PR TITLE
Fix #139: dismiss context menu on zoom-band transitions

### DIFF
--- a/scripts/hud.lua
+++ b/scripts/hud.lua
@@ -652,6 +652,8 @@ end
 --   * item-contents popup (#142): mounted on hud.world_page, so hiding
 --     the page only takes it off-view; its logical state stays open and
 --     could reappear stale. closeIfOpen() tears it down.
+--   * right-click context menu (#139): own modal page, anchored to the
+--     click target; hide() it so it can't survive over the wrong view.
 --   * ground-item selection (#175): per-world cursor state the item
 --     watcher (item_info_panel.update) keeps polling and would use to
 --     repopulate the panel. item.deselect() clears the active world's
@@ -695,6 +697,13 @@ function hud.reconcileView()
 
     infoPanel.clear()
     require("scripts.item_contents_panel").closeIfOpen()
+    -- Right-click context menu (#139): it lives on its own modal page and
+    -- is anchored to the tile/unit/item under the click in the zoomed-in
+    -- view. Hiding the world/zoom pages above only takes it off-view; its
+    -- logical state stays open and it can reappear over the wrong view.
+    -- hide() is idempotent (no-op when no menu is open), so dismiss it on
+    -- every band change.
+    require("scripts.ui.context_menu").hide()
     if newView ~= "zoomed_in" then
         require("scripts.debug").hide()
     end


### PR DESCRIPTION
## Summary
The right-click context menu lives on its own modal page anchored to the tile/unit/item under the click in the zoomed-in view. `hud.reconcileView()` — the per-transition teardown run from both `hud.update()` (per-tick) and `hud.onScroll()` — clears the info panel, item-contents popup, debug overlay, and ground-item selection on every zoom-band change, but never dismissed the context menu. So a menu opened in the zoomed-in world could remain visible after zooming out or entering the fade zone, floating over the wrong view.

## Fix
Add an idempotent `require("scripts.ui.context_menu").hide()` to `reconcileView()`, so the menu is torn down on every real band transition. This mirrors the dismissal the HUD-teardown path (`hud.hide()`) already performs for menu/view exits, and matches the established pattern used for the other overlays already cleared here (#142 item-contents, #175 ground-item, #147 debug overlay).

`cm.hide()` is a no-op when no menu is open, so calling it unconditionally on every band change is safe.

## Verification
- Lua-only change; no Haskell rebuild required.
- `luajit` syntax check on `scripts/hud.lua` passes.
- The context menu's visual lifecycle is GUI-only (not headless-verifiable), but the dismissal call mirrors the proven `hud.hide()` teardown path and uses the existing idempotent `cm.hide()`.

Closes #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)