### PR TITLE
Fix #145: gate debug_anim_panel on the gameplay zoomed-in view

### DIFF
--- a/scripts/debug_anim_panel.lua
+++ b/scripts/debug_anim_panel.lua
@@ -351,7 +351,16 @@ function panel.update(dt)
     -- is active. Otherwise the menu would pop on every unit selection in
     -- normal play. Reset activeUid so it rebuilds cleanly if the overlay
     -- is toggled back on while the same unit is still selected.
-    if not uid or not debugOverlay.isVisible() then
+    --
+    -- Also gate on debugOverlay.canShow() (gameplay input active AND the
+    -- zoomed-in world view) — the same test the click handler uses (#152).
+    -- The panel is only meaningful in the zoomed-in gameplay view, but it
+    -- is driven purely by unit selection, so without this it could linger
+    -- over the zoom map, the fade band, or a menu while a unit stays
+    -- selected (#145). Tying it directly to the gameplay view keeps it
+    -- from depending on the overlay's own teardown (#147) firing first,
+    -- and makes update() symmetric with tryClaimClick().
+    if not uid or not debugOverlay.isVisible() or not debugOverlay.canShow() then
         if panel.visible then hide() end
         panel.activeUid = nil
         return


### PR DESCRIPTION
## Summary
Closes #145. The `debug_anim_panel` was driven purely by unit selection — `panel.update()` only hid it when no unit was selected or the F8 debug overlay was off (`isVisible()`). With a unit still selected it could linger over the zoom map, the fade band, or a menu, even though the panel is only meaningful in the zoomed-in gameplay view.

## Root cause / current state
Since #145 was filed, **#147** added `debug.hide()` to the zoom (`hud.reconcileView`) and menu (`hud.hide`, `ui_manager.showMenu`) teardown paths. That hides the overlay and so *transitively* hides this panel within one 0.1s tick. But the panel still had **no direct view-lifecycle gate of its own** — it depended entirely on #147's overlay teardown firing at every site — and its `update()` gate was asymmetric with its own click handler, which already refuses to act outside gameplay via `debugOverlay.canShow()` (the #152 fix).

## Fix
Add the same `canShow()` test (gameplay input active **and** `currentView == "zoomed_in"`) to the `update()` hide-gate. The panel now hides itself whenever it leaves the gameplay view — independent of whether the overlay's teardown ran first — and `update()` becomes symmetric with `tryClaimClick()`. This follows the maintainer's established gating philosophy (commit 3493c9cf, #137, #152) rather than enumerating new teardown call-sites.

One-line logic change; the rest is an explanatory comment.

## Testing
Lua-only change (no Haskell rebuild; hspec tiers don't exercise this script). Verified with a `luajit` harness driving the **real** `panel.update()` across view states:
- normal gameplay (overlay on, unit selected, `canShow()` true) → panel **visible** (no regression)
- `canShow()` false (zoom/menu transition) while unit stays selected → panel **hidden** ✓
- return to gameplay → visible again
- overlay off (F8) → hidden (old gate path unchanged)
- no unit selected → hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)