### PR TITLE
Use YAML portrait assets in unit_info_v2 with live-frame fallback (#36)

### DIFF
--- a/scripts/unit_info_v2.lua
+++ b/scripts/unit_info_v2.lua
@@ -3593,10 +3593,13 @@ function unitInfoV2.update(dt)
         label.setText(unitInfoV2.headerActionLabelId, text)
     end
 
-    -- Refresh every visible tab's texture from its unit's current
-    -- animation frame. Skip setSpriteTexture when the handle hasn't
-    -- changed to avoid needless mutations. We only animate VISIBLE
-    -- tabs — scrolled-off tabs would just thrash invisibly.
+    -- Refresh every visible tab's portrait. Prefer the unit def's
+    -- authored portrait (static), falling back to the live animation
+    -- frame for defs that ship no `portrait:`. Skip setSpriteTexture
+    -- when the handle hasn't changed to avoid needless mutations — for
+    -- an authored portrait this means it's set once and then left
+    -- alone. We only refresh VISIBLE tabs — scrolled-off tabs would
+    -- just thrash invisibly.
     if unitInfoV2.tabLayout and #unitInfoV2.tabs > 0 then
         local visible = unitInfoV2.tabLayout.visibleCount
         local first   = unitInfoV2.scrollOffset + 1
@@ -3604,7 +3607,10 @@ function unitInfoV2.update(dt)
         for i = first, last do
             local tab = unitInfoV2.tabs[i]
             if tab then
-                local tex = unit.getFrameTexture(tab.uid)
+                local tex = unit.getPortraitTexture(tab.uid)
+                if not tex or tex == 0 then
+                    tex = unit.getFrameTexture(tab.uid)
+                end
                 if tex and tex > 0 and tex ~= tab.lastTex then
                     UI.setSpriteTexture(tab.spriteId, tex)
                     tab.lastTex = tex

--- a/src/Engine/Asset/YamlUnits.hs
+++ b/src/Engine/Asset/YamlUnits.hs
@@ -305,8 +305,9 @@ data UnitYamlDef = UnitYamlDef
     , uydDirectionalSprites ∷ !(Map.Map Text Text)
       -- ^ optional: direction key ("S","SW",…) → texture path
     , uydPortrait          ∷ !(Maybe Text)
-      -- ^ optional: path to portrait texture for info panel.
-      -- Reserved for future use — parsed and carried but not yet rendered.
+      -- ^ optional: path to portrait texture for the info panel. When
+      --   present it is loaded into `udPortrait` and preferred by the v2
+      --   info pane; defs without it fall back to the live frame texture.
     , uydStateAnimations   ∷ !(Map.Map Text Text)
       -- ^ optional: state name → animation name (e.g. "idle" → "idle-standing")
     , uydAnimations        ∷ !(Map.Map Text UnitYamlAnim)

--- a/src/Engine/Scripting/Lua/API.hs
+++ b/src/Engine/Scripting/Lua/API.hs
@@ -341,6 +341,7 @@ registerLuaAPI lst env backendState = Lua.runWith lst $ do
   registerLuaFunction "addItem"        (unitAddItemFn env)
   registerLuaFunction "getVisibleTiles" (unitGetVisibleTilesFn env)
   registerLuaFunction "getFrameTexture" (unitGetFrameTextureFn env)
+  registerLuaFunction "getPortraitTexture" (unitGetPortraitTextureFn env)
   registerLuaFunction "addModifier"    (unitAddModifierFn env)
   registerLuaFunction "removeModifier" (unitRemoveModifierFn env)
   registerLuaFunction "getModifiers"   (unitGetModifiersFn env)

--- a/src/Engine/Scripting/Lua/API/Units.hs
+++ b/src/Engine/Scripting/Lua/API/Units.hs
@@ -88,6 +88,7 @@ module Engine.Scripting.Lua.API.Units
     , unitAddItemFn
     , unitGetVisibleTilesFn
     , unitGetFrameTextureFn
+    , unitGetPortraitTextureFn
     ) where
 
 import UPrelude
@@ -174,6 +175,14 @@ loadUnitYamlFn env backendState = do
 
                     handle ← loadAndRegister env backendState lteq
                                  ("unit_" <> name) spritePath
+
+                    -- Load the optional authored portrait (info panel).
+                    -- Nothing → the UI mirrors the live animation frame.
+                    portraitH ← case uydPortrait def of
+                        Nothing → return Nothing
+                        Just p  → Just <$> loadAndRegister env backendState lteq
+                                     ("unit_" <> name <> "_portrait")
+                                     (T.unpack p)
 
                     -- Load directional sprites (if any)
                     dirMap ← foldM (\acc (dirKey, texPath) →
@@ -324,6 +333,7 @@ loadUnitYamlFn env backendState = do
                         unitDef = UnitDef
                             { udName          = name
                             , udTexture       = handle
+                            , udPortrait      = portraitH
                             , udDirSprites    = dirMap
                             , udBaseWidth     = uydBaseWidth def
                             , udMaxSpeed      = uydMaxSpeed def
@@ -4122,6 +4132,32 @@ unitGetFrameTextureFn env = do
                             -- flag from `pickFrame` is consumed by the
                             -- renderer at draw time, not here.
                             Just def → Just (fst (pickFrame now (camFacing cam) inst def))
+            case mTex of
+                Just (TextureHandle k) → Lua.pushinteger (fromIntegral k)
+                Nothing → Lua.pushinteger 0
+            return 1
+
+-- | unit.getPortraitTexture(uid) → texture handle integer (0 if the
+--   unit is missing or its def declares no authored `portrait:`).
+--   The info pane prefers this static authored portrait and falls back
+--   to `getFrameTexture` (the live animation frame) when it returns 0.
+unitGetPortraitTextureFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+unitGetPortraitTextureFn env = do
+    idArg ← Lua.tointeger 1
+    case idArg of
+        Nothing → do
+            Lua.pushinteger 0
+            return 1
+        Just n → do
+            let uid = UnitId (fromIntegral n)
+            mTex ← Lua.liftIO $ do
+                um ← readIORef (unitManagerRef env)
+                pure $ case HM.lookup uid (umInstances um) of
+                    Nothing → Nothing
+                    Just inst →
+                        case HM.lookup (uiDefName inst) (umDefs um) of
+                            Nothing  → Nothing
+                            Just def → udPortrait def
             case mTex of
                 Just (TextureHandle k) → Lua.pushinteger (fromIntegral k)
                 Nothing → Lua.pushinteger 0

--- a/src/Unit/Types.hs
+++ b/src/Unit/Types.hs
@@ -304,6 +304,9 @@ defaultNaturalResistance = NaturalResistance 0.0 0.0 0.0
 data UnitDef = UnitDef
     { udName       ∷ !Text                            -- ^ e.g. "acolyte"
     , udTexture    ∷ !TextureHandle                   -- ^ default sprite handle
+    , udPortrait   ∷ !(Maybe TextureHandle)
+      -- ^ optional authored portrait for the info panel (YAML `portrait:`).
+      --   Nothing → the UI falls back to the unit's live animation frame.
     , udDirSprites ∷ !(Map.Map Direction TextureHandle)
       -- ^ directional sprite overrides (may be empty)
     , udBaseWidth  ∷ !Float                           -- ^ ground contact diameter

--- a/test-headless/Test/Headless/Combat/Severing.hs
+++ b/test-headless/Test/Headless/Combat/Severing.hs
@@ -17,7 +17,7 @@ import Combat.Wounds (propagateSevering)
 -- Body: arm → hand → finger chain, so we can watch the loss propagate.
 def ∷ UnitDef
 def = UnitDef
-    { udName = "t", udTexture = TextureHandle 0, udDirSprites = Map.empty
+    { udName = "t", udTexture = TextureHandle 0, udPortrait = Nothing, udDirSprites = Map.empty
     , udBaseWidth = 0, udMaxSpeed = 1.0, udRunThreshold = 0.6
     , udAnimations = HM.empty, udStateAnims = HM.empty, udEagerStats = False
     , udStatTemplates = HM.empty, udBodyTemplates = HM.empty

--- a/test-headless/Test/Headless/Combat/Wounds.hs
+++ b/test-headless/Test/Headless/Combat/Wounds.hs
@@ -35,7 +35,7 @@ mgrWith effs = InfectionManager (HM.fromList [("bug", d)])
 -- A minimal single-part body (one targetable "l_thigh").
 def ∷ UnitDef
 def = UnitDef
-    { udName = "t", udTexture = TextureHandle 0, udDirSprites = Map.empty
+    { udName = "t", udTexture = TextureHandle 0, udPortrait = Nothing, udDirSprites = Map.empty
     , udBaseWidth = 0, udMaxSpeed = 1.0, udRunThreshold = 0.6
     , udAnimations = HM.empty, udStateAnims = HM.empty, udEagerStats = False
     , udStatTemplates = HM.empty, udBodyTemplates = HM.empty

--- a/test-headless/Test/Headless/Unit/Anim.hs
+++ b/test-headless/Test/Headless/Unit/Anim.hs
@@ -15,6 +15,7 @@ mkDef ∷ HM.HashMap Text Text → UnitDef
 mkDef stateAnims = UnitDef
     { udName          = "t"
     , udTexture       = TextureHandle 0
+    , udPortrait      = Nothing
     , udDirSprites    = Map.empty
     , udBaseWidth     = 0
     , udMaxSpeed      = 1.0

--- a/test-headless/Test/Headless/Unit/Fall.hs
+++ b/test-headless/Test/Headless/Unit/Fall.hs
@@ -28,7 +28,7 @@ part pid parent vital hLow layers = BodyPart
 
 humanoid ∷ UnitDef
 humanoid = UnitDef
-    { udName = "t", udTexture = TextureHandle 0, udDirSprites = Map.empty
+    { udName = "t", udTexture = TextureHandle 0, udPortrait = Nothing, udDirSprites = Map.empty
     , udBaseWidth = 0, udMaxSpeed = 1.0, udRunThreshold = 0.6
     , udAnimations = HM.empty, udStateAnims = HM.empty, udEagerStats = False
     , udStatTemplates = HM.empty, udBodyTemplates = HM.empty

--- a/test-headless/Test/Headless/Unit/Render/PickFrame.hs
+++ b/test-headless/Test/Headless/Unit/Render/PickFrame.hs
@@ -33,6 +33,7 @@ mkDef ∷ HM.HashMap Text Animation → UnitDef
 mkDef anims = UnitDef
     { udName          = "test-unit"
     , udTexture       = h 0
+    , udPortrait      = Nothing
     , udDirSprites    = Map.fromList [(DirS, h 1)]
     , udBaseWidth     = 0
     , udMaxSpeed      = 1.0


### PR DESCRIPTION
Closes #36.

## What

`UnitYamlDef.uydPortrait` was already parsed from `portrait:` in unit YAML but marked "carried but not yet rendered" — the v2 info pane always mirrored the unit's **live animation frame** via `unit.getFrameTexture`. This wires the authored portrait through end-to-end.

## Changes

- **`UnitDef`** gains `udPortrait :: Maybe TextureHandle`.
- **`loadUnitYaml`** (`API/Units.hs`) loads the optional `portrait:` path into a texture handle (via the same `loadAndRegister` path as the sprite), or `Nothing` when absent.
- **New Lua API** `unit.getPortraitTexture(uid)` → portrait handle integer, `0` when the unit is missing or its def declares no portrait.
- **`unit_info_v2.lua`** prefers the authored portrait and falls back to `unit.getFrameTexture` for defs without one (the existing "skip when handle unchanged" guard means an authored portrait is set once and left alone).
- Updated the stale `uydPortrait` doc comment; added `udPortrait = Nothing` to the test `UnitDef` fixtures (strict field).

## Verification

Headless data-path check (port 9036), arena world + spawned units:

| query | result | meaning |
|---|---|---|
| `getPortraitTexture(red_squirrel)` | `121` | authored portrait, **distinct** from its frame handle `395` |
| `getFrameTexture(red_squirrel)` | `395` | live frame |
| `getPortraitTexture(acolyte)` | `0` | no portrait → UI falls back to frame `2437` |
| `getPortraitTexture(999)` | `0` | missing unit guard |

- `cabal build exe:synarchy` ✅ and `cabal build synarchy-test-headless` ✅
- Unit specs: 105 examples, 0 failures ✅ · Combat specs: 40 examples, 0 failures ✅
- Lua script parses (luajit) ✅

No save-version bump (`UnitDef` is rebuilt from YAML, not serialized) and no worldgen output change.

## Note for reviewer

The final **pixel** confirmation is GUI-only (headless does no GPU work): select a `red_squirrel` and confirm its info-pane tab shows the authored `portrait.png`, and a unit without a `portrait:` (e.g. acolyte) still shows its live sprite. The data path is verified above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)