### PR TITLE
Multi-key KeyBindings model + array config format (#274)

### DIFF
--- a/config/keybinds.yaml
+++ b/config/keybinds.yaml
@@ -1,15 +1,21 @@
 keybinds:
-  # Movement
-  moveUp: W
-  moveDown: S
-  moveLeft: A
-  moveRight: D
+  # Movement — arrows and WASD. Each action accepts a list of keys and
+  # fires when any of them is held.
+  moveUp: [Up, W]
+  moveDown: [Down, S]
+  moveLeft: [Left, A]
+  moveRight: [Right, D]
+
+  # Camera / view
+  rotateCCW: [Q]
+  rotateCW: [E]
+  resetZTracking: [Home]
 
   # System
-  # `escape` is intentionally hardcoded to Escape in the engine —
-  # rebinding the entry here has no effect.
-  escape: Escape
-  openShell: Grave
+  # `escape` and `openShell` are intentionally hardcoded in the engine —
+  # rebinding the entries here has no effect.
+  escape: [Escape]
+  openShell: [Grave]
 
-  # UI panels (alphanumeric, rebind freely)
-  toggleEventLog: L
+  # UI panels (rebind freely)
+  toggleEventLog: [L]

--- a/config/keybinds_default.yaml
+++ b/config/keybinds_default.yaml
@@ -1,10 +1,18 @@
 keybinds:
-  # Movement
-  moveUp: W
-  moveDown: S
-  moveLeft: A
-  moveRight: D
-  
-  # System
-  escape: Escape
-  openShell:  Grave
+  # Movement — arrows and WASD
+  moveUp: [Up, W]
+  moveDown: [Down, S]
+  moveLeft: [Left, A]
+  moveRight: [Right, D]
+
+  # Camera / view
+  rotateCCW: [Q]
+  rotateCW: [E]
+  resetZTracking: [Home]
+
+  # System (hardcoded in the engine; not editable)
+  escape: [Escape]
+  openShell: [Grave]
+
+  # UI panels
+  toggleEventLog: [L]

--- a/src/Engine/Input/Bindings.hs
+++ b/src/Engine/Input/Bindings.hs
@@ -4,33 +4,60 @@ module Engine.Input.Bindings where
 import UPrelude
 import qualified Data.Map as Map
 import qualified Data.Text as T
+import qualified Data.Vector as V
 import qualified Data.Yaml as Yaml
-import Data.Aeson ((.:?), (.!=), FromJSON(..), Value(..))
+import Data.Aeson ((.:?), FromJSON(..), ToJSON(..), Value(..), object, (.=))
+import Data.Aeson.Types (Parser)
 import qualified Graphics.UI.GLFW as GLFW
 import Engine.Input.Types
 import Engine.Core.Log (LoggerState, logWarn, logInfo, LogCategory(..), logDebug)
 
-type KeyBindings = Map.Map T.Text T.Text
+-- | Each action maps to a **list** of key names; the action fires when
+--   *any* of them is held. Persisted in @keybinds.yaml@ as YAML arrays.
+type KeyBindings = Map.Map T.Text [T.Text]
 
 defaultKeyBindings ∷ KeyBindings
 defaultKeyBindings = Map.fromList
-    [ ("moveUp", "W")
-    , ("moveDown", "S")
-    , ("moveLeft", "A")
-    , ("moveRight", "D")
-    , ("escape", "Escape")
-    , ("shell", "Grave")
-    , ("toggleEventLog", "L")
+    [ ("moveUp",         ["Up", "W"])
+    , ("moveDown",       ["Down", "S"])
+    , ("moveLeft",       ["Left", "A"])
+    , ("moveRight",      ["Right", "D"])
+    , ("rotateCCW",      ["Q"])
+    , ("rotateCW",       ["E"])
+    , ("resetZTracking", ["Home"])
+    -- escape/openShell are engine-hardcoded and NOT editable; kept here
+    -- and in the config for reference only.
+    , ("escape",         ["Escape"])
+    , ("openShell",      ["Grave"])
+    , ("toggleEventLog", ["L"])
     ]
 
 data KeyBindingConfig = KeyBindingConfig
     { kbcBindings ∷ KeyBindings
     } deriving (Show, Eq)
 
+-- | Backward-compatible parse: each binding value may be either the
+--   legacy scalar form (@moveUp: W@) or the new list form
+--   (@moveUp: [Up, W]@). A missing @keybinds@ key falls back to defaults.
 instance FromJSON KeyBindingConfig where
-  parseJSON (Object v) =
-    KeyBindingConfig ⊚ v .:? "keybinds" .!= defaultKeyBindings
+  parseJSON (Object v) = do
+    mRaw ← v .:? "keybinds" ∷ Parser (Maybe (Map.Map T.Text Value))
+    case mRaw of
+      Nothing  → pure (KeyBindingConfig defaultKeyBindings)
+      Just raw → KeyBindingConfig ⊚ traverse parseKeyList raw
   parseJSON _ = fail "Expected Object for KeyBindingConfig value"
+
+instance ToJSON KeyBindingConfig where
+  toJSON (KeyBindingConfig bindings) = object ["keybinds" .= bindings]
+
+-- | Parse one binding value: a bare string becomes a singleton list, a
+--   YAML array becomes a list of strings.
+parseKeyList ∷ Value → Parser [T.Text]
+parseKeyList (String s) = pure [s]
+parseKeyList (Array a)  = traverse parseEntry (V.toList a)
+  where parseEntry (String s) = pure s
+        parseEntry _          = fail "keybind list entries must be strings"
+parseKeyList _ = fail "keybind value must be a string or a list of strings"
 
 -- | Load keybindings from a YAML file
 loadKeyBindings ∷ LoggerState → FilePath → IO KeyBindings
@@ -47,14 +74,22 @@ loadKeyBindings logger path = do
             logDebug logger CatInput $ "Key bindings loaded: " <> T.pack (show (Map.size bindings)) <> " actions"
             return bindings
 
+-- | Save keybindings back to a YAML file as @keybinds:@ arrays.
+saveKeyBindings ∷ LoggerState → FilePath → KeyBindings → IO ()
+saveKeyBindings logger path bindings = do
+    Yaml.encodeFile path (KeyBindingConfig bindings)
+    logInfo logger CatInput $ "Saved keybindings to " <> T.pack path
+                            <> " (" <> T.pack (show (Map.size bindings)) <> " actions)"
+
+-- | True when *any* key bound to the action is currently held.
 isActionDown ∷ Text → KeyBindings → InputState → Bool
 isActionDown action bindings state =
     case Map.lookup action bindings of
-        Just keyName → checkKeyDown keyName state
+        Just keyNames → any (`checkKeyDown` state) keyNames
         Nothing → False
 
-getKeyForAction ∷ Text → KeyBindings → Maybe Text
-getKeyForAction = Map.lookup
+getKeysForAction ∷ Text → KeyBindings → Maybe [Text]
+getKeysForAction = Map.lookup
 
 -- | GLFW keys a key name matches. The canonical vocabulary is
 --   'keyToText' (what Lua's onKeyDown/onKeyUp report), inverted via

--- a/src/Engine/Input/Bindings.hs
+++ b/src/Engine/Input/Bindings.hs
@@ -38,13 +38,19 @@ data KeyBindingConfig = KeyBindingConfig
 
 -- | Backward-compatible parse: each binding value may be either the
 --   legacy scalar form (@moveUp: W@) or the new list form
---   (@moveUp: [Up, W]@). A missing @keybinds@ key falls back to defaults.
+--   (@moveUp: [Up, W]@). The parsed bindings are merged *over*
+--   'defaultKeyBindings' (file entries win), so a config written before
+--   a new action existed still picks up that action's default binding
+--   rather than leaving it unbound. A missing @keybinds@ key falls back
+--   to defaults entirely.
 instance FromJSON KeyBindingConfig where
   parseJSON (Object v) = do
     mRaw ← v .:? "keybinds" ∷ Parser (Maybe (Map.Map T.Text Value))
     case mRaw of
       Nothing  → pure (KeyBindingConfig defaultKeyBindings)
-      Just raw → KeyBindingConfig ⊚ traverse parseKeyList raw
+      Just raw → do
+        parsed ← traverse parseKeyList raw
+        pure (KeyBindingConfig (Map.union parsed defaultKeyBindings))
   parseJSON _ = fail "Expected Object for KeyBindingConfig value"
 
 instance ToJSON KeyBindingConfig where

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -164,6 +164,7 @@ test-suite synarchy-test-headless
                    Test.Headless.Magma.Shape
                    Test.Headless.Sim.Seam
                    Test.Headless.Input.KeyNames
+                   Test.Headless.Input.Bindings
                    Test.Headless.UI.Tooltip
                    Test.Headless.World.Calendar
                    Test.Headless.River.Graph

--- a/test-headless/Spec.hs
+++ b/test-headless/Spec.hs
@@ -29,6 +29,7 @@ import qualified Test.Headless.Combat.Wounds as CombatWounds
 import qualified Test.Headless.Magma.Shape as MagmaShape
 import qualified Test.Headless.Sim.Seam as SimSeam
 import qualified Test.Headless.Input.KeyNames as InputKeyNames
+import qualified Test.Headless.Input.Bindings as InputBindings
 import qualified Test.Headless.UI.Tooltip as UITooltip
 import qualified Test.Headless.World.Calendar as Calendar
 import qualified Test.Headless.River.Graph as RiverGraph
@@ -70,6 +71,7 @@ main = hspec $ do
     describe "World.Magma.Shape" MagmaShape.spec
     describe "Sim.Fluid.Seam" SimSeam.spec
     describe "Input.KeyNames" InputKeyNames.spec
+    describe "Input.Bindings" InputBindings.spec
     describe "UI.Tooltip" UITooltip.spec
     describe "World.Calendar" Calendar.spec
     describe "River.Graph" RiverGraph.spec

--- a/test-headless/Test/Headless/Input/Bindings.hs
+++ b/test-headless/Test/Headless/Input/Bindings.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE UnicodeSyntax, OverloadedStrings #-}
+-- | Multi-key binding data-model tests (issue #274). The contract under
+--   test: 'KeyBindings' is action → list-of-keys; the YAML parser accepts
+--   both the legacy scalar form (@moveUp: W@) and the new array form
+--   (@moveUp: [Up, W]@); 'isActionDown' fires when *any* bound key is
+--   held; and the writer round-trips through the reader.
+module Test.Headless.Input.Bindings (spec) where
+
+import UPrelude
+import Test.Hspec
+import Data.ByteString (ByteString)
+import qualified Data.Map as Map
+import qualified Data.Yaml as Yaml
+import qualified Graphics.UI.GLFW as GLFW
+import Engine.Input.Types
+import Engine.Input.Bindings
+
+-- | Input state with exactly the given GLFW keys held down.
+heldState ∷ [GLFW.Key] → InputState
+heldState ks = defaultInputState
+    { inpKeyStates = Map.fromList
+        [(k, defaultKeyState { keyPressed = True }) | k ← ks] }
+
+-- | Parse a keybinds YAML document or fail the test loudly.
+parseConfig ∷ ByteString → KeyBindings
+parseConfig bs = case Yaml.decodeEither' bs of
+    Left err  → error ("decode failed: " ⧺ show err)
+    Right cfg → kbcBindings cfg
+
+spec ∷ Spec
+spec = do
+    describe "config parsing" $ do
+        it "accepts the legacy scalar form (one key per action)" $ do
+            let b = parseConfig "keybinds:\n  moveUp: W\n  toggleEventLog: L\n"
+            Map.lookup "moveUp" b         `shouldBe` Just ["W"]
+            Map.lookup "toggleEventLog" b `shouldBe` Just ["L"]
+
+        it "accepts the new list form (multiple keys per action)" $ do
+            let b = parseConfig "keybinds:\n  moveUp: [Up, W]\n  moveLeft: [Left, A]\n"
+            Map.lookup "moveUp" b   `shouldBe` Just ["Up", "W"]
+            Map.lookup "moveLeft" b `shouldBe` Just ["Left", "A"]
+
+        it "accepts a single-element list" $ do
+            let b = parseConfig "keybinds:\n  rotateCW: [E]\n"
+            Map.lookup "rotateCW" b `shouldBe` Just ["E"]
+
+        it "accepts scalar and list entries mixed in one file" $ do
+            let b = parseConfig "keybinds:\n  moveUp: [Up, W]\n  toggleEventLog: L\n"
+            Map.lookup "moveUp" b         `shouldBe` Just ["Up", "W"]
+            Map.lookup "toggleEventLog" b `shouldBe` Just ["L"]
+
+        it "falls back to defaults when keybinds key is absent" $
+            parseConfig "{}" `shouldBe` defaultKeyBindings
+
+    describe "defaults" $ do
+        it "binds movement to arrows and WASD" $ do
+            Map.lookup "moveUp" defaultKeyBindings    `shouldBe` Just ["Up", "W"]
+            Map.lookup "moveDown" defaultKeyBindings  `shouldBe` Just ["Down", "S"]
+            Map.lookup "moveLeft" defaultKeyBindings  `shouldBe` Just ["Left", "A"]
+            Map.lookup "moveRight" defaultKeyBindings `shouldBe` Just ["Right", "D"]
+
+    describe "isActionDown (any bound key)" $ do
+        let bindings = Map.fromList [("moveUp", ["Up", "W"])]
+        it "fires when the first bound key is held" $
+            isActionDown "moveUp" bindings (heldState [GLFW.Key'Up]) `shouldBe` True
+
+        it "fires when the second bound key is held" $
+            isActionDown "moveUp" bindings (heldState [GLFW.Key'W]) `shouldBe` True
+
+        it "is false when no bound key is held" $
+            isActionDown "moveUp" bindings (heldState [GLFW.Key'S]) `shouldBe` False
+
+        it "is false for an unbound action" $
+            isActionDown "noSuchAction" bindings (heldState [GLFW.Key'W]) `shouldBe` False
+
+    describe "save round-trip" $
+        it "encodes then decodes back to the same bindings" $ do
+            let bs = Yaml.encode (KeyBindingConfig defaultKeyBindings)
+            parseConfig bs `shouldBe` defaultKeyBindings

--- a/test-headless/Test/Headless/Input/Bindings.hs
+++ b/test-headless/Test/Headless/Input/Bindings.hs
@@ -52,6 +52,18 @@ spec = do
         it "falls back to defaults when keybinds key is absent" $
             parseConfig "{}" `shouldBe` defaultKeyBindings
 
+        it "merges over defaults so a pre-existing config inherits new actions" $ do
+            -- A config written before rotateCW/resetZTracking existed.
+            let b = parseConfig "keybinds:\n  moveUp: W\n  toggleEventLog: L\n"
+            -- File entries win...
+            Map.lookup "moveUp" b         `shouldBe` Just ["W"]
+            Map.lookup "toggleEventLog" b `shouldBe` Just ["L"]
+            -- ...and absent actions fall back to their defaults rather
+            -- than being left unbound.
+            Map.lookup "rotateCW" b       `shouldBe` Just ["E"]
+            Map.lookup "resetZTracking" b `shouldBe` Just ["Home"]
+            Map.lookup "moveLeft" b       `shouldBe` Just ["Left", "A"]
+
     describe "defaults" $ do
         it "binds movement to arrows and WASD" $ do
             Map.lookup "moveUp" defaultKeyBindings    `shouldBe` Just ["Up", "W"]


### PR DESCRIPTION
Closes #274. First child of epic #273 (rebindable keybinding system) — the data layer only. No gameplay rewiring (#275), Lua API (#276), or UI (#277).

## What changed
- **`KeyBindings` is now `Map Text [Text]`** — multiple keys per action. `isActionDown` is true when *any* bound key is held.
- **Backward-compatible config parsing**: `FromJSON KeyBindingConfig` accepts both the legacy scalar form (`moveUp: W`) and the new list form (`moveUp: [Up, W]`), so old `keybinds.yaml` files still load. Added `ToJSON` + a `saveKeyBindings` writer (emits YAML arrays).
- **Defaults** → arrows **and** WASD, plus the soon-to-be-bindable view actions: `moveUp [Up,W]`, `moveDown [Down,S]`, `moveLeft [Left,A]`, `moveRight [Right,D]`, `rotateCCW [Q]`, `rotateCW [E]`, `resetZTracking [Home]`, `toggleEventLog [L]`. `escape`/`openShell` stay engine-hardcoded (listed for reference, not editable).
- **`config/keybinds.yaml` + `keybinds_default.yaml`** rewritten as arrays.
- Renamed the unused `getKeyForAction → getKeysForAction` (now `Maybe [Text]`); no consumers.

The Lua `isActionDown` API and `loadKeyBindings` keep their external signatures, so consumers (`Init`, `State`, `Lua.API.Input`) needed no changes — the full library compiles against the new type.

## Testing
New `Test.Headless.Input.Bindings` (11 examples, all pass): scalar/list/mixed/empty parse, defaults, any-key `isActionDown`, and a save→load round-trip. `Input.KeyNames` still green. Verified the real config files parse to all-array bindings.

No `currentSaveVersion` bump — `keybinds.yaml` is plain config, not the binary save format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)