### PR TITLE
Fix #37: retire dead popup button plumbing for the line-click model

### DIFF
--- a/data/notification_categories.yaml
+++ b/data/notification_categories.yaml
@@ -10,13 +10,10 @@
 #   log   — default value of "event log"  checkbox
 #   popup — default value of "popup"      checkbox
 #   pause — default value of "pause"      checkbox
-# buttons        — optional list of {label, action} pairs. Defaults to
-#                  [{OK, dismiss}] if omitted. Action tags:
-#                    dismiss   — close the popup
-#                    go_to     — pan camera to the event's (gx, gy)
-#                                payload (set by engine.emitEventAt).
-#                                Skipped if the event was emitted
-#                                without coordinates.
+# popup buttons   — every popup shows a single OK button. Clicking a
+#                   popup line that carries coords (events emitted via
+#                   engine.emitEventAt) pans the camera there. There are
+#                   no per-category navigation buttons.
 # coalesce_window — wall-seconds (sub-second OK). When >0, POPUPS of
 #                   this category arriving within the window collapse
 #                   into a single popup line with an (xN) count and
@@ -47,9 +44,6 @@ categories:
     # bursts into a single popup line with an (xN) counter.
     coalesce_window: 1.0
     log_coalesce_window: 1.0
-    buttons:
-      - { label: "Go To", action: "go_to" }
-      - { label: "OK",    action: "dismiss" }
 
   - id: survival_warning
     display_name: Survival (Warning)
@@ -58,9 +52,6 @@ categories:
     default_settings: { log: true,  popup: true,  pause: false }
     coalesce_window: 1.0
     log_coalesce_window: 1.0
-    buttons:
-      - { label: "Go To", action: "go_to" }
-      - { label: "OK",    action: "dismiss" }
 
   - id: combat
     display_name: Combat
@@ -71,18 +62,12 @@ categories:
     # readable without losing the burst signal.
     coalesce_window: 2.0
     log_coalesce_window: 1.0
-    buttons:
-      - { label: "Go To", action: "go_to" }
-      - { label: "OK",    action: "dismiss" }
 
   - id: building
     display_name: Building / Construction
     description: Construction progress and completion events.
     text_color: [0.8, 0.9, 1.0, 1.0]
     default_settings: { log: true,  popup: false, pause: false }
-    buttons:
-      - { label: "Go To", action: "go_to" }
-      - { label: "OK",    action: "dismiss" }
 
   - id: weather
     display_name: Weather
@@ -95,9 +80,6 @@ categories:
     description: Spawning, recruitment, idle state changes.
     text_color: [1.0, 1.0, 1.0, 1.0]
     default_settings: { log: true,  popup: false, pause: false }
-    buttons:
-      - { label: "Go To", action: "go_to" }
-      - { label: "OK",    action: "dismiss" }
 
   - id: unit_event
     display_name: Unit Event
@@ -106,9 +88,6 @@ categories:
     # Logged but never pops up: ambient flavour the player can browse in
     # the event log (or a unit's Log tab), not alerts that interrupt.
     default_settings: { log: true,  popup: false, pause: false }
-    buttons:
-      - { label: "Go To", action: "go_to" }
-      - { label: "OK",    action: "dismiss" }
 
   - id: unit_warning
     display_name: Unit Warning
@@ -120,9 +99,6 @@ categories:
     # flip popup to true here if you want failures to interrupt).
     default_settings: { log: true,  popup: false, pause: false }
     log_coalesce_window: 1.0
-    buttons:
-      - { label: "Go To", action: "go_to" }
-      - { label: "OK",    action: "dismiss" }
 
   - id: debug
     display_name: Debug

--- a/docs/player_events.md
+++ b/docs/player_events.md
@@ -6,6 +6,17 @@ proper events pipeline that the player controls.
 
 Status: design accepted 2026-05-18. Phase 1 ready to implement.
 
+> **Note (2026-06, issue #37):** this is the original design record.
+> The shipped popup diverged from it in a few places. In particular the
+> per-category **popup button** model below (decision #14, the
+> `PopupButton` / `PopupAction` / `go_to` surface) was **retired**:
+> popups now show a single OK button and navigation is done by
+> **clicking a popup line** (which pans the camera to that event's
+> coords, when present). The `buttons:` YAML key and the
+> `PopupButton`/`PopupAction` Haskell types no longer exist. Other
+> sections (coalescing, category header) have also since changed; treat
+> this doc as design history, not a current API reference.
+
 ---
 
 ## 1. Overview

--- a/scripts/event_log.lua
+++ b/scripts/event_log.lua
@@ -599,7 +599,7 @@ end
 -- elemHandle back to a filteredEvents index, then call the popup
 -- module's onShowPopup directly with the same shape the engine
 -- broadcasts (so the popup re-spawns at the next free slot with the
--- original category color + buttons + coords).
+-- original category color + coords).
 function eventLog.onRowClick(elemHandle)
     local idx = eventLog.rowClickBoxes[elemHandle]
     if not idx then return false end
@@ -622,8 +622,7 @@ function eventLog.onRowClick(elemHandle)
     end
 
     local popupMod = require("scripts.popup")
-    popupMod.onShowPopup(ev.category, ev.text, r, g, b, a,
-                        ev.buttons, ev.coords)
+    popupMod.onShowPopup(ev.category, ev.text, r, g, b, a, ev.coords)
     return true
 end
 

--- a/scripts/popup.lua
+++ b/scripts/popup.lua
@@ -9,9 +9,9 @@
 -- subsequent clicks cycle through additional coords until the
 -- player moves the camera (then the cycle resets).
 --
--- One bottom button: OK, dismisses the popup. The YAML "go_to"
--- buttons are still parsed (so older categories load fine) but no
--- longer rendered — line clicks replace them.
+-- One bottom button: OK, dismisses the popup. Navigation is handled
+-- entirely by clicking a popup line (pans the camera to that event's
+-- coords) — there is no per-category "go_to" button.
 
 local scale  = require("scripts.ui.scale")
 local panel  = require("scripts.ui.panel")
@@ -651,12 +651,11 @@ end
 -- Engine broadcast handler
 -----------------------------------------------------------
 
-function popup.onShowPopup(category, text, r, g, b, a, buttons, coords)
+function popup.onShowPopup(category, text, r, g, b, a, coords)
     local entry = {
         category = category,
         text     = text,
         color    = { r or 1.0, g or 1.0, b or 1.0, a or 1.0 },
-        buttons  = buttons,
         coords   = coords,    -- nil or {x, y}
     }
     -- Coalesce path: if this category has an active popup AND the

--- a/src/Engine/Asset/YamlNotifications.hs
+++ b/src/Engine/Asset/YamlNotifications.hs
@@ -16,9 +16,7 @@ import Data.Foldable (toList)
 import System.Directory (doesFileExist, createDirectoryIfMissing)
 import System.FilePath (takeDirectory)
 import Engine.Core.Log (LoggerState, logInfo, logWarn, LogCategory(..))
-import Engine.PlayerEvent (NotificationCfg, CategoryCfg(..)
-                          , PopupButton(..), PopupAction(..)
-                          , defaultPopupButtons, parsePopupAction)
+import Engine.PlayerEvent (NotificationCfg, CategoryCfg(..))
 
 -- | Per-category checkbox triple. Used both for registry defaults
 --   (under "default_settings") and for the player's overrides file
@@ -42,19 +40,6 @@ instance ToJSON CategorySettings where
         , "pause" .= csPause cs
         ]
 
--- | One button entry as it appears in the YAML registry under the
---   @buttons:@ list. Two fields: a visible label and an action tag
---   that maps to 'PopupAction' via 'parsePopupAction'.
-data ButtonYaml = ButtonYaml
-    { byLabel  ∷ !Text
-    , byAction ∷ !Text
-    } deriving (Show, Eq, Generic)
-
-instance FromJSON ButtonYaml where
-    parseJSON = withObject "ButtonYaml" $ \v → ButtonYaml
-        ⊚ v .:  "label"
-        ⊛ v .:  "action"
-
 -- | One row of the YAML registry — what's shipped with the game.
 data RegistryEntry = RegistryEntry
     { reId          ∷ !Text
@@ -62,7 +47,6 @@ data RegistryEntry = RegistryEntry
     , reDescription ∷ !Text
     , reTextColor   ∷ !(Float, Float, Float, Float)
     , reDefaults    ∷ !CategorySettings
-    , reButtons     ∷ ![ButtonYaml]
     , rePopupCoalesceWindow ∷ !Double
     , reLogCoalesceWindow   ∷ !Double
     } deriving (Show, Eq, Generic)
@@ -75,14 +59,13 @@ instance FromJSON RegistryEntry where
         rawCol  ← v .:? "text_color"  .!= [1.0, 1.0, 1.0, 1.0]
         defs    ← v .:? "default_settings"
                     .!= CategorySettings False False False
-        btns    ← v .:? "buttons" .!= []
         popupCw ← v .:? "coalesce_window" .!= (0 ∷ Double)
         logCw   ← v .:? "log_coalesce_window" .!= (0 ∷ Double)
         col ← case rawCol of
             [r, g, b, a] → return (r, g, b, a)
             _            → fail $ "text_color must be [r,g,b,a]: "
                                     <> T.unpack rid
-        return $ RegistryEntry rid disp desc col defs btns popupCw logCw
+        return $ RegistryEntry rid disp desc col defs popupCw logCw
 
 newtype RegistryFile = RegistryFile { rfCategories ∷ [RegistryEntry] }
     deriving (Show, Eq, Generic)
@@ -128,9 +111,8 @@ loadNotificationCfg logger registryPath overridesPath = do
             return (HM.empty, [])
         Right (RegistryFile entries) → do
             overrides ← loadOverrides logger overridesPath entries
-            resolvedPairs ← forM entries $ \e → do
-                cfg ← mkCategoryCfg logger e overrides
-                return (reId e, cfg)
+            let resolvedPairs =
+                    [ (reId e, mkCategoryCfg e overrides) | e ← entries ]
             let resolved = HM.fromList resolvedPairs
                 order    = map reId entries
             logInfo logger CatEvent $
@@ -158,14 +140,12 @@ writeNotificationOverrides path cfg = do
 
 -- | Resolve one registry row against the player overrides. Missing
 --   override entry → use registry defaults.
-mkCategoryCfg ∷ LoggerState
-              → RegistryEntry
+mkCategoryCfg ∷ RegistryEntry
               → HM.HashMap Text CategorySettings
-              → IO CategoryCfg
-mkCategoryCfg logger e overrides = do
+              → CategoryCfg
+mkCategoryCfg e overrides =
     let cs = HM.lookupDefault (reDefaults e) (reId e) overrides
-    buttons ← resolveButtons logger e
-    return $ CategoryCfg
+    in CategoryCfg
         { ccId          = reId e
         , ccDisplayName = reDisplayName e
         , ccDescription = reDescription e
@@ -173,34 +153,9 @@ mkCategoryCfg logger e overrides = do
         , ccLog         = csLog   cs
         , ccPopup       = csPopup cs
         , ccPause       = csPause cs
-        , ccButtons     = buttons
         , ccPopupCoalesceWindow = rePopupCoalesceWindow e
         , ccLogCoalesceWindow   = reLogCoalesceWindow e
         }
-
--- | Translate the YAML button list into 'PopupButton's, warning on
---   unknown action tags. An empty list (the YAML default if the
---   @buttons:@ key is omitted) falls back to 'defaultPopupButtons'
---   so every category always renders at least an OK.
-resolveButtons ∷ LoggerState → RegistryEntry → IO [PopupButton]
-resolveButtons logger e
-    | null (reButtons e) = return defaultPopupButtons
-    | otherwise = do
-        resolved ← forM (reButtons e) $ \b →
-            case parsePopupAction (byAction b) of
-                Just act → return $ Just (PopupButton (byLabel b) act)
-                Nothing  → do
-                    logWarn logger CatEvent $
-                        "Notification category '" <> reId e
-                          <> "': unknown button action '"
-                          <> byAction b
-                          <> "'; button '" <> byLabel b
-                          <> "' dropped"
-                    return Nothing
-        let buttons = catMaybes resolved
-        if null buttons
-            then return defaultPopupButtons
-            else return buttons
 
 -- | Load 'config/notifications.yaml' if present, else materialize it
 --   from the registry defaults so the player has a file to edit.

--- a/src/Engine/PlayerEvent.hs
+++ b/src/Engine/PlayerEvent.hs
@@ -1,14 +1,9 @@
 {-# LANGUAGE Strict, UnicodeSyntax, DeriveGeneric, OverloadedStrings #-}
 module Engine.PlayerEvent
     ( PlayerEvent(..)
-    , PopupButton(..)
-    , PopupAction(..)
     , CategoryCfg(..)
     , NotificationCfg
     , eventStoreCap
-    , defaultPopupButtons
-    , popupActionTag
-    , parsePopupAction
     ) where
 
 import UPrelude
@@ -25,19 +20,15 @@ data PlayerEvent = PlayerEvent
     , peGameTime ∷ !Double        -- ^ 'gameTimeRef' at emit time.
     , peSource   ∷ !Text          -- ^ Subsystem tag for dev debug, e.g.
                                   --   "World.Save". Not displayed in P1.
-    , peButtons  ∷ ![PopupButton] -- ^ Buttons from the resolved
-                                  --   'CategoryCfg.ccButtons'. The
-                                  --   popup module renders these and
-                                  --   silently skips action buttons
-                                  --   that need data this event
-                                  --   doesn't have (e.g. 'ActGoTo'
-                                  --   when 'peCoords' is 'Nothing').
     , peCoords   ∷ !(Maybe (Int, Int))
                                   -- ^ Optional grid coordinates set
-                                  --   by 'emitEventAt'. Consumed by
-                                  --   'ActGoTo' buttons; 'Nothing'
-                                  --   for events without a natural
-                                  --   location (e.g. save success).
+                                  --   by 'emitEventAt'. The popup
+                                  --   module makes a line carrying
+                                  --   coords clickable (click pans the
+                                  --   camera there); 'Nothing' for
+                                  --   events without a natural location
+                                  --   (e.g. save success), whose lines
+                                  --   are non-clickable.
     , peUid      ∷ !(Maybe Word32)
                                   -- ^ Optional unit this event is ABOUT
                                   --   (set via 'engine.emitEventForUnit').
@@ -58,39 +49,6 @@ data PlayerEvent = PlayerEvent
     } deriving (Show, Eq, Generic)
 -- No Serialize derivation: events are per-session and never saved.
 
--- | A single popup button. Forward-compat surface — Phase 1 only
---   ever uses 'defaultPopupButtons' and the Lua side hardcodes the
---   OK-dismiss behavior. Phase 2 wires real action routing.
-data PopupButton = PopupButton
-    { pbLabel  ∷ !Text
-    , pbAction ∷ !PopupAction
-    } deriving (Show, Eq, Generic)
-
-data PopupAction
-    = ActDismiss
-    -- ^ Close the popup.
-    | ActGoTo
-    -- ^ Pan camera to the event's @(gx, gy)@ payload (set by
-    --   'emitEventAt'). If the event has no payload, the Lua side
-    --   skips this button entirely rather than rendering a dead one.
-    -- P2+ extensions (not implemented):
-    --   ActLuaCallback !Text   — invoke a registered Lua handler
-    --   ActChain ![PopupAction]
-    deriving (Show, Eq, Generic)
-
--- | Wire-format tag for a 'PopupAction', sent to the Lua popup
---   module via 'LuaShowPopup'. Keep in sync with @scripts/popup.lua@.
-popupActionTag ∷ PopupAction → Text
-popupActionTag ActDismiss = "dismiss"
-popupActionTag ActGoTo    = "go_to"
-
--- | Inverse of 'popupActionTag'; returns 'Nothing' for unknown tags
---   so the YAML loader can warn instead of silently coercing.
-parsePopupAction ∷ Text → Maybe PopupAction
-parsePopupAction "dismiss" = Just ActDismiss
-parsePopupAction "go_to"   = Just ActGoTo
-parsePopupAction _         = Nothing
-
 -- | One row of the notification registry, with the player's three
 --   per-category switches resolved on top of the YAML defaults.
 --   Immutable for the session in Phase 1.
@@ -102,13 +60,6 @@ data CategoryCfg = CategoryCfg
     , ccLog         ∷ !Bool                          -- ^ append to log ring
     , ccPopup       ∷ !Bool                          -- ^ queue popup
     , ccPause       ∷ !Bool                          -- ^ flip enginePausedRef
-    , ccButtons     ∷ ![PopupButton]
-      -- ^ Buttons rendered at the bottom of the popup. From the
-      --   category's YAML @buttons:@ section, defaulting to
-      --   'defaultPopupButtons' (one OK→Dismiss) if omitted. Action
-      --   buttons that need event-specific data (e.g. @ActGoTo@) are
-      --   silently skipped by the Lua popup module when the event
-      --   has no payload.
     , ccPopupCoalesceWindow ∷ !Double
       -- ^ When >0, repeated events of this category within this
       --   many wall-seconds collapse into the same popup line
@@ -134,7 +85,3 @@ type NotificationCfg = HM.HashMap Text CategoryCfg
 --   are dropped first when the buffer overflows.
 eventStoreCap ∷ Int
 eventStoreCap = 1000
-
--- | The default button set assigned to every event emitted in Phase 1.
-defaultPopupButtons ∷ [PopupButton]
-defaultPopupButtons = [PopupButton "OK" ActDismiss]

--- a/src/Engine/PlayerEvent/Emit.hs
+++ b/src/Engine/PlayerEvent/Emit.hs
@@ -45,11 +45,9 @@ emitEvent env category source eventText =
     emitEventAt env category source eventText Nothing
 
 -- | Like 'emitEvent', but with optional grid coordinates. The
---   coordinates are routed to the Lua popup so 'ActGoTo' buttons can
---   pan the camera. Categories whose YAML 'buttons' include a
---   @go_to@ entry get the button rendered iff the caller passed
---   coords; categories with only @dismiss@ buttons ignore the
---   payload entirely.
+--   coordinates are routed to the Lua popup, which makes that popup
+--   line clickable — clicking pans the camera to @(gx, gy)@. Events
+--   emitted without coords produce non-clickable lines.
 emitEventAt ∷ EngineEnv
             → Text                  -- ^ category id
             → Text                  -- ^ source tag (dev debug)
@@ -87,7 +85,6 @@ emitEventFull env category source eventText mCoords mUid = do
                     , peText     = eventText
                     , peGameTime = now
                     , peSource   = source
-                    , peButtons  = ccButtons cfg
                     , peCoords   = mCoords
                     , peUid      = mUid
                     , peCount    = 1
@@ -98,12 +95,8 @@ emitEventFull env category source eventText mCoords mUid = do
             when (ccPopup cfg) $ do
                 atomically $ modifyTVar' (popupQueueRef env) (|> ev)
                 let (r, g, b, a) = ccTextColor cfg
-                    buttonPairs  = map
-                        (\b → (pbLabel b, popupActionTag (pbAction b)))
-                        (ccButtons cfg)
                 Q.writeQueue (luaQueue env)
-                    (LuaShowPopup category eventText r g b a
-                        buttonPairs mCoords)
+                    (LuaShowPopup category eventText r g b a mCoords)
             when (ccPause cfg) $
                 writeIORef (enginePausedRef env) True
 

--- a/src/Engine/Scripting/Lua/API/PlayerEvent.hs
+++ b/src/Engine/Scripting/Lua/API/PlayerEvent.hs
@@ -17,8 +17,7 @@ import qualified HsLua as Lua
 import Engine.Asset.YamlNotifications (writeNotificationOverrides)
 import Engine.Core.Log (LogCategory(..), logWarn)
 import Engine.Core.State (EngineEnv(..))
-import Engine.PlayerEvent (CategoryCfg(..), PopupButton(..)
-                          , popupActionTag)
+import Engine.PlayerEvent (CategoryCfg(..))
 import Engine.PlayerEvent.Emit (PlayerEvent(..), emitEvent, emitEventAt
                                , emitEventFull, readEventLog)
 
@@ -39,10 +38,9 @@ emitEventFn env = do
     return 0
 
 -- | @engine.emitEventAt(category, text, gx, gy)@ — fire a popup with
---   a location payload. If the category's YAML buttons include
---   @go_to@, the popup renders a "Go To" button that pans the
---   camera to @(gx, gy)@. Categories without a @go_to@ button
---   ignore the payload.
+--   a location payload. The popup makes that event's line clickable —
+--   clicking it pans the camera to @(gx, gy)@. Events emitted without
+--   coordinates produce non-clickable lines.
 emitEventAtFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 emitEventAtFn env = do
     catArg  ← Lua.tostring 1
@@ -86,12 +84,10 @@ emitEventForUnitFn env = do
     return 0
 
 -- | @engine.getEventLog()@ — return the event-log ring buffer as a
---   Lua array of @{category, text, gameTime, source, buttons,
---   coords}@ tables, oldest-first. @buttons@ is an array of
---   @{label, action}@ pairs (per the event's resolved category cfg
---   at emit time); @coords@ is either @{x, y}@ or @nil@. Sufficient
---   payload for the event-log panel to re-pop the popup from a row
---   click without a second engine round-trip.
+--   Lua array of @{category, text, gameTime, source, uid, count,
+--   coords}@ tables, oldest-first. @coords@ is either @{x, y}@ or
+--   @nil@. Sufficient payload for the event-log panel to re-pop the
+--   popup from a row click without a second engine round-trip.
 getEventLogFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 getEventLogFn env = do
     events ← Lua.liftIO $ readEventLog env
@@ -116,23 +112,9 @@ getEventLogFn env = do
         Lua.pushinteger (fromIntegral (peCount ev))
         Lua.setfield (-2) "count"
 
-        -- buttons array (same shape as getNotificationCfg's buttons
-        -- field) — needed for the event-log panel's row click to
-        -- spawn a popup with the original button set.
-        Lua.newtable
-        forM_ (zip [1..] (peButtons ev)) $ \(j, btn) → do
-            Lua.newtable
-            Lua.pushstring (TE.encodeUtf8 (pbLabel btn))
-            Lua.setfield (-2) "label"
-            Lua.pushstring (TE.encodeUtf8 (popupActionTag (pbAction btn)))
-            Lua.setfield (-2) "action"
-            Lua.rawseti (-2) j
-        Lua.setfield (-2) "buttons"
-
         -- coords: either a {x, y} subtable or nil. nil means the
         -- event was emitted via emitEvent (no location) — repop
-        -- should suppress any 'go_to' buttons just like the first
-        -- spawn did.
+        -- leaves the line non-clickable just like the first spawn did.
         case peCoords ev of
             Just (gx, gy) → do
                 Lua.newtable
@@ -184,17 +166,6 @@ getNotificationCfgFn env = do
                 Lua.pushnumber (Lua.Number (realToFrac a))
                 Lua.setfield (-2) "a"
                 Lua.setfield (-2) "textColor"
-                -- buttons array: { {label, action}, ... }
-                Lua.newtable
-                forM_ (zip [1..] (ccButtons c)) $ \(j, btn) → do
-                    Lua.newtable
-                    Lua.pushstring (TE.encodeUtf8 (pbLabel btn))
-                    Lua.setfield (-2) "label"
-                    Lua.pushstring
-                        (TE.encodeUtf8 (popupActionTag (pbAction btn)))
-                    Lua.setfield (-2) "action"
-                    Lua.rawseti (-2) j
-                Lua.setfield (-2) "buttons"
                 -- coalesceWindow: popup wall-seconds (0 = disabled)
                 Lua.pushnumber (Lua.Number (ccPopupCoalesceWindow c))
                 Lua.setfield (-2) "coalesceWindow"

--- a/src/Engine/Scripting/Lua/Thread.hs
+++ b/src/Engine/Scripting/Lua/Thread.hs
@@ -594,7 +594,7 @@ processLuaMsg env ls stateRef msg = case msg of
   LuaWorldPreviewReady handleInt →
     broadcastToModules ls "onWorldPreviewReady"
       [ScriptNumber (fromIntegral handleInt)]
-  LuaShowPopup category msg r g b a buttons mCoords →
+  LuaShowPopup category msg r g b a mCoords →
     broadcastToModules ls "onShowPopup"
       [ ScriptString category
       , ScriptString msg
@@ -602,7 +602,6 @@ processLuaMsg env ls stateRef msg = case msg of
       , ScriptNumber (realToFrac g)
       , ScriptNumber (realToFrac b)
       , ScriptNumber (realToFrac a)
-      , buttonsToScriptValue buttons
       , coordsToScriptValue mCoords
       ]
 
@@ -615,21 +614,9 @@ intsToScriptArray xs = ScriptTable $
                     , ScriptNumber (fromIntegral x) ))
             [1..] xs
 
--- | Build a Lua array @{ {label=..., action=...}, ... }@ from the
---   button list carried by 'LuaShowPopup'. Lua-side popup module
---   iterates with @ipairs@ and reads @b.label@ / @b.action@.
-buttonsToScriptValue ∷ [(Text, Text)] → ScriptValue
-buttonsToScriptValue btns = ScriptTable $
-    zipWith (\i (lbl, act) →
-        (ScriptNumber (fromIntegral (i ∷ Int))
-        , ScriptTable
-            [ (ScriptString "label",  ScriptString lbl)
-            , (ScriptString "action", ScriptString act)
-            ]))
-        [1..] btns
-
 -- | Encode the optional payload as either @{x=gx, y=gy}@ or 'nil'.
---   Lua-side popup module checks for nil before allowing 'go_to'.
+--   The Lua-side popup module makes a line clickable only when its
+--   coords are non-nil.
 coordsToScriptValue ∷ Maybe (Int, Int) → ScriptValue
 coordsToScriptValue Nothing = ScriptNil
 coordsToScriptValue (Just (gx, gy)) = ScriptTable

--- a/src/Engine/Scripting/Lua/Types.hs
+++ b/src/Engine/Scripting/Lua/Types.hs
@@ -161,17 +161,14 @@ data LuaMsg = LuaTextureLoaded TextureHandle AssetId
             | LuaHudLogResourcesInfo Text
             | LuaWorldPreviewReady Int
             | LuaShowPopup Text Text Float Float Float Float
-                           [(Text, Text)] (Maybe (Int, Int))
+                           (Maybe (Int, Int))
               -- ^ Player-events popup. Fields, in order:
               --     1. category id (e.g. "save_load")
               --     2. body text
               --     3-6. text color r,g,b,a
-              --     7. buttons — list of (label, actionTag) pairs;
-              --        actionTag is one of "dismiss" / "go_to" (see
-              --        'Engine.PlayerEvent.popupActionTag').
-              --     8. optional (gx, gy) grid coords for 'go_to'.
-              --        'Nothing' means buttons that need coords are
-              --        suppressed by the Lua popup module.
+              --     7. optional (gx, gy) grid coords. When present the
+              --        popup line is clickable (click pans the camera
+              --        there); 'Nothing' leaves the line non-clickable.
             deriving (Eq, Show)
 
 data LuaResult = LuaSuccess

--- a/tools/test_lua_save_api.sh
+++ b/tools/test_lua_save_api.sh
@@ -214,8 +214,8 @@ sleep 0.2
 assert_eq "popup queue grew" "$((PRE_QUEUE + 1))" \
     "require('scripts.popup').queueLength()"
 
-echo "[13] engine.getNotificationCfg returns 8 categories in registry order"
-assert_eq "category count" "8" "#engine.getNotificationCfg()"
+echo "[13] engine.getNotificationCfg returns 10 categories in registry order"
+assert_eq "category count" "10" "#engine.getNotificationCfg()"
 assert_eq "first id is save_load"        "true" \
     "engine.getNotificationCfg()[1].id == 'save_load'"
 assert_eq "second id is survival_critical" "true" \
@@ -254,23 +254,7 @@ sleep 0.2
 assert_eq "save_load.popup restored" "true" \
     "engine.getNotificationCfg()[1].popup"
 
-echo "[17] Category buttons exposed from YAML"
-# save_load has no buttons section in YAML → default [OK]
-assert_eq "save_load has 1 button" "true" \
-    "#engine.getNotificationCfg()[1].buttons == 1"
-assert_eq "save_load button[1] label is OK" "true" \
-    "engine.getNotificationCfg()[1].buttons[1].label == 'OK'"
-assert_eq "save_load button[1] action is dismiss" "true" \
-    "engine.getNotificationCfg()[1].buttons[1].action == 'dismiss'"
-# survival_critical has [Go To, OK] in YAML
-assert_eq "survival_critical has 2 buttons" "true" \
-    "#engine.getNotificationCfg()[2].buttons == 2"
-assert_eq "survival_critical button[1] is Go To" "true" \
-    "engine.getNotificationCfg()[2].buttons[1].action == 'go_to'"
-assert_eq "survival_critical button[2] is OK" "true" \
-    "engine.getNotificationCfg()[2].buttons[2].action == 'dismiss'"
-
-echo "[18] emitEventAt routes coords through the popup queue"
+echo "[17] emitEventAt routes coords through the popup queue"
 # Engine pushes onShowPopup with coords; popup module stashes them
 # in the queued entry for the spawn step.
 lua "engine.setPaused(false)" > /dev/null
@@ -284,11 +268,8 @@ assert_eq "queued entry has coords.x=10" "true" \
     "(function() local q = require('scripts.popup').queue; local e = q[#q]; return e.coords ~= nil and e.coords.x == 10 end)()"
 assert_eq "queued entry has coords.y=20" "true" \
     "(function() local q = require('scripts.popup').queue; local e = q[#q]; return e.coords ~= nil and e.coords.y == 20 end)()"
-# And the buttons array is the survival_critical YAML config.
-assert_eq "queued entry has 2 buttons" "true" \
-    "(function() local q = require('scripts.popup').queue; return #q[#q].buttons == 2 end)()"
 
-echo "[19] emitEvent (no coords) leaves coords nil"
+echo "[18] emitEvent (no coords) leaves coords nil"
 PRE_QUEUE=$(lua "return require('scripts.popup').queueLength()")
 lua "engine.emitEvent('save_load', 'plain save event')" > /dev/null
 sleep 0.2
@@ -297,7 +278,7 @@ assert_eq "queue grew without coords" "$((PRE_QUEUE + 1))" \
 assert_eq "queued entry has no coords" "true" \
     "(function() local q = require('scripts.popup').queue; return q[#q].coords == nil end)()"
 
-echo "[20] engine.realTime returns a POSIX-shaped double"
+echo "[19] engine.realTime returns a POSIX-shaped double"
 # We just check it's a number and >= a sanity floor; the actual
 # value is wall-clock so it shifts every run.
 assert_eq "realTime is a number" "true" \
@@ -305,7 +286,7 @@ assert_eq "realTime is a number" "true" \
 assert_eq "realTime is a recent timestamp" "true" \
     "engine.realTime() > 1700000000"
 
-echo "[21] coalesce_window exposed via getNotificationCfg"
+echo "[20] coalesce_window exposed via getNotificationCfg"
 # save_load has no coalesce_window in YAML → default 0
 assert_eq "save_load coalesceWindow is 0"  "true" \
     "engine.getNotificationCfg()[1].coalesceWindow == 0"
@@ -316,7 +297,7 @@ assert_eq "survival_critical coalesceWindow is 1.0" "true" \
 assert_eq "combat coalesceWindow is 2.0" "true" \
     "math.abs(engine.getNotificationCfg()[4].coalesceWindow - 2.0) < 0.001"
 
-echo "[22] popup module exposes coalesce-test helpers"
+echo "[21] popup module exposes coalesce-test helpers"
 assert_eq "onLineClick is a function" "true" \
     "type(require('scripts.popup').onLineClick) == 'function'"
 assert_eq "activeLineCount is a function" "true" \


### PR DESCRIPTION
Closes #37.

## Problem
`scripts/popup.lua` moved to a **line-click** navigation model (clicking a popup line pans the camera to that event's coords) and has only ever rendered a single **OK** button. But a full per-category button stack still rode through the entire pipeline — `buttons:`/`go_to` in YAML, `PopupButton`/`PopupAction` in Haskell, parsed → resolved → broadcast to Lua → exposed via `getEventLog`/`getNotificationCfg` — and was **silently ignored** by the popup module. Dead config and API surface plus comments promising buttons that never appear.

## Decision
Per the issue ("choose one consistent model"), commit to the shipped **line-click** model and retire the dead button plumbing. The line click already provides the `go_to` behavior (camera pan), so nothing user-facing is lost.

## Changes
- **YAML** (`data/notification_categories.yaml`): removed the `buttons:` blocks (6 categories) and the `buttons` doc comment.
- **Haskell**: removed `PopupButton`, `PopupAction`, `popupActionTag`, `parsePopupAction`, `defaultPopupButtons`, `ccButtons`, `peButtons`, `ButtonYaml`/`resolveButtons`, and the `buttons` payload on `LuaShowPopup` (+ `buttonsToScriptValue`). **`coords` is preserved** — the line-click pan still relies on it. (`PlayerEvent.hs`, `Asset/YamlNotifications.hs`, `PlayerEvent/Emit.hs`, `Scripting/Lua/{Types,Thread}.hs`, `Scripting/Lua/API/PlayerEvent.hs`)
- **Lua**: dropped the ignored `buttons` arg from `popup.onShowPopup` and the event-log re-pop call (`scripts/popup.lua`, `scripts/event_log.lua`).
- **Docs** (`docs/player_events.md`): added a note that the button model was retired (the doc is the original design record and is stale in other ways too).

## Testing
- `cabal build exe:synarchy synarchy-test-headless` — clean.
- `cabal test synarchy-test-headless` — **346/346 pass**.
- `tools/test_lua_save_api.sh` — button assertions removed; coords-routing assertions still pass.

Not an output-affecting worldgen change → no baseline recapture or save-version bump.

### Note on a pre-existing test failure
`tools/test_lua_save_api.sh` has a pre-existing, unrelated failure: **"timestamp is ISO 8601"** (save-metadata, a different subsystem). It fails on `master` and is untouched here. I did correct that same test's stale category count (`8` → `10`, which was also already failing) since it lives in the `getNotificationCfg` step this PR edits and would otherwise look like a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)