### PR TITLE
Fix #176: clear building selection on zoom/menu transitions

### DIFF
--- a/scripts/hud.lua
+++ b/scripts/hud.lua
@@ -621,6 +621,15 @@ function hud.hide()
     -- world. The world thread clears it deterministically in
     -- handleWorldHideCommand, keyed on the exact page being hidden (which
     -- worldView.hide()/testArena.hide() issue just before this runs).
+    --
+    -- Building selection (#176), by contrast, IS cleared here: it is a
+    -- single global id (bmSelected), not a per-world cursor, so deselect()
+    -- has no wrong-world hazard and is a no-op when nothing is selected.
+    -- Suppressing the panel alone is not enough — the building-info watcher
+    -- keeps polling building.getSelected() and re-pushing the selected
+    -- building into the panel's stored content, which hud.show() then
+    -- restores stale. Clearing the selection stops the repopulation.
+    building.deselect()
     pcall(function() require("scripts.event_log").hide() end)
     pcall(function() require("scripts.combat_log").hide() end)
     pcall(function() require("scripts.injury_log_panel").hide() end)
@@ -872,6 +881,15 @@ function hud.reconcileView()
         require("scripts.debug").hide()
     end
     item.deselect()
+    -- Building selection (#176): unlike the per-world cursor selections
+    -- below, building selection is a single global id (bmSelected), so the
+    -- page swap above never touches it and the building-info watcher keeps
+    -- polling building.getSelected() and re-pushing the same building into
+    -- the shared info panel — repopulating it stale after the band change.
+    -- deselect() clears the global selection and is a no-op when nothing is
+    -- selected, matching item.deselect() above; no wrong-world hazard since
+    -- there is no per-world building cursor to resolve through activeWorld.
+    building.deselect()
     -- Chunk/tile cursor selection (#132): the zoom-map chunk selection
     -- (zoomSelectedPos) and zoomed-in tile selection (worldSelectedTile)
     -- both live in the per-world cursor (wsCursorRef), independent of the


### PR DESCRIPTION
## Summary
Building selection survived leaving the zoomed-in world view (zoom-band change) and the HUD hiding for a menu. Only the shared info panel was hidden/cleared — `building.getSelected()` stayed live, and `building_info_panel`'s watcher kept re-pushing the same building into the panel's stored content, so stale building info repopulated after the transition (notably restored on `hud.show()` via `infoPanel.unsuppress`).

## Fix
Add `building.deselect()` to both teardown paths:
- `hud.reconcileView()` — the zoom-band transition (also covers `hud.onScroll()`, which calls it), right beside the existing `item.deselect()` / `#132` cursor clears.
- `hud.hide()` — the menu transition.

Unlike the per-world cursor/item selections (whose Lua deselect can resolve to the wrong world via `activeWorld`, so `#175` defers them to the world thread), building selection is a single **global** id (`bmSelected`). So `building.deselect()` has no wrong-world hazard and is a no-op when nothing is selected — the same unguarded call already used in the `#177` Escape handler. Lua-only change; no schema/save impact.

## Test
GUI panel behavior isn't headless-observable, but the data path is, and it mirrors the already-tested `#132`/`#177` precedent:
- `luajit` bytecode-compile of `hud.lua` — OK.
- Booted the engine headless with the modified scripts to READY — all scripts (incl. `hud.lua`, `building_info_panel.lua`) load with no Lua errors.
- Debug console: `building.deselect()` → `building.getSelected()` returns `nil`; `pcall(hud.hide)` → `true` (the edited teardown runs the new deselect end-to-end without error).

Closes #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)