### PR TITLE
[keybinds] C — Keybind Lua API (#276)

### DIFF
--- a/src/Engine/Scripting/Lua/API.hs
+++ b/src/Engine/Scripting/Lua/API.hs
@@ -33,7 +33,10 @@ import Engine.Scripting.Lua.API.Input (isKeyDownFn, isActionDownFn,
                                        getMousePositionFn,
                                        isMouseButtonDownFn, getWindowSizeFn, 
                                        getFramebufferSizeFn, getWorldCoordFn)
-import Engine.Scripting.Lua.API.Text (loadFontFn, spawnTextFn, setTextFn, 
+import Engine.Scripting.Lua.API.Keybinds (getKeybindsFn, setActionKeysFn,
+                                          addActionKeyFn, removeActionKeyFn,
+                                          saveKeybindsFn, loadDefaultKeybindsFn)
+import Engine.Scripting.Lua.API.Text (loadFontFn, spawnTextFn, setTextFn,
                                        getTextFn, getTextWidthFn)
 import Engine.Scripting.Lua.API.Focus (registerFocusableFn, requestFocusFn, 
                                         releaseFocusFn, getFocusIdFn)
@@ -173,7 +176,14 @@ registerLuaAPI lst env backendState = Lua.runWith lst $ do
   registerLuaFunction "getWindowSize"     (getWindowSizeFn env backendState)
   registerLuaFunction "getFramebufferSize" (getFramebufferSizeFn env backendState)
   registerLuaFunction "getWorldCoord"     (getWorldCoordFn env backendState)
-  
+
+  registerLuaFunction "getKeybinds"        (getKeybindsFn env)
+  registerLuaFunction "setActionKeys"      (setActionKeysFn env)
+  registerLuaFunction "addActionKey"       (addActionKeyFn env)
+  registerLuaFunction "removeActionKey"    (removeActionKeyFn env)
+  registerLuaFunction "saveKeybinds"       (saveKeybindsFn env)
+  registerLuaFunction "loadDefaultKeybinds" (loadDefaultKeybindsFn env)
+
   registerLuaFunction "loadFont"     (loadFontFn env backendState)
   registerLuaFunction "spawnText"    (spawnTextFn env backendState)
   registerLuaFunction "setText"      (setTextFn env)

--- a/src/Engine/Scripting/Lua/API/Keybinds.hs
+++ b/src/Engine/Scripting/Lua/API/Keybinds.hs
@@ -1,0 +1,149 @@
+{-# LANGUAGE Strict, UnicodeSyntax, OverloadedStrings #-}
+-- | Lua bindings for the keybinding system. Exposes 'keyBindingsRef' to
+--   Lua so the Input settings UI can read and edit bindings.
+--
+--   The action → @[key]@ model lives in "Engine.Input.Bindings"; this
+--   module is a thin Lua façade over it. Key names are validated through
+--   'textToKey' (the canonical vocabulary), and @Escape@ / @Grave@ are
+--   refused — they are engine-hardcoded (escape cascade, shell toggle)
+--   and must never be reassigned.
+module Engine.Scripting.Lua.API.Keybinds
+  ( getKeybindsFn
+  , setActionKeysFn
+  , addActionKeyFn
+  , removeActionKeyFn
+  , saveKeybindsFn
+  , loadDefaultKeybindsFn
+  ) where
+
+import UPrelude
+import qualified HsLua as Lua
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Data.IORef (readIORef, writeIORef, atomicModifyIORef')
+import Engine.Core.State (EngineEnv(..))
+import Engine.Input.Bindings (KeyBindings, loadKeyBindings, saveKeyBindings)
+import Engine.Input.Types (textToKey)
+
+-- | A key name is bindable when it parses to a real key AND is not one of
+--   the two engine-reserved names. Rejecting them here means no action can
+--   ever capture Escape or Grave, regardless of which action is edited.
+isBindableKey ∷ Text → Bool
+isBindableKey k = k /= "Escape" ∧ k /= "Grave" ∧ isJust (textToKey k)
+
+-- | Push a 'KeyBindings' map as a Lua table @{ action = { key1, ... } }@.
+--   Leaves exactly one value (the outer table) on the stack.
+pushBindings ∷ KeyBindings → Lua.LuaE Lua.Exception ()
+pushBindings bindings = do
+    Lua.newtable
+    forM_ (Map.toList bindings) $ \(action, keys) → do
+        Lua.newtable
+        forM_ (zip [1..] keys) $ \(i, k) → do
+            Lua.pushstring (TE.encodeUtf8 k)
+            Lua.rawseti (-2) i
+        Lua.setfield (-2) (Lua.Name (TE.encodeUtf8 action))
+
+-- | Read a Lua string array at the given stack index into @[Text]@.
+--   Non-string / non-table entries are skipped; a non-table arg yields [].
+readKeyList ∷ Lua.StackIndex → Lua.LuaE Lua.Exception [Text]
+readKeyList idx = do
+    n ← Lua.rawlen idx
+    let go i acc
+          | i > fromIntegral n = return (reverse acc)
+          | otherwise = do
+              _ ← Lua.rawgeti idx i
+              m ← Lua.tostring (-1)
+              Lua.pop 1
+              case m of
+                  Just bs → go (i + 1) (TE.decodeUtf8 bs : acc)
+                  Nothing → go (i + 1) acc
+    go 1 []
+
+-- | engine.getKeybinds() → { action = { key1, key2, ... }, ... }
+getKeybindsFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+getKeybindsFn env = do
+    bindings ← Lua.liftIO $ readIORef (keyBindingsRef env)
+    pushBindings bindings
+    return 1
+
+-- | engine.setActionKeys(action, {keys}) → bool
+--   Replace an action's key list. Rejected (no change, returns false) if
+--   any key is invalid or reserved. An empty list is allowed (unbinds the
+--   action). The action need not already exist.
+setActionKeysFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+setActionKeysFn env = do
+    actionArg ← Lua.tostring 1
+    keys ← readKeyList 2
+    case actionArg of
+        Just actionBS | all isBindableKey keys → do
+            let action = TE.decodeUtf8 actionBS
+            Lua.liftIO $ atomicModifyIORef' (keyBindingsRef env) $ \b →
+                (Map.insert action keys b, ())
+            Lua.pushboolean True
+        _ → Lua.pushboolean False
+    return 1
+
+-- | engine.addActionKey(action, key) → bool
+--   Append a key to an action (creating the action if absent). No-op if the
+--   key is already bound to that action. Rejected if the key is invalid.
+addActionKeyFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+addActionKeyFn env = do
+    actionArg ← Lua.tostring 1
+    keyArg ← Lua.tostring 2
+    case (actionArg, keyArg) of
+        (Just actionBS, Just keyBS) | isBindableKey (TE.decodeUtf8 keyBS) → do
+            let action = TE.decodeUtf8 actionBS
+                key    = TE.decodeUtf8 keyBS
+            Lua.liftIO $ atomicModifyIORef' (keyBindingsRef env) $ \b →
+                let cur = Map.findWithDefault [] action b
+                    new = if key `elem` cur then cur else cur ++ [key]
+                in (Map.insert action new b, ())
+            Lua.pushboolean True
+        _ → Lua.pushboolean False
+    return 1
+
+-- | engine.removeActionKey(action, key) → bool
+--   Remove a key from an action's list. Returns false if the action or key
+--   was not present (nothing changed). The action entry is kept even when
+--   its list becomes empty (an action with no keys is simply unbound).
+removeActionKeyFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+removeActionKeyFn env = do
+    actionArg ← Lua.tostring 1
+    keyArg ← Lua.tostring 2
+    case (actionArg, keyArg) of
+        (Just actionBS, Just keyBS) → do
+            let action = TE.decodeUtf8 actionBS
+                key    = TE.decodeUtf8 keyBS
+            changed ← Lua.liftIO $ atomicModifyIORef' (keyBindingsRef env) $ \b →
+                case Map.lookup action b of
+                    Just cur | key `elem` cur →
+                        (Map.insert action (filter (/= key) cur) b, True)
+                    _ → (b, False)
+            Lua.pushboolean changed
+        _ → Lua.pushboolean False
+    return 1
+
+-- | engine.saveKeybinds() → bool
+--   Persist the live bindings to config/keybinds.yaml.
+saveKeybindsFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+saveKeybindsFn env = do
+    Lua.liftIO $ do
+        bindings ← readIORef (keyBindingsRef env)
+        logger ← readIORef (loggerRef env)
+        saveKeyBindings logger "config/keybinds.yaml" bindings
+    Lua.pushboolean True
+    return 1
+
+-- | engine.loadDefaultKeybinds() → { action = { keys } }
+--   Load config/keybinds_default.yaml into the live ref (for a Reset
+--   action) and return the resulting table.
+loadDefaultKeybindsFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+loadDefaultKeybindsFn env = do
+    bindings ← Lua.liftIO $ do
+        logger ← readIORef (loggerRef env)
+        defaults ← loadKeyBindings logger "config/keybinds_default.yaml"
+        writeIORef (keyBindingsRef env) defaults
+        return defaults
+    pushBindings bindings
+    return 1

--- a/src/Engine/Scripting/Lua/API/Keybinds.hs
+++ b/src/Engine/Scripting/Lua/API/Keybinds.hs
@@ -32,6 +32,16 @@ import Engine.Input.Types (textToKey)
 isBindableKey ∷ Text → Bool
 isBindableKey k = k /= "Escape" ∧ k /= "Grave" ∧ isJust (textToKey k)
 
+-- | Actions whose keys the engine handles outside the binding table
+--   (Escape cascade, Grave shell toggle — see "Engine.Input.Thread").
+--   Editing them would persist a config the runtime cannot honor, so the
+--   edit functions refuse them outright.
+reservedActions ∷ [Text]
+reservedActions = ["escape", "openShell"]
+
+isEditableAction ∷ Text → Bool
+isEditableAction a = a `notElem` reservedActions
+
 -- | Push a 'KeyBindings' map as a Lua table @{ action = { key1, ... } }@.
 --   Leaves exactly one value (the outer table) on the stack.
 pushBindings ∷ KeyBindings → Lua.LuaE Lua.Exception ()
@@ -44,21 +54,30 @@ pushBindings bindings = do
             Lua.rawseti (-2) i
         Lua.setfield (-2) (Lua.Name (TE.encodeUtf8 action))
 
--- | Read a Lua string array at the given stack index into @[Text]@.
---   Non-string / non-table entries are skipped; a non-table arg yields [].
-readKeyList ∷ Lua.StackIndex → Lua.LuaE Lua.Exception [Text]
+-- | Strictly read a Lua string array at the given stack index into
+--   @[Text]@. Returns 'Nothing' (caller rejects the whole call) if the
+--   argument is not a table or if *any* element is not a string — so a
+--   partial/garbage list never produces a partial update. An empty table
+--   yields @Just []@ (a valid unbind).
+readKeyList ∷ Lua.StackIndex → Lua.LuaE Lua.Exception (Maybe [Text])
 readKeyList idx = do
-    n ← Lua.rawlen idx
-    let go i acc
-          | i > fromIntegral n = return (reverse acc)
-          | otherwise = do
-              _ ← Lua.rawgeti idx i
-              m ← Lua.tostring (-1)
-              Lua.pop 1
-              case m of
-                  Just bs → go (i + 1) (TE.decodeUtf8 bs : acc)
-                  Nothing → go (i + 1) acc
-    go 1 []
+    isT ← Lua.istable idx
+    if not isT
+      then return Nothing
+      else do
+        n ← Lua.rawlen idx
+        let go i acc
+              | i > fromIntegral n = return (Just (reverse acc))
+              | otherwise = do
+                  _ ← Lua.rawgeti idx i
+                  ty ← Lua.ltype (-1)
+                  ms ← if ty ≡ Lua.TypeString then Lua.tostring (-1)
+                                              else return Nothing
+                  Lua.pop 1
+                  case ms of
+                      Just bs → go (i + 1) (TE.decodeUtf8 bs : acc)
+                      Nothing → return Nothing
+        go 1 []
 
 -- | engine.getKeybinds() → { action = { key1, key2, ... }, ... }
 getKeybindsFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
@@ -69,14 +88,17 @@ getKeybindsFn env = do
 
 -- | engine.setActionKeys(action, {keys}) → bool
 --   Replace an action's key list. Rejected (no change, returns false) if
---   any key is invalid or reserved. An empty list is allowed (unbinds the
+--   the action is reserved, the second arg is not a string-table, or any
+--   key is invalid/reserved. An empty list is allowed (unbinds the
 --   action). The action need not already exist.
 setActionKeysFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 setActionKeysFn env = do
     actionArg ← Lua.tostring 1
-    keys ← readKeyList 2
-    case actionArg of
-        Just actionBS | all isBindableKey keys → do
+    mkeys ← readKeyList 2
+    case (actionArg, mkeys) of
+        (Just actionBS, Just keys)
+          | isEditableAction (TE.decodeUtf8 actionBS)
+          , all isBindableKey keys → do
             let action = TE.decodeUtf8 actionBS
             Lua.liftIO $ atomicModifyIORef' (keyBindingsRef env) $ \b →
                 (Map.insert action keys b, ())
@@ -86,13 +108,16 @@ setActionKeysFn env = do
 
 -- | engine.addActionKey(action, key) → bool
 --   Append a key to an action (creating the action if absent). No-op if the
---   key is already bound to that action. Rejected if the key is invalid.
+--   key is already bound to that action. Rejected if the action is reserved
+--   or the key is invalid.
 addActionKeyFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 addActionKeyFn env = do
     actionArg ← Lua.tostring 1
     keyArg ← Lua.tostring 2
     case (actionArg, keyArg) of
-        (Just actionBS, Just keyBS) | isBindableKey (TE.decodeUtf8 keyBS) → do
+        (Just actionBS, Just keyBS)
+          | isEditableAction (TE.decodeUtf8 actionBS)
+          , isBindableKey (TE.decodeUtf8 keyBS) → do
             let action = TE.decodeUtf8 actionBS
                 key    = TE.decodeUtf8 keyBS
             Lua.liftIO $ atomicModifyIORef' (keyBindingsRef env) $ \b →
@@ -104,15 +129,17 @@ addActionKeyFn env = do
     return 1
 
 -- | engine.removeActionKey(action, key) → bool
---   Remove a key from an action's list. Returns false if the action or key
---   was not present (nothing changed). The action entry is kept even when
---   its list becomes empty (an action with no keys is simply unbound).
+--   Remove a key from an action's list. Returns false if the action is
+--   reserved, or if the action or key was not present (nothing changed).
+--   The action entry is kept even when its list becomes empty (an action
+--   with no keys is simply unbound).
 removeActionKeyFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 removeActionKeyFn env = do
     actionArg ← Lua.tostring 1
     keyArg ← Lua.tostring 2
     case (actionArg, keyArg) of
-        (Just actionBS, Just keyBS) → do
+        (Just actionBS, Just keyBS)
+          | isEditableAction (TE.decodeUtf8 actionBS) → do
             let action = TE.decodeUtf8 actionBS
                 key    = TE.decodeUtf8 keyBS
             changed ← Lua.liftIO $ atomicModifyIORef' (keyBindingsRef env) $ \b →

--- a/src/Engine/Scripting/Lua/API/Keybinds.hs
+++ b/src/Engine/Scripting/Lua/API/Keybinds.hs
@@ -54,30 +54,56 @@ pushBindings bindings = do
             Lua.rawseti (-2) i
         Lua.setfield (-2) (Lua.Name (TE.encodeUtf8 action))
 
+-- | Count every entry in a Lua table (array part *and* associative part)
+--   by full traversal. Reads only key/value *presence*, never converting
+--   a key (lua_tostring on a numeric key mutates it in place and breaks
+--   the following lua_next).
+tableEntryCount ∷ Lua.StackIndex → Lua.LuaE Lua.Exception Int
+tableEntryCount idx = do
+    Lua.pushvalue idx   -- work on a copy so a relative index stays stable
+    Lua.pushnil         -- first key
+    let loop c = do
+          more ← Lua.next (-2)
+          if not more
+            then Lua.pop 1 >> return c   -- pop the table copy; done
+            else Lua.pop 1 >> loop (c + 1)  -- pop value, keep key for next
+    loop (0 ∷ Int)
+
 -- | Strictly read a Lua string array at the given stack index into
 --   @[Text]@. Returns 'Nothing' (caller rejects the whole call) if the
---   argument is not a table or if *any* element is not a string — so a
---   partial/garbage list never produces a partial update. An empty table
---   yields @Just []@ (a valid unbind).
+--   argument is not a table, is not a pure sequence (any non-array /
+--   associative key), or has any non-string element — so a partial or
+--   malformed list never produces a partial update. An empty table yields
+--   @Just []@ (a valid unbind).
+--
+--   The pure-sequence check compares the dense length ('rawlen') against
+--   the total entry count: any extra associative key (e.g. @{ "W", x=1 }@)
+--   or a stray non-array key (e.g. @{ foo = "W" }@) makes the counts
+--   differ and is rejected. The element loop then rejects holes (a nil in
+--   the @1..n@ range) and any non-string value.
 readKeyList ∷ Lua.StackIndex → Lua.LuaE Lua.Exception (Maybe [Text])
 readKeyList idx = do
     isT ← Lua.istable idx
     if not isT
       then return Nothing
       else do
-        n ← Lua.rawlen idx
-        let go i acc
-              | i > fromIntegral n = return (Just (reverse acc))
-              | otherwise = do
-                  _ ← Lua.rawgeti idx i
-                  ty ← Lua.ltype (-1)
-                  ms ← if ty ≡ Lua.TypeString then Lua.tostring (-1)
-                                              else return Nothing
-                  Lua.pop 1
-                  case ms of
-                      Just bs → go (i + 1) (TE.decodeUtf8 bs : acc)
-                      Nothing → return Nothing
-        go 1 []
+        n     ← Lua.rawlen idx
+        total ← tableEntryCount idx
+        if total ≠ fromIntegral n
+          then return Nothing   -- associative / mixed table → reject
+          else do
+            let go i acc
+                  | i > fromIntegral n = return (Just (reverse acc))
+                  | otherwise = do
+                      _ ← Lua.rawgeti idx i
+                      ty ← Lua.ltype (-1)
+                      ms ← if ty ≡ Lua.TypeString then Lua.tostring (-1)
+                                                  else return Nothing
+                      Lua.pop 1
+                      case ms of
+                          Just bs → go (i + 1) (TE.decodeUtf8 bs : acc)
+                          Nothing → return Nothing
+            go 1 []
 
 -- | engine.getKeybinds() → { action = { key1, key2, ... }, ... }
 getKeybindsFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -343,6 +343,7 @@ library
                      Engine.Scripting.Lua.API.PlayerEvent
                      Engine.Scripting.Lua.API.Graphics
                      Engine.Scripting.Lua.API.Input
+                     Engine.Scripting.Lua.API.Keybinds
                      Engine.Scripting.Lua.API.Text
                      Engine.Scripting.Lua.API.Focus
                      Engine.Scripting.Lua.API.Shell


### PR DESCRIPTION
Closes #276. Part of epic #273; builds on the multi-key data model from #274.

## What
New module `Engine.Scripting.Lua.API.Keybinds` exposing the keybinding system to Lua, so the Input settings UI (#277) can read and edit bindings.

Functions on the `engine` table:
- `engine.getKeybinds()` → `{ action = { key1, key2, ... }, ... }` from `keyBindingsRef`
- `engine.setActionKeys(action, {keys})` — replace an action's key list
- `engine.addActionKey(action, key)` / `engine.removeActionKey(action, key)`
- `engine.saveKeybinds()` — write `keyBindingsRef` to `config/keybinds.yaml` via `saveKeyBindings`
- `engine.loadDefaultKeybinds()` — load `config/keybinds_default.yaml` into `keyBindingsRef` (for a Reset action), returning the table

## Validation rules
- Key names validated via `Engine.Input.Types.textToKey`; unknown names rejected.
- `Escape` and `Grave` are rejected everywhere — engine-hardcoded (escape cascade / shell toggle), never bindable.
- `setActionKeys` validates **all** keys before applying: a list containing any invalid key is rejected wholesale (returns `false`, no change). An empty list is allowed (unbinds the action).
- `addActionKey` dedups (no duplicate keys per action); `removeActionKey` returns `false` if the action/key wasn't present.
- Rejected calls return `false` and never mutate the live bindings.

## Testing
Acceptance per the issue — headless Lua console round-trip:
- `getKeybinds` → `addActionKey`/`removeActionKey`/`setActionKeys` → `saveKeybinds` persists to `keybinds.yaml` (verified on-disk), `loadDefaultKeybinds` resets the live ref to defaults.
- Invalid / `Escape` / `Grave` keys return `false` and leave bindings unchanged.

Regression gate: `cabal test synarchy-test-headless` — 369 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)