### PR TITLE
Fix #38: load unit pathing cost tunables from config/pathing.yaml

### DIFF
--- a/config/pathing.yaml
+++ b/config/pathing.yaml
@@ -1,0 +1,44 @@
+# Unit pathing cost tunables.
+#
+# These weights drive how units choose routes: the cost of a single
+# grid step is the horizontal distance plus the modifiers below. The
+# planner (local A*) and the greedy mover both read the same numbers,
+# so they always agree on what a route costs.
+#
+# Every key is optional — an omitted key keeps its built-in default
+# (shown here), and a missing or malformed file falls back to all
+# defaults, so deleting this file is harmless. Edit a value and restart
+# to retune routing without recompiling.
+
+# Cost added per +1 z of a CLIFF climb (a vertical face). High enough
+# that units prefer flat detours; low enough that they'll climb when
+# nothing else is available.
+climb_factor: 10.0
+
+# Cost added per +1 z of a WALKABLE RAMP (a 1-z step the tile slopes up
+# to). Barely above flat so units walk up gentle slopes instead of
+# detouring around them or treating them as cliffs.
+ramp_factor: 0.5
+
+# Base of the exponential fall cost on a real fall: cost = fall_factor
+# ** drop. A 2-z drop costs fall_factor², a 3-z drop fall_factor³ — so
+# the planner avoids damaging drops in favour of any reasonable detour.
+fall_factor: 5.0
+
+# Drop magnitude (in z) at which a descent stops being a free walk-off
+# and becomes a costed/transitioned fall. A drop smaller than this is a
+# normal step-down; this drop or worse triggers the fall transition.
+fall_trigger_drop: 2
+
+# Cost added for wading one river tile. Rivers are passable at a
+# penalty (ocean and lava are impassable, not tunable here).
+river_penalty: 8.0
+
+# Cost added for wading one lake tile. Slightly higher than rivers
+# since lakes are usually deeper.
+lake_penalty: 12.0
+
+# Greedy-step cost above which the mover triggers a local A* detour to
+# look for a flatter route. Lower = pickier units (more replanning);
+# higher = greedier units that climb whatever is in their direct line.
+replan_cost_threshold: 5.0

--- a/src/Engine/Core/Init.hs
+++ b/src/Engine/Core/Init.hs
@@ -50,6 +50,7 @@ import Infection.Types (emptyInfectionManager)
 import World.Types (WorldCommand, emptyWorldManager, emptyFloraCatalog)
 import World.Material (emptyMaterialRegistry)
 import World.Generate.Config (loadWorldGenConfig)
+import Unit.Pathing.Config (loadPathingConfig)
 
 data EngineInitResult = EngineInitResult
   { eirEnv ∷ EngineEnv }
@@ -131,6 +132,8 @@ initializeEngineWith logBackend = do
   injuryEventsRef ← newIORef Combat.Types.emptyEventQueue
   worldGenConfig ← loadWorldGenConfig "config/world_gen_default.yaml"
   worldGenConfigRef ← newIORef worldGenConfig
+  pathingConfig ← loadPathingConfig logger "config/pathing.yaml"
+  pathingConfigRef ← newIORef pathingConfig
 
   enginePausedRef ← newIORef False
   gameTimeRef     ← newIORef (0 ∷ Double)
@@ -208,6 +211,7 @@ initializeEngineWith logBackend = do
         , injuryEventsRef    = injuryEventsRef
         , buildingGhostRef   = buildingGhostRef
         , worldGenConfigRef  = worldGenConfigRef
+        , pathingConfigRef   = pathingConfigRef
         , simQueue          = simQueue
         , enginePausedRef   = enginePausedRef
         , gameTimeRef       = gameTimeRef

--- a/src/Engine/Core/State.hs
+++ b/src/Engine/Core/State.hs
@@ -56,6 +56,7 @@ import World.Types (WorldCommand, WorldManager, FloraCatalog
                    , WorldState, WorldPageId, wmWorlds, wmVisible)
 import World.Material (MaterialRegistry)
 import World.Generate.Config (WorldGenConfig)
+import Unit.Pathing.Config (PathingConfig)
 import Sim.Command.Types (SimCommand)
 
 data EngineEnv = EngineEnv
@@ -159,6 +160,12 @@ data EngineEnv = EngineEnv
     --   each frame and draws an alpha-blended (and possibly red-tinted)
     --   sprite at the hovered tile.
   , worldGenConfigRef   ∷ IORef WorldGenConfig
+  , pathingConfigRef    ∷ IORef PathingConfig
+    -- ^ Unit pathing cost tunables (climb/ramp/fall/river/lake
+    --   penalties + replan threshold), loaded from
+    --   @config/pathing.yaml@ at init (defaults if absent). In an IORef
+    --   so a future settings UI can retune routing live; the movement
+    --   tick rereads it each tick.
   , simQueue           ∷ Q.Queue SimCommand
   , enginePausedRef    ∷ IORef Bool
     -- ^ Global pause flag. When True, threads that advance simulated

--- a/src/Unit/Pathing/AStar.hs
+++ b/src/Unit/Pathing/AStar.hs
@@ -20,7 +20,7 @@ import qualified Data.HashSet        as HS
 import qualified Data.Set            as Set
 import Data.List (foldl')
 import Data.Maybe (fromMaybe)
-import Unit.Pathing.Cost (stepCost)
+import Unit.Pathing.Cost (stepCost, PathingConfig)
 import World.Tile.Types (WorldTileData)
 
 -- | Default search radius. Roughly the size of a chunk (16×16 tiles).
@@ -36,8 +36,8 @@ defaultMaxRadius = 16
 --     tile by Euclidean distance to dst.
 --   * Returns `[]` if `src == dst` or if no neighbor of src is
 --     passable.
-localAStar ∷ WorldTileData → (Int, Int) → (Int, Int) → Int → [(Int, Int)]
-localAStar wtd src dst maxRadius
+localAStar ∷ PathingConfig → WorldTileData → (Int, Int) → (Int, Int) → Int → [(Int, Int)]
+localAStar pc wtd src dst maxRadius
     | src ≡ dst = []
     | otherwise =
         let h0 = euclid src dst
@@ -50,7 +50,7 @@ localAStar wtd src dst maxRadius
                 , asBestH  = h0
                 }
             budget = max 64 (maxRadius * maxRadius * 4)
-            final  = run wtd src dst maxRadius budget initial
+            final  = run pc wtd src dst maxRadius budget initial
             endTile
                 | HS.member dst (asClosed final) = dst
                 | otherwise                      = asBest final
@@ -70,8 +70,8 @@ data AS = AS
 
 -- | Drive the A* loop. Recurses until dst is closed, the open set
 --   empties, or the node budget runs out.
-run ∷ WorldTileData → (Int, Int) → (Int, Int) → Int → Int → AS → AS
-run wtd src dst maxR budget st
+run ∷ PathingConfig → WorldTileData → (Int, Int) → (Int, Int) → Int → Int → AS → AS
+run pc wtd src dst maxR budget st
     | HS.size (asClosed st) ≥ budget = st
     | otherwise = case Set.minView (asOpen st) of
         Nothing -> st
@@ -79,25 +79,26 @@ run wtd src dst maxR budget st
             | cur ≡ dst ->
                 st { asOpen = open', asClosed = HS.insert cur (asClosed st) }
             | HS.member cur (asClosed st) ->
-                run wtd src dst maxR budget (st { asOpen = open' })
+                run pc wtd src dst maxR budget (st { asOpen = open' })
             | otherwise ->
                 let st1 = st { asOpen   = open'
                              , asClosed = HS.insert cur (asClosed st)
                              }
-                    st2 = expand wtd src dst maxR cur st1
-                in  run wtd src dst maxR budget st2
+                    st2 = expand pc wtd src dst maxR cur st1
+                in  run pc wtd src dst maxR budget st2
 
 -- | Relax all 8 neighbors of `cur`.
-expand ∷ WorldTileData → (Int, Int) → (Int, Int) → Int → (Int, Int) → AS → AS
-expand wtd src dst maxR cur st0 =
-    foldl' (relax wtd src dst maxR cur) st0 (neighbors cur)
+expand ∷ PathingConfig → WorldTileData → (Int, Int) → (Int, Int) → Int → (Int, Int) → AS → AS
+expand pc wtd src dst maxR cur st0 =
+    foldl' (relax pc wtd src dst maxR cur) st0 (neighbors cur)
 
 -- | Standard A* relaxation with two extra guards:
 --   * Skip neighbors farther than `maxR` (Chebyshev) from src.
 --   * Track the best-h-so-far so we can return a partial path on
 --     failure to reach dst.
 relax
-    ∷ WorldTileData
+    ∷ PathingConfig
+    → WorldTileData
     → (Int, Int)  -- ^ src
     → (Int, Int)  -- ^ dst
     → Int         -- ^ maxR
@@ -105,10 +106,10 @@ relax
     → AS
     → (Int, Int)  -- ^ nbr
     → AS
-relax wtd src dst maxR cur st nbr
+relax pc wtd src dst maxR cur st nbr
     | HS.member nbr (asClosed st)    = st
     | chebyshev src nbr > maxR       = st
-    | otherwise = case stepCost wtd cur nbr of
+    | otherwise = case stepCost pc wtd cur nbr of
         Nothing → st
         Just c  →
             let curG  = fromMaybe 0 (HM.lookup cur (asGScore st))

--- a/src/Unit/Pathing/Config.hs
+++ b/src/Unit/Pathing/Config.hs
@@ -16,6 +16,7 @@
 module Unit.Pathing.Config
     ( PathingConfig(..)
     , defaultPathingConfig
+    , normalizePathingConfig
     , loadPathingConfig
     ) where
 
@@ -56,6 +57,31 @@ defaultPathingConfig = PathingConfig
     , pcReplanCostThreshold = 5.0
     }
 
+-- | Clamp a parsed config to runtime-safe ranges. Two invariants the
+--   cost/movement code relies on:
+--
+--     * @fall_trigger_drop@ must be ≥ 1. The fall checks are
+--       @drop ≥ pcFallTriggerDrop@; at 0 (or negative) a flat step
+--       (@drop == 0@) reads as a fall, so the planner surcharges level
+--       ground and the mover enters the Falling transition while
+--       walking across same-height tiles.
+--     * every cost/penalty must be ≥ 0. A* (and the greedy stepper's
+--       replan trigger) assume non-negative edge weights; a negative
+--       weight breaks the search's admissibility.
+--
+--   Out-of-range values are clamped (not rejected) so a single bad knob
+--   degrades to a sane default instead of failing engine init.
+normalizePathingConfig ∷ PathingConfig → PathingConfig
+normalizePathingConfig pc = pc
+    { pcClimbFactor         = max 0 (pcClimbFactor pc)
+    , pcRampFactor          = max 0 (pcRampFactor pc)
+    , pcFallFactor          = max 0 (pcFallFactor pc)
+    , pcFallTriggerDrop     = max 1 (pcFallTriggerDrop pc)
+    , pcRiverPenalty        = max 0 (pcRiverPenalty pc)
+    , pcLakePenalty         = max 0 (pcLakePenalty pc)
+    , pcReplanCostThreshold = max 0 (pcReplanCostThreshold pc)
+    }
+
 -- | Per-key optional parse: any omitted key keeps its default. (Using
 --   `.:?`/`.!=` matters — a `.:` on a single missing key would fail the
 --   whole document and silently discard every override.)
@@ -80,7 +106,7 @@ loadPathingConfig logger path = do
         else do
             result ← Yaml.decodeFileEither path
             case result of
-                Right pc → return pc
+                Right pc → return (normalizePathingConfig pc)
                 Left err → do
                     logWarn logger CatInit $ "Error loading pathing config: "
                                            <> T.pack (show err)

--- a/src/Unit/Pathing/Config.hs
+++ b/src/Unit/Pathing/Config.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE Strict, UnicodeSyntax #-}
+-- | Loadable tunables for the unit pathing cost function.
+--
+-- These used to be hard-coded constants in `Unit.Pathing.Cost`
+-- (climb / ramp / fall / river / lake penalties + the replan
+-- threshold). They now live in a record so they can be loaded from
+-- @config/pathing.yaml@ and tuned without recompiling. The numbers in
+-- `defaultPathingConfig` are the historical constants — an absent or
+-- malformed config file falls back to them, so default behaviour is
+-- byte-for-byte the old behaviour.
+--
+-- The record is deliberately a flat bag of scalars so future
+-- material / weather / per-unit modifiers can be appended as new
+-- fields (and new YAML keys) without reshaping the call sites that
+-- thread it through `stepCost`.
+module Unit.Pathing.Config
+    ( PathingConfig(..)
+    , defaultPathingConfig
+    , loadPathingConfig
+    ) where
+
+import UPrelude
+import qualified Data.Text as T
+import qualified Data.Yaml as Yaml
+import Data.Aeson ((.:?), (.!=), FromJSON(..), withObject)
+import System.Directory (doesFileExist)
+import Engine.Core.Log (LoggerState, logWarn, LogCategory(..))
+
+-- | Resolved pathing cost tunables. See the field comments in
+--   `Unit.Pathing.Cost` (the constants these replaced) for the meaning
+--   and tuning intent of each knob.
+data PathingConfig = PathingConfig
+    { pcClimbFactor         ∷ !Float -- ^ Cost per +1 z of a CLIFF climb.
+    , pcRampFactor          ∷ !Float -- ^ Cost per +1 z of a walkable RAMP.
+    , pcFallFactor          ∷ !Float -- ^ Base of the exponential fall cost.
+    , pcFallTriggerDrop     ∷ !Int   -- ^ Drop (z) at which a descent
+                                      --   becomes a costed/transitioned fall.
+    , pcRiverPenalty        ∷ !Float -- ^ Cost added for wading a river tile.
+    , pcLakePenalty         ∷ !Float -- ^ Cost added for wading a lake tile.
+    , pcReplanCostThreshold ∷ !Float -- ^ Greedy-step cost above which the
+                                      --   mover triggers a local A* detour.
+    } deriving (Show, Eq)
+
+-- | The historical hard-coded values. Used as the fallback when no
+--   config file is present and as the per-field default for any key
+--   omitted from the YAML (so a partial file only overrides what it
+--   names).
+defaultPathingConfig ∷ PathingConfig
+defaultPathingConfig = PathingConfig
+    { pcClimbFactor         = 10.0
+    , pcRampFactor          = 0.5
+    , pcFallFactor          = 5.0
+    , pcFallTriggerDrop     = 2
+    , pcRiverPenalty        = 8.0
+    , pcLakePenalty         = 12.0
+    , pcReplanCostThreshold = 5.0
+    }
+
+-- | Per-key optional parse: any omitted key keeps its default. (Using
+--   `.:?`/`.!=` matters — a `.:` on a single missing key would fail the
+--   whole document and silently discard every override.)
+instance FromJSON PathingConfig where
+    parseJSON = withObject "PathingConfig" $ \o → PathingConfig
+        <$> o .:? "climb_factor"          .!= pcClimbFactor         defaultPathingConfig
+        <*> o .:? "ramp_factor"           .!= pcRampFactor          defaultPathingConfig
+        <*> o .:? "fall_factor"           .!= pcFallFactor          defaultPathingConfig
+        <*> o .:? "fall_trigger_drop"     .!= pcFallTriggerDrop     defaultPathingConfig
+        <*> o .:? "river_penalty"         .!= pcRiverPenalty        defaultPathingConfig
+        <*> o .:? "lake_penalty"          .!= pcLakePenalty         defaultPathingConfig
+        <*> o .:? "replan_cost_threshold" .!= pcReplanCostThreshold defaultPathingConfig
+
+-- | Load pathing tunables from a YAML file. A missing file is normal
+--   (defaults). A malformed file warns and falls back to defaults
+--   rather than failing engine init.
+loadPathingConfig ∷ LoggerState → FilePath → IO PathingConfig
+loadPathingConfig logger path = do
+    exists ← doesFileExist path
+    if not exists
+        then return defaultPathingConfig
+        else do
+            result ← Yaml.decodeFileEither path
+            case result of
+                Right pc → return pc
+                Left err → do
+                    logWarn logger CatInit $ "Error loading pathing config: "
+                                           <> T.pack (show err)
+                    return defaultPathingConfig

--- a/src/Unit/Pathing/Cost.hs
+++ b/src/Unit/Pathing/Cost.hs
@@ -33,14 +33,9 @@ module Unit.Pathing.Cost
     , lookupFluidType
     , lookupSlopeAt
     , isCliffStep
-    -- * Tunables (constants for now; future: load from config)
-    , climbFactor
-    , rampFactor
-    , fallFactor
-    , fallTriggerDrop
-    , riverPenalty
-    , lakePenalty
-    , replanCostThreshold
+    -- * Tunables (loaded from config/pathing.yaml; see "Unit.Pathing.Config")
+    , PathingConfig(..)
+    , defaultPathingConfig
     ) where
 
 import UPrelude
@@ -53,62 +48,7 @@ import World.Types (WorldTileData(..), LoadedChunk(..), columnIndex, lookupChunk
 import World.Chunk.Types (ColumnTiles(..))
 import World.Fluid.Types (FluidCell(..), FluidType(..))
 import World.Generate (globalToChunk)
-
--- * Tunables
---
--- These are placeholder values to start with. Tune after seeing units
--- actually navigate. They live here so Phase D's threshold trigger
--- imports from the same place as the cost function itself.
-
--- | Cost added per +1 z of a CLIFF climb (a vertical face, per
---   `isCliffStep`). A 1-z cliff costs ~`climbFactor` on top of the
---   horizontal distance. High enough that units prefer flat detours;
---   low enough that they'll climb when nothing else is available.
-climbFactor ∷ Float
-climbFactor = 10.0
-
--- | Cost added per +1 z of a WALKABLE RAMP (a 1-z step whose tile has a
---   slope bit toward the source — `isCliffStep` is False). Barely above
---   flat so the planner walks up gentle slopes instead of detouring
---   around them or treating them as cliffs. This is what keeps the cost
---   layer (A*) in agreement with the movement layer, which already
---   walks ramps via `isCliffStep`.
-rampFactor ∷ Float
-rampFactor = 0.5
-
--- | Base for fall cost on a REAL fall (drop ≥ `fallTriggerDrop`):
---   `fallCost = fallFactor ** drop`, exponential in height. A 2-z drop
---   is `fallFactor²`, a 3-z drop `fallFactor³` — steep enough that the
---   planner takes any reasonable detour rather than a damaging fall.
---   Drops below the trigger (a single step down) cost nothing: they're
---   a free walk-off, matching the movement layer's `fallTriggerDz`.
-fallFactor ∷ Float
-fallFactor = 5.0
-
--- | Drop magnitude (in z) at which a descent stops being a free
---   step-down and becomes a costed fall. Mirrors
---   `Unit.Thread.Movement.fallTriggerDz` (kept as a local constant to
---   avoid a Cost↔Movement import cycle — Movement imports Cost).
-fallTriggerDrop ∷ Int
-fallTriggerDrop = 2
-
--- | Cost added for stepping into a river/lake tile. River and lake
---   are wadeable — high cost but not impassable. Ocean and lava are
---   `Nothing`.
-riverPenalty ∷ Float
-riverPenalty = 8.0
-
--- | Lake-crossing penalty. Slightly higher than rivers since lakes
---   are usually deeper.
-lakePenalty ∷ Float
-lakePenalty = 12.0
-
--- | If a greedy step's cost exceeds this, the mover triggers a local
---   A* to look for a flatter alternative. Lower = more replanning
---   (units pickier about route), higher = greedier (units climb
---   anything in their direct line).
-replanCostThreshold ∷ Float
-replanCostThreshold = 5.0
+import Unit.Pathing.Config (PathingConfig(..), defaultPathingConfig)
 
 -- * Cost function
 
@@ -125,12 +65,12 @@ replanCostThreshold = 5.0
 --   `Nothing` — units can't path into unloaded territory. This
 --   enforces the "movement clamped to loaded chunks" rule
 --   bottom-up.
-stepCost ∷ WorldTileData → (Int, Int) → (Int, Int) → Maybe Float
-stepCost wtd (sgx, sgy) (dgx, dgy) = do
+stepCost ∷ PathingConfig → WorldTileData → (Int, Int) → (Int, Int) → Maybe Float
+stepCost pc wtd (sgx, sgy) (dgx, dgy) = do
     srcZ <- lookupTerrainZ wtd sgx sgy
     dstZ <- lookupTerrainZ wtd dgx dgy
     let fluidAtDst = lookupFluidType wtd dgx dgy
-    fluidCost <- fluidPenalty fluidAtDst
+    fluidCost <- fluidPenalty pc fluidAtDst
     -- No-corner-cutting: a diagonal step grazes the two axis-aligned
     -- neighbours of the source tile. Reject the step if either neighbour
     -- is impassable (Ocean/Lava/unloaded chunk), so a mover can't slip
@@ -142,7 +82,7 @@ stepCost wtd (sgx, sgy) (dgx, dgy) = do
     -- in its walk animation.)
     let isDiagonal = sgx ≢ dgx ∧ sgy ≢ dgy
         cornerBlocked = isDiagonal
-                      ∧ not (passable wtd dgx sgy ∧ passable wtd sgx dgy)
+                      ∧ not (passable pc wtd dgx sgy ∧ passable pc wtd sgx dgy)
     if cornerBlocked
       then Nothing
       else
@@ -157,14 +97,14 @@ stepCost wtd (sgx, sgy) (dgx, dgy) = do
             -- just walk up.
             climb  = if dz > 0
                      then if isCliffStep wtd (sgx, sgy) (dgx, dgy) srcZ dstZ
-                          then climbFactor * fromIntegral dz
-                          else rampFactor  * fromIntegral dz
+                          then pcClimbFactor pc * fromIntegral dz
+                          else pcRampFactor  pc * fromIntegral dz
                      else 0
             -- Downward: a single step is a free walk-off; a real fall
-            -- (drop ≥ fallTriggerDrop) costs an exponential in height so
+            -- (drop ≥ pcFallTriggerDrop) costs an exponential in height so
             -- the planner avoids damaging drops.
-            fall   = if negate dz ≥ fallTriggerDrop
-                     then fallFactor ** fromIntegral (negate dz)
+            fall   = if negate dz ≥ pcFallTriggerDrop pc
+                     then pcFallFactor pc ** fromIntegral (negate dz)
                      else 0
         in pure $! horizD + climb + fall + fluidCost
 
@@ -172,23 +112,23 @@ stepCost wtd (sgx, sgy) (dgx, dgy) = do
 --   is loaded (terrain z resolves) and its fluid isn't a non-wadeable
 --   barrier (Ocean/Lava). Used by the no-corner-cutting gate in
 --   `stepCost` to test the two axis-neighbours a diagonal step grazes.
-passable ∷ WorldTileData → Int → Int → Bool
-passable wtd gx gy =
+passable ∷ PathingConfig → WorldTileData → Int → Int → Bool
+passable pc wtd gx gy =
     case lookupTerrainZ wtd gx gy of
         Nothing → False
-        Just _  → case fluidPenalty (lookupFluidType wtd gx gy) of
+        Just _  → case fluidPenalty pc (lookupFluidType wtd gx gy) of
             Just _  → True
             Nothing → False
 
 -- | Map fluid type at the destination to a step-cost modifier.
 --   Ocean and lava are non-traversable (`Nothing`); rivers and lakes
 --   are wadeable at a penalty. Dry tiles add 0.
-fluidPenalty ∷ Maybe FluidType → Maybe Float
-fluidPenalty Nothing       = Just 0
-fluidPenalty (Just Ocean)  = Nothing
-fluidPenalty (Just Lava)   = Nothing
-fluidPenalty (Just River)  = Just riverPenalty
-fluidPenalty (Just Lake)   = Just lakePenalty
+fluidPenalty ∷ PathingConfig → Maybe FluidType → Maybe Float
+fluidPenalty _  Nothing       = Just 0
+fluidPenalty _  (Just Ocean)  = Nothing
+fluidPenalty _  (Just Lava)   = Nothing
+fluidPenalty pc (Just River)  = Just (pcRiverPenalty pc)
+fluidPenalty pc (Just Lake)   = Just (pcLakePenalty pc)
 
 -- * World lookups
 

--- a/src/Unit/Thread/Movement.hs
+++ b/src/Unit/Thread/Movement.hs
@@ -40,7 +40,8 @@ import World.Tile.Types (WorldTileData(..))
 import Unit.Sim.Types
 import Unit.Types (UnitInstance(..), UnitManager(..), UnitId(..), UnitDef(..)
                   , Wound(..))
-import Unit.Pathing.Cost (stepCost, lookupTerrainZ, isCliffStep, replanCostThreshold)
+import Unit.Pathing.Cost (stepCost, lookupTerrainZ, isCliffStep
+                         , PathingConfig(..))
 import Unit.Pathing.AStar (localAStar, defaultMaxRadius)
 import Unit.Fall (FallInjury(..), fallInjuries, fallStunFor, gravity, metresPerZ)
 
@@ -105,6 +106,11 @@ tickAllMovement dt env utsRef = do
     -- so a unit with no stats declared behaves like an unmodified
     -- acolyte against the impact thresholds.
     um ← readIORef (unitManagerRef env)
+    -- Pathing cost tunables (climb/ramp/fall/river/lake penalties +
+    -- replan threshold), loaded once from config/pathing.yaml. Read per
+    -- tick so a future settings UI that mutates the ref takes effect
+    -- live; the read is a single IORef deref.
+    pc ← readIORef (pathingConfigRef env)
     let statsFor uid = case HM.lookup uid (umInstances um) of
             Just inst →
                 -- Gait threshold (absolute tiles/s) from the unit's def:
@@ -126,7 +132,7 @@ tickAllMovement dt env utsRef = do
     uts ← readIORef utsRef
     let simStates  = utsSimStates uts
         simStates' = HM.mapWithKey
-                        (\uid ss → tickUnit now dt mWtd (statsFor uid) ss)
+                        (\uid ss → tickUnit pc now dt mWtd (statsFor uid) ss)
                         simStates
 
     -- Climb slip rolls + climb→fall conversions. Two passes that
@@ -365,10 +371,10 @@ snapshotVisibleWorldTiles env = do
             Nothing → pure Nothing
             Just ws → Just <$> readIORef (wsTilesRef ws)
 
-tickUnit ∷ Double → Double → Maybe WorldTileData
+tickUnit ∷ PathingConfig → Double → Double → Maybe WorldTileData
          → UnitMoveStats
          → UnitSimState → UnitSimState
-tickUnit now dt mWtd stats us =
+tickUnit pc now dt mWtd stats us =
     let us1 = handleGetUp now
             $ handleTransitionExpiry now
             $ handlePickupExpiry now
@@ -393,7 +399,7 @@ tickUnit now dt mWtd stats us =
                 let subGoal = case usLocalPath us2 of
                         (p : _) → p
                         []      → (mtTargetX mt, mtTargetY mt)
-                in stepTowardSubGoal now dt mWtd stats us2 mt subGoal
+                in stepTowardSubGoal pc now dt mWtd stats us2 mt subGoal
 
 -- | While the unit is in TransitioningTo Climbing, lerp usRealZ up the
 --   WALL portion of the cliff only — from the base z to the climb-top
@@ -616,12 +622,12 @@ startJump now ss tgx tgy =
           , usLocalPath        = []
           }
 
--- | The Z drop magnitude at which a descent step stops being a
---   "walk off the edge" and becomes a real fall. dz of -1 still
---   plays the regular walking animation; dz of -2 or worse triggers
---   the Standing→Falling transition + impact calc.
-fallTriggerDz ∷ Int
-fallTriggerDz = 2
+-- The Z drop magnitude at which a descent step stops being a "walk off
+-- the edge" and becomes a real fall is now the configurable
+-- `pcFallTriggerDrop` (config/pathing.yaml) — the same knob the cost
+-- function uses, so the planner and the mover agree on what counts as a
+-- fall. dz of -1 still plays the regular walking animation; dz of
+-- -pcFallTriggerDrop or worse triggers the Standing→Falling transition.
 
 -- | Legacy scalar fall impact (dz × mass/50 / toughness). The landing
 --   OUTCOME no longer uses this — falls now go through the `Unit.Fall`
@@ -848,7 +854,8 @@ chainStepDuration = 0.8
 -- | Try to advance toward `subGoal`. If we arrive, pop the waypoint
 --   (or clear the final target). Otherwise, take one step.
 stepTowardSubGoal
-    ∷ Double
+    ∷ PathingConfig
+    → Double
     → Double
     → Maybe WorldTileData
     → UnitMoveStats
@@ -856,7 +863,7 @@ stepTowardSubGoal
     → MoveTarget
     → (Float, Float)
     → UnitSimState
-stepTowardSubGoal now dt mWtd stats us mt (gx, gy) =
+stepTowardSubGoal pc now dt mWtd stats us mt (gx, gy) =
     let dx   = gx - usRealX us
         dy   = gy - usRealY us
         dist = sqrt (dx * dx + dy * dy)
@@ -868,7 +875,7 @@ stepTowardSubGoal now dt mWtd stats us mt (gx, gy) =
         step = effSpeed * realToFrac dt
     in if dist ≤ max step arrivalEpsilon
        then arriveAtSubGoal stats us mt (gx, gy) mWtd
-       else moveToward now stats us mt mWtd dx dy dist step
+       else moveToward pc now stats us mt mWtd dx dy dist step
 
 -- | Top speed (tiles/sec) of a unit dragging itself along on a maimed
 --   body. Slow enough to read as a crawl; the injury speed-multiplier
@@ -915,7 +922,8 @@ arriveAtSubGoal stats us mt (gx, gy) mWtd =
 --   crossing is a cliff (Z step that has no slope ramp), initiate a
 --   climb transition instead of taking the step.
 moveToward
-    ∷ Double             -- now (game time, for transition expiry)
+    ∷ PathingConfig
+    → Double             -- now (game time, for transition expiry)
     → UnitMoveStats
     → UnitSimState
     → MoveTarget
@@ -925,7 +933,7 @@ moveToward
     → Float    -- distance to sub-goal
     → Float    -- step length this tick
     → UnitSimState
-moveToward now stats us mt mWtd dx dy dist step =
+moveToward pc now stats us mt mWtd dx dy dist step =
     let nx   = dx / dist
         ny   = dy / dist
         newX = usRealX us + nx * step
@@ -938,7 +946,7 @@ moveToward now stats us mt mWtd dx dy dist step =
         mCost
             | srcTile ≡ dstTile = Just 0  -- sub-tile motion, no boundary cross
             | otherwise = case mWtd of
-                Just wtd → stepCost wtd srcTile dstTile
+                Just wtd → stepCost pc wtd srcTile dstTile
                 Nothing  → Just 0  -- no world snapshot: don't block
         followingPath = not (null (usLocalPath us))
         -- Cliff and fall detection: only meaningful when actually
@@ -964,14 +972,14 @@ moveToward now stats us mt mWtd dx dy dist step =
                 case (lookupTerrainZ wtd (fst srcTile) (snd srcTile),
                       lookupTerrainZ wtd (fst dstTile) (snd dstTile)) of
                     (Just sz, Just dz)
-                        | sz - dz ≥ fallTriggerDz → Just (sz, dz)
+                        | sz - dz ≥ pcFallTriggerDrop pc → Just (sz, dz)
                     _ → Nothing
             _ → Nothing
     in case mCost of
         Nothing →
-            replan us mt mWtd srcTile
-        Just c | not followingPath ∧ c > replanCostThreshold →
-            replan us mt mWtd srcTile
+            replan pc us mt mWtd srcTile
+        Just c | not followingPath ∧ c > pcReplanCostThreshold pc →
+            replan pc us mt mWtd srcTile
         Just _ → case (mCliff, mFall) of
             (Just (srcZ, dstZ), _) →
                 -- Face the CLIFF, not the unit's walking sub-step.
@@ -1131,15 +1139,16 @@ startFall now stats us ((dgx, dgy), dstZ) srcZ (nx, ny) =
 --   sits this tick — `usTarget` is preserved so the next tick can
 --   try again ("never gives up").
 replan
-    ∷ UnitSimState
+    ∷ PathingConfig
+    → UnitSimState
     → MoveTarget
     → Maybe WorldTileData
     → (Int, Int)
     → UnitSimState
-replan us mt mWtd srcTile =
+replan pc us mt mWtd srcTile =
     let finalTile = (floor (mtTargetX mt), floor (mtTargetY mt))
         tilePath = case mWtd of
-            Just wtd → localAStar wtd srcTile finalTile defaultMaxRadius
+            Just wtd → localAStar pc wtd srcTile finalTile defaultMaxRadius
             Nothing  → []
         wps = map tileCenter tilePath
     in if null wps

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -149,6 +149,7 @@ test-suite synarchy-test-headless
                    Test.Headless.WorldGen.WrapSeam
                    Test.Headless.Unit.Pathing.Cost
                    Test.Headless.Unit.Pathing.AStar
+                   Test.Headless.Unit.Pathing.Config
                    Test.Headless.Unit.Render.PickFrame
                    Test.Headless.Unit.Anim
                    Test.Headless.Unit.Injury
@@ -196,6 +197,8 @@ test-suite synarchy-test-headless
                 , deepseq
                 , random
                 , linear
+                , bytestring
+                , yaml
     default-language: GHC2024
     if flag(dev)
       if os(darwin)
@@ -401,6 +404,7 @@ library
                      Unit.Selection
                      Unit.HitTest
                      Unit.LineOfSight
+                     Unit.Pathing.Config
                      Unit.Pathing.Cost
                      Unit.Pathing.AStar
                      Unit.Fall

--- a/test-headless/Spec.hs
+++ b/test-headless/Spec.hs
@@ -14,6 +14,7 @@ import qualified Test.Headless.WorldGen.BorderProbe as BorderProbe
 import qualified Test.Headless.WorldGen.WrapSeam as WrapSeam
 import qualified Test.Headless.Unit.Pathing.Cost as PathingCost
 import qualified Test.Headless.Unit.Pathing.AStar as PathingAStar
+import qualified Test.Headless.Unit.Pathing.Config as PathingConfig
 import qualified Test.Headless.Unit.Render.PickFrame as PickFrame
 import qualified Test.Headless.Unit.Anim as AnimTest
 import qualified Test.Headless.Unit.Injury as InjuryTest
@@ -53,6 +54,7 @@ main = hspec $ do
     describe "Wrap Seam" WrapSeam.spec
     describe "Unit.Pathing.Cost" PathingCost.spec
     describe "Unit.Pathing.AStar" PathingAStar.spec
+    describe "Unit.Pathing.Config" PathingConfig.spec
     describe "Unit.Render.pickFrame" PickFrame.spec
     describe "Unit.Anim" AnimTest.spec
     describe "Unit.Injury" InjuryTest.spec

--- a/test-headless/Test/Headless/Unit/Pathing/AStar.hs
+++ b/test-headless/Test/Headless/Unit/Pathing/AStar.hs
@@ -15,6 +15,12 @@ import World.Fluid.Types (FluidCell(..), FluidType(..), emptyIceMap)
 import World.Flora.Types (emptyFloraChunkData)
 import Structure.Types (emptyChunkStructures)
 import Unit.Pathing.AStar
+import Unit.Pathing.Cost (PathingConfig, defaultPathingConfig)
+
+-- A* cost comes from the pathing config; the tests use the default
+-- profile (the historical hard-coded weights).
+pc ∷ PathingConfig
+pc = defaultPathingConfig
 
 flatChunk ∷ Int → LoadedChunk
 flatChunk terrZ =
@@ -76,13 +82,13 @@ spec = do
             let wtd = worldWith (flatChunk 5)
 
             it "src == dst → empty path" $
-                localAStar wtd (3, 3) (3, 3) 16 `shouldBe` []
+                localAStar pc wtd (3, 3) (3, 3) 16 `shouldBe` []
 
             it "one cardinal step" $
-                localAStar wtd (3, 3) (4, 3) 16 `shouldBe` [(4, 3)]
+                localAStar pc wtd (3, 3) (4, 3) 16 `shouldBe` [(4, 3)]
 
             it "corner-to-corner of chunk uses 15 diagonal steps" $ do
-                let path = localAStar wtd (0, 0) (15, 15) 32
+                let path = localAStar pc wtd (0, 0) (15, 15) 32
                 length path `shouldBe` 15
                 last path `shouldBe` (15, 15)
 
@@ -95,7 +101,7 @@ spec = do
                 onLava (x, y) = x ≡ 8 ∧ y > 0 ∧ y < 15
 
             it "routes around the lava wall" $ do
-                let path = localAStar wtd (5, 5) (12, 5) 32
+                let path = localAStar pc wtd (5, 5) (12, 5) 32
                 any onLava path `shouldBe` False
                 last path `shouldBe` (12, 5)
 
@@ -105,7 +111,7 @@ spec = do
                     if lx ≡ 8 then (10, Just Lava) else (5, Nothing)
 
             it "returns a partial path that ends at the wall" $ do
-                let path = localAStar wtd (5, 5) (12, 5) 16
+                let path = localAStar pc wtd (5, 5) (12, 5) 16
                 case path of
                     [] → expectationFailure "expected partial progress toward wall"
                     _  → let (lx, _) = last path
@@ -115,7 +121,7 @@ spec = do
             let wtd = worldWith (flatChunk 5)
 
             it "tiny radius yields a path that stops at the bound" $ do
-                let path = localAStar wtd (0, 0) (15, 15) 3
+                let path = localAStar pc wtd (0, 0) (15, 15) 3
                 length path `shouldBe` 3
                 last path `shouldBe` (3, 3)
 
@@ -133,7 +139,7 @@ spec = do
                        else (5, Nothing)
 
             it "prefers the flat passage at ly=0 over climbing the ridge" $ do
-                let path = localAStar wtd (5, 5) (12, 5) 32
+                let path = localAStar pc wtd (5, 5) (12, 5) 32
                 -- Path must include at least one tile at ly=0.
                 any (\(_, y) → y ≡ 0) path `shouldBe` True
                 last path `shouldBe` (12, 5)

--- a/test-headless/Test/Headless/Unit/Pathing/Config.hs
+++ b/test-headless/Test/Headless/Unit/Pathing/Config.hs
@@ -46,3 +46,32 @@ spec = do
     describe "empty mapping yields all defaults" $
         it "decodes {} to the default profile" $
             decode "{}\n" `shouldBe` Right defaultPathingConfig
+
+    describe "normalizePathingConfig clamps unsafe values" $ do
+        it "raises fall_trigger_drop ≤ 0 to 1 (a 0 makes flat ground a fall)" $ do
+            pcFallTriggerDrop (normalizePathingConfig
+                defaultPathingConfig { pcFallTriggerDrop = 0 }) `shouldBe` 1
+            pcFallTriggerDrop (normalizePathingConfig
+                defaultPathingConfig { pcFallTriggerDrop = -3 }) `shouldBe` 1
+
+        it "clamps negative costs/penalties to 0 (A* needs non-negative weights)" $
+            normalizePathingConfig PathingConfig
+                { pcClimbFactor         = -1.0
+                , pcRampFactor          = -2.0
+                , pcFallFactor          = -3.0
+                , pcFallTriggerDrop     = -1
+                , pcRiverPenalty        = -4.0
+                , pcLakePenalty         = -5.0
+                , pcReplanCostThreshold = -6.0
+                } `shouldBe` PathingConfig
+                { pcClimbFactor         = 0.0
+                , pcRampFactor          = 0.0
+                , pcFallFactor          = 0.0
+                , pcFallTriggerDrop     = 1
+                , pcRiverPenalty        = 0.0
+                , pcLakePenalty         = 0.0
+                , pcReplanCostThreshold = 0.0
+                }
+
+        it "leaves a valid config unchanged" $
+            normalizePathingConfig defaultPathingConfig `shouldBe` defaultPathingConfig

--- a/test-headless/Test/Headless/Unit/Pathing/Config.hs
+++ b/test-headless/Test/Headless/Unit/Pathing/Config.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE Strict, UnicodeSyntax, OverloadedStrings #-}
+-- | Tests for Unit.Pathing.Config YAML decoding.
+--   The subtle bit is the per-key optional merge: a partial document
+--   must override only the keys it names and keep defaults for the
+--   rest (the `.:?`/`.!=` gotcha — a `.:` would fail the whole parse on
+--   one missing key). These tests pin that behaviour.
+module Test.Headless.Unit.Pathing.Config (spec) where
+
+import UPrelude
+import Test.Hspec
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.Yaml as Yaml
+import Unit.Pathing.Config
+
+decode ∷ BS.ByteString → Either String PathingConfig
+decode = either (Left . show) Right . Yaml.decodeEither'
+
+spec ∷ Spec
+spec = do
+    describe "full document overrides every field" $
+        it "parses all keys" $ do
+            let yaml = BS.unlines
+                    [ "climb_factor: 1.0"
+                    , "ramp_factor: 2.0"
+                    , "fall_factor: 3.0"
+                    , "fall_trigger_drop: 4"
+                    , "river_penalty: 5.0"
+                    , "lake_penalty: 6.0"
+                    , "replan_cost_threshold: 7.0"
+                    ]
+            decode yaml `shouldBe` Right PathingConfig
+                { pcClimbFactor         = 1.0
+                , pcRampFactor          = 2.0
+                , pcFallFactor          = 3.0
+                , pcFallTriggerDrop     = 4
+                , pcRiverPenalty        = 5.0
+                , pcLakePenalty         = 6.0
+                , pcReplanCostThreshold = 7.0
+                }
+
+    describe "partial document keeps defaults for omitted keys" $
+        it "overrides only the named key" $ do
+            let yaml = "climb_factor: 99.0\n"
+            decode yaml `shouldBe` Right defaultPathingConfig { pcClimbFactor = 99.0 }
+
+    describe "empty mapping yields all defaults" $
+        it "decodes {} to the default profile" $
+            decode "{}\n" `shouldBe` Right defaultPathingConfig

--- a/test-headless/Test/Headless/Unit/Pathing/Cost.hs
+++ b/test-headless/Test/Headless/Unit/Pathing/Cost.hs
@@ -77,6 +77,11 @@ worldWith lc = WorldTileData
 approxEq ∷ Float → Float → Bool
 approxEq a b = abs (a - b) < 0.001
 
+-- The pathing tunables now live in a config record; the tests exercise
+-- the default profile (the historical hard-coded values).
+pc ∷ PathingConfig
+pc = defaultPathingConfig
+
 spec ∷ Spec
 spec = do
     describe "Unit.Pathing.Cost.stepCost" $ do
@@ -85,17 +90,17 @@ spec = do
             let wtd = worldWith (flatChunk 5)
 
             it "cardinal step on flat terrain costs 1.0" $
-                case stepCost wtd (3, 3) (4, 3) of
+                case stepCost pc wtd (3, 3) (4, 3) of
                     Just c  → c `shouldSatisfy` approxEq 1.0
                     Nothing → expectationFailure "expected Just"
 
             it "diagonal step on flat terrain costs ≈ sqrt(2)" $
-                case stepCost wtd (3, 3) (4, 4) of
+                case stepCost pc wtd (3, 3) (4, 4) of
                     Just c  → c `shouldSatisfy` approxEq (sqrt 2)
                     Nothing → expectationFailure "expected Just"
 
             it "two-tile horizontal step costs 2.0" $
-                case stepCost wtd (3, 3) (5, 3) of
+                case stepCost pc wtd (3, 3) (5, 3) of
                     Just c  → c `shouldSatisfy` approxEq 2.0
                     Nothing → expectationFailure "expected Just"
 
@@ -106,13 +111,13 @@ spec = do
                     let z = if lx < 8 then 5 else 6
                     in (z, Nothing)
 
-            it "1-z climb adds climbFactor on top of horizontal cost" $
-                case stepCost wtd (7, 5) (8, 5) of
-                    Just c  → c `shouldSatisfy` approxEq (1.0 + climbFactor)
+            it "1-z climb adds the climb factor on top of horizontal cost" $
+                case stepCost pc wtd (7, 5) (8, 5) of
+                    Just c  → c `shouldSatisfy` approxEq (1.0 + pcClimbFactor pc)
                     Nothing → expectationFailure "expected Just"
 
             it "stepping down 1-z is a free walk-off (no fall cost)" $
-                case stepCost wtd (8, 5) (7, 5) of
+                case stepCost pc wtd (8, 5) (7, 5) of
                     Just c  →
                         -- A single step down is below fallTriggerDrop (2),
                         -- so it costs nothing beyond the horizontal
@@ -129,8 +134,8 @@ spec = do
                     wtd3 = worldWith $ customChunk $ \(lx, _) →
                         let z = if lx < 8 then 5 else 2
                         in (z, Nothing)
-                let c1 = stepCost wtd1 (7, 5) (8, 5)
-                    c3 = stepCost wtd3 (7, 5) (8, 5)
+                let c1 = stepCost pc wtd1 (7, 5) (8, 5)
+                    c3 = stepCost pc wtd3 (7, 5) (8, 5)
                 case (c1, c3) of
                     (Just v1, Just v3) → do
                         -- Exponential: cost ratio should be much greater than 3
@@ -144,10 +149,10 @@ spec = do
                     else (5, Nothing)
 
             it "step into ocean is Nothing" $
-                stepCost wtd (4, 3) (5, 3) `shouldBe` Nothing
+                stepCost pc wtd (4, 3) (5, 3) `shouldBe` Nothing
 
             it "step into lava is Nothing" $
-                stepCost wtd (7, 3) (6, 3) `shouldBe` Nothing
+                stepCost pc wtd (7, 3) (6, 3) `shouldBe` Nothing
 
         describe "fluid penalties" $ do
             let wtd = worldWith $ customChunk $ \(lx, _) →
@@ -155,23 +160,23 @@ spec = do
                     else if lx ≡ 6 then (5, Just Lake)
                     else (5, Nothing)
 
-            it "step into river adds riverPenalty" $
-                case stepCost wtd (4, 3) (5, 3) of
-                    Just c  → c `shouldSatisfy` approxEq (1.0 + riverPenalty)
+            it "step into river adds the river penalty" $
+                case stepCost pc wtd (4, 3) (5, 3) of
+                    Just c  → c `shouldSatisfy` approxEq (1.0 + pcRiverPenalty pc)
                     Nothing → expectationFailure "expected Just"
 
-            it "step into lake adds lakePenalty" $
-                case stepCost wtd (7, 3) (6, 3) of
-                    Just c  → c `shouldSatisfy` approxEq (1.0 + lakePenalty)
+            it "step into lake adds the lake penalty" $
+                case stepCost pc wtd (7, 3) (6, 3) of
+                    Just c  → c `shouldSatisfy` approxEq (1.0 + pcLakePenalty pc)
                     Nothing → expectationFailure "expected Just"
 
         describe "unloaded chunks" $ do
             it "step into a tile in an unloaded chunk is Nothing" $ do
                 let wtd = worldWith (flatChunk 5)
                 -- (50, 50) is in chunk (3, 3), not loaded
-                stepCost wtd (15, 15) (50, 50) `shouldBe` Nothing
+                stepCost pc wtd (15, 15) (50, 50) `shouldBe` Nothing
 
         describe "tunable thresholds are sane" $ do
-            it "replanCostThreshold sits between flat and 1-z climb" $ do
-                replanCostThreshold `shouldSatisfy` (> sqrt 2)
-                replanCostThreshold `shouldSatisfy` (< 1.0 + climbFactor)
+            it "replan cost threshold sits between flat and 1-z climb" $ do
+                pcReplanCostThreshold pc `shouldSatisfy` (> sqrt 2)
+                pcReplanCostThreshold pc `shouldSatisfy` (< 1.0 + pcClimbFactor pc)


### PR DESCRIPTION
Closes #38.

## What

The unit-pathing cost tunables — climb / ramp / fall / river / lake penalties, the fall-trigger drop, and the replan threshold — were hard-coded in `Unit.Pathing.Cost`, which itself flagged them as *"constants for now; future: load from config"*. They are now loaded from `config/pathing.yaml`, with the historical numbers as defaults.

## How

- **`Unit.Pathing.Config`** (new): `PathingConfig` record + `defaultPathingConfig` (the old values) + `loadPathingConfig`. Per-key optional parsing (`.:?`/`.!=`) so a partial or absent file falls back to defaults rather than discarding the whole document.
- **`config/pathing.yaml`** (new): ships the defaults, one documented knob each.
- Config is loaded once at engine init into a new `pathingConfigRef :: IORef PathingConfig` on `EngineEnv` and threaded into the pure cost path (`stepCost` → `localAStar`) and the movement tick (`moveToward` / `replan`). The movement tick re-reads the ref each tick, leaving room for a future settings UI to retune routing live.
- The duplicate Movement-side `fallTriggerDz` is gone; the cost function and the mover now share `pcFallTriggerDrop`, so they can't drift apart.
- The record is a flat scalar bag so future material/weather/per-unit modifiers can be appended without reshaping the call sites that thread it.

## Validation

- **Default config == current behaviour:** existing `Unit.Pathing.Cost` / `Unit.Pathing.AStar` hspec specs now run against `defaultPathingConfig` and pass unchanged.
- **New parse spec** (`Unit.Pathing.Config`): full-document, partial-document-keeps-defaults, and empty-mapping cases.
- Full headless suite: **343 examples, 0 failures**.
- **Knob changes route choice without recompilation:** `tools/movement_probe.py --course ramp_choice` — with the default file the unit detours to the cheap ramp and *walks* up; editing only `replan_cost_threshold` in the YAML (no rebuild) makes the same binary *climb* the nearer cliff instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)