### PR TITLE
Fix #64: arm the gen-complete structural rebind on the save-load path

### DIFF
--- a/scripts/main_menu.lua
+++ b/scripts/main_menu.lua
@@ -373,6 +373,18 @@ function mainMenu.loadAndShowSave(saveName)
     worldView.loadedFromSave = true
 
     worldView.sendTexturesToWorld("main_world")
+
+    -- Arm the one-shot gen-complete structural rebind, exactly as
+    -- worldView.createWorld does. The world's quad cache bakes each tile's
+    -- bindless texture slot in at build time; if the structural textures
+    -- (blank tile, facemaps) are still GPU-loading when that cache is first
+    -- built, it bakes the magenta "undefined" slot and never self-heals.
+    -- worldView.update re-binds the structural set once world generation
+    -- reports done (phase 3) — by then they've loaded — busting the stale
+    -- cache. createWorld arms this; the load path previously did not, so a
+    -- loaded save could render a magenta interior / missing facemaps (#64).
+    worldView.structuralRebound = false
+
     world.show("main_world")
 
     -- Show loading screen instead of jumping straight to world_view.


### PR DESCRIPTION
Closes #64.

## Problem
The world renderer caches each tile's geometry with the **bindless texture slot baked into the vertex**. If the structural textures (the blank tile + facemaps) are still GPU-loading when that quad cache is first built, the cache bakes the magenta "undefined" slot and **never self-heals** — the tile stays magenta / missing facemaps even after the textures finish loading.

`worldView.createWorld` defends against this: it arms a one-shot rebind (`worldView.structuralRebound = false`) so that once world generation reports done (phase 3, by which point the small structural textures have loaded), `worldView.update` re-binds the structural set and busts the stale cache.

`mainMenu.loadAndShowSave` runs the same `sendTexturesToWorld` + `world.show` flow but **never armed that rebind**, so a save loaded while the structural textures were still in flight could come up with a magenta interior / missing facemaps.

## Fix
One line: arm the same one-shot rebind on the load path, exactly as `createWorld` does.

```lua
worldView.sendTexturesToWorld("main_world")
worldView.structuralRebound = false   -- <-- added
world.show("main_world")
```

## Scope notes
- This is intentionally the minimal "use the same mechanism `createWorld` uses" fix #64 asks for. The durable engine-side cache-invalidation fix that would remove the rebind workaround entirely remains tracked in **#35**.
- An earlier revision of this PR also tried to "honor a `sendTexturesToWorld` failure" (the other half of #64 part A) with a defer/retry. Investigation showed `sendTexturesToWorld` can never actually return `false` (its `texturesLoadedCount`/`texturesNeeded` counters start equal and only grow), and there is **no Lua-visible texture-residency signal** to gate on (`engine.loadTexture` is async; names register at request time; the `onAssetLoaded` callback doesn't re-fire for cache-hit re-requests). So that path was unreachable dead code and has been dropped — the rebind (above) is the mechanism that actually prevents the magenta. A robust residency gate would need engine work that overlaps #35.

## Why this isn't routinely visible
In normal play the structural textures are tiny and are queued during the boot loading screen, so they're GPU-resident long before you reach the load menu — the cache bakes valid slots and there's no magenta. The bug is a latent timing race (e.g. an instant-gen world, or a starved render thread), which is why `createWorld` carries the same rebind as a backstop.

## Testing
- Pure Lua HUD-script change; both touched files pass `luajit` syntax check.
- No hspec/headless coverage exists for this path and GPU rendering can't be observed headless. The visual result is GUI-only verifiable (consistent with the GUI-only repro noted in the issue and `gotcha_loadtexture_dedup`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)