### PR TITLE
Fix #22: enforce deterministic baseline summaries in world_check

### DIFF
--- a/tools/test_audit.py
+++ b/tools/test_audit.py
@@ -21,6 +21,10 @@ from world_audit import (  # type: ignore
     audit_dump, INT64_MIN, severity_of,
     BUG_CATEGORIES, QUALITY_CATEGORIES, QUALITY_THRESHOLDS,
 )
+from world_check import (  # type: ignore
+    CheckResult, check_issue_summary, check_determinism_status,
+    PASS, FAIL, IMPROVED,
+)
 
 
 # ----- Helpers -------------------------------------------------------------
@@ -560,6 +564,123 @@ def test_determinism_of_audit() -> None:
     expect(a == b and b == c, "audit output not deterministic")
 
 
+# ----- world_check logic tests ---------------------------------------------
+
+def _result() -> CheckResult:
+    return CheckResult(seed=0, world_size=32, region=(0, 0, 0, 0), status=PASS)
+
+
+def test_check_summary_strict_match() -> None:
+    """Deterministic seed whose summary equals the baseline passes."""
+    print("test_check_summary_strict_match")
+    r = _result()
+    base = {"LAKE_HOLE": 4, "FLOATING_LAKE": 300}
+    check_issue_summary([dict(base)], base, {}, strict=True, result=r)
+    expect(r.status == PASS, f"exact match should PASS, got {r.status}: {r.failures}")
+    expect(not r.failures, f"no failures expected, got {r.failures}")
+
+
+def test_check_summary_strict_regression() -> None:
+    """Deterministic count above baseline (under threshold) is a regression."""
+    print("test_check_summary_strict_regression")
+    r = _result()
+    base = {"LAKE_HOLE": 4}
+    check_issue_summary([{"LAKE_HOLE": 5}], base, {}, strict=True, result=r)
+    expect(r.status == FAIL, f"regression should FAIL, got {r.status}")
+    expect(any("regressed above baseline" in f for f in r.failures),
+           f"expected regression message, got {r.failures}")
+
+
+def test_check_summary_strict_improvement() -> None:
+    """Deterministic count below baseline is an improvement, not a failure."""
+    print("test_check_summary_strict_improvement")
+    r = _result()
+    base = {"LAKE_HOLE": 4}
+    check_issue_summary([{"LAKE_HOLE": 2}], base, {}, strict=True, result=r)
+    expect(r.status == IMPROVED, f"improvement should be IMPROVED, got {r.status}")
+    expect(not r.failures, f"no failures expected, got {r.failures}")
+    expect(any("below baseline" in i for i in r.improvements),
+           f"expected improvement message, got {r.improvements}")
+
+
+def test_check_summary_strict_drop_to_zero() -> None:
+    """A baseline category absent from the current summary counts as 0 (improvement)."""
+    print("test_check_summary_strict_drop_to_zero")
+    r = _result()
+    base = {"LAKE_HOLE": 4}
+    check_issue_summary([{}], base, {}, strict=True, result=r)
+    expect(r.status == IMPROVED, f"drop-to-zero should be IMPROVED, got {r.status}")
+    expect(any("LAKE_HOLE" in i for i in r.improvements),
+           f"expected LAKE_HOLE improvement, got {r.improvements}")
+
+
+def test_check_summary_bug_overrides_match() -> None:
+    """A BUG category fails even when the deterministic count matches baseline."""
+    print("test_check_summary_bug_overrides_match")
+    r = _result()
+    base = {"TERRAIN_SPIKE": 2}
+    check_issue_summary([{"TERRAIN_SPIKE": 2}], base, {}, strict=True, result=r)
+    expect(r.status == FAIL, f"nonzero BUG should FAIL despite match, got {r.status}")
+    expect(any("must be 0" in f for f in r.failures),
+           f"expected must-be-0 message, got {r.failures}")
+
+
+def test_check_summary_threshold_overrides() -> None:
+    """Exceeding the QUALITY threshold fails regardless of strict/baseline."""
+    print("test_check_summary_threshold_overrides")
+    over = QUALITY_THRESHOLDS["LAKE_HOLE"] + 1
+    r = _result()
+    # Baseline "matches" the over-threshold value, but the cap still fails.
+    check_issue_summary([{"LAKE_HOLE": over}], {"LAKE_HOLE": over}, {},
+                        strict=True, result=r)
+    expect(r.status == FAIL, f"over-threshold should FAIL, got {r.status}")
+    expect(any("exceeds threshold" in f for f in r.failures),
+           f"expected threshold message, got {r.failures}")
+
+
+def test_check_summary_racy_no_match_required() -> None:
+    """Racy seeds don't require an exact match; under-threshold drift is a note."""
+    print("test_check_summary_racy_no_match_required")
+    r = _result()
+    base = {"LAKE_HOLE": 2}
+    env = {"LAKE_HOLE": {"min": 2, "max": 2}}
+    # 5 != baseline 2, but it's under the threshold (25); racy mode must
+    # not fail on the mismatch (the strict match rule does not apply).
+    check_issue_summary([{"LAKE_HOLE": 5}], base, env, strict=False, result=r)
+    expect(r.status == PASS, f"racy under-threshold mismatch should PASS, got {r.status}")
+    expect(not r.failures, f"racy mode should not fail on mismatch, got {r.failures}")
+
+
+def test_check_determinism_regression() -> None:
+    """A seed that was deterministic and is now racy fails."""
+    print("test_check_determinism_regression")
+    r = _result()
+    check_determinism_status(deterministic_baseline=True, deterministic_now=False,
+                             n_distinct=3, runs=3, result=r)
+    expect(r.status == FAIL, f"determinism regression should FAIL, got {r.status}")
+    expect(any("determinism regression" in f for f in r.failures),
+           f"expected determinism-regression message, got {r.failures}")
+
+
+def test_check_determinism_improvement() -> None:
+    """A seed that was racy and is now deterministic across runs>1 improves."""
+    print("test_check_determinism_improvement")
+    r = _result()
+    check_determinism_status(deterministic_baseline=False, deterministic_now=True,
+                             n_distinct=1, runs=3, result=r)
+    expect(r.status == IMPROVED, f"racy->det should be IMPROVED, got {r.status}")
+
+
+def test_check_determinism_single_run_safe() -> None:
+    """With runs==1 a deterministic baseline can't trip a false regression."""
+    print("test_check_determinism_single_run_safe")
+    r = _result()
+    check_determinism_status(deterministic_baseline=True, deterministic_now=True,
+                             n_distinct=1, runs=1, result=r)
+    expect(r.status == PASS, f"single-run det should stay PASS, got {r.status}")
+    expect(not r.failures, f"no failures expected, got {r.failures}")
+
+
 # ----- Runner --------------------------------------------------------------
 
 def main() -> int:
@@ -589,6 +710,16 @@ def main() -> int:
         test_severity_classification,
         test_wetland_on_slope,
         test_desert_soil_on_slope,
+        test_check_summary_strict_match,
+        test_check_summary_strict_regression,
+        test_check_summary_strict_improvement,
+        test_check_summary_strict_drop_to_zero,
+        test_check_summary_bug_overrides_match,
+        test_check_summary_threshold_overrides,
+        test_check_summary_racy_no_match_required,
+        test_check_determinism_regression,
+        test_check_determinism_improvement,
+        test_check_determinism_single_run_safe,
     ]
 
     for t in tests:

--- a/tools/world_check.py
+++ b/tools/world_check.py
@@ -9,8 +9,15 @@ For each seed:
   2. Runs the audit on the first dump
   3. Compares to the stored baseline:
      - Tile count and elevation stats must match exactly
-     - Fluid stats must match (deterministic seeds) or be within envelope (racy)
-     - Issue summary must match (deterministic) or fall within envelope (racy)
+     - Fluid stats must stay within the baseline envelope (with a
+       tile-count-scaled tolerance for racy shuffling)
+     - Issue summary:
+         * BUG categories must be zero (always)
+         * QUALITY categories must stay under their threshold (always),
+           and for a deterministic seed must additionally MATCH the
+           baseline summary exactly — a count above baseline fails as a
+           regression, below baseline is reported as an improvement
+         * racy seeds only get an informational envelope-drift note
      - Determinism status: improvement is OK, regression is a failure
 
 Exit codes:
@@ -105,6 +112,105 @@ def check_envelope(label: str, current: int, env: dict[str, int] | None,
             result.status = IMPROVED
 
 
+def check_determinism_status(deterministic_baseline: bool, deterministic_now: bool,
+                            n_distinct: int, runs: int, result: CheckResult) -> None:
+    """Apply the determinism-status rule: improvement is OK, regression fails.
+
+    A seed that was deterministic in the baseline but produced more than
+    one distinct output across this run's dumps is a regression (FAIL).
+    A seed that was racy and is now deterministic across runs>1 is an
+    improvement. With runs==1 only a single dump exists, so a regression
+    cannot be observed — pass runs>=2 to exercise this check.
+    """
+    if deterministic_baseline and not deterministic_now:
+        result.status = FAIL
+        result.failures.append(
+            f"determinism regression: baseline deterministic, now "
+            f"{n_distinct} distinct outputs across {runs} runs"
+        )
+    elif not deterministic_baseline and deterministic_now and runs > 1:
+        result.improvements.append(
+            f"determinism status: was racy, now deterministic across {runs} runs"
+        )
+        if result.status == PASS:
+            result.status = IMPROVED
+
+
+def check_issue_summary(current_summaries: list[dict[str, int]],
+                        baseline_summary: dict[str, int],
+                        issue_env: dict[str, Any],
+                        strict: bool, result: CheckResult) -> None:
+    """Check the audit issue summary against the baseline.
+
+    Severity rules (see world_audit.py::BUG_CATEGORIES / QUALITY_CATEGORIES):
+
+      BUG     — any non-zero count fails, always. A baseline cannot bless
+                corruption, so this overrides the match/threshold logic
+                regardless of determinism.
+
+      QUALITY — first, an absolute threshold cap (QUALITY_THRESHOLDS) that
+                fails unconditionally. Under the cap:
+                  strict (deterministic baseline AND deterministic current)
+                    → the count must MATCH the baseline summary exactly.
+                      A count above baseline is a regression (FAIL); below
+                      baseline is an improvement (re-baseline, IMPROVED).
+                  racy
+                    → only an informational envelope-drift note, since the
+                      baseline cannot capture the full race space.
+
+    `strict` should be `deterministic_baseline and deterministic_now`. In
+    that case every current summary is identical, so the max over runs is
+    the single deterministic value.
+    """
+    all_categories: set[str] = set(issue_env.keys()) | set(baseline_summary.keys())
+    for cs in current_summaries:
+        all_categories.update(cs.keys())
+
+    for cat in sorted(all_categories):
+        current_values = [cs.get(cat, 0) for cs in current_summaries]
+        cur_max = max(current_values)
+        sev = severity_of(cat)
+        if sev == "BUG":
+            if cur_max > 0:
+                result.status = FAIL
+                result.failures.append(
+                    f"BUG issue.{cat}: {cur_max} occurrence(s) — must be 0"
+                )
+            continue
+
+        threshold = QUALITY_THRESHOLDS.get(cat, 1000)
+        if cur_max > threshold:
+            result.status = FAIL
+            result.failures.append(
+                f"QUALITY issue.{cat}: {cur_max} exceeds threshold {threshold}"
+            )
+            continue
+
+        if strict:
+            base_val = baseline_summary.get(cat, 0)
+            if cur_max > base_val:
+                result.status = FAIL
+                result.failures.append(
+                    f"QUALITY issue.{cat}: {cur_max} regressed above baseline "
+                    f"{base_val} (deterministic seed — summary must match baseline)"
+                )
+            elif cur_max < base_val:
+                result.improvements.append(
+                    f"issue.{cat}: {cur_max} below baseline {base_val} "
+                    f"(deterministic improvement — re-baseline to lock in)"
+                )
+                if result.status == PASS:
+                    result.status = IMPROVED
+        else:
+            env = issue_env.get(cat)
+            if env is not None:
+                env_max = env.get("max", 0)
+                if cur_max > env_max + max(50, env_max // 4):
+                    result.notes.append(
+                        f"quality drift issue.{cat}: {cur_max} (baseline max {env_max})"
+                    )
+
+
 def check_seed(entry: dict[str, Any], runs: int) -> CheckResult:
     seed = entry["seed"]
     world_size = entry["world_size"]
@@ -131,19 +237,9 @@ def check_seed(entry: dict[str, Any], runs: int) -> CheckResult:
     deterministic_now = len(set(hashes)) == 1
     deterministic_baseline = baseline["determinism"]["deterministic"]
 
-    # Determinism status: informational only. We report changes but don't
-    # fail, since the pipeline is currently racy and classification is
-    # unreliable across runs. After the refactor the check will be strict.
-    if deterministic_baseline and not deterministic_now:
-        result.notes.append(
-            f"determinism status changed: was deterministic, now {len(set(hashes))} distinct outputs"
-        )
-    elif not deterministic_baseline and deterministic_now and runs > 1:
-        result.improvements.append(
-            f"determinism status: was racy, now deterministic across {runs} runs"
-        )
-        if result.status == PASS:
-            result.status = IMPROVED
+    check_determinism_status(
+        deterministic_baseline, deterministic_now, len(set(hashes)), runs, result
+    )
 
     # Audit every dump to get a current envelope
     current_audits = [
@@ -197,45 +293,15 @@ def check_seed(entry: dict[str, Any], runs: int) -> CheckResult:
             check_envelope(f"fluidStats.{fluid}", cur_min, env,
                            result, tolerance=fluid_tolerance)
 
-    # Issue summary check. Two modes depending on severity (see
-    # world_audit.py::BUG_CATEGORIES / QUALITY_CATEGORIES):
-    #
-    #   BUG     — any non-zero count fails. The check is "must be zero",
-    #             not "must match baseline". Used for unambiguous bugs.
-    #
-    #   QUALITY — fails when count exceeds the configured threshold
-    #             (QUALITY_THRESHOLDS). Baseline envelope drift is
-    #             reported as an informational note, not a failure;
-    #             some drift is expected as generation tunes.
+    # Issue summary check (see check_issue_summary for the full rule).
+    # Deterministic seeds must reproduce the baseline summary exactly;
+    # racy seeds fall back to per-category thresholds.
+    strict_summary = deterministic_baseline and deterministic_now
+    baseline_summary = baseline.get("representativeAudit", {}).get("summary", {})
     issue_env = baseline.get("auditEnvelope", {})
-    all_categories: set[str] = set(issue_env.keys())
-    for cs in current_summaries:
-        all_categories.update(cs.keys())
-
-    for cat in sorted(all_categories):
-        current_values = [cs.get(cat, 0) for cs in current_summaries]
-        cur_max = max(current_values)
-        env = issue_env.get(cat)
-        sev = severity_of(cat)
-        if sev == "BUG":
-            if cur_max > 0:
-                result.status = FAIL
-                result.failures.append(
-                    f"BUG issue.{cat}: {cur_max} occurrence(s) — must be 0"
-                )
-        else:
-            threshold = QUALITY_THRESHOLDS.get(cat, 1000)
-            if cur_max > threshold:
-                result.status = FAIL
-                result.failures.append(
-                    f"QUALITY issue.{cat}: {cur_max} exceeds threshold {threshold}"
-                )
-            elif env is not None:
-                env_max = env.get("max", 0)
-                if cur_max > env_max + max(50, env_max // 4):
-                    result.notes.append(
-                        f"quality drift issue.{cat}: {cur_max} (baseline max {env_max})"
-                    )
+    check_issue_summary(
+        current_summaries, baseline_summary, issue_env, strict_summary, result
+    )
 
     return result
 


### PR DESCRIPTION
Closes #22.

## Problem
`tools/world_check.py`'s docstring promised that a deterministic seed's issue summary **must match** the stored baseline and that a determinism regression **is a failure**, but the code only enforced `BUG=0` / `QUALITY`-threshold for summaries and treated a determinism regression as an informational note.

All 21 baseline seeds are now deterministic, so the long-anticipated strict check (the code's own `"after the refactor the check will be strict"`) is enabled — implementing the issue's suggested approach rather than relaxing the docs.

## Changes
- **`check_determinism_status`** (extracted): a seed deterministic in the baseline but now racy is a **FAIL** (was a note). `runs==1` can't observe this, so it only bites with `--runs 2+`.
- **`check_issue_summary`** (extracted): for a deterministic baseline + deterministic current run, each `QUALITY` count must **match the baseline summary exactly** — above baseline is a regression (FAIL), below is an improvement (IMPROVED → re-baseline). `BUG` categories still must be zero always (a baseline can't bless corruption); the absolute `QUALITY` threshold still caps unconditionally. Racy seeds keep the threshold + drift-note behavior.
- Docstring updated to describe the implemented behavior precisely.
- 10 lightweight unit tests added to `tools/test_audit.py` around the new helpers.

## Validation
- `python3 tools/test_audit.py` → **All 35 test groups passed**.
- Quick gate behavior unchanged on real seeds: deterministic seeds (42, 137, 12321) still PASS via exact match; the pre-existing `TERRAIN_SPIKE` BUG seeds (7, 314) still FAIL (unrelated worldgen bug, out of scope here).
- Confirmed `strict=True` engages end-to-end for deterministic seed 42, and that an injected upward drift (baseline lowered by 1) is now caught as a regression — which the old code would have silently passed under the threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)