### PR TITLE
Fix #140: cancel build placement on zoom-band transitions

### DIFF
--- a/scripts/hud.lua
+++ b/scripts/hud.lua
@@ -803,6 +803,14 @@ function hud.reconcileView()
     -- no panel; mode only resets from "picker"), so tear it down on every
     -- transition. It deliberately does NOT touch "placement" mode.
     require("scripts.build_tool").hidePicker()
+    -- Build placement (#140): once the build tool enters "placement" mode,
+    -- its ghost preview and click handling keep running off the world
+    -- cursor regardless of the HUD view. The page swap above only takes
+    -- the world-page tool UI off-view, so placement stays live in
+    -- zoomed-out / fade-zone and keeps consuming clicks. exitPlacement()
+    -- is idempotent (clearGhost no-ops with no ghost; mode resets to
+    -- "off"), so cancel any in-progress placement on every band change.
+    require("scripts.build_tool").exitPlacement()
     if newView ~= "zoomed_in" then
         require("scripts.debug").hide()
     end


### PR DESCRIPTION
## Summary
Once the build tool enters `"placement"` mode, `buildTool.update()` keeps driving the ghost from `world.pickTile(...)` and `buildTool.handleMouseDown()` keeps consuming clicks — both gated only on `state.mode == "placement"`, never on the HUD view. `hud.reconcileView()`, the central zoom-band teardown, hid the picker (#143) but never cancelled placement. So starting placement in the zoomed-in world view and then zooming out or into the fade zone left placement logic live and swallowing clicks off-view.

## Fix
Add `require("scripts.build_tool").exitPlacement()` to `reconcileView`'s teardown list, matching the established idempotent-teardown pattern (#139/#144/#146/#143).

`exitPlacement()` is idempotent: `building.clearGhost()` is a no-op when there's no ghost, and it resets `state.mode` to `"off"`. So it safely cancels any in-progress placement on every band change and does nothing otherwise.

## Testing
Lua-only UI-lifecycle change; the build ghost is GUI and not headless-renderable (same as the sibling fixes). Verification:
- `luajit` syntax check of `scripts/hud.lua` passes.
- `exitPlacement()` confirmed safe to call unconditionally; `reconcileView` only runs while the HUD is visible and acts solely on a real band change (early-returns when the view is unchanged).

Closes #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)