### PR TITLE
Fix #143: tear down build picker on zoom-band transitions

### DIFF
--- a/scripts/hud.lua
+++ b/scripts/hud.lua
@@ -795,6 +795,14 @@ function hud.reconcileView()
     -- cancel() is idempotent (clears Lua state + WorldClearMineAnchor is a
     -- no-op when nothing is pending), so tear it down on every transition.
     require("scripts.mine_tool").cancel()
+    -- Build picker (#143): the picker panel lives on hud.world_page and
+    -- its "picker" mode persists across band changes. The world/zoom page
+    -- swap above only takes it off-view, so a picker opened in zoomed_in
+    -- stays logically alive and reappears stale when the world page is
+    -- next shown. hidePicker() is idempotent (destroyPicker no-ops with
+    -- no panel; mode only resets from "picker"), so tear it down on every
+    -- transition. It deliberately does NOT touch "placement" mode.
+    require("scripts.build_tool").hidePicker()
     if newView ~= "zoomed_in" then
         require("scripts.debug").hide()
     end


### PR DESCRIPTION
## Summary
The build picker panel lives on `hud.world_page` with `state.mode = "picker"` and only closed through explicit tool-mode changes, `hidePicker()`, or placement/exit paths. `hud.reconcileView()` — the central zoom-band teardown that already cancels the right-click context menu (#139), the active drag-select box (#146), the mine-designation anchor (#144), and item selection — never touched the picker.

So a picker opened in zoomed-in view only got taken **off-view** by the world/zoom page swap; its logical `"picker"` state survived the band change and the panel reappeared stale when the world page was next shown.

## Fix
Add `require("scripts.build_tool").hidePicker()` to `reconcileView`'s teardown list, matching the existing idempotent-teardown pattern used for the sibling lifecycle bugs.

`hidePicker()` → `destroyPicker()` is a no-op when no picker is open (panel id guard; icon/tab lists iterate empty), and `hidePicker()` only resets the mode when it is `"picker"`, so it deliberately leaves `"placement"` mode untouched — that's the separate #140.

## Testing
Lua-only UI-lifecycle change. Like its siblings (#139/#144/#146), the picker is GUI and not headless-renderable, so verification is:
- `luajit` syntax check of `scripts/hud.lua` passes.
- `hidePicker()` confirmed safe to call unconditionally (guarded teardown + mode-gated reset); `reconcileView` only runs while the HUD is visible and acts solely on a real band change (early-returns when the view is unchanged).

Closes #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)