### PR TITLE
Fix #114: drag-select no longer arms on tool/overlay-claimed clicks

### DIFF
--- a/scripts/init.lua
+++ b/scripts/init.lua
@@ -195,6 +195,15 @@ function game.onMouseDown(button, x, y)
         return
     end
 
+    -- Arm unit drag-select. Forward-only (handle*, not a broadcast) so
+    -- it sits in THIS ordered claim chain: every guard above has already
+    -- returned on a consumed click, so a click eaten by the debug
+    -- overlay / anim panel / build tool / mine tool can no longer also
+    -- start a background box-selection (#114). It doesn't consume the
+    -- click — the single-unit selection / tile-cursor logic below still
+    -- runs; the drag only takes over on mouse-up if it passes threshold.
+    require("scripts.unit_drag_select").handleMouseDown(button, x, y)
+
     if button == MOUSE_LEFT then
         -- Debug spawn mode: if armed, this click is a spawn, not a
         -- selection. Spawn at the hovered tile and stay armed.

--- a/scripts/init.lua
+++ b/scripts/init.lua
@@ -195,15 +195,6 @@ function game.onMouseDown(button, x, y)
         return
     end
 
-    -- Arm unit drag-select. Forward-only (handle*, not a broadcast) so
-    -- it sits in THIS ordered claim chain: every guard above has already
-    -- returned on a consumed click, so a click eaten by the debug
-    -- overlay / anim panel / build tool / mine tool can no longer also
-    -- start a background box-selection (#114). It doesn't consume the
-    -- click — the single-unit selection / tile-cursor logic below still
-    -- runs; the drag only takes over on mouse-up if it passes threshold.
-    require("scripts.unit_drag_select").handleMouseDown(button, x, y)
-
     if button == MOUSE_LEFT then
         -- Debug spawn mode: if armed, this click is a spawn, not a
         -- selection. Spawn at the hovered tile and stay armed.
@@ -302,6 +293,20 @@ function game.onMouseDown(button, x, y)
             end
             return
         end
+
+        -- Arm unit drag-select. Forward-only (handle*, not a broadcast)
+        -- so it sits in THIS ordered claim chain: every guard above —
+        -- the debug overlay / anim panel / build tool / mine tool, AND
+        -- the debug armed-placement modes (spawn / item / fluid /
+        -- terrain / location / structure) that each `return` above —
+        -- has already consumed and bailed on its own click. So a click
+        -- eaten by any of them can no longer also start a background
+        -- box-selection (#114). Placed below those returns rather than
+        -- enumerating the armed* fields, so a future armed mode stays
+        -- shielded for free. It doesn't consume the click — the
+        -- single-unit selection / tile-cursor logic below still runs;
+        -- the drag only takes over on mouse-up if it passes threshold.
+        require("scripts.unit_drag_select").handleMouseDown(button, x, y)
 
         local id = unit.hitTestAt(x, y)
         local shift = engine.isKeyDown("LeftShift")

--- a/scripts/unit_drag_select.lua
+++ b/scripts/unit_drag_select.lua
@@ -144,12 +144,21 @@ function dragSelect.update(dt)
     end
 end
 
-function dragSelect.onMouseDown(button, x, y)
+-- Arm the drag. Forward-only: called from game.onMouseDown (init.lua)
+-- AFTER the ordered tool/overlay claim guards (debug overlay, debug
+-- anim panel, build tool, mine tool) have each had their crack and
+-- returned early on a consumed click. That single ordered decision is
+-- the only thing that arms drag-select now, so a click already eaten by
+-- one of those handlers can no longer start a background box-selection
+-- (#114).
+--
+-- Named handle* (not on*) deliberately: this module is engine-loaded
+-- (loadScript), so an on*-named function would ALSO fire on every engine
+-- broadcast — independent of the ordered guards above, which was the
+-- bug. handle* keeps it forward-only (same convention as build_tool /
+-- mine_tool / debug.lua's tryClaimClick).
+function dragSelect.handleMouseDown(button, x, y)
     if button ~= 1 then return end
-    -- Defer to debug overlay's parallel hit-test; if it claims the
-    -- click, we don't start a drag from a debug UI element.
-    local debugOverlay = require("scripts.debug")
-    if debugOverlay.tryClaimClick(button, x, y) then return end
 
     dragSelect.state  = "pressed"
     dragSelect.startX = x


### PR DESCRIPTION
Closes #114.

## Problem
`dragSelect.onMouseDown` was an engine **broadcast** handler that armed `pressed` independently of the ordered `game.onMouseDown` claim chain, shielding only against `scripts.debug.tryClaimClick()`. So a click already consumed by the **debug anim panel**, **build tool**, or **mine tool** could still arm drag-select in the background. If the cursor moved past the drag threshold before release, the release performed a stray unit box-selection on top of the tool action.

Re-running each handler's claim check inside drag-select isn't viable: `debug_anim_panel.tryClaimClick` has no dedup and `build_tool` / `mine_tool` `handleMouseDown` actually *perform* the placement/anchor — calling them a second time would double-act.

## Fix
Make drag-select part of the **single ordered decision** in `game.onMouseDown` instead of a parallel broadcast:

- Rename `dragSelect.onMouseDown` → `dragSelect.handleMouseDown` (`handle*`, forward-only — same convention build_tool / mine_tool already use to stay off the broadcast).
- Forward to it from `game.onMouseDown` *after* the debug-overlay / anim-panel / build-tool / mine-tool guards have each returned early on a consumed click.

Because the arm now lives in the ordered chain, every current and future ordered consumer shields it automatically — no per-handler ad-hoc guard. The drop of the old `debugOverlay.tryClaimClick` guard is intentional: that guard is now upstream in the chain.

The forward does **not** consume the click — `game.onMouseDown`'s own single-unit / tile-cursor logic still runs, and the drag only takes over on mouse-up if it passes threshold. `onMouseUp` stays a broadcast, so drag teardown (including the swallowed-route focus-loss cancel) is unchanged.

## Testing
Pure-Lua change (no Haskell touched), so the hspec/worldgen tiers don't cover it and mouse broadcasts don't fire headless. Verified with a luajit harness that stubs the minimal engine surface:
- module no longer defines `onMouseDown` (so the broadcast can't arm it),
- exposes `handleMouseDown`,
- arms `pressed` on left-click and records start coords,
- ignores non-left buttons.

Both changed files also pass a `luajit -b` syntax check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)