### PR TITLE
Fix #141: tear down cargo inventory popup on zoom transitions

### DIFF
--- a/scripts/hud.lua
+++ b/scripts/hud.lua
@@ -658,6 +658,10 @@ end
 --   * item-contents popup (#142): mounted on hud.world_page, so hiding
 --     the page only takes it off-view; its logical state stays open and
 --     could reappear stale. closeIfOpen() tears it down.
+--   * cargo-inventory popup (#141): same story as the item-contents
+--     popup — mounted on hud.world_page, so a band change only hides the
+--     page while state.open stays true and the popup reappears stale on
+--     return. closeIfOpen() (idempotent) tears it down on every band change.
 --   * right-click context menu (#139): own modal page, anchored to the
 --     click target; hide() it so it can't survive over the wrong view.
 --   * ground-item selection (#175): per-world cursor state the item
@@ -703,6 +707,7 @@ function hud.reconcileView()
 
     infoPanel.clear()
     require("scripts.item_contents_panel").closeIfOpen()
+    require("scripts.cargo_inventory_panel").closeIfOpen()
     -- Right-click context menu (#139): it lives on its own modal page and
     -- is anchored to the tile/unit/item under the click in the zoomed-in
     -- view. Hiding the world/zoom pages above only takes it off-view; its


### PR DESCRIPTION
## Summary
Closes #141.

The cargo inventory popup (`cargo_inventory_panel.lua`) is mounted on `hud.world_page`. On a zoom band change, `hud.reconcileView()` only **hides** that page, while `cargoInventoryPanel.state.open` stays `true`. Zooming back in re-shows the page and the **stale** popup reappears.

`reconcileView()` is the central per-transition teardown and already does exactly this for the sibling item-contents popup (#142). This adds the matching idempotent `closeIfOpen()` call for the cargo popup.

## Change
- `scripts/hud.lua` — one line in `hud.reconcileView()`:
  `require("scripts.cargo_inventory_panel").closeIfOpen()`, right after the existing `item_contents_panel` teardown, plus a header-comment entry documenting it in the established style.

## Why this is the right spot
- `reconcileView()` runs on **every** real zoom-band transition (driven per-tick from `hud.update()` and immediately from `hud.onScroll()`), and only while the HUD owns the view — so it can't clobber a hidden world.
- `closeIfOpen()` is the documented public API (`cargo_inventory_panel.lua:586`) and is idempotent (early-returns when not open), so calling it unconditionally on every band change is safe.
- The `hud.hide()` (menu) path already closes the popup (`hud.lua:571`); this fills the remaining zoom-transition gap.

## Testing
Lua-only change mirroring already-working production lines.
- `luajit` syntax check of `hud.lua` passes.
- Require path `scripts.cargo_inventory_panel` confirmed (used in 5 existing call sites).
- The popup is GUI and not headless-verifiable; the data path it relies on (`closeIfOpen`) is the same idempotent call already proven for the item-contents popup one line above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)