### PR TITLE
Fix #21: refine lake-hole / water-water-cliff audit classification

### DIFF
--- a/tools/world_audit.py
+++ b/tools/world_audit.py
@@ -357,8 +357,13 @@ def check_island_1tile(grid: dict[tuple[int, int], dict[str, Any]],
 
 def check_lake_hole(grid: dict[tuple[int, int], dict[str, Any]],
                     issues: list[Issue]) -> None:
-    """Single dry tiles fully surrounded by lake water. These are
-    "holes" in a lake that should have been filled by equilibration."""
+    """Single dry tiles fully surrounded by lake water whose terrain
+    sits BELOW the lake surface — a genuine "hole" the lake failed to
+    fill by equilibration. A tile whose terrain is AT (==) or above the
+    surface is a flush islet/shoal poking up to the waterline, which is
+    legitimate, not a defect — those are excluded to avoid false
+    positives (a terrain bump that sits below water with only 3 water
+    neighbours is still caught by check_submerged_bump)."""
     for (x, y), tile in grid.items():
         if tile["fluidType"] is not None:
             continue
@@ -374,6 +379,10 @@ def check_lake_hole(grid: dict[tuple[int, int], dict[str, Any]],
             continue
         if all(n["fluidType"] == "lake" for n in nbrs):
             lake_surf = nbrs[0]["fluidSurf"]
+            # Only a depression below the water line is an unfilled hole;
+            # terrain at/above the surface is a flush islet (not a defect).
+            if lake_surf is None or tile["terrainZ"] >= lake_surf:
+                continue
             issues.append(Issue(
                 "LAKE_HOLE", x, y,
                 f"terrainZ={tile['terrainZ']} surrounded by lake (surf={lake_surf})",
@@ -545,7 +554,13 @@ def check_water_water_cliff(grid: dict[tuple[int, int], dict[str, Any]],
     renderer draws side faces between them, making the height
     difference visible as a water cliff inside what should be a
     flat water body. Ocean is excluded (the renderer skips it for
-    side faces). Connected water bodies should have uniform surface."""
+    side faces).
+
+    A 1-z surface step is natural where water flows downhill, so it is
+    excluded when a river is involved — consistent with WATER_CLIFF and
+    MID_RIVER_CLIFF, which both treat a 1-z step as natural. Lakes are
+    equilibrated flat, so a 1-z step between two lake tiles is a real
+    (if minor) artifact and is still flagged."""
     seen = set()
     for (x, y), tile in grid.items():
         if tile["fluidType"] not in ("river", "lake"):
@@ -565,6 +580,10 @@ def check_water_water_cliff(grid: dict[tuple[int, int], dict[str, Any]],
             if nsurf is None:
                 continue
             diff = abs(wsurf - nsurf)
+            # Natural downhill flow: a 1-z step involving a river is
+            # expected, not a cliff. Lake-to-lake 1-z steps stay flagged.
+            if diff == 1 and "river" in (tile["fluidType"], n["fluidType"]):
+                continue
             if diff > 0:
                 seen.add(pair)
                 # Report the higher tile (the side face is drawn on it)
@@ -995,7 +1014,12 @@ QUALITY_THRESHOLDS = {
                                   # 2026-06-11 (was 150, obs max 52).
     "ISOLATED_FLUID":        90,  # observed max 74 (seed 2718; was 77
                                   # even with old constants)
-    "LAKE_HOLE":             25,  # observed max 4
+    "LAKE_HOLE":             25,  # observed max 0 after the terrainZ<surf
+                                  # refinement (#21): flush waterline
+                                  # islets no longer counted, only genuine
+                                  # depressions the lake failed to fill.
+                                  # Threshold kept for headroom against a
+                                  # real unfilled-hole regression.
     "MULTI_ISLAND":          25,  # observed max 4
     "RIVER_CHUNK_GAP":       50,  # observed max 14
     "RIVER_MOUTH_DROP":      50,  # observed max 15
@@ -1027,7 +1051,11 @@ QUALITY_THRESHOLDS = {
     "RIVER_UNDER_TERRAIN":  500,  # observed max 251 (underground rivers OK)
     "WATER_ABOVE_LAND":     300,  # observed max 152 (steep valleys)
     "WATER_CLIFF":          300,  # observed max 152
-    "WATER_WATER_CLIFF":   3500,  # observed max 2425 (stair-step gradient)
+    "WATER_WATER_CLIFF":   3500,  # observed max 2704 (seed 13579) after the
+                                  # #21 refinement: river-involved 1-z steps
+                                  # (natural downhill flow) excluded, lake-to-
+                                  # lake 1-z steps still flagged. Threshold
+                                  # kept; headroom retained against new seeds.
 }
 
 

--- a/tools/world_audit.py
+++ b/tools/world_audit.py
@@ -378,14 +378,21 @@ def check_lake_hole(grid: dict[tuple[int, int], dict[str, Any]],
         if len(nbrs) < 4:
             continue
         if all(n["fluidType"] == "lake" for n in nbrs):
-            lake_surf = nbrs[0]["fluidSurf"]
-            # Only a depression below the water line is an unfilled hole;
-            # terrain at/above the surface is a flush islet (not a defect).
-            if lake_surf is None or tile["terrainZ"] >= lake_surf:
+            # A genuine hole is terrain below the LOWEST surrounding lake
+            # surface — water at that level would still flood it. If the
+            # terrain reaches any neighbour's waterline it's a flush
+            # islet/shore/saddle, not a hole. Compare against all four
+            # surfaces collectively so the result is independent of
+            # neighbour ordering (mirrors check_submerged_bump's min()).
+            surfs = [n["fluidSurf"] for n in nbrs if n["fluidSurf"] is not None]
+            if not surfs:
+                continue
+            min_surf = min(surfs)
+            if tile["terrainZ"] >= min_surf:
                 continue
             issues.append(Issue(
                 "LAKE_HOLE", x, y,
-                f"terrainZ={tile['terrainZ']} surrounded by lake (surf={lake_surf})",
+                f"terrainZ={tile['terrainZ']} surrounded by lake (minSurf={min_surf})",
             ))
 
 


### PR DESCRIPTION
Closes #21.

## Problem
`world_check.py` reported two hydrology QUALITY threshold failures in the baseline set:
- `LAKE_HOLE` = **29** (> 25) on seed 2718
- `WATER_WATER_CLIFF` = **3655** (> 3500) on seed 13579

Both were **audit false positives**, not generation defects — confirmed by reproducing each failure against a fresh build with the original audit, then diffing the recaptured baselines (dump hashes byte-identical to master).

## Diagnosis
- **LAKE_HOLE**: every flagged tile — and *every* LAKE_HOLE across all 21 baseline seeds — had `terrainZ == lake surface`. That's a flush waterline islet/shoal, not an unfilled hole (which is terrain *below* the surface that equilibration failed to flood). The check never caught a single real hole; it was 100% false positives.
- **WATER_WATER_CLIFF**: ~950 of seed 13579's entries were `diff=1` river steps — natural downhill flow. The two sibling checks (`WATER_CLIFF`, `MID_RIVER_CLIFF`) already treat a 1-z step as natural and exclude it; this one didn't.

## Fix (audit classification only)
- `check_lake_hole`: only flag when `terrainZ < lake_surf` (a genuine depression). Sub-surface bumps with 3 water neighbours are still caught by `check_submerged_bump`.
- `check_water_water_cliff`: exclude `diff=1` **only when a river is involved** (natural flow). Lakes are equilibrated flat, so **lake-to-lake 1-z steps are still flagged** — coverage retained (verified on seed 42/32: 582 vs 581 if excluded outright).
- Thresholds left unchanged (now ample headroom); stale "observed max" comments refreshed.

Effect: seed-set maxima `LAKE_HOLE` 29 → **0**, `WATER_WATER_CLIFF` 3655 → **2704**.

## Generation untouched / no save bump
Only `tools/world_audit.py` changed. Recaptured baseline dump hashes and all generation-derived fields (tileCount, elevation, fluid stats) are **byte-identical to master** — no worldgen change, no save-version bump.

## Validation
- Reproduced both failures on a fresh build with the original audit (stashed).
- Recaptured all 21 baselines via `world_baseline.py` — all deterministic, dumps identical.
- `python3 tools/world_check.py` → **21/21 PASS**.
- `python3 tools/test_audit.py` → **35/35 PASS**.
- Synthetic unit-tests of both refined checks (flush islet / island / true hole; river-river / lake-lake / river-lake at diff 1 and 2).

> Note: `tools/baselines/` is gitignored (per-machine), so this PR is the `world_audit.py` change only. Reviewers should re-run `python3 tools/world_baseline.py` locally to refresh their baselines after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)