### PR TITLE
Fix #132: clear chunk/tile selection on zoom-band transitions

### DIFF
--- a/scripts/hud.lua
+++ b/scripts/hud.lua
@@ -745,6 +745,13 @@ end
 --     selection — and here the world is still the visible/active one, so
 --     activeWorld resolves correctly (unlike the menu-hide path, which is
 --     handled engine-side in handleWorldHideCommand).
+--   * chunk/tile cursor selection (#132): zoomSelectedPos (zoom-map chunk)
+--     and worldSelectedTile (zoomed-in tile) also live in the per-world
+--     cursor. infoPanel.clear() blanks the panel, but the selection itself
+--     survives the band change, and pollCursorInfo only republishes on a
+--     selection *change* — so without clearing it the highlight stays set
+--     while the panel stays empty. clearZoom/WorldCursorSelect tear both
+--     down with the panel.
 function hud.reconcileView()
     local zoom = camera.getZoom()
     local zoomFadeStart = camera.getZoomFadeStart()
@@ -835,6 +842,20 @@ function hud.reconcileView()
         require("scripts.debug").hide()
     end
     item.deselect()
+    -- Chunk/tile cursor selection (#132): the zoom-map chunk selection
+    -- (zoomSelectedPos) and zoomed-in tile selection (worldSelectedTile)
+    -- both live in the per-world cursor (wsCursorRef), independent of the
+    -- HUD pages swapped above. The info panel is cleared on this transition
+    -- (infoPanel.clear() above), but pollCursorInfo only republishes when
+    -- the selection *changes* — so a selection that survives the band change
+    -- unchanged leaves the highlight logically set while the panel stays
+    -- blank until the user re-selects. Clear both selections here, exactly
+    -- like item.deselect() does for the ground-item selection, so the
+    -- highlight and panel tear down together. The clears are keyed on
+    -- hud.worldId (the visible/active world that owns this view, the same id
+    -- onMouseDown uses), and are no-ops when nothing is selected.
+    world.clearZoomCursorSelect(hud.worldId)
+    world.clearWorldCursorSelect(hud.worldId)
 end
 
 -- Wheel hook (no UI element under cursor, no shift). Reconcile immediately


### PR DESCRIPTION
## Summary
Fixes #132. Crossing zoom bands (zoomed-in ↔ fade ↔ zoomed-out) cleared the HUD info panel but left the underlying chunk/tile cursor selection set, so the highlight stayed logically active while the panel went blank until the user re-selected.

## Root cause
`hud.reconcileView()` (scripts/hud.lua) runs on every real zoom-band transition. It calls `infoPanel.clear()` and tears down every other lingering selection (ground-item via `item.deselect()`, mine anchor, drag-select, build placement, context menu, popups…) — but it never cleared the chunk/tile cursor selection (`zoomSelectedPos` / `worldSelectedTile`), which lives in the same per-world cursor (`wsCursorRef`).

`pollCursorInfo` (src/World/Thread/Cursor.hs) only republishes HUD info when the selection **changes**. A selection that survives the band change unchanged therefore never triggers a republish after the panel was cleared → highlight set, panel blank.

## Fix
Clear both selections at the end of `reconcileView`, exactly as `item.deselect()` already does for the ground-item selection, so the highlight and panel tear down together:

```lua
world.clearZoomCursorSelect(hud.worldId)
world.clearWorldCursorSelect(hud.worldId)
```

These route through the existing `WorldSetZoomCursorDeselect` / `WorldSetWorldCursorDeselect` handlers (src/World/Thread/Command/Cursor.hs), which clear `zoomSelectedPos`/`zoomSelectNow` and `worldSelectedTile`/`worldSelectNow` respectively and are safe no-ops when nothing is selected or the page isn't found. Keyed on `hud.worldId` — the same visible/active page id `onMouseDown` uses — avoiding any wrong-world risk.

## Scope
Lua-only (`scripts/hud.lua`); no Haskell change, no save-version impact. Reuses already-registered cursor-clear APIs.

## Validation
- `luajit` syntax check of the edited `scripts/hud.lua` passes.
- Verified the Haskell deselect handlers clear exactly the surviving cursor fields and no-op safely.
- The reconcileView transition itself is GUI-driven (camera zoom band), so the visual behavior — select a chunk/tile, zoom away and back, confirm no orphaned highlight with a blank panel — warrants an in-game eyeball pass, consistent with how the rest of this hud-selection cluster was validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)