### PR TITLE
Fix #183: clear tile/chunk cursor selection on world hide

### DIFF
--- a/src/World/Render/Zoom/Cursor.hs
+++ b/src/World/Render/Zoom/Cursor.hs
@@ -63,6 +63,16 @@ makeCursorQuad facing camera winW winH fbW fbH worldSize csRef lookupSlot defFmS
 
     cs' ← if zoomSelectNow cs
            then atomicModifyIORef' csRef $ \current →
+                  -- Re-check the arm flag against 'current' (not the earlier
+                  -- 'cs' read): the world thread can clear zoomSelectNow
+                  -- between that read and this atomic write — e.g.
+                  -- handleWorldHideCommand clearing the selection on hide
+                  -- (#183). Committing off the stale read would clobber that
+                  -- clear and recreate the chunk selection on the now-hidden
+                  -- world. Mirrors the tile path (Render.Quads), which gates
+                  -- its commit on 'worldSelectNow current'.
+                  if not (zoomSelectNow current) then (current, current)
+                  else
                   -- The newest selection owns the cursor: committing a
                   -- chunk selection drops any zoomed-in tile selection, so
                   -- returning to the zoomed-in view shows no stale tile

--- a/src/World/Thread/Command/UI.hs
+++ b/src/World/Thread/Command/UI.hs
@@ -79,18 +79,27 @@ handleWorldHideCommand env logger pageId = do
         ( mgr { wmVisible = filter (/= pageId) (wmVisible mgr) }
         , pageId `elem` wmVisible mgr )
 
-    -- Clear this page's ground-item cursor selection on hide. Selection is
-    -- per-world (wsCursorRef), but the Lua-side deselect resolves through
-    -- activeWorld, which head-falls-back to another registered world once
-    -- this page leaves wmVisible — so a Lua deselect could clear the wrong
-    -- world and leave this one's selection live to repopulate the HUD when
-    -- it's shown again (#175). Doing it here, keyed on the exact pageId
-    -- being hidden, is race-free and always targets the right world.
+    -- Clear this page's cursor selection on hide: the ground-item
+    -- selection (#175) and the zoom-map chunk / zoomed-in tile selection
+    -- (#183). All three live in the per-world cursor (wsCursorRef), but a
+    -- Lua-side deselect resolves through activeWorld, which head-falls-back
+    -- to another registered world once this page leaves wmVisible — so a
+    -- Lua deselect could clear the wrong world and leave this one's
+    -- selection live. For the tile/chunk selection that strands the HUD on
+    -- re-show: resolveActiveWorld still resolves this page (head-fallback
+    -- over wmWorlds), so 'pollCursorInfo' sees no active-world change and
+    -- the cursor snapshot sees no selection change, so it never re-sends
+    -- the info text — leaving a live selection with an empty HUD panel
+    -- (#183). Clearing here, keyed on the exact pageId being hidden, is
+    -- race-free and always targets the right world; the next cursor poll
+    -- then blanks the panel and updates the snapshot to match.
     mgr ← readIORef (worldManagerRef env)
     case lookup pageId (wmWorlds mgr) of
         Just worldState →
             atomicModifyIORef' (wsCursorRef worldState) $ \cs →
-                (cs { selectedGroundItem = Nothing }, ())
+                (cs { selectedGroundItem = Nothing
+                    , zoomSelectedPos    = Nothing
+                    , worldSelectedTile  = Nothing }, ())
         Nothing → pure ()
 
     when wasVisible $

--- a/src/World/Thread/Command/UI.hs
+++ b/src/World/Thread/Command/UI.hs
@@ -93,13 +93,27 @@ handleWorldHideCommand env logger pageId = do
     -- (#183). Clearing here, keyed on the exact pageId being hidden, is
     -- race-free and always targets the right world; the next cursor poll
     -- then blanks the panel and updates the snapshot to match.
+    --
+    -- Also clear the one-shot ARM flags (zoomSelectNow/worldSelectNow).
+    -- Chunk/tile selection is two-step: setZoomCursorSelect /
+    -- setWorldCursorSelect only set the *Now flag, and the render thread
+    -- commits it into zoomSelectedPos/worldSelectedTile at draw time
+    -- (makeCursorQuad / Render.Quads). A hide that lands after the arm but
+    -- before the commit would leave the flag set, so the first render after
+    -- re-show would re-commit the selection — re-stranding the HUD exactly
+    -- as above. Clearing the flags too matches what the existing
+    -- WorldSetZoomCursorDeselect / WorldSetWorldCursorDeselect handlers do
+    -- (both reset position AND *Now), and is unambiguously correct here: a
+    -- hidden world has no pending selection to commit.
     mgr ← readIORef (worldManagerRef env)
     case lookup pageId (wmWorlds mgr) of
         Just worldState →
             atomicModifyIORef' (wsCursorRef worldState) $ \cs →
                 (cs { selectedGroundItem = Nothing
                     , zoomSelectedPos    = Nothing
-                    , worldSelectedTile  = Nothing }, ())
+                    , zoomSelectNow      = False
+                    , worldSelectedTile  = Nothing
+                    , worldSelectNow     = False }, ())
         Nothing → pure ()
 
     when wasVisible $


### PR DESCRIPTION
## Summary
Fixes #183. A menu transition that hides the gameplay world left the per-world tile/chunk cursor selection live underneath, while the HUD info panel was hidden/cleared — so returning to gameplay showed a stale, empty info panel over a still-selected tile/chunk.

## Root cause
- `handleWorldHideCommand` (`src/World/Thread/Command/UI.hs`) only cleared `selectedGroundItem` (#175); `zoomSelectedPos` and `worldSelectedTile` survived the hide.
- `pollCursorInfo`'s cursor snapshot only re-broadcasts HUD info when the selection differs from the last sent one.
- `resolveActiveWorld` still resolves the hidden page via its **head-fallback over `wmWorlds`** (hide only mutates `wmVisible`). So on re-show the active world looks unchanged **and** the selection looks unchanged → no `onSetInfoText` resend → the panel stays stale/empty over a live selection.

## Fix
Clear `zoomSelectedPos` and `worldSelectedTile` alongside the existing ground-item clear in `handleWorldHideCommand`, keyed on the exact `pageId` being hidden. This is the race-free, correct-world place to do it — a Lua-side deselect would resolve through `activeWorld`'s head-fallback and could clear the wrong world. The next cursor poll then blanks the panel and updates the snapshot to match.

This extends the "clear selection on transition" model already established for ground-item (#175) and building (#176) selection.

## Verification
- **Headless probe:** a capture module logging every `onSetInfoText` broadcast showed: select tile → non-empty tile info; **hide world → blank tile broadcast (selection cleared)**; re-show → nothing stale. Without the fix, no blank broadcast fires on hide and the stale selection persists.
- **hspec:** `cabal test synarchy-test-headless` → 346 examples, 0 failures.
- Not a worldgen change, so `world_check` is not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)