### PR TITLE
Fix #144: tear down mine-designation anchor on zoom transitions

### DIFF
--- a/scripts/hud.lua
+++ b/scripts/hud.lua
@@ -715,6 +715,14 @@ function hud.reconcileView()
     -- hide() is idempotent (no-op when no menu is open), so dismiss it on
     -- every band change.
     require("scripts.ui.context_menu").hide()
+    -- Mine-designation anchor (#144): a pending first-corner anchor lives in
+    -- mine_tool's Lua state + the world cursor (mineAnchor) and renders a
+    -- preview grid. The tool only acts in zoomed_in, but nothing cleared the
+    -- anchor on a band change, so it survived off-view and could not be
+    -- canceled there (Escape/right-click are gated on the zoomed_in view).
+    -- cancel() is idempotent (clears Lua state + WorldClearMineAnchor is a
+    -- no-op when nothing is pending), so tear it down on every transition.
+    require("scripts.mine_tool").cancel()
     if newView ~= "zoomed_in" then
         require("scripts.debug").hide()
     end


### PR DESCRIPTION
## Summary
Closes #144.

A pending mine-designation anchor (the first-corner click) lived in `mine_tool`'s Lua state and the world cursor (`mineAnchor`, rendered as a preview grid). It was only cleared by `mineTool.cancel()`, reachable via right-click, Escape, or `onToolMode` — all gated on `currentView == "zoomed_in"`. `hud.reconcileView()`, the per-band-transition teardown that already clears the info panel, item/cargo popups, the context menu, the debug overlay, and ground-item selection, never touched it. So zooming out or entering the fade zone stranded the anchor off-view, where it could not be canceled, and it reappeared stale on return.

## Fix
Add `require("scripts.mine_tool").cancel()` to `reconcileView()` alongside the existing sibling teardowns. `cancel()` is idempotent: it nils the Lua anchor and issues `WorldClearMineAnchor`, which just sets the cursor's `mineAnchor` to `Nothing` (a no-op when nothing is pending). This matches the established #139/#141/#142/#175 teardown pattern. The world is still the visible/active one at this point, so `worldId` resolves correctly (same reasoning as the adjacent `item.deselect()`).

## Testing
- The symptom is GUI-only: the anchor's sole observable effect is the render-side preview grid (`World/Render/Quads.hs:518`); there is no Lua getter and `reconcileView` is driven by the GUI zoom/camera path, so there is no headless reproduction (same as the sibling lifecycle fixes).
- `luajit` syntax check of the modified `hud.lua` passes.
- Worktree builds clean (`cabal build exe:synarchy`, exit 0); headless boot reaches `READY`, responds, and shuts down cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)