### PR TITLE
Fix #123: live pick on click instead of stale cached hover

### DIFF
--- a/scripts/hud.lua
+++ b/scripts/hud.lua
@@ -659,8 +659,31 @@ function hud.onMouseDown(button_num, mx, my)
        or not require("scripts.ui_manager").isGameplayInputActive() then
         return
     end
+    -- Recover window-pixel click coords. uiManager.onMouseDown forwards
+    -- mx,my already scaled into FRAMEBUFFER space, but the synchronous
+    -- pickers (world.pickTile) and the zoom-cursor hit-test
+    -- (pixelToChunkOrigin, fed by setZoomCursorHover) both expect WINDOW
+    -- pixels — the same space engine.getMousePosition() reports. Convert
+    -- back so a click resolves at the actual click position rather than
+    -- the 0.1s-stale cached hover the select APIs would otherwise read
+    -- (#123).
+    local cx, cy = mx, my
+    do
+        local ww, wh   = engine.getWindowSize()
+        local fbW, fbH = engine.getFramebufferSize()
+        if fbW and fbH and fbW > 0 and fbH > 0 then
+            cx = mx * (ww / fbW)
+            cy = my * (wh / fbH)
+        end
+    end
     if hud.currentView == "zoomed_out" then
         if button_num == 1 then
+            -- Refresh the zoom-cursor position to the actual click coords
+            -- before arming the select. The chunk is committed from
+            -- zoomCursorPos at render time (makeCursorQuad); without this
+            -- it would commit the periodically-cached hover, so a fast
+            -- move-then-click selected the previously hovered chunk (#123).
+            world.setZoomCursorHover(hud.worldId, cx, cy)
             world.setZoomCursorSelect(hud.worldId)
         elseif button_num == 2 then
             world.clearZoomCursorSelect(hud.worldId)
@@ -696,12 +719,19 @@ function hud.onMouseDown(button_num, mx, my)
             if world.getToolMode and world.getToolMode() ~= "info" then
                 return
             end
-            world.setWorldCursorSelect(hud.worldId)
-            -- Refresh the tile-editor popup at the just-selected
-            -- tile. Gated internally by arenaMode so non-arena worlds
-            -- silently no-op.
-            local gx, gy = world.getHoverTile()
+            -- Live pick at the click coords, then select that tile
+            -- directly. setWorldCursorSelect would arm a select that
+            -- commits from the 0.1s-cached worldHoverTile at render time,
+            -- so a fast move-then-click selected the previously hovered
+            -- tile; pickTile resolves the tile under the click NOW and
+            -- world.selectTile sets it in one shot (also dropping any
+            -- chunk selection, #135) (#123).
+            local gx, gy = world.pickTile(cx, cy)
             if gx and gy then
+                world.selectTile(hud.worldId, gx, gy)
+                -- Refresh the tile-editor popup at the just-selected
+                -- tile. Gated internally by arenaMode so non-arena worlds
+                -- silently no-op.
                 local tileEditor = require("scripts.tile_editor")
                 tileEditor.onTileSelected(gx, gy)
             end

--- a/scripts/init.lua
+++ b/scripts/init.lua
@@ -239,7 +239,9 @@ function game.onMouseDown(button, x, y)
         -- faction (portal spawns → "player"; world-gen wildlife
         -- spawns → "wildlife").
         if debugOverlay.armedDef then
-            local gx, gy = world.getHoverTile()
+            -- Live pick at the click coords, not the 0.1s-cached hover, so
+            -- a fast move-then-click spawns under the click (#123).
+            local gx, gy = world.pickTile(x, y)
             if gx and gy then
                 unit.spawn(debugOverlay.armedDef, gx + 0.5, gy + 0.5,
                            nil, "debug")
@@ -253,11 +255,12 @@ function game.onMouseDown(button, x, y)
         -- derives from terrain at render). Tile-center fallback
         -- covers the no-hover edge case.
         if debugOverlay.armedItemDef then
-            local hx, hy = world.getHoverPos()
+            -- Live sub-tile pick at the click coords (#123).
+            local hx, hy = world.pickPos(x, y)
             if hx and hy then
                 item.spawnGround(debugOverlay.armedItemDef, hx, hy)
             else
-                local gx, gy = world.getHoverTile()
+                local gx, gy = world.pickTile(x, y)
                 if gx and gy then
                     item.spawnGround(debugOverlay.armedItemDef,
                                      gx + 0.5, gy + 0.5)
@@ -269,7 +272,7 @@ function game.onMouseDown(button, x, y)
         -- Debug fluid-spawn mode: arms a kind ("water" / "lava"); the
         -- click places one tile of that fluid on top of the column.
         if debugOverlay.armedFluidType then
-            local gx, gy = world.getHoverTile()
+            local gx, gy = world.pickTile(x, y)  -- live pick (#123)
             if gx and gy then
                 local hud = require("scripts.hud")
                 local worldId = (hud and hud.worldId) or "test_arena"
@@ -283,7 +286,7 @@ function game.onMouseDown(button, x, y)
         -- raises the column at the hover tile one z of that material
         -- (WeAddTile through the edit log — persists like any edit).
         if debugOverlay.armedTerrainId then
-            local gx, gy = world.getHoverTile()
+            local gx, gy = world.pickTile(x, y)  -- live pick (#123)
             if gx and gy then
                 local hud = require("scripts.hud")
                 local worldId = (hud and hud.worldId) or "test_arena"
@@ -297,7 +300,7 @@ function game.onMouseDown(button, x, y)
         -- stamps that premade structure (room/outpost/...) anchored at the
         -- hover tile (world.setCell terrain edits + content spawns).
         if debugOverlay.armedLocation then
-            local gx, gy = world.getHoverTile()
+            local gx, gy = world.pickTile(x, y)  -- live pick (#123)
             if gx and gy then
                 local hud = require("scripts.hud")
                 local worldId = (hud and hud.worldId) or "test_arena"
@@ -312,12 +315,14 @@ function game.onMouseDown(button, x, y)
         -- post). Floor/ceiling/post place on the clicked tile; a wall goes
         -- in the clicked QUARTER of the tile (→ its diamond edge).
         if debugOverlay.armedStructure then
-            -- Derive the tile from the FRACTIONAL hover position (floor), NOT
-            -- getHoverTile: the latter rounds in a ~0.17-tile-shifted space, so
-            -- near a tile border it disagrees with the quarter-corner/edge frac
-            -- (computed from getHoverPos) → posts landed on the wrong tile and
-            -- the floor-gate flaked. floor(hx,hy) keeps tile + corner consistent.
-            local hx, hy = world.getHoverPos()
+            -- Derive the tile from the FRACTIONAL pick (floor), NOT pickTile:
+            -- the latter rounds in a ~0.17-tile-shifted space, so near a tile
+            -- border it disagrees with the quarter-corner/edge frac (from the
+            -- fractional pick) → posts landed on the wrong tile and the
+            -- floor-gate flaked. floor(hx,hy) keeps tile + corner consistent.
+            -- pickPos runs the hit-test live at the click coords, not the
+            -- 0.1s-cached hover (#123).
+            local hx, hy = world.pickPos(x, y)
             if hx and hy then
                 local structures = require("scripts.structures")
                 structures.placeKind(math.floor(hx), math.floor(hy),
@@ -759,7 +764,9 @@ function game.onMouseDown(button, x, y)
         -- tile cursor — that's fine, it doesn't touch unit selection.
         local selected = unit.getSelected()
         if selected and #selected > 0 then
-            local gx, gy = world.getHoverTile()
+            -- Live pick at the click coords so the move order targets the
+            -- tile under the click, not the 0.1s-cached hover (#123).
+            local gx, gy = world.pickTile(x, y)
             if gx and gy then
                 local tx = gx + 0.5
                 local ty = gy + 0.5
@@ -782,7 +789,10 @@ function game.onMouseDown(button, x, y)
             -- item menu ("Info") as a smoke test of the right-click +
             -- context-menu plumbing; per-target providers replace
             -- this hardcoded list later.
-            local gx, gy = world.getHoverTile()
+            -- Capture the right-clicked tile with a live pick at the click
+            -- coords (the cached hover lags a fast move, and once the menu
+            -- opens the cursor moves off the tile anyway) (#123).
+            local gx, gy = world.pickTile(x, y)
             if gx and gy then
                 local hud = require("scripts.hud")
                 local contextMenu = require("scripts.ui.context_menu")

--- a/scripts/mine_tool.lua
+++ b/scripts/mine_tool.lua
@@ -53,7 +53,9 @@ function mineTool.handleMouseDown(button, x, y)
     if not active() then return false end
 
     if button == MOUSE_LEFT then
-        local gx, gy = world.getHoverTile()
+        -- Live pick at the click coords, not the 0.1s-cached hover, so a
+        -- fast move-then-click anchors/commits on the clicked tile (#123).
+        local gx, gy = world.pickTile(x, y)
         if not gx or not gy then
             -- Clicked off-world: swallow so the click doesn't fall
             -- through, but don't disturb a pending anchor.

--- a/src/Engine/Scripting/Lua/API.hs
+++ b/src/Engine/Scripting/Lua/API.hs
@@ -528,6 +528,7 @@ registerLuaAPI lst env backendState = Lua.runWith lst $ do
   registerLuaFunction "getHoverTile" (worldGetHoverTileFn env)
   registerLuaFunction "getHoverPos"  (worldGetHoverPosFn env)
   registerLuaFunction "pickTile"     (worldPickTileFn env)
+  registerLuaFunction "pickPos"      (worldPickPosFn env)
   registerLuaFunction "getClimateAt" (worldGetClimateAtFn env)
 
   Lua.setglobal (Lua.Name "world")

--- a/src/Engine/Scripting/Lua/API/WorldQuery.hs
+++ b/src/Engine/Scripting/Lua/API/WorldQuery.hs
@@ -11,6 +11,7 @@ module Engine.Scripting.Lua.API.WorldQuery
     , worldGetHoverTileFn
     , worldGetHoverPosFn
     , worldPickTileFn
+    , worldPickPosFn
     , worldGetClimateAtFn
     ) where
 
@@ -578,6 +579,59 @@ worldPickTileFn env = do
                         Just (gx, gy, _, _, _) → do
                             Lua.pushinteger (fromIntegral gx)
                             Lua.pushinteger (fromIntegral gy)
+                            return 2
+                        Nothing → do
+                            Lua.pushnil
+                            return 1
+                Nothing → do
+                    Lua.pushnil
+                    return 1
+        _ → do
+            Lua.pushnil
+            return 1
+
+-- | world.pickPos(pixX, pixY) → hx, hy or nil
+--   Synchronous fractional-position analog of pickTile: the live
+--   screen-pixel → sub-tile hit-test from the given click coordinates
+--   (item/unit convention, tile k spans [k, k+1)). Like pickTile it
+--   runs the hit-test NOW against the live camera + window + tile state
+--   rather than reading the periodically-pushed worldHoverPos cache, so
+--   it reflects exactly where the passed pixel points this instant. Use
+--   it on click paths that place sub-tile content (ground-item / quarter-
+--   corner structure placement) where the async hover cache can lag a
+--   fast cursor move and place at a stale fractional position. Returns
+--   nil when the pixel is off-world / over no solid tile.
+worldPickPosFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+worldPickPosFn env = do
+    mPx ← Lua.tonumber 1
+    mPy ← Lua.tonumber 2
+    case (mPx, mPy) of
+        (Just px', Just py') → do
+            let px = round px'
+                py = round py'
+            manager ← Lua.liftIO $ readIORef (worldManagerRef env)
+            case mVisibleWorldState manager of
+                Just ws → do
+                    camera   ← Lua.liftIO $ readIORef (cameraRef env)
+                    tileData ← Lua.liftIO $ readIORef (wsTilesRef ws)
+                    paramsM  ← Lua.liftIO $ readIORef (wsGenParamsRef ws)
+                    (winW, winH) ← Lua.liftIO $ readIORef (windowSizeRef env)
+                    (fbW, fbH)   ← Lua.liftIO $ readIORef (framebufferSizeRef env)
+                    let facing   = camFacing camera
+                        zoom     = camZoom camera
+                        zSlice   = camZSlice camera
+                        (camX, camY) = camPosition camera
+                        worldSize = case paramsM of
+                                      Nothing     → 128
+                                      Just params → wgpWorldSize params
+                        effectiveDepth = min viewDepth
+                                           (max 8 (round (zoom * 80.0 + 8.0 ∷ Float)))
+                        vb = computeViewBounds camera fbW fbH effectiveDepth
+                    case pickWorldTile facing zoom zSlice camX camY fbW fbH winW winH
+                                       worldSize effectiveDepth vb tileData px py of
+                        Just (_, _, _, _, (hx, hy)) → do
+                            Lua.pushnumber (Lua.Number (realToFrac hx))
+                            Lua.pushnumber (Lua.Number (realToFrac hy))
                             return 2
                         Nothing → do
                             Lua.pushnil


### PR DESCRIPTION
## Problem
Click actions resolved their target from the render-thread hover cache (`worldHoverTile` / `worldHoverPos` / `zoomCursorPos`), which only refreshes on the UI manager's 0.1s tick (`hud.update` → `setWorldCursorHover`/`setZoomCursorHover`). After a fast move-then-click, **selection, move orders, mine designation, and debug placement could act on the previously hovered tile/chunk** rather than the one under the click.

Fixes #123, consolidates #124.

## Approach
Resolve every click-action target with a **synchronous pick at the click coordinates** — the pattern `build_tool` already uses (`world.pickTile`, from #66).

### Haskell
- Add `world.pickPos(px, py)` — the live fractional-position analog of `pickTile` (reuses `pickWorldTile`'s `hoverPos`), for the sub-tile placement paths (ground-item / quarter-corner structure).

### Lua
- **`hud.onMouseDown`**: recover **window-pixel** click coords (`uiManager.onMouseDown` forwards framebuffer-scaled coords, but the pickers expect window pixels — matters on the user's retina Mac). Zoomed-out select refreshes the zoom cursor to the click coords before arming the render-time commit; zoomed-in select uses `pickTile` + `world.selectTile` (one-shot, also clears the opposing chunk selection per #135).
- **`init.lua`**: the six armed debug placements (unit/item/fluid/terrain/location/structure), the right-click move order, and the right-click tile context-menu target capture now live-pick.
- **`mine_tool`**: anchor/commit clicks live-pick.

### Deliberately unchanged
The render-highlight path (`Quads.hs` `renderWorldCursorQuads`) stays cache-driven — it's the continuous *visual* hover indicator, legitimately updated at the tick cadence. The bug is click **actions**.

## Testing
- `cabal build all` + `cabal build synarchy-test-headless` — clean.
- `cabal test synarchy-test-headless` — **346 examples, 0 failures** (incl. the `pixelToChunkOrigin` viewport tests).
- Headless boot: all game scripts load with no errors; `world.pickPos`/`pickTile` register and execute without crashing.
- ⚠️ The click *behavior* (live pick under fast move+click) is screen-pixel/GUI-timing dependent and can't be exercised headlessly (the picker needs a live window). **Needs an in-app check** — same as how build_tool's #66 fix was validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)