### PR TITLE
Fix #125: scope drag-select hit-test to the active world

### DIFF
--- a/src/Unit/HitTest.hs
+++ b/src/Unit/HitTest.hs
@@ -144,13 +144,19 @@ hitTestUnitsInRect env x1d y1d x2d y2d = do
     camera   ← readIORef (cameraRef env)
     (winW, winH) ← readIORef (windowSizeRef env)
     texSizes ← readIORef (textureSizeRef env)
+    mgr      ← readIORef (worldManagerRef env)
 
     let x1 = realToFrac (min x1d x2d) ∷ Float
         x2 = realToFrac (max x1d x2d) ∷ Float
         y1 = realToFrac (min y1d y2d) ∷ Float
         y2 = realToFrac (max y1d y2d) ∷ Float
 
-        instances = umInstances um
+        -- Only the active world's units are selectable (#125) — mirrors
+        -- the same filter in hitTestUnitAt so box-select and click-select
+        -- agree and drag-select never grabs hidden-page units.
+        instances = case resolveActiveWorld mgr of
+            Just (pid, _) → unitsOnPage pid (umInstances um)
+            Nothing       → HM.empty
         facing  = camFacing camera
         zoom    = camZoom camera
         zSlice  = camZSlice camera


### PR DESCRIPTION
Closes #125.

## Problem
Box (drag) selection could grab units that only exist on hidden world pages. `unit.hitTestAt` (point-click) was already updated to filter `umInstances` through `resolveActiveWorld`/`unitsOnPage` (#78), but `unit.hitTestInRect` was never given the same fix and still iterated the raw `umInstances`. `scripts/unit_drag_select.lua` uses `hitTestInRect` on mouse-up, so box-select saw cross-world units even though point-click did not.

## Fix
`hitTestUnitsInRect` now reads `worldManagerRef` and resolves `instances` via the exact same `resolveActiveWorld`/`unitsOnPage` filter already used by `hitTestUnitAt`, so box-select and click-select agree and drag-select never includes hidden-page units. When no world is active it selects nothing.

- `src/Unit/HitTest.hs` — `hitTestUnitsInRect`

## Testing
- `cabal build all` — clean.
- `cabal test synarchy-test-headless` — 346 examples, 0 failures.

Not a worldgen-output change, so no baseline re-capture or save-version bump needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)