### PR TITLE
Fix #20: recalibrate FLOATING_LAVA threshold for deep contained pools

### DIFF
--- a/tools/world_audit.py
+++ b/tools/world_audit.py
@@ -1009,7 +1009,16 @@ QUALITY_THRESHOLDS = {
                                   # "floating lake" (deep water column)
                                   # count rises. High-variance metric,
                                   # recalibrated 2026-06-08.
-    "FLOATING_LAVA":        100,  # not observed in baselines
+    "FLOATING_LAVA":        450,  # observed max 301 (seed 1337): a deep
+                                  # but FULLY CONTAINED lava pool (lava
+                                  # pools v3) — every dry tile bordering
+                                  # the pool sits at or above the lava
+                                  # surface, so nothing is perched/spilling;
+                                  # the metric just measures column depth,
+                                  # exactly like FLOATING_LAKE. The old 100
+                                  # ("not observed") predated deep lava
+                                  # pools. 1.5× obs-max per the calibration
+                                  # policy above. Recalibrated 2026-06-27.
     "FLOATING_RIVER":       300,  # not observed in baselines
     "FLOATING_FLUID":       300,  # generic fallback
     "ISLAND_1TILE":         100,  # not observed; small islands possible


### PR DESCRIPTION
Closes #20.

## Problem
`python3 tools/world_check.py --seed 1337` flags `FLOATING_LAVA: 301` against a threshold of `100`. The threshold carried the note "not observed in baselines" — it predated deep lava pools.

## Investigation
Audited all 301 flagged tiles on seed 1337 (size 32, region -4,-4,4,4):
- They share a flat lava surface and form **deep but fully contained lava pools** (lava pools v3), 16-21 deep.
- Containment verified programmatically: **zero** dry tiles bordering any pool sit below the lava surface — the rim is at or above the surface everywhere, so nothing perches or spills.
- The `check_floating_fluid` metric simply measures fluid **column depth** (`fluidSurf - terrainZ > 15`). A deep contained pool trips it the same way a deep lake trips `FLOATING_LAKE` — which was already recalibrated (to 7000) for the identical "deep basins are supposed to be deep" reason.

So this is an **outdated threshold**, not a lava placement/rim/cap bug. (Per #20, generation was preferred over threshold bumps — but there is no generation bug to fix here; the pools are well-formed.)

## Fix
Recalibrate `FLOATING_LAVA` from `100` to `450` (1.5x the worst observed 301, matching the file's documented calibration policy) with a comment explaining the contained-deep-pool geometry. **Tools-only**: no engine change, no save-version bump, no dump re-baseline (the baseline already records 301; only the quality threshold moves).

## Validation
- `python3 tools/world_check.py --seed 1337` no longer reports any FLOATING_LAVA failure (`quality=0`).

## Out of scope — follow-up filed
Seed 1337 has a **second, independent** `world_check` blocker: a pre-existing `TERRAIN_SPIKE: 2` BUG (two mountain peaks +16/+19 above neighbours; baseline `2,2,2`). It is unrelated to lava and would require a worldgen-output change + full re-baseline, overlapping #224/#225. Tracked separately in #254. This PR resolves the FLOATING_LAVA portion of #20 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)