### PR TITLE
Fix #137: gate unit_info_v2 pane on zoom view + HUD visibility

### DIFF
--- a/scripts/unit_info_v2.lua
+++ b/scripts/unit_info_v2.lua
@@ -3578,14 +3578,20 @@ function unitInfoV2.update(dt)
 
     -- Visibility gate. The pane belongs to the zoomed-in gameplay view,
     -- so a selection alone is not enough to show it: it must also hide
-    -- when the gameplay HUD itself is hidden (a menu is open → hud.hide()
-    -- cleared hud.visible) or when the camera isn't in the zoomed-in band
-    -- (zoomed-out map / fade band). Driving show/hide off a single
-    -- predicate keeps it in sync with zoom + menu transitions instead of
-    -- only selection count, so the pane can no longer persist over the
-    -- zoomed-out map or non-gameplay menus (#137).
+    -- when gameplay UI isn't actually active or when the camera isn't in
+    -- the zoomed-in band (zoomed-out map / fade band). Driving show/hide
+    -- off a single predicate keeps it in sync with zoom + menu transitions
+    -- instead of only selection count, so the pane can no longer persist
+    -- over the zoomed-out map or non-gameplay menus (#137).
+    --
+    -- isGameplayInputActive() is the authoritative "gameplay UI is active"
+    -- check (#182): it is false for any non-gameplay currentMenu AND while
+    -- the pause overlay is up. That covers the modal paths that DON'T call
+    -- hud.hide() — pauseMenu.show() and uiManager.showMenu("settings") in
+    -- its keepWorld path — which a bare hud.visible check would miss.
+    local uiManager = require("scripts.ui_manager")
     local want = count > 0
-                 and hud.visible
+                 and uiManager.isGameplayInputActive()
                  and hud.currentView == "zoomed_in"
     if want ~= unitInfoV2.lastWantVisible then
         if want then
@@ -3607,10 +3613,11 @@ function unitInfoV2.onFramebufferResize(width, height)
         -- update tick will see "new" selection and rebuild).
         unitInfoV2.lastSelKey = ""
         -- Re-apply the same visibility gate as update() so a resize while
-        -- a menu is open / the camera is zoomed out doesn't flash the pane
-        -- back on (#137).
+        -- a menu / pause / settings overlay is open or the camera is zoomed
+        -- out doesn't flash the pane back on (#137).
+        local uiManager = require("scripts.ui_manager")
         local want = unitInfoV2.lastSelCount > 0
-                     and hud.visible
+                     and uiManager.isGameplayInputActive()
                      and hud.currentView == "zoomed_in"
         if want then
             UI.showPage(unitInfoV2.page)

--- a/scripts/unit_info_v2.lua
+++ b/scripts/unit_info_v2.lua
@@ -42,6 +42,7 @@ unitInfoV2.outerBoxId    = nil
 unitInfoV2.dividerIds    = {}   -- thin sprite handles for inter-section rules
 unitInfoV2.ownedLabels   = {}   -- label.* IDs to clean up
 unitInfoV2.lastSelCount  = 0
+unitInfoV2.lastWantVisible = false  -- last resolved pane-visibility gate (#137)
 unitInfoV2.whitePixelTex = nil  -- 1×1 white texture for dividers
 unitInfoV2.tabSelectedTex = nil -- shaped backdrop drawn behind the active tab's sprite
 unitInfoV2.subTabSelectedTexSet   = nil  -- 9-patch box set for active sub-tab
@@ -3575,10 +3576,24 @@ function unitInfoV2.update(dt)
         end
     end
 
-    if count > 0 and unitInfoV2.lastSelCount == 0 then
-        UI.showPage(unitInfoV2.page)
-    elseif count == 0 and unitInfoV2.lastSelCount > 0 then
-        UI.hidePage(unitInfoV2.page)
+    -- Visibility gate. The pane belongs to the zoomed-in gameplay view,
+    -- so a selection alone is not enough to show it: it must also hide
+    -- when the gameplay HUD itself is hidden (a menu is open → hud.hide()
+    -- cleared hud.visible) or when the camera isn't in the zoomed-in band
+    -- (zoomed-out map / fade band). Driving show/hide off a single
+    -- predicate keeps it in sync with zoom + menu transitions instead of
+    -- only selection count, so the pane can no longer persist over the
+    -- zoomed-out map or non-gameplay menus (#137).
+    local want = count > 0
+                 and hud.visible
+                 and hud.currentView == "zoomed_in"
+    if want ~= unitInfoV2.lastWantVisible then
+        if want then
+            UI.showPage(unitInfoV2.page)
+        else
+            UI.hidePage(unitInfoV2.page)
+        end
+        unitInfoV2.lastWantVisible = want
     end
     unitInfoV2.lastSelCount = count
 end
@@ -3591,11 +3606,18 @@ function unitInfoV2.onFramebufferResize(width, height)
         -- them for the current selection (lastSelKey reset so the next
         -- update tick will see "new" selection and rebuild).
         unitInfoV2.lastSelKey = ""
-        if unitInfoV2.lastSelCount > 0 then
+        -- Re-apply the same visibility gate as update() so a resize while
+        -- a menu is open / the camera is zoomed out doesn't flash the pane
+        -- back on (#137).
+        local want = unitInfoV2.lastSelCount > 0
+                     and hud.visible
+                     and hud.currentView == "zoomed_in"
+        if want then
             UI.showPage(unitInfoV2.page)
         else
             UI.hidePage(unitInfoV2.page)
         end
+        unitInfoV2.lastWantVisible = want
     end
 end
 
@@ -3756,6 +3778,7 @@ function unitInfoV2.shutdown()
     end
     unitInfoV2.bootstrapped = false
     unitInfoV2.lastSelCount = 0
+    unitInfoV2.lastWantVisible = false
 end
 
 return unitInfoV2


### PR DESCRIPTION
Closes #137.

## Problem
`unit_info_v2` showed/hid its right-edge overlay page purely from selection count (`count` 0↔>0 transitions in `update()`), with no regard for the current zoom band or whether the gameplay HUD was hidden. A selected unit could keep the pane visible over the zoomed-out map or non-gameplay menus. The count-only transition also meant returning to the zoomed-in view with an unchanged selection never re-showed the pane.

## Fix
Drive visibility off a single predicate that ANDs in the authoritative HUD signals:

```lua
local want = count > 0 and hud.visible and hud.currentView == "zoomed_in"
```

- `hud.visible` is cleared by `hud.hide()` when a menu opens (`ui_manager.showMenu`).
- `hud.currentView` is kept authoritative across zoom bands by `hud.reconcileView()`.

The pane belongs to the zoomed-in gameplay view, so it now hides on menu open and on zoom-out/fade-band transitions, and reliably re-shows on return to the zoomed-in view. The same gate is applied in `onFramebufferResize` so a resize while a menu is open / camera is zoomed out can't flash it back on. `lastWantVisible` tracks the resolved state so show/hide only fire on genuine changes.

`unit_info_v2` ticks independently at 0.03s via `engine.loadScript`, so the gate re-evaluates every tick regardless of menu state.

## Testing
- `luajit` syntax check passes.
- Headless boot loads `unit_info_v2` and ticks with no Lua errors (`hud.visible`/`hud.currentView` exist from module load, so the gate is always safe to read).
- Pure Lua change, no engine recompile of behavior; the on-screen pane hide/show is GUI-facing and warrants a quick in-app eyeball per project convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)