### PR TITLE
Fix #152: gate debug anim panel click-claim on the gameplay view

### DIFF
--- a/scripts/debug_anim_panel.lua
+++ b/scripts/debug_anim_panel.lua
@@ -289,6 +289,14 @@ function panel.tryClaimClick(button, x, y)
     if not panel.visible or not debugOverlay.isVisible() then return false end
     if button ~= MOUSE_LEFT then return false end
 
+    -- Gate on the current view too (#152): the panel is only interactive in
+    -- the gameplay (zoomed-in) world view. If it survived into the zoom map,
+    -- a menu, the pause screen, or the fade zone, its rows must NOT swallow a
+    -- click meant for that screen — panel.visible / overlay-visible alone don't
+    -- catch those states. Reuses the same gameplay-view test the overlay uses
+    -- to decide it can open (gameplay input active AND currentView zoomed_in).
+    if not debugOverlay.canShow() then return false end
+
     -- onMouseDown delivers WINDOW pixels; our rects are in
     -- FRAMEBUFFER pixels. Convert before AABB-test (same fix as
     -- `debug.lua`).


### PR DESCRIPTION
Closes #152.

## Problem
`debug_anim_panel.tryClaimClick()` only checked `panel.visible` and the debug overlay's own visibility (`debugOverlay.isVisible()`). If the panel survived into a non-gameplay state — the zoom map, a menu, the pause screen, or the fade zone — its clickable animation rows could still consume left clicks that belonged to that screen.

## Fix
Add the same gameplay-view gate the overlay already uses to decide it can open: `debugOverlay.canShow()`, which checks `ui_manager.isGameplayInputActive()` **and** `hud.currentView == "zoomed_in"` (pcall-wrapped). The panel already requires `scripts.debug` as `debugOverlay`, so this reuses the existing, tested predicate rather than duplicating the view-state checks.

- In the normal zoomed-in gameplay view `canShow()` is true → the panel claims exactly as before (no regression).
- Outside gameplay it is false → `tryClaimClick` returns false and the click falls through to the active screen.

This mirrors the same parallel-hit-test pattern as `debug.lua` and is the sibling of the overlay guard (#151).

## Testing
- `luajit -bl scripts/debug_anim_panel.lua` — syntax OK.
- The panel's click interactivity is GUI-driven (`hud.currentView` / menu state are runtime Lua state with no headless/dump path), so the visual no-swallow behavior outside gameplay needs in-game confirmation, consistent with how other UI-lifecycle fixes in this repo are verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)