### PR TITLE
Fix #31: add hover feedback for slider, toggle, and randbox widgets

### DIFF
--- a/scripts/ui/randbox.lua
+++ b/scripts/ui/randbox.lua
@@ -34,7 +34,12 @@ local texSetNormal = nil
 local texSetSelected = nil
 local texRandomNormal = nil
 local texRandomClicked = nil
+local texHighlight = nil
 local assetsLoaded = false
+
+-- Hover overlay colour, matched to the dropdown/list highlight so the
+-- whole UI kit gives the same hover affordance.
+local HIGHLIGHT_COLOR = {0.3, 0.5, 0.8, 0.8}
 
 local cursorBlinkTime = 0
 local cursorBlinkRate = 0.5
@@ -153,6 +158,7 @@ function randbox.init()
     texSetSelected = boxTextures.load("assets/textures/ui/textboxselected", "textbox")
     texRandomNormal = engine.loadTexture("assets/textures/ui/randomize.png")
     texRandomClicked = engine.loadTexture("assets/textures/ui/randomizeclicked.png")
+    texHighlight = engine.loadTexture("assets/textures/ui/highlight.png")
 
     -- Seed the RNG
     math.randomseed(os.time())
@@ -206,6 +212,8 @@ function randbox.new(params)
         textId = nil,
         cursorId = nil,
         btnSpriteId = nil,
+        boxHighlightId = nil,
+        btnHighlightId = nil,
         -- State
         focused = false,
     }
@@ -272,6 +280,35 @@ function randbox.new(params)
     -- Text box click focuses for editing
     UI.setClickable(rb.boxId, true)
     UI.setOnClick(rb.boxId, RANDBOX_CALLBACK)
+
+    -- Hover highlights: non-clickable overlays parented to the box and
+    -- the randomize button. As children they resolve their hover target
+    -- up to the clickable parent (no flicker). Hidden until hovered. The
+    -- box overlay (zIndex 0) sits below the text (zIndex 1) so it tints
+    -- the field without obscuring its value.
+    rb.boxHighlightId = UI.newSprite(
+        rb.name .. "_box_hl",
+        rb.inputWidth, rb.height,
+        texHighlight,
+        HIGHLIGHT_COLOR[1], HIGHLIGHT_COLOR[2],
+        HIGHLIGHT_COLOR[3], HIGHLIGHT_COLOR[4],
+        rb.page
+    )
+    UI.addChild(rb.boxId, rb.boxHighlightId, 0, 0)
+    UI.setZIndex(rb.boxHighlightId, 0)
+    UI.setVisible(rb.boxHighlightId, false)
+
+    rb.btnHighlightId = UI.newSprite(
+        rb.name .. "_btn_hl",
+        rb.btnSize, rb.btnSize,
+        texHighlight,
+        HIGHLIGHT_COLOR[1], HIGHLIGHT_COLOR[2],
+        HIGHLIGHT_COLOR[3], HIGHLIGHT_COLOR[4],
+        rb.page
+    )
+    UI.addChild(rb.btnSpriteId, rb.btnHighlightId, 0, 0)
+    UI.setZIndex(rb.btnHighlightId, 1)
+    UI.setVisible(rb.btnHighlightId, false)
 
     -- Position elements
     UI.addToPage(rb.page, rb.boxId, rb.x, rb.y)
@@ -735,13 +772,30 @@ function randbox.onClickOutside(mouseX, mouseY)
 end
 
 -----------------------------------------------------------
--- Hover Handling (placeholder for consistency)
+-- Hover Handling
 -----------------------------------------------------------
 
+-- Resolve the hover-highlight overlay for the box or randomize-button
+-- handle. Returns nil if the handle isn't one of ours.
+local function highlightForHandle(elemHandle)
+    for _, rb in pairs(randboxes) do
+        if rb.boxId == elemHandle then
+            return rb.boxHighlightId
+        elseif rb.btnSpriteId == elemHandle then
+            return rb.btnHighlightId
+        end
+    end
+    return nil
+end
+
 function randbox.onHoverEnter(elemHandle)
+    local hlId = highlightForHandle(elemHandle)
+    if hlId then UI.setVisible(hlId, true) end
 end
 
 function randbox.onHoverLeave(elemHandle)
+    local hlId = highlightForHandle(elemHandle)
+    if hlId then UI.setVisible(hlId, false) end
 end
 
 return randbox

--- a/scripts/ui/randbox.lua
+++ b/scripts/ui/randbox.lua
@@ -736,6 +736,14 @@ function randbox.setVisible(id, visible)
     if rb.cursorId and not visible then UI.setVisible(rb.cursorId, false) end
     if rb.btnSpriteId then UI.setVisible(rb.btnSpriteId, visible) end
 
+    -- UI.setVisible doesn't cascade to children, so a randbox hovered
+    -- when hidden would come back already highlighted on the next show.
+    -- Clear both hover overlays explicitly when hiding.
+    if not visible then
+        if rb.boxHighlightId then UI.setVisible(rb.boxHighlightId, false) end
+        if rb.btnHighlightId then UI.setVisible(rb.btnHighlightId, false) end
+    end
+
     if not visible and rb.focused then
         randbox.unfocus(id)
     end

--- a/scripts/ui/slider.lua
+++ b/scripts/ui/slider.lua
@@ -21,7 +21,12 @@ local texLeft  = nil
 local texTrack = nil
 local texRight = nil
 local texKnob  = nil
+local texHighlight = nil
 local assetsLoaded = false
+
+-- Hover overlay colour, matched to the dropdown/list highlight so the
+-- whole UI kit gives the same hover affordance.
+local HIGHLIGHT_COLOR = {0.3, 0.5, 0.8, 0.8}
 
 -- Drag state (only one slider can be dragged at a time)
 local draggingId = nil
@@ -38,6 +43,7 @@ function slider.init()
     texTrack = engine.loadTexture("assets/textures/ui/slider/slidertrack.png")
     texRight = engine.loadTexture("assets/textures/ui/slider/sliderright.png")
     texKnob  = engine.loadTexture("assets/textures/ui/slider/sliderknob.png")
+    texHighlight = engine.loadTexture("assets/textures/ui/highlight.png")
 
     assetsLoaded = true
     engine.logDebug("Slider module initialized")
@@ -126,6 +132,8 @@ function slider.new(params)
         trackSpriteId = nil,
         rightCapId    = nil,
         knobSpriteId  = nil,
+        highlightId   = nil,
+        hovered       = false,
     }
 
     -- Clamp default
@@ -177,6 +185,21 @@ function slider.new(params)
     UI.setClickable(sl.knobSpriteId, true)
     UI.setOnClick(sl.knobSpriteId, KNOB_CALLBACK)
 
+    -- Hover highlight: a non-clickable overlay parented to the knob so
+    -- it tracks the knob automatically and resolves its hover target up
+    -- to the clickable knob (no flicker). Hidden until hovered.
+    sl.highlightId = UI.newSprite(
+        sl.name .. "_hl",
+        knobWidth, height,
+        texHighlight,
+        HIGHLIGHT_COLOR[1], HIGHLIGHT_COLOR[2],
+        HIGHLIGHT_COLOR[3], HIGHLIGHT_COLOR[4],
+        sl.page
+    )
+    UI.addChild(sl.knobSpriteId, sl.highlightId, 0, 0)
+    UI.setZIndex(sl.highlightId, 1)
+    UI.setVisible(sl.highlightId, false)
+
     -- Z-indices: track parts share one layer, knob sits above
     if sl.zIndex then
         UI.setZIndex(sl.leftCapId,     sl.zIndex)
@@ -203,6 +226,7 @@ function slider.destroy(id)
         draggingId = nil
     end
 
+    if sl.highlightId   then UI.deleteElement(sl.highlightId) end
     if sl.leftCapId     then UI.deleteElement(sl.leftCapId) end
     if sl.trackSpriteId then UI.deleteElement(sl.trackSpriteId) end
     if sl.rightCapId    then UI.deleteElement(sl.rightCapId) end
@@ -269,6 +293,11 @@ function slider.setVisible(id, visible)
     UI.setVisible(sl.trackSpriteId, visible)
     UI.setVisible(sl.rightCapId, visible)
     UI.setVisible(sl.knobSpriteId, visible)
+    -- Never leave a stale hover highlight on a hidden slider.
+    if not visible then
+        sl.hovered = false
+        UI.setVisible(sl.highlightId, false)
+    end
 end
 
 -----------------------------------------------------------
@@ -393,15 +422,36 @@ function slider.onMouseUp()
 end
 
 -----------------------------------------------------------
--- Hover (visual feedback — optional, stub for now)
+-- Hover (visual feedback)
 -----------------------------------------------------------
 
+-- Resolve a slider id from the knob or track element handle. Hovering
+-- either part highlights the knob — the grabbable affordance.
+function slider.findByElementHandle(elemHandle)
+    for id, sl in pairs(sliders) do
+        if sl.knobSpriteId == elemHandle or sl.trackSpriteId == elemHandle then
+            return id
+        end
+    end
+    return nil
+end
+
 function slider.onHoverEnter(elemHandle)
-    -- Could swap knob texture to a highlighted version
+    local id = slider.findByElementHandle(elemHandle)
+    if id then
+        local sl = sliders[id]
+        sl.hovered = true
+        UI.setVisible(sl.highlightId, true)
+    end
 end
 
 function slider.onHoverLeave(elemHandle)
-    -- Revert knob texture
+    local id = slider.findByElementHandle(elemHandle)
+    if id then
+        local sl = sliders[id]
+        sl.hovered = false
+        UI.setVisible(sl.highlightId, false)
+    end
 end
 
 return slider

--- a/scripts/ui/toggle.lua
+++ b/scripts/ui/toggle.lua
@@ -20,12 +20,37 @@ local OPTION_CALLBACK       = "onToggleOptionClick"
 local groups      = {}   -- groupId -> group data
 local nextGroupId = 1
 
+local texHighlight = nil
+
+-- Hover overlay colour, matched to the dropdown/list highlight so the
+-- whole UI kit gives the same hover affordance.
+local HIGHLIGHT_COLOR = {0.3, 0.5, 0.8, 0.8}
+
 -----------------------------------------------------------
 -- Initialization (call once from ui_manager)
 -----------------------------------------------------------
 
 function toggle.init()
+    texHighlight = engine.loadTexture("assets/textures/ui/highlight.png")
     engine.logDebug("Toggle module initialized")
+end
+
+-- Create a hidden hover-highlight overlay parented to a button/option
+-- sprite. As a child it tracks the sprite and resolves its hover target
+-- up to the clickable sprite (no flicker). Returns the overlay handle.
+local function makeHighlight(grp, parentSpriteId, label)
+    local hlId = UI.newSprite(
+        grp.name .. "_hl_" .. label,
+        grp.size, grp.size,
+        texHighlight,
+        HIGHLIGHT_COLOR[1], HIGHLIGHT_COLOR[2],
+        HIGHLIGHT_COLOR[3], HIGHLIGHT_COLOR[4],
+        grp.page
+    )
+    UI.addChild(parentSpriteId, hlId, 0, 0)
+    UI.setZIndex(hlId, 1)
+    UI.setVisible(hlId, false)
+    return hlId
 end
 
 -----------------------------------------------------------
@@ -185,6 +210,8 @@ local function openOptions(grp, btnIdx)
         popup.sprites[rank] = {
             spriteId    = spriteId,
             optionIndex = rank,
+            highlightId = makeHighlight(grp, spriteId,
+                "opt_" .. btnIdx .. "_" .. rank),
         }
     end
 
@@ -288,6 +315,7 @@ function toggle.new(params)
             texSelected = item.texSelected,
             tooltip     = item.tooltip,
             options     = opts,
+            highlightId = makeHighlight(grp, spriteId, (item.name or tostring(i))),
         }
 
         applyButtonTooltip(grp, i)
@@ -547,15 +575,37 @@ function toggle.dismissOpenPopups()
 end
 
 -----------------------------------------------------------
--- Hover (stubs)
+-- Hover (visual feedback)
 -----------------------------------------------------------
 
+-- Resolve the hover-highlight overlay for a button or open-popup option
+-- sprite handle. Returns nil if the handle isn't one of ours.
+local function highlightForHandle(elemHandle)
+    for _, grp in pairs(groups) do
+        for _, btn in ipairs(grp.buttons) do
+            if btn.spriteId == elemHandle then
+                return btn.highlightId
+            end
+        end
+        if grp.openPopup then
+            for _, opt in ipairs(grp.openPopup.sprites) do
+                if opt.spriteId == elemHandle then
+                    return opt.highlightId
+                end
+            end
+        end
+    end
+    return nil
+end
+
 function toggle.onHoverEnter(elemHandle)
-    -- TODO: optional hover highlight
+    local hlId = highlightForHandle(elemHandle)
+    if hlId then UI.setVisible(hlId, true) end
 end
 
 function toggle.onHoverLeave(elemHandle)
-    -- TODO: optional hover unhighlight
+    local hlId = highlightForHandle(elemHandle)
+    if hlId then UI.setVisible(hlId, false) end
 end
 
 -----------------------------------------------------------


### PR DESCRIPTION
Closes #31.

## Problem
`ui_manager` already dispatches hover enter/leave to the slider, toggle, and randbox modules, but those modules left the handlers stubbed (`scripts/ui/slider.lua`, `scripts/ui/toggle.lua`, `scripts/ui/randbox.lua`). So those controls gave no visible hover affordance, while buttons, dropdowns, and lists already do.

## Fix
Add a hidden `highlight.png` overlay — using the same highlight colour as the dropdown/list widgets — parented to each widget's clickable sub-element, toggled visible on hover-enter and hidden on hover-leave:

- **slider** — knob overlay, shown when hovering the knob *or* the track (the track click-jumps the knob, so highlighting the grabbable knob is the clearest affordance).
- **toggle** — per-button overlay, plus a per-option overlay inside the right-click expand popup (option sprites also route through `isToggleCallback`).
- **randbox** — independent overlays on the text box and the randomize button.

## Why a child overlay (no flicker)
`findElementAt` returns the *topmost* element regardless of clickability, then `findHoverTarget` walks up to the nearest clickable ancestor (`src/UI/Manager.hs`, `src/Engine/Scripting/Lua/API/UI/Hierarchy.hs`). A sibling overlay on top would become the hit element with no clickable ancestor and flicker the hover state. Parenting the overlay to the clickable element instead means the hover target resolves back to that element, so the hover stays stable. Hidden elements short-circuit the whole subtree in `hitsAtPointBy`, and `deleteElement` cascades to children, so there's no extra hit-test cost and no leak. `slider.setVisible` also clears a stale highlight when the slider is hidden.

Purely visual — click/drag/focus handling is untouched.

## Testing
- `luajit -p` syntax check on all three modules.
- A stubbed-runtime harness exercising create → hover-enter/leave (knob, track, button, box) → unknown-handle no-op → `setVisible(false)` → destroy for all three widgets, asserting the highlight starts hidden, becomes visible on enter, hides on leave, and that toggle/randbox highlights are independent per element.

The pixel-level appearance still needs a quick visual confirm in the running GUI (headless has no renderer), but the data path and hover-target resolution are verified.