### PR TITLE
Per-unit generated names (#264)

### DIFF
--- a/data/names/humanoid.yaml
+++ b/data/names/humanoid.yaml
@@ -1,0 +1,84 @@
+# Name pool for humanoid units (acolytes). Referenced from a unit def's
+# `name_pool: "humanoid"` key. At spawn the engine draws one `given` and
+# (if the list is non-empty) one `family` entry and joins them with a
+# space to form the unit's persistent display name (#264).
+#
+# Both lists are optional and independent: a pool with only `given`
+# yields single-token names; an empty pool yields no name (the unit
+# falls back to its species label in the UI).
+given:
+  - Aldous
+  - Aurelio
+  - Bran
+  - Caspian
+  - Cyriac
+  - Dorian
+  - Edric
+  - Emeric
+  - Fenwick
+  - Gideon
+  - Hadrian
+  - Ignatius
+  - Jorin
+  - Kael
+  - Lazarus
+  - Lucian
+  - Magnus
+  - Nadir
+  - Orrin
+  - Phineas
+  - Quillon
+  - Rafael
+  - Silas
+  - Thaddeus
+  - Tobias
+  - Ulric
+  - Valen
+  - Wystan
+  - Amara
+  - Beatrix
+  - Calla
+  - Despina
+  - Elowen
+  - Fia
+  - Galena
+  - Helena
+  - Isolde
+  - Junia
+  - Liora
+  - Mira
+  - Nerys
+  - Ottoline
+  - Perpetua
+  - Rosalind
+  - Seraphine
+  - Thessaly
+  - Verena
+  - Wilhelmina
+  - Yara
+family:
+  - Ashforth
+  - Brandt
+  - Calvert
+  - Dreghorn
+  - Ellory
+  - Farrow
+  - Greaves
+  - Halloran
+  - Inwood
+  - Jardine
+  - Kessler
+  - Larkspur
+  - Marchetti
+  - Nascimbeni
+  - Orvieto
+  - Pellan
+  - Quennell
+  - Rookwood
+  - Saltire
+  - Thorne
+  - Underhill
+  - Vellan
+  - Wendover
+  - Yorke
+  - Ziegler

--- a/data/units/acolyte.yaml
+++ b/data/units/acolyte.yaml
@@ -1,5 +1,8 @@
 units:
   - name: "acolyte"
+    # Personal names are drawn at spawn from data/names/humanoid.yaml (#264).
+    name_pool: "humanoid"
+    display_name: "Acolyte"
     sprite: "assets/textures/units/acolyte/animations/idle/south/frame_000.png"
     base_width: 8
     # Top sprint speed in tiles/sec. AI candidates derive walk /

--- a/data/units/bear_brown.yaml
+++ b/data/units/bear_brown.yaml
@@ -1,5 +1,8 @@
 units:
   - name: "bear_brown"
+    # No name_pool — wildlife isn't personally named (#264). The species
+    # label below is shown in its place.
+    display_name: "Brown Bear"
     sprite: "assets/textures/units/bear_brown/animations/idle/south/frame_000.png"
     # Bears are wider than humans. Acolyte = 8; bear roughly 2x that.
     base_width: 16

--- a/data/units/red_squirrel.yaml
+++ b/data/units/red_squirrel.yaml
@@ -1,5 +1,6 @@
 units:
   - name: "red_squirrel"
+    display_name: "Red Squirrel"
     sprite: "assets/textures/units/red_squirrel/animations/idle/south/frame_000.png"
     portrait: "assets/textures/units/red_squirrel/portrait.png"
     # Tiny critter. Acolyte = 8 (48px), bear = 16 (92px); the squirrel

--- a/data/units/technomule.yaml
+++ b/data/units/technomule.yaml
@@ -1,5 +1,6 @@
 units:
   - name: "technomule"
+    display_name: "Technomule"
     sprite: "assets/textures/units/technomule/animations/idle/south/frame_000.png"
     # Big pack quadruped — bear-class footprint.
     base_width: 16

--- a/scripts/cargo_inventory_panel.lua
+++ b/scripts/cargo_inventory_panel.lua
@@ -650,7 +650,17 @@ function cargoInventoryPanel.handleItemRightClick(elemHandle)
     local items = {}
     if target then
         local info = unit.getInfo(target)
-        local who  = (info and info.defName or "unit")
+        -- Prefer the unit's personal name, else its species label (#264).
+        local who  = "unit"
+        if info then
+            if info.name and info.name ~= "" then
+                who = info.name
+            elseif info.displayName and info.displayName ~= "" then
+                who = info.displayName
+            elseif info.defName then
+                who = info.defName
+            end
+        end
         items[1] = {
             label    = "Withdraw with " .. who,
             callback = function()

--- a/scripts/combat_log.lua
+++ b/scripts/combat_log.lua
@@ -363,12 +363,16 @@ local function displayName(uid)
     local info = unit.getInfo(uid)
     -- A named unit (acolyte) reads as its personal name (#264).
     if info and info.name and info.name ~= "" then return info.name end
-    if info and info.defName then
-        local mapped = DISPLAY_NAMES[info.defName]
+    if info then
+        -- Mapped wildlife reads with the definite article in prose
+        -- ("the brown bear"); anything else uses the def's species label
+        -- (display_name / prettified def name) so unmapped units don't
+        -- surface as a raw "Red_squirrel" (#264).
+        local mapped = info.defName and DISPLAY_NAMES[info.defName]
         if mapped then return mapped end
-        -- Capitalise: "acolyte" → "Acolyte"
-        local name = info.defName
-        return name:sub(1, 1):upper() .. name:sub(2)
+        if info.displayName and info.displayName ~= "" then
+            return info.displayName
+        end
     end
     return "unit_" .. tostring(uid)
 end
@@ -404,9 +408,14 @@ local function tabUnitName(uid)
     if info and info.name and info.name ~= "" then
         return info.name:match("^(%S+)") or info.name
     end
-    local def = info and info.defName
+    if not info then return "Unit" end
+    local short = info.defName and TAB_SHORT_NAMES[info.defName]
+    if short then return short end
+    -- Species label (display_name / prettified def name) for unmapped defs.
+    if info.displayName and info.displayName ~= "" then return info.displayName end
+    local def = info.defName
     if not def then return "Unit" end
-    return TAB_SHORT_NAMES[def] or (def:sub(1, 1):upper() .. def:sub(2))
+    return def:sub(1, 1):upper() .. def:sub(2)
 end
 
 local function newBattle(atk, tgt, gameTime)

--- a/scripts/combat_log.lua
+++ b/scripts/combat_log.lua
@@ -361,6 +361,8 @@ local DISPLAY_NAMES = {
 local function displayName(uid)
     if not uid then return "?" end
     local info = unit.getInfo(uid)
+    -- A named unit (acolyte) reads as its personal name (#264).
+    if info and info.name and info.name ~= "" then return info.name end
     if info and info.defName then
         local mapped = DISPLAY_NAMES[info.defName]
         if mapped then return mapped end
@@ -398,7 +400,11 @@ local TAB_SHORT_NAMES = {
 local function tabUnitName(uid)
     if not uid then return nil end
     local info = unit.getInfo(uid)
-    local def  = info and info.defName
+    -- Named unit: first token of the personal name keeps the tab short (#264).
+    if info and info.name and info.name ~= "" then
+        return info.name:match("^(%S+)") or info.name
+    end
+    local def = info and info.defName
     if not def then return "Unit" end
     return TAB_SHORT_NAMES[def] or (def:sub(1, 1):upper() .. def:sub(2))
 end

--- a/scripts/injury_log_panel.lua
+++ b/scripts/injury_log_panel.lua
@@ -302,6 +302,8 @@ local DISPLAY_NAMES = {
 local function displayName(uid)
     if not uid then return "?" end
     local info = unit.getInfo(uid)
+    -- A named unit (acolyte) reads as its personal name (#264).
+    if info and info.name and info.name ~= "" then return info.name end
     if info and info.defName then
         local mapped = DISPLAY_NAMES[info.defName]
         if mapped then return mapped end
@@ -318,7 +320,11 @@ local TAB_SHORT_NAMES = {
 local function tabUnitName(uid)
     if not uid then return "Unit" end
     local info = unit.getInfo(uid)
-    local def  = info and info.defName
+    -- Named unit: first token of the personal name keeps the tab short (#264).
+    if info and info.name and info.name ~= "" then
+        return info.name:match("^(%S+)") or info.name
+    end
+    local def = info and info.defName
     if not def then return "Unit" end
     return TAB_SHORT_NAMES[def] or (def:sub(1, 1):upper() .. def:sub(2))
 end

--- a/scripts/injury_log_panel.lua
+++ b/scripts/injury_log_panel.lua
@@ -304,11 +304,14 @@ local function displayName(uid)
     local info = unit.getInfo(uid)
     -- A named unit (acolyte) reads as its personal name (#264).
     if info and info.name and info.name ~= "" then return info.name end
-    if info and info.defName then
-        local mapped = DISPLAY_NAMES[info.defName]
+    if info then
+        local mapped = info.defName and DISPLAY_NAMES[info.defName]
         if mapped then return mapped end
-        local name = info.defName
-        return name:sub(1, 1):upper() .. name:sub(2)
+        -- Species label (display_name / prettified def name) so unmapped
+        -- units don't surface as a raw "Red_squirrel" (#264).
+        if info.displayName and info.displayName ~= "" then
+            return info.displayName
+        end
     end
     return "unit_" .. tostring(uid)
 end
@@ -324,9 +327,14 @@ local function tabUnitName(uid)
     if info and info.name and info.name ~= "" then
         return info.name:match("^(%S+)") or info.name
     end
-    local def = info and info.defName
+    if not info then return "Unit" end
+    local short = info.defName and TAB_SHORT_NAMES[info.defName]
+    if short then return short end
+    -- Species label (display_name / prettified def name) for unmapped defs.
+    if info.displayName and info.displayName ~= "" then return info.displayName end
+    local def = info.defName
     if not def then return "Unit" end
-    return TAB_SHORT_NAMES[def] or (def:sub(1, 1):upper() .. def:sub(2))
+    return def:sub(1, 1):upper() .. def:sub(2)
 end
 
 -- Find the (recent enough) unit-log for a victim uid. Skips logs silent

--- a/scripts/unit_info_v2.lua
+++ b/scripts/unit_info_v2.lua
@@ -62,6 +62,7 @@ unitInfoV2.lastContentUid = nil   -- (uid, subtab) we last built content for
 unitInfoV2.lastContentTab = nil
 
 -- Header
+unitInfoV2.headerNameLabelId   = nil  -- the name row; refreshed per active unit (#264)
 unitInfoV2.headerTypeLabelId   = nil  -- the "acolyte" row; refreshed per active unit
 unitInfoV2.headerActionLabelId = nil  -- the action row; refreshed per active unit from unit_ai
 
@@ -269,6 +270,7 @@ local function clearOwned()
     unitInfoV2.invRows         = {}
     unitInfoV2.lastInvKey      = nil
 
+    unitInfoV2.headerNameLabelId   = nil
     unitInfoV2.headerTypeLabelId   = nil
     unitInfoV2.headerActionLabelId = nil
 
@@ -3285,9 +3287,10 @@ end
 -----------------------------------------------------------
 -- Header: stacks Name / Type / Role / Action rows in a virtual rect.
 -- No box around it; section boundaries are marked by horizontal rules.
--- Name + Role are placeholders (real values aren't implemented yet);
--- Type and Action are live — Type shows the unit's def name, Action
--- shows the current AI action mapped through ACTION_DISPLAY below.
+-- Name (#264), Type and Action are live — Name shows the unit's personal
+-- name (or species label for the unnamed), Type shows the unit's def
+-- name, Action shows the current AI action mapped through ACTION_DISPLAY
+-- below. Role remains a placeholder (see #265).
 -----------------------------------------------------------
 
 -- Map unit_ai action names → human-readable display strings.
@@ -3315,7 +3318,7 @@ local function placeHeader(x, y, w, h)
     local rowH = math.floor(h / #rows)
     local fontSize = 16
     for i, text in ipairs(rows) do
-        local isLive = (i == 2 or i == 4)   -- type + action are real content
+        local isLive = (i == 1 or i == 2 or i == 4)  -- name + type + action are real content
         local lblId = label.new({
             name     = "unit_info_v2_header_row" .. i,
             text     = text,
@@ -3333,7 +3336,9 @@ local function placeHeader(x, y, w, h)
                      + math.floor(fontSize * 0.3)
         UI.addToPage(unitInfoV2.page, lblHandle, x + SECTION_PAD, rowY)
         UI.setZIndex(lblHandle, 12)
-        if i == 2 then
+        if i == 1 then
+            unitInfoV2.headerNameLabelId = lblId
+        elseif i == 2 then
             unitInfoV2.headerTypeLabelId = lblId
         elseif i == 4 then
             unitInfoV2.headerActionLabelId = lblId
@@ -3572,6 +3577,19 @@ function unitInfoV2.update(dt)
     -- by a content-hash so the per-tick redraw is cheap when nothing
     -- has changed.
     rebuildInventorySection()
+
+    -- Header name row (#264): the unit's personal name when it has one,
+    -- else its species label (display_name / prettified def name).
+    if unitInfoV2.activeUid and unitInfoV2.headerNameLabelId then
+        local info = unit.getInfo(unitInfoV2.activeUid)
+        local nameText
+        if info and info.name and info.name ~= "" then
+            nameText = info.name
+        else
+            nameText = (info and info.displayName) or "—"
+        end
+        label.setText(unitInfoV2.headerNameLabelId, nameText)
+    end
 
     -- Header type row: rewrite each tick from the active unit's def.
     -- All units are "acolyte" right now so this is effectively a no-op

--- a/scripts/unit_log.lua
+++ b/scripts/unit_log.lua
@@ -135,11 +135,14 @@ local function displayName(uid)
     local info = unit.getInfo(uid)
     -- A named unit (acolyte) reads as its personal name (#264).
     if info and info.name and info.name ~= "" then return info.name end
-    if info and info.defName then
-        local mapped = DISPLAY_NAMES[info.defName]
+    if info then
+        local mapped = info.defName and DISPLAY_NAMES[info.defName]
         if mapped then return mapped end
-        local name = info.defName
-        return name:sub(1, 1):upper() .. name:sub(2)
+        -- Species label (display_name / prettified def name) so unmapped
+        -- units don't surface as a raw "Red_squirrel" (#264).
+        if info.displayName and info.displayName ~= "" then
+            return info.displayName
+        end
     end
     return "unit_" .. tostring(uid)
 end

--- a/scripts/unit_log.lua
+++ b/scripts/unit_log.lua
@@ -133,6 +133,8 @@ local DISPLAY_NAMES = {
 local function displayName(uid)
     if not uid then return "?" end
     local info = unit.getInfo(uid)
+    -- A named unit (acolyte) reads as its personal name (#264).
+    if info and info.name and info.name ~= "" then return info.name end
     if info and info.defName then
         local mapped = DISPLAY_NAMES[info.defName]
         if mapped then return mapped end

--- a/scripts/unit_resources.lua
+++ b/scripts/unit_resources.lua
@@ -247,8 +247,13 @@ local DEHYDRATION_REARM_FRAC   = 0.50  -- clear flag when hydration > 50%
 -- today; this is enough to make alert text presentable. If
 -- individual unit names land later this becomes <name>.
 local function unitLabel(info)
-    -- A named unit (acolyte) reads as its personal name (#264).
+    -- A named unit (acolyte) reads as its personal name (#264); otherwise
+    -- the species label (display_name / prettified def name) so survival
+    -- alerts say "Brown Bear", not "Bear_brown".
     if info and info.name and info.name ~= "" then return info.name end
+    if info and info.displayName and info.displayName ~= "" then
+        return info.displayName
+    end
     local n = (info and info.defName) or "Unit"
     return n:sub(1, 1):upper() .. n:sub(2)
 end

--- a/scripts/unit_resources.lua
+++ b/scripts/unit_resources.lua
@@ -247,6 +247,8 @@ local DEHYDRATION_REARM_FRAC   = 0.50  -- clear flag when hydration > 50%
 -- today; this is enough to make alert text presentable. If
 -- individual unit names land later this becomes <name>.
 local function unitLabel(info)
+    -- A named unit (acolyte) reads as its personal name (#264).
+    if info and info.name and info.name ~= "" then return info.name end
     local n = (info and info.defName) or "Unit"
     return n:sub(1, 1):upper() .. n:sub(2)
 end

--- a/src/Engine/Asset/YamlNames.hs
+++ b/src/Engine/Asset/YamlNames.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE Strict, UnicodeSyntax, DeriveGeneric, OverloadedStrings #-}
+-- | Loads a unit name pool from YAML. A pool is two flat lists — given
+--   names and (optional) family names — referenced from a unit def's
+--   `name_pool:` key. At spawn the engine draws one of each to form a
+--   unit's persistent display name (#264).
+module Engine.Asset.YamlNames
+    ( loadNamePool
+    ) where
+
+import UPrelude
+import qualified Data.Text as T
+import qualified Data.Yaml as Yaml
+import Data.Aeson (FromJSON(..), (.:?), (.!=), withObject)
+import GHC.Generics (Generic)
+import Engine.Core.Log (LoggerState, logDebug, logWarn, LogCategory(..))
+import Unit.Types (NamePool(..))
+
+-- | YAML shape of a name-pool file. Both lists default to empty so a
+--   pool may declare only `given` (single-token names) — or neither,
+--   which yields no name.
+data NameYamlFile = NameYamlFile
+    { nyfGiven  ∷ ![Text]
+    , nyfFamily ∷ ![Text]
+    } deriving (Show, Eq, Generic)
+
+instance FromJSON NameYamlFile where
+    parseJSON = withObject "NameYamlFile" $ \v → NameYamlFile
+        ⊚ v .:? "given"  .!= []
+        ⊛ v .:? "family" .!= []
+
+-- | Load a name pool from a YAML file. A parse failure or missing file
+--   logs a warning and yields an empty pool (so units fall back to their
+--   species label rather than crashing the loader).
+loadNamePool ∷ LoggerState → FilePath → IO NamePool
+loadNamePool logger path = do
+    result ← Yaml.decodeFileEither path
+    case result of
+        Left err → do
+            logWarn logger CatAsset $ "Failed to parse name pool "
+                <> T.pack path <> ": " <> T.pack (show err)
+            return (NamePool [] [])
+        Right nf → do
+            let pool = NamePool (nyfGiven nf) (nyfFamily nf)
+            logDebug logger CatAsset $ "Loaded name pool from "
+                <> T.pack path <> " (" <> T.pack (show (length (nyfGiven nf)))
+                <> " given, " <> T.pack (show (length (nyfFamily nf)))
+                <> " family)"
+            return pool

--- a/src/Engine/Asset/YamlUnits.hs
+++ b/src/Engine/Asset/YamlUnits.hs
@@ -298,6 +298,13 @@ instance FromJSON UnitYamlNaturalResistance where
 -- | Only @name@ and @sprite@ are mandatory; everything else has defaults
 data UnitYamlDef = UnitYamlDef
     { uydName              ∷ !Text       -- ^ unique identifier (e.g. "acolyte")
+    , uydNamePool          ∷ !(Maybe Text)
+      -- ^ optional: id of the name pool this unit type draws personal
+      --   names from (resolves to data/names/<id>.yaml). Nothing → the
+      --   unit type has no personal names (#264).
+    , uydDisplayName       ∷ !(Maybe Text)
+      -- ^ optional: human-readable species label ("Brown Bear") for the
+      --   UI. Nothing → the prettified def name is used.
     , uydSprite            ∷ !Text       -- ^ path to default sprite texture
     , uydBaseWidth         ∷ !Float      -- ^ ground contact diameter in pixels (0 = point)
     , uydMaxSpeed          ∷ !Float      -- ^ tiles/sec reference top speed at agility 1.0 (default 3.0)
@@ -363,6 +370,8 @@ data UnitYamlDef = UnitYamlDef
 instance FromJSON UnitYamlDef where
     parseJSON = withObject "UnitYamlDef" $ \v → UnitYamlDef
         ⊚ v .:  "name"
+        ⊛ v .:? "name_pool"
+        ⊛ v .:? "display_name"
         ⊛ v .:  "sprite"
         ⊛ v .:? "base_width"          .!= 0.0
         ⊛ v .:? "max_speed"           .!= 3.0

--- a/src/Engine/Scripting/Lua/API/Units.hs
+++ b/src/Engine/Scripting/Lua/API/Units.hs
@@ -121,6 +121,8 @@ import Engine.Asset.YamlUnits (UnitYamlDef(..), UnitYamlAnim(..),
                                UnitYamlStrike(..),
                                UnitYamlNaturalResistance(..),
                                loadUnitYaml)
+import Engine.Asset.YamlNames (loadNamePool)
+import System.FilePath (takeDirectory, (</>), (<.>))
 import qualified Engine.Core.Queue as Q
 import Unit.Types
 import Unit.Command.Types (UnitCommand(..))
@@ -174,6 +176,15 @@ loadUnitYamlFn env backendState = do
 
                     handle ← loadAndRegister env backendState lteq
                                  ("unit_" <> name) spritePath
+
+                    -- Resolve the name pool (#264). The id maps to a
+                    -- file alongside the units dir: data/names/<id>.yaml.
+                    mNamePool ← case uydNamePool def of
+                        Nothing     → return Nothing
+                        Just poolId → do
+                            let poolPath = takeDirectory (takeDirectory filePath)
+                                           </> "names" </> T.unpack poolId <.> "yaml"
+                            Just <$> loadNamePool logger poolPath
 
                     -- Load directional sprites (if any)
                     dirMap ← foldM (\acc (dirKey, texPath) →
@@ -323,6 +334,8 @@ loadUnitYamlFn env backendState = do
                             ]
                         unitDef = UnitDef
                             { udName          = name
+                            , udNamePool      = mNamePool
+                            , udDisplayName   = uydDisplayName def
                             , udTexture       = handle
                             , udDirSprites    = dirMap
                             , udBaseWidth     = uydBaseWidth def
@@ -366,6 +379,20 @@ loadUnitYamlFn env backendState = do
 
             Lua.pushnumber (Lua.Number (fromIntegral count))
             return 1
+
+-- | Prettify a def name for UI display when no explicit display_name is
+--   set: underscores → spaces, each word capitalised. "bear_brown" →
+--   "Bear Brown", "acolyte" → "Acolyte".
+prettifyDefName ∷ Text → Text
+prettifyDefName = T.unwords . map capWord . T.words . T.map underToSpace
+  where
+    underToSpace c = if c ≡ '_' then ' ' else c
+    capWord w = case T.uncons w of
+        Nothing      → w
+        Just (c, cs) → T.cons (toUpperC c) cs
+    toUpperC c = if c ≥ 'a' ∧ c ≤ 'z'
+                 then toEnum (fromEnum c - 32)
+                 else c
 
 -- | Surface Z at a tile in ONE specific world. The unit's height must
 --   come from the same page the unit is stamped into — walking wmVisible
@@ -2526,6 +2553,15 @@ unitGetInfoFn env = do
                     Lua.newtable
                     Lua.pushstring (TE.encodeUtf8 (uiDefName inst))
                     Lua.setfield (-2) "defName"
+                    -- Persistent personal name; "" for unnamed units (#264).
+                    Lua.pushstring (TE.encodeUtf8 (uiName inst))
+                    Lua.setfield (-2) "name"
+                    -- Species label: the def's display_name, else a
+                    -- prettified def name ("bear_brown" → "Bear Brown").
+                    Lua.pushstring (TE.encodeUtf8
+                        (fromMaybe (prettifyDefName (uiDefName inst))
+                                   (mDef >>= udDisplayName)))
+                    Lua.setfield (-2) "displayName"
                     Lua.pushnumber (Lua.Number (realToFrac (uiGridX inst)))
                     Lua.setfield (-2) "gridX"
                     Lua.pushnumber (Lua.Number (realToFrac (uiGridY inst)))

--- a/src/Unit/Stats.hs
+++ b/src/Unit/Stats.hs
@@ -14,11 +14,13 @@ module Unit.Stats
     , boxMuller
     , effectiveStat
     , applySkillXP
+    , pickName
     ) where
 
 import UPrelude
+import qualified Data.Text as T
 import System.Random (StdGen, randomR)
-import Unit.Types (StatModifier(..))
+import Unit.Types (StatModifier(..), NamePool(..))
 
 -- | One standard-normal sample via Box-Muller. Returns (z, newGen).
 --   Only consumes two uniform draws; the second normal sample of the
@@ -82,3 +84,20 @@ rollStat base range g
                             (base + z * (range / 4))))
                 , g'
                 )
+
+-- | Draw a persistent display name from a name pool (#264). Picks one
+--   `given` name and, if the pool has any, one `family` name, joining
+--   them with a space. An empty given list yields "" (the unit stays
+--   unnamed and falls back to its species label in the UI).
+pickName ∷ NamePool → StdGen → (Text, StdGen)
+pickName pool g0 =
+    case npGiven pool of
+        [] → ("", g0)
+        givens →
+            let (gi, g1)  = randomR (0, length givens - 1) g0
+                given     = givens !! gi
+            in case npFamily pool of
+                [] → (given, g1)
+                fams →
+                    let (fi, g2) = randomR (0, length fams - 1) g1
+                    in (given <> T.pack " " <> (fams !! fi), g2)

--- a/src/Unit/Thread/Command.hs
+++ b/src/Unit/Thread/Command.hs
@@ -20,7 +20,7 @@ import Engine.Core.Log (logDebug, logInfo, logWarn, LogCategory(..))
 import qualified Engine.Core.Queue as Q
 import Unit.Types
 import Unit.Sim.Types
-import Unit.Stats (rollStat)
+import Unit.Stats (rollStat, pickName)
 import Unit.Direction (Direction(..))
 import Unit.Command.Types (UnitCommand(..))
 import Unit.Thread.Movement (startJump, jumpMaxTiles)
@@ -107,6 +107,12 @@ handleUnitCommand env utsRef (UnitSpawn uid defName gx gy gz factionId pageId) =
                         (HM.empty, g0)
                         (udKnowledgeTemplates def)
                 in (g', rolled)
+            -- Persistent personal name (#264): draw from the def's name
+            -- pool if it has one (humanoids); animals stay unnamed ("").
+            initialName ← case udNamePool def of
+                Nothing   → return ""
+                Just pool → atomicModifyIORef' (statRNGRef env) $ \g0 →
+                    let (nm, g') = pickName pool g0 in (g', nm)
             -- Starting inventory: look each entry up in the ItemManager
             -- and build an ItemInstance. Unknown names are dropped
             -- with a warning (load-order issue: items loaded after
@@ -140,6 +146,7 @@ handleUnitCommand env utsRef (UnitSpawn uid defName gx gy gz factionId pageId) =
                                           taggedInventory
             let inst = UnitInstance
                     { uiDefName    = defName
+                    , uiName       = initialName
                     , uiPage       = pageId
                     , uiTexture    = udTexture def
                     , uiDirSprites = udDirSprites def

--- a/src/Unit/Types.hs
+++ b/src/Unit/Types.hs
@@ -9,6 +9,7 @@ module Unit.Types
     , StrikeProfile(..)
     , NaturalResistance(..)
     , defaultNaturalResistance
+    , NamePool(..)
     , UnitDef(..)
     , UnitInstance(..)
     , UnitManager(..)
@@ -299,10 +300,29 @@ data NaturalResistance = NaturalResistance
 defaultNaturalResistance ∷ NaturalResistance
 defaultNaturalResistance = NaturalResistance 0.0 0.0 0.0
 
+-- | A pool of names a unit type can draw from at spawn (#264). `npGiven`
+--   is required for a unit to be named; `npFamily` is optional — a pool
+--   with only given names yields single-token names. An empty pool means
+--   the unit type has no personal names and falls back to its species
+--   label in the UI. Loaded from data/names/<id>.yaml, referenced from a
+--   unit def's `name_pool:` key.
+data NamePool = NamePool
+    { npGiven  ∷ ![Text]
+    , npFamily ∷ ![Text]
+    } deriving (Show, Eq, Generic)
+
 -- | A unit definition (loaded from YAML, immutable after init).
 --   This is the "template" — one per unit type.
 data UnitDef = UnitDef
     { udName       ∷ !Text                            -- ^ e.g. "acolyte"
+    , udNamePool   ∷ !(Maybe NamePool)
+      -- ^ resolved name pool for this unit type, or Nothing if the def
+      --   declares no `name_pool` (animals). When present, spawn draws a
+      --   persistent personal name into `uiName` (#264).
+    , udDisplayName ∷ !(Maybe Text)
+      -- ^ optional human-readable species label ("Brown Bear") for the
+      --   UI. Nothing → the prettified def name is used. Surfaced through
+      --   unit.getInfo as `displayName`.
     , udTexture    ∷ !TextureHandle                   -- ^ default sprite handle
     , udDirSprites ∷ !(Map.Map Direction TextureHandle)
       -- ^ directional sprite overrides (may be empty)
@@ -393,6 +413,11 @@ data UnitDef = UnitDef
 --   Engine is agnostic to player vs NPC — Lua drives behavior.
 data UnitInstance = UnitInstance
     { uiDefName    ∷ !Text           -- ^ which UnitDef this came from
+    , uiName       ∷ !Text
+      -- ^ persistent per-unit display name, drawn from the def's name
+      --   pool at spawn (#264). Empty for unnamed units (animals): the
+      --   UI then falls back to the species label. Roundtrips through
+      --   SaveData (v57+).
     , uiPage       ∷ !WorldPageId
       -- ^ which world this unit belongs to. Runtime-only (not serialized
       --   — a save holds one world; loaded units are stamped with the

--- a/src/World/Save/Types.hs
+++ b/src/World/Save/Types.hs
@@ -107,7 +107,7 @@ saveMagic = 0x53595241
 --       chunk-level ocean test so sub-sea tiles the coarse chunk-flood
 --       missed render ocean (sea-stops-at-chunk-boundary fix).
 currentSaveVersion ∷ Int
-currentSaveVersion = 56  -- v56: item-instance identity (iiInstanceId) + sdNextItemInstanceId (#67)
+currentSaveVersion = 57  -- v57: per-unit name (uisName) (#264)
                          -- v55: despike spike-only convergence pass (#254) — base
                          --      terrain output shifts on regen, so reject older saves
                          -- v54: structure edits (WeSetStructure/WeClearStructure) + sdTexPalette
@@ -388,6 +388,9 @@ data UnitInstanceSnapshot = UnitInstanceSnapshot
     , uisBlood       ∷ !Float
       -- ^ v16: current blood volume in litres. Spawn-time seeded
       --   from body_mass; ticked down by Combat.Wounds bleeding.
+    , uisName        ∷ !Text
+      -- ^ v57: persistent per-unit display name (#264). "" for unnamed
+      --   units. Appended last — Serialize roundtrip is positional.
     } deriving (Show, Serialize, Generic)
 
 -- | Build a snapshot from a live UnitManager, restricted to the world
@@ -428,6 +431,7 @@ toUnitInstanceSnapshot ui = UnitInstanceSnapshot
     , uisImmuneResponse = uiImmuneResponse ui
     , uisImmunities  = uiImmunities ui
     , uisBlood       = uiBlood ui
+    , uisName        = uiName ui
     }
 
 -- | Restore a UnitManager from a snapshot. Like buildings: instances
@@ -460,6 +464,7 @@ fromUnitInstanceSnapshot ∷ WorldPageId → UnitDef → UnitInstanceSnapshot
                          → UnitInstance
 fromUnitInstanceSnapshot page def s = UnitInstance
     { uiDefName     = uisDefName s
+    , uiName        = uisName s
     , uiPage        = page                -- runtime world scoping (#78)
     , uiTexture     = udTexture def       -- re-resolved
     , uiDirSprites  = udDirSprites def    -- re-resolved

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -261,6 +261,7 @@ library
                      Engine.Asset.YamlTextures
                      Engine.Asset.YamlFlora
                      Engine.Asset.YamlUnits
+                     Engine.Asset.YamlNames
                      Engine.Asset.YamlNotifications
                      Engine.Event.Base
                      Engine.Event.Types

--- a/test-headless/Test/Headless/Combat/Severing.hs
+++ b/test-headless/Test/Headless/Combat/Severing.hs
@@ -17,7 +17,8 @@ import Combat.Wounds (propagateSevering)
 -- Body: arm → hand → finger chain, so we can watch the loss propagate.
 def ∷ UnitDef
 def = UnitDef
-    { udName = "t", udTexture = TextureHandle 0, udDirSprites = Map.empty
+    { udName = "t", udNamePool = Nothing, udDisplayName = Nothing
+    , udTexture = TextureHandle 0, udDirSprites = Map.empty
     , udBaseWidth = 0, udMaxSpeed = 1.0, udRunThreshold = 0.6
     , udAnimations = HM.empty, udStateAnims = HM.empty, udEagerStats = False
     , udStatTemplates = HM.empty, udBodyTemplates = HM.empty
@@ -41,7 +42,7 @@ def = UnitDef
 
 inst ∷ [Wound] → UnitInstance
 inst ws = UnitInstance
-    { uiDefName = "t", uiPage = WorldPageId "test"
+    { uiDefName = "t", uiName = "", uiPage = WorldPageId "test"
     , uiTexture = TextureHandle 0, uiDirSprites = Map.empty
     , uiBaseWidth = 0, uiGridX = 0, uiGridY = 0, uiGridZ = 0, uiRealZ = 0
     , uiFacing = DirS, uiCurrentAnim = "", uiAnimStart = 0, uiAnimReverse = False

--- a/test-headless/Test/Headless/Combat/Wounds.hs
+++ b/test-headless/Test/Headless/Combat/Wounds.hs
@@ -35,7 +35,8 @@ mgrWith effs = InfectionManager (HM.fromList [("bug", d)])
 -- A minimal single-part body (one targetable "l_thigh").
 def ∷ UnitDef
 def = UnitDef
-    { udName = "t", udTexture = TextureHandle 0, udDirSprites = Map.empty
+    { udName = "t", udNamePool = Nothing, udDisplayName = Nothing
+    , udTexture = TextureHandle 0, udDirSprites = Map.empty
     , udBaseWidth = 0, udMaxSpeed = 1.0, udRunThreshold = 0.6
     , udAnimations = HM.empty, udStateAnims = HM.empty, udEagerStats = False
     , udStatTemplates = HM.empty, udBodyTemplates = HM.empty
@@ -56,7 +57,7 @@ def = UnitDef
 -- bleed can't kill it mid-test (we're testing infection, not death).
 inst ∷ [Wound] → UnitInstance
 inst ws = UnitInstance
-    { uiDefName = "t", uiPage = WorldPageId "test"
+    { uiDefName = "t", uiName = "", uiPage = WorldPageId "test"
     , uiTexture = TextureHandle 0, uiDirSprites = Map.empty
     , uiBaseWidth = 0, uiGridX = 0, uiGridY = 0, uiGridZ = 0, uiRealZ = 0
     , uiFacing = DirS, uiCurrentAnim = "", uiAnimStart = 0, uiAnimReverse = False

--- a/test-headless/Test/Headless/Unit/Anim.hs
+++ b/test-headless/Test/Headless/Unit/Anim.hs
@@ -14,6 +14,8 @@ import Unit.Types
 mkDef ∷ HM.HashMap Text Text → UnitDef
 mkDef stateAnims = UnitDef
     { udName          = "t"
+    , udNamePool      = Nothing
+    , udDisplayName   = Nothing
     , udTexture       = TextureHandle 0
     , udDirSprites    = Map.empty
     , udBaseWidth     = 0

--- a/test-headless/Test/Headless/Unit/Fall.hs
+++ b/test-headless/Test/Headless/Unit/Fall.hs
@@ -28,7 +28,8 @@ part pid parent vital hLow layers = BodyPart
 
 humanoid ∷ UnitDef
 humanoid = UnitDef
-    { udName = "t", udTexture = TextureHandle 0, udDirSprites = Map.empty
+    { udName = "t", udNamePool = Nothing, udDisplayName = Nothing
+    , udTexture = TextureHandle 0, udDirSprites = Map.empty
     , udBaseWidth = 0, udMaxSpeed = 1.0, udRunThreshold = 0.6
     , udAnimations = HM.empty, udStateAnims = HM.empty, udEagerStats = False
     , udStatTemplates = HM.empty, udBodyTemplates = HM.empty

--- a/test-headless/Test/Headless/Unit/Render/PickFrame.hs
+++ b/test-headless/Test/Headless/Unit/Render/PickFrame.hs
@@ -32,6 +32,8 @@ pickTex t cam inst def = fst (pickFrame t cam inst def)
 mkDef ∷ HM.HashMap Text Animation → UnitDef
 mkDef anims = UnitDef
     { udName          = "test-unit"
+    , udNamePool      = Nothing
+    , udDisplayName   = Nothing
     , udTexture       = h 0
     , udDirSprites    = Map.fromList [(DirS, h 1)]
     , udBaseWidth     = 0
@@ -57,6 +59,7 @@ mkDef anims = UnitDef
 mkInst ∷ Text → Double → UnitInstance
 mkInst animName start = UnitInstance
     { uiDefName     = "test-unit"
+    , uiName        = ""
     , uiPage        = WorldPageId "test"
     , uiTexture     = h 0
     , uiDirSprites  = Map.fromList [(DirS, h 1)]

--- a/test-headless/Test/Headless/Unit/Stats.hs
+++ b/test-headless/Test/Headless/Unit/Stats.hs
@@ -8,8 +8,9 @@ module Test.Headless.Unit.Stats (spec) where
 import UPrelude
 import Test.Hspec
 import System.Random (mkStdGen)
-import Unit.Stats (rollStat, effectiveStat, applySkillXP)
-import Unit.Types (StatModifier(..))
+import qualified Data.Text as T
+import Unit.Stats (rollStat, effectiveStat, applySkillXP, pickName)
+import Unit.Types (StatModifier(..), NamePool(..))
 
 -- | Roll one stat with the given seed and return just the value.
 rollOne ∷ Float → Float → Int → Float
@@ -135,3 +136,23 @@ spec = do
             -- Just verify it doesn't crash / NaN.
             let v = applySkillXP 0.0 1.0
             v `shouldSatisfy` (\x → not (isNaN x) ∧ not (isInfinite x))
+
+    describe "pickName (#264)" $ do
+        let givenFamily = NamePool ["Mira", "Kael"] ["Vellan", "Thorne"]
+            givenOnly   = NamePool ["Pip"] []
+            emptyPool   = NamePool [] []
+            pickOne p s = fst (pickName p (mkStdGen s))
+        it "joins a given and family name with a space" $ do
+            let nm = pickOne givenFamily 1
+            length (T.words nm) `shouldBe` 2
+        it "draws given/family from the declared pools" $ do
+            let nm = pickOne givenFamily 1
+                [g, f] = T.words nm
+            g `shouldSatisfy` (`elem` npGiven givenFamily)
+            f `shouldSatisfy` (`elem` npFamily givenFamily)
+        it "yields a single token when family list is empty" $
+            pickOne givenOnly 5 `shouldBe` "Pip"
+        it "yields \"\" for an empty pool" $
+            pickOne emptyPool 5 `shouldBe` ""
+        it "is deterministic for a given seed" $
+            pickOne givenFamily 42 `shouldBe` pickOne givenFamily 42


### PR DESCRIPTION
Closes #264. Closes the **Name** half of #30.

## What

Units now carry a real, persistent, save-roundtripped **display name**.

- A unit def declares an optional `name_pool: "<id>"` in its YAML, which
  references a **separate** `data/names/<id>.yaml` holding flat `given`
  and (optional) `family` name lists.
- At spawn, a unit with a pool draws one given + one family name
  (deterministically, from the shared spawn RNG) into a new `uiName`
  field. Units whose def has no pool (animals) stay unnamed.
- Animals instead carry an optional `display_name` species label
  (e.g. "Brown Bear") for the UI.

The acolyte references the new `data/names/humanoid.yaml` (~49 given,
25 family). Bear / squirrel / technomule get species `display_name`s and
no personal names — per the design discussion on the issue.

## Where it surfaces

`unit.getInfo` now returns `name` (personal, `""` when unnamed) and
`displayName` (species label — `display_name`, or a prettified def name).
Threaded through:

- the **unit_info_v2 header Name row** (was a dim `"Name"` placeholder)
- **combat / injury / unit-log** prose + tab labels (`displayName`
  chokepoints prefer the personal name; first token used for narrow tabs)
- **survival event-log** text (`unit_resources.unitLabel`)

## Storage / save

New `uiName` on `UnitInstance` + `uisName` on `UnitInstanceSnapshot`
(appended last — positional Serialize). **Save version bumped 56 → 57.**

## Testing

- `Unit.Stats.pickName` hspec spec (given+family join, single-token,
  empty pool, determinism).
- Full headless suite: **351 examples, 0 failures**; `test_audit.py` 35/35.
- Headless end-to-end probe (spawn + save/load): acolytes get distinct
  given+family names, `displayName` = "Acolyte"; bear has no name and
  `displayName` = "Brown Bear"; name survives a save/load roundtrip. All
  7 checks pass.

Not an output-affecting worldgen change, so no baseline recapture needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)