### PR TITLE
Fix #138: tear down arena tile-editor popup on zoom-band transitions

### DIFF
--- a/scripts/hud.lua
+++ b/scripts/hud.lua
@@ -811,6 +811,16 @@ function hud.reconcileView()
     -- is idempotent (clearGhost no-ops with no ghost; mode resets to
     -- "off"), so cancel any in-progress placement on every band change.
     require("scripts.build_tool").exitPlacement()
+    -- Arena tile-editor popup (#138): the test-arena tile editor lives on
+    -- hud.world_page and was only torn down on empty tile-info broadcasts,
+    -- tool changes, or arena exit. The page swap above only takes it
+    -- off-view, and zoom-map chunk selection produces non-empty HUD info
+    -- text, so neither the band change nor the empty-text clear path
+    -- closed it — it survived off-view and reappeared stale when the world
+    -- page returned. clear() is idempotent (destroyPopup no-ops with no
+    -- popup, and is a no-op outside arena mode), so tear it down on every
+    -- transition.
+    require("scripts.tile_editor").clear()
     if newView ~= "zoomed_in" then
         require("scripts.debug").hide()
     end


### PR DESCRIPTION
## Summary
The test-arena tile-editor popup lives on `hud.world_page` and was only torn down on empty tile-info broadcasts (`onSetInfoText` with `basic == ""`), tool changes, or arena exit. `hud.reconcileView()`, the central zoom-band teardown, hid the world page but never cleared the popup — and zoom-map chunk selection produces **non-empty** HUD info text, so it didn't trip the empty-text clear path either. The popup survived off-view and reappeared stale when the world page returned.

## Fix
Add `require("scripts.tile_editor").clear()` to `reconcileView`'s teardown list, matching the established idempotent-teardown pattern (#139/#144/#146/#143).

`clear()` → `destroyPopup()` is idempotent: it nil-guards the panel/button handles, so it's a no-op when no popup is open and there is nothing to tear down outside arena mode.

## Testing
Lua-only UI-lifecycle change; the arena tile editor is GUI and not headless-renderable (same as the sibling fixes). Verification:
- `luajit` syntax check of `scripts/hud.lua` passes.
- `clear()` confirmed safe to call unconditionally; `reconcileView` only runs while the HUD is visible and acts solely on a real band change (early-returns when the view is unchanged).

Closes #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)