### PR TITLE
Fix #254: converge despike on residual peak pillars (TERRAIN_SPIKE)

### DIFF
--- a/src/World/Generate/Timeline.hs
+++ b/src/World/Generate/Timeline.hs
@@ -48,14 +48,28 @@ removeElevationSpikes
     → (VU.Vector Int, VU.Vector MaterialId)
     → (VU.Vector Int, VU.Vector MaterialId)
 removeElevationSpikes threshold maxIters bSize (elevVec, matVec) =
-    (go maxIters elevVec, matVec)
+    (go False spikeConvergeCap (go True maxIters elevVec), matVec)
   where
     area = bSize * bSize
 
-    go 0 ev = ev
-    go n ev =
-        let (ev', changed) = pass ev
-        in if changed then go (n - 1) ev' else ev'
+    -- Two phases. Phase 1 (cliff on) is the existing combined pass:
+    -- isolated-pillar spike removal AND the iteration-limited cliff
+    -- ramp that tames sheer walls. Its `maxIters` budget is deliberately
+    -- small so it doesn't over-flatten mountains (see project_timeline_
+    -- depth). But that same budget can run out mid-ramp on a steep peak:
+    -- the flank below the summit is still being lowered when the cap is
+    -- hit, leaving the summit standing as an isolated pillar (#254: seed
+    -- 1337 kept +16/+19 TERRAIN_SPIKE peaks because the cliff ramp never
+    -- finished re-exposing them). Phase 2 (cliff off) runs spike removal
+    -- ONLY, to convergence: it lowers such residual pillars to
+    -- mxNbr+(threshold-1) but never touches a tile's neighbours, so it
+    -- can't cascade or flatten slopes and settles in 1-2 passes.
+    spikeConvergeCap = 32
+
+    go _       0 ev = ev
+    go cliffOn n ev =
+        let (ev', changed) = pass cliffOn ev
+        in if changed then go cliffOn (n - 1) ev' else ev'
 
     -- Double-buffered: read neighbors from the immutable input `ev`,
     -- write changes to a fresh mutable `em`. This makes each pass
@@ -65,7 +79,7 @@ removeElevationSpikes threshold maxIters bSize (elevVec, matVec) =
     -- spike clusters resolve (audit #20). The outer `go` loop still
     -- iterates until convergence; updates just don't cascade within
     -- a single pass.
-    pass ev = runST $ do
+    pass cliffOn ev = runST $ do
         em ← VUM.new area
         forM_ [0 .. area - 1] $ \i →
             VUM.write em i (ev VU.! i)
@@ -102,7 +116,7 @@ removeElevationSpikes threshold maxIters bSize (elevVec, matVec) =
                     cliffThreshold = 28
                     spikeTarget = if e - mxNbr > threshold
                                   then mxNbr + (threshold - 1) else e
-                    cliffTarget = if e - mnNbr > cliffThreshold
+                    cliffTarget = if cliffOn ∧ e - mnNbr > cliffThreshold
                                   then mnNbr + cliffThreshold else e
                     target = min spikeTarget cliffTarget
                 when (target < e) $ do

--- a/src/World/Save/Types.hs
+++ b/src/World/Save/Types.hs
@@ -107,7 +107,9 @@ saveMagic = 0x53595241
 --       chunk-level ocean test so sub-sea tiles the coarse chunk-flood
 --       missed render ocean (sea-stops-at-chunk-boundary fix).
 currentSaveVersion ∷ Int
-currentSaveVersion = 54  -- v54: structure edits (WeSetStructure/WeClearStructure) + sdTexPalette
+currentSaveVersion = 55  -- v55: despike spike-only convergence pass (#254) — base
+                         --      terrain output shifts on regen, so reject older saves
+                         -- v54: structure edits (WeSetStructure/WeClearStructure) + sdTexPalette
                          -- v52: UnitSimState gains usJumpApex (leap arc state)
                          -- v50: UnitInstance gains uiImmuneResponse + uiImmunities (immunity system)
                          -- v49: Wound gains woundInfectionType (data-driven infections)


### PR DESCRIPTION
## Summary
Fixes #254. Seed 1337 (size 32, region -4,-4,4,4) reported `TERRAIN_SPIKE: 2` — a BUG-severity category that must be 0 — keeping the `world_check` gate red even after #20's lava fix. The two spikes are high mountain-peak tiles standing +19/+16 above their tallest cardinal neighbour:

```
TERRAIN_SPIKE x=40 y=-10 terrainZ=221 maxNbr=202 delta=+19
TERRAIN_SPIKE x=51 y=-14 terrainZ=251 maxNbr=235 delta=+16
```

## Root cause
`removeElevationSpikes` (`World.Generate.Timeline`) runs two clamps together for a small, fixed iteration budget (`maxIters=4`): isolated-pillar **spike** removal, and an iteration-limited **cliff** ramp that tames sheer walls. The cliff budget is deliberately small so it doesn't over-flatten mountains (see `project_timeline_depth`).

On a steep peak that budget runs out mid-ramp: the flank below the summit is still being lowered when the cap is hit, which **re-exposes the summit as an isolated pillar** the pass never gets a final iteration to clear. (Confirmed by instrumentation — the despike never sees the final neighbour configuration, because the neighbours are still descending when iterations run out.)

## Fix
Add a second phase that runs **spike removal only** (cliff clamp off) to convergence. It lowers residual pillars to `mxNbr + (threshold-1)` but never touches a tile's neighbours, so it can't cascade or flatten slopes and settles in 1–2 passes.

A naive alternative (just bumping `maxIters`) was rejected: it changed 83 tiles on seed 1337, flattened real mountains (e.g. 305→258), and pushed coastal tiles sub-sea triggering seabed fill — conflicting with #224. This targeted phase changes **exactly 3 tiles** on seed 1337 (the two peaks + one adjacent pillar the first reveals), leaving slopes and every fluid/quality metric untouched.

## Validation
- `world_audit --seed 1337`: `TERRAIN_SPIKE` 2 → **0**; full quality summary otherwise **identical** to baseline.
- `world_check --seed 1337`: **PASS** (the issue's criterion).
- All **21 baseline seeds**: every BUG category **0**; `TERRAIN_SPIKE` eliminated across the set — this also clears the 7/314/5050/9999 cases noted in #19.
- Full `SYNARCHY_FULL_TESTS=1 cabal test synarchy-test-headless`: **346 examples, 0 failures**.
- The two remaining `world_check` failures (2718 `LAKE_HOLE=29`, 13579 `WATER_WATER_CLIFF=3655`) are **pre-existing on master** — byte-identical to their baselines, unchanged by this PR — and belong to #21.

## Notes for the maintainer
- Worldgen-output change: `currentSaveVersion` bumped 54 → **55**.
- Baselines are gitignored (local artifact), so they are not in this PR. After merge, recapture baselines for seeds whose max-elevation tile was a spike (e.g. seed 314: elevation max 374 → 357) with `python3 tools/world_baseline.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)