### PR TITLE
Race-safe, late-texture-robust world render-cache invalidation (#35)

### DIFF
--- a/scripts/main_menu.lua
+++ b/scripts/main_menu.lua
@@ -374,17 +374,10 @@ function mainMenu.loadAndShowSave(saveName)
 
     worldView.sendTexturesToWorld("main_world")
 
-    -- Arm the one-shot gen-complete structural rebind, exactly as
-    -- worldView.createWorld does. The world's quad cache bakes each tile's
-    -- bindless texture slot in at build time; if the structural textures
-    -- (blank tile, facemaps) are still GPU-loading when that cache is first
-    -- built, it bakes the magenta "undefined" slot and never self-heals.
-    -- worldView.update re-binds the structural set once world generation
-    -- reports done (phase 3) — by then they've loaded — busting the stale
-    -- cache. createWorld arms this; the load path previously did not, so a
-    -- loaded save could render a magenta interior / missing facemaps (#64).
-    worldView.structuralRebound = false
-
+    -- sendTexturesToWorld binds the structural set (and so busts the quad
+    -- cache); the engine also self-heals the cache when any dependent
+    -- texture finishes loading (#35), so no Lua-side gen-complete rebind is
+    -- needed for the loaded-save magenta-interior case (#64) anymore.
     world.show("main_world")
 
     -- Show loading screen instead of jumping straight to world_view.

--- a/scripts/world_view.lua
+++ b/scripts/world_view.lua
@@ -300,17 +300,10 @@ function worldView.createWorld()
         -- materials and vegetation textures sent via sendTexturesToWorld
     })
     worldManager.showWorld()
-
-    -- Structural textures (blank, facemaps) can still be GPU-loading when
-    -- the world's quad cache is first built, baking the undefined/magenta
-    -- slot + empty facemaps. The engine's own post-load cache invalidation
-    -- is unreliable here (it only touches already-visible worlds and races
-    -- the render thread's cache write-back). Re-bind the structural set ONCE
-    -- when world generation reports done (worldView.update polls for it): by
-    -- the time chunk generation finishes the small structural textures have
-    -- loaded, and the world.setTexture re-bind busts the stale quad cache so
-    -- it rebuilds with valid slots.
-    worldView.structuralRebound = false
+    -- The engine now rebuilds a world's quad cache by itself when a texture
+    -- it depends on finishes loading (race-safe generation counter, covers
+    -- not-yet-visible worlds — #35), so the structural set no longer needs a
+    -- Lua-side post-gen re-bind to bust a stale cache.
 end
 
 -----------------------------------------------------------
@@ -378,18 +371,6 @@ end
 function worldView.update(dt)
     if not worldView.visible then return end
     worldManager.update(dt)
-
-    -- One-shot structural re-bind when world generation completes (phase 3).
-    -- Busts the stale quad cache so the interior + facemaps render with the
-    -- now-loaded textures. Polls only until it fires, then stops.
-    if worldView.structuralRebound == false and worldManager.isActive() then
-        local phase = world.getInitProgress()
-        if phase == 3 then
-            worldView.structuralRebound = true
-            local wid = worldManager.getCurrentWorld()
-            if wid then worldView.rebindStructural(wid) end
-        end
-    end
 end
 
 -----------------------------------------------------------
@@ -516,9 +497,7 @@ function worldView.sendTexturesToWorld(worldId)
 
     engine.logInfo("Sending textures to loaded world: " .. worldId)
 
-    -- Structural (ocean/blank/facemaps). Bound via a shared helper so the
-    -- post-load rebind (worldView.onAssetLoaded) can re-issue exactly these
-    -- bindings to bust a stale quad cache.
+    -- Structural (ocean/blank/facemaps), bound via the shared helper.
     worldView.rebindStructural(worldId)
 
     -- Vegetation tiles: look up from registry by numeric ID

--- a/src/Engine/Scripting/Lua/API/Camera.hs
+++ b/src/Engine/Scripting/Lua/API/Camera.hs
@@ -360,7 +360,7 @@ invalidateWorldCaches env = do
     camera ← readIORef (cameraRef env)
     manager ← readIORef (worldManagerRef env)
     forM_ (wmWorlds manager) $ \(_, ws) → do
-        writeIORef (wsQuadCacheRef ws)     Nothing
+        bumpQuadCacheGen ws
         writeIORef (wsZoomQuadCacheRef ws) Nothing
         writeIORef (wsBgQuadCacheRef ws)   Nothing
         writeIORef (wsBakedZoomRef ws)     (V.empty, defaultWorldTextures, FaceSouth)

--- a/src/Engine/Scripting/Lua/Message.hs
+++ b/src/Engine/Scripting/Lua/Message.hs
@@ -57,7 +57,7 @@ import Engine.Scene.Manager (addObjectToScene)
 import Engine.Scene.Types
 import Engine.Scripting.Lua.Types
 import World.Render.Zoom.Types (ZoomAtlasInfo(..), zoomTileSize)
-import World.State.Types (WorldManager(..), WorldState(..))
+import World.State.Types (WorldManager(..), WorldState(..), bumpQuadCacheGen)
 import qualified Graphics.UI.GLFW as GLFW
 import Vulkan.Core10
 import Vulkan.Zero (zero)
@@ -74,16 +74,20 @@ data TextureUploadPrep = TextureUploadPrep
     , tupCleanImage ∷ !(IO ())
     }
 
-invalidateVisibleWorldRenderCaches ∷ EngineEnv → IO ()
-invalidateVisibleWorldRenderCaches env = do
+-- | Invalidate every loaded world's render caches after a texture load.
+--   Iterates ALL worlds in 'wmWorlds', not just 'wmVisible', so a world
+--   whose dependent textures finish loading *before* it is shown still
+--   refreshes when displayed (the old visible-only sweep missed it). The
+--   close-up quad cache is invalidated via the race-safe generation
+--   counter ('bumpQuadCacheGen'); the zoom/background caches are nulled
+--   directly (they have a single writer and no cross-thread rebuild race).
+invalidateAllWorldRenderCaches ∷ EngineEnv → IO ()
+invalidateAllWorldRenderCaches env = do
     mgr ← readIORef (worldManagerRef env)
-    forM_ (wmVisible mgr) $ \pageId →
-        case lookup pageId (wmWorlds mgr) of
-            Nothing → pure ()
-            Just ws → do
-                writeIORef (wsQuadCacheRef ws) Nothing
-                writeIORef (wsZoomQuadCacheRef ws) Nothing
-                writeIORef (wsBgQuadCacheRef ws) Nothing
+    forM_ (wmWorlds mgr) $ \(_, ws) → do
+        bumpQuadCacheGen ws
+        writeIORef (wsZoomQuadCacheRef ws) Nothing
+        writeIORef (wsBgQuadCacheRef ws) Nothing
 
 processLuaMessages ∷ EngineM ε σ ()
 processLuaMessages = do
@@ -502,7 +506,7 @@ handleLoadTextureBatch requests = do
     forM_ (reverse cachedReqs) $ \(handle, assetId, atlas) →
         duplicateCachedTextureHandle env handle assetId atlas
 
-    let invalidateVisible = liftIO $ invalidateVisibleWorldRenderCaches env
+    let invalidateRenderCaches = liftIO $ invalidateAllWorldRenderCaches env
 
     when (not (null freshReqs)) $ do
         gs ← gets graphicsState
@@ -606,7 +610,7 @@ handleLoadTextureBatch requests = do
                             logWarnM CatTexture $
                                 "Missing canonical texture for deduped alias: "
                                     <> T.pack (show handle)
-                invalidateVisible
+                invalidateRenderCaches
 
             _ → logWarnM CatTexture "Cannot batch-load textures: Vulkan not ready"
 

--- a/src/World/Render.hs
+++ b/src/World/Render.hs
@@ -80,14 +80,23 @@ updateWorldTiles env = do
             quads ← forM (wmVisible worldManager) $ \pageId →
                 case lookup pageId (wmWorlds worldManager) of
                     Just worldState → do
+                        -- Snapshot the invalidation generation BEFORE building.
+                        -- A cache is only reusable when its generation still
+                        -- matches; if an invalidation lands while we rebuild,
+                        -- the generation we stamp is already stale and the cache
+                        -- rebuilds next frame (the invalidation is never lost,
+                        -- even though the render thread is the sole writer of
+                        -- wsQuadCacheRef).
+                        curGen ← readIORef (wsQuadCacheGenRef worldState)
                         cached ← readIORef (wsQuadCacheRef worldState)
                         case cached of
-                            Just wqc | not (cameraChanged (wqcCamera wqc) currentSnap) →
+                            Just wqc | wqcGen wqc ≡ curGen
+                                     , not (cameraChanged (wqcCamera wqc) currentSnap) →
                                 return (wqcQuads wqc)
                             _ → do
                                 result ← renderWorldQuads env worldState tileAlpha currentSnap
                                 writeIORef (wsQuadCacheRef worldState) $
-                                    Just (WorldQuadCache currentSnap result)
+                                    Just (WorldQuadCache curGen currentSnap result)
                                 return result
                     Nothing → return V.empty
             return $ V.concat quads

--- a/src/World/Render/Camera/Types.hs
+++ b/src/World/Render/Camera/Types.hs
@@ -21,7 +21,8 @@ data WorldCameraSnapshot = WorldCameraSnapshot
     } deriving (Show, Eq)
 
 data WorldQuadCache = WorldQuadCache
-    { wqcCamera ∷ !WorldCameraSnapshot
+    { wqcGen    ∷ !Int                       -- ^ Invalidation generation this cache was built at
+    , wqcCamera ∷ !WorldCameraSnapshot
     , wqcQuads  ∷ !(V.Vector SortableQuad)
     } deriving (Show)
 

--- a/src/World/State/Types.hs
+++ b/src/World/State/Types.hs
@@ -2,6 +2,7 @@
 module World.State.Types
     ( WorldState(..)
     , emptyWorldState
+    , bumpQuadCacheGen
     , WorldManager(..)
     , emptyWorldManager
     , CursorSnapshot(..)
@@ -9,7 +10,7 @@ module World.State.Types
     ) where
 
 import UPrelude
-import Data.IORef (IORef, newIORef)
+import Data.IORef (IORef, newIORef, atomicModifyIORef')
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Vector as V
 import Engine.Graphics.Camera (CameraFacing(..))
@@ -40,6 +41,13 @@ data WorldState = WorldState
     , wsTimeScaleRef ∷ IORef Float    -- ^ Game-minutes per real-second
     , wsZoomCacheRef ∷ IORef (V.Vector ZoomChunkEntry)  -- ^ Pre-computed zoom map cache for current world state
     , wsQuadCacheRef  ∷ IORef (Maybe WorldQuadCache)  -- ^ Cached quads for current camera state
+    , wsQuadCacheGenRef ∷ IORef Int
+      -- ^ Invalidation generation for the quad cache. Bumped atomically
+      --   (from any thread) instead of nulling 'wsQuadCacheRef', so a
+      --   cross-thread invalidation can't be clobbered by the render
+      --   thread's read-rebuild-write of the cache. A cache is only valid
+      --   when its 'wqcGen' matches this counter; the render thread is the
+      --   sole writer of 'wsQuadCacheRef'. See 'bumpQuadCacheGen'.
     , wsZoomQuadCacheRef ∷ IORef (Maybe ZoomQuadCache)  -- ^ Cached quads for zoomed-out view
     , wsBgQuadCacheRef ∷ IORef (Maybe ZoomQuadCache)    -- ^ Cached quads for background layer
     , wsBakedZoomRef ∷ IORef (V.Vector BakedZoomEntry, WorldTextures, CameraFacing)  -- ^ Pre-baked
@@ -103,6 +111,7 @@ emptyWorldState = do
     timeScaleRef ← newIORef 1.0   -- 1 game-minute per real-second
     zoomCacheRef ← newIORef V.empty
     quadCacheRef  ← newIORef Nothing
+    quadCacheGenRef ← newIORef 0
     zoomQCRef   ← newIORef Nothing
     bgQCRef     ← newIORef Nothing
     bakedZoomRef ← newIORef (V.empty, defaultWorldTextures, FaceSouth)
@@ -122,13 +131,24 @@ emptyWorldState = do
     wsStructureStageRef ← newIORef emptyChunkStructures
     return $ WorldState tilesRef cameraRef texturesRef genParamsRef
                         timeRef dateRef timeScaleRef zoomCacheRef
-                        quadCacheRef zoomQCRef bgQCRef
+                        quadCacheRef quadCacheGenRef zoomQCRef bgQCRef
                         bakedZoomRef bakedBgRef wsInitQueueRef
                         wsMapModeRef
                         wsCursorRef wsToolModeRef wsCursorSnapshotRef
                         wsLoadPhaseRef wsZoomAtlasRef wsEditsRef
                         wsOreSurveyRef wsMineDesignationsRef
                         wsGroundItemsRef wsSpoilRef wsStructureStageRef
+
+-- | Invalidate a world's cached render quads in a thread-safe way.
+--   Bumps the generation counter atomically rather than nulling
+--   'wsQuadCacheRef', so an invalidation from the world/Lua thread can
+--   never be lost to the render thread's read-rebuild-write of the cache:
+--   the render thread stamps each rebuilt cache with the generation it
+--   observed, and a cache whose 'wqcGen' no longer matches is treated as
+--   stale and rebuilt next frame.
+bumpQuadCacheGen ∷ WorldState → IO ()
+bumpQuadCacheGen ws =
+    atomicModifyIORef' (wsQuadCacheGenRef ws) (\g → (g + 1, ()))
 
 data WorldManager = WorldManager
     { wmWorlds  ∷ [(WorldPageId, WorldState)]

--- a/src/World/Thread/ChunkLoading.hs
+++ b/src/World/Thread/ChunkLoading.hs
@@ -142,7 +142,7 @@ updateChunkLoading env logger = do
                                 forM_ evicted $ \cc →
                                     Q.writeQueue (simQueue env)
                                         (SimChunkUnloaded pageId cc)
-                                writeIORef (wsQuadCacheRef worldState) Nothing
+                                bumpQuadCacheGen worldState
                                 writeIORef (wsZoomQuadCacheRef worldState) Nothing
                                 writeIORef (wsBgQuadCacheRef worldState) Nothing
 
@@ -276,7 +276,7 @@ drainInitQueues env logger = do
                         _ ← evaluate (rnf toForce)
 
                         -- Invalidate all render caches so new chunks appear immediately
-                        writeIORef (wsQuadCacheRef worldState) Nothing
+                        bumpQuadCacheGen worldState
                         writeIORef (wsZoomQuadCacheRef worldState) Nothing
                         writeIORef (wsBgQuadCacheRef worldState) Nothing
 

--- a/src/World/Thread/Command.hs
+++ b/src/World/Thread/Command.hs
@@ -181,7 +181,7 @@ handleApplyFluidsCommand env (FluidWritebackBatch pageId writebacks mAck) = do
             Just ws → do
                 atomicModifyIORef' (wsTilesRef ws) $ \wtd →
                     (foldl' applyOneWriteback wtd writebacks, ())
-                writeIORef (wsQuadCacheRef ws)     Nothing
+                bumpQuadCacheGen ws
                 writeIORef (wsZoomQuadCacheRef ws) Nothing
                 writeIORef (wsBgQuadCacheRef ws)   Nothing
     forM_ mAck (`putMVar` ())

--- a/src/World/Thread/Command/Edit.hs
+++ b/src/World/Thread/Command/Edit.hs
@@ -109,7 +109,7 @@ handleWorldDeleteTileCommand env logger pageId gx gy = do
                         syncEditToSim env pageId lc'
                         -- Invalidate all three render caches so the next
                         -- tick rebuilds quads from the modified chunk.
-                        writeIORef (wsQuadCacheRef ws)     Nothing
+                        bumpQuadCacheGen ws
                         writeIORef (wsZoomQuadCacheRef ws) Nothing
                         writeIORef (wsBgQuadCacheRef ws)   Nothing
                         -- Re-snap any idle unit standing on this tile to
@@ -166,7 +166,7 @@ handleWorldAddTileCommand env logger pageId gx gy mat = do
                         atomicModifyIORef' (wsEditsRef ws) $ \es →
                             (appendEdit coord edit es, ())
                         syncEditToSim env pageId lc'
-                        writeIORef (wsQuadCacheRef ws)     Nothing
+                        bumpQuadCacheGen ws
                         writeIORef (wsZoomQuadCacheRef ws) Nothing
                         writeIORef (wsBgQuadCacheRef ws)   Nothing
                         -- Units standing on the tile ride up.
@@ -306,7 +306,7 @@ handleWorldSetSlopeCommand env logger pageId gx gy z bits = do
                         -- elevation nor fluid the sim reads, so there is no
                         -- stale sim state to refresh (#60), and re-seeding
                         -- would needlessly reset an in-flight fluid sim.
-                        writeIORef (wsQuadCacheRef ws)     Nothing
+                        bumpQuadCacheGen ws
                         writeIORef (wsZoomQuadCacheRef ws) Nothing
                         writeIORef (wsBgQuadCacheRef ws)   Nothing
                         logDebug logger CatWorld $
@@ -355,7 +355,7 @@ handleWorldSetCellCommand env logger pageId gx gy z mat = do
                         atomicModifyIORef' (wsEditsRef ws) $ \es →
                             (appendEdit coord edit es, ())
                         syncEditToSim env pageId lc'
-                        writeIORef (wsQuadCacheRef ws)     Nothing
+                        bumpQuadCacheGen ws
                         writeIORef (wsZoomQuadCacheRef ws) Nothing
                         writeIORef (wsBgQuadCacheRef ws)   Nothing
                         -- A surface-changing cell write (e.g. a staircase
@@ -524,7 +524,7 @@ handleWorldDigTileCommand env logger pageId gx gy ux uy amount skill percep = do
                                     let lc' = applyDigSlopeToChunk (gx, gy) md' lc
                                     atomicModifyIORef' (wsTilesRef ws) $ \w →
                                         (insertChunk lc' w, ())
-                                    writeIORef (wsQuadCacheRef ws)     Nothing
+                                    bumpQuadCacheGen ws
                                     writeIORef (wsZoomQuadCacheRef ws) Nothing
                                     writeIORef (wsBgQuadCacheRef ws)   Nothing
   where
@@ -624,7 +624,7 @@ promoteFullSpoilTiles env logger pageId ws startV = do
                             (appendEdit coord edit es, ())
                         atomicModifyIORef' (wsSpoilRef ws) $ \sp →
                             (debitPromotedTile tile sp, ())
-                        writeIORef (wsQuadCacheRef ws)     Nothing
+                        bumpQuadCacheGen ws
                         writeIORef (wsZoomQuadCacheRef ws) Nothing
                         writeIORef (wsBgQuadCacheRef ws)   Nothing
                         -- Anything standing on the tile rides up.
@@ -663,7 +663,7 @@ handleWorldSetFluidTileCommand env logger pageId gx gy fluidType = do
                     -- settles instead of being overwritten by stale sim
                     -- output (#60).
                     syncEditToSim env pageId lc'
-                    writeIORef (wsQuadCacheRef ws)     Nothing
+                    bumpQuadCacheGen ws
                     writeIORef (wsZoomQuadCacheRef ws) Nothing
                     writeIORef (wsBgQuadCacheRef ws)   Nothing
                     logDebug logger CatWorld $

--- a/src/World/Thread/Command/Texture.hs
+++ b/src/World/Thread/Command/Texture.hs
@@ -101,7 +101,7 @@ handleWorldSetTextureCommand env logger pageId texType texHandle = do
             -- (arena fast-boot), keep the new handles but force the next
             -- render to rebuild against them instead of reusing the old
             -- checkerboard-slot cache until the camera happens to move.
-            writeIORef (wsQuadCacheRef worldState) Nothing
+            bumpQuadCacheGen worldState
             writeIORef (wsZoomQuadCacheRef worldState) Nothing
             writeIORef (wsBgQuadCacheRef worldState) Nothing
             logDebug logger CatWorld $ 

--- a/src/World/Thread/Command/UI.hs
+++ b/src/World/Thread/Command/UI.hs
@@ -62,6 +62,13 @@ handleWorldShowCommand env logger pageId = do
         logDebug logger CatWorld $
             "Visible worlds after show: " <> T.pack (show $ length $ wmVisible mgr)
 
+        -- Force a quad-cache rebuild when a world becomes visible: a world
+        -- can have been cached while invisible (or before its textures
+        -- finished loading) and the render thread only rebuilds when the
+        -- generation no longer matches. Cheap insurance against showing a
+        -- world with a stale cache (#35).
+        forM_ (lookup pageId (wmWorlds mgr)) bumpQuadCacheGen
+
         -- Activate this world in the sim thread. The sim no longer holds the
         -- tile ref — it emits WorldApplyFluids back to the world thread (the
         -- sole writer of wsTilesRef) — so this is just a per-world "is


### PR DESCRIPTION
Closes #35.

## Problem
The world quad cache (`wsQuadCacheRef`) bakes the bindless texture **slot index** into each vertex. Structural world textures (`blanktexture`, iso/veg facemaps) load late and async, so the cache built at world creation baked slot 0 → the magenta "undefined" checkerboard for the terrain interior and empty facemaps. It didn't self-heal:

1. `invalidateVisibleWorldRenderCaches` only nulled caches for worlds **already in `wmVisible`**, missing a world whose textures landed before it was shown.
2. It nulled `wsQuadCacheRef` from the **Lua thread**, racing the **render thread's** read-rebuild-write of the same `IORef` — the render wrote back the stale cache it had started building, clobbering the invalidation.

A shipped Lua workaround (`scripts/world_view.lua` `structuralRebound`) polled `world.getInitProgress()` and re-bound the structural set once gen reported done, leaning on "chunk gen outlasts the texture loads" timing.

## Fix (engine-side)
- **Per-world generation counter** `wsQuadCacheGenRef`. All invalidation sites bump it atomically (`bumpQuadCacheGen`) instead of nulling the cache. A cache is valid only when its new `wqcGen` field matches the counter; the render thread snapshots the gen *before* building and stamps the rebuilt cache with it. An invalidation landing mid-build leaves the written-back cache stale (gen mismatch) → rebuild next frame, never lost. **The render thread is now the sole writer of `wsQuadCacheRef`** → no cross-thread clobber.
- **Texture-load invalidation sweeps all loaded worlds** (`wmWorlds`, not just `wmVisible`) → covers the not-yet-visible case.
- **World show bumps the gen** as cheap insurance against a stale cache on display.
- Converted all existing `writeIORef wsQuadCacheRef Nothing` sites (ChunkLoading, Texture, Command, Edit, Camera) to `bumpQuadCacheGen`. Zoom/background caches keep direct nulling (single writer, no rebuild race).

## Workaround removal
Removed the `structuralRebound` gen-poll one-shot from `world_view.lua` and `main_menu.lua`. The shared `rebindStructural` binder is **kept** — it's still used by the save-load `sendTexturesToWorld` path.

## Validation
- `cabal build all` — clean (lib + executable).
- `cabal test synarchy-test-headless` — **351 examples, 0 failures**.
- `python3 tools/test_audit.py` — 35 groups passed.
- No worldgen-output change → no baseline recapture, no save-version bump.

⚠️ **GUI verification needed:** the magenta-interior repro is GPU-only (headless does no GPU work, and small test worlds have no peaks above the z-slice to draw the blank quads). Please create a world with mountains and confirm the interior comes up grey with facemaps once gen finishes, with no persistent magenta flash — and that a loaded save (#64 path) likewise renders correctly. If anything regresses, restoring the 8-line Lua one-shot is trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)