### PR TITLE
Fix #224: exposed hard rock slopes & reads as jagged peaks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ cabal run exe:synarchy -- --dump --seed 1337 --worldSize 256 --plates 5 --region
 cabal run exe:synarchy -- --dump=ice,terrain --seed 42 --region -3,-3,3,3 2>/dev/null | python3 analyze.py
 ```
 
-**Layer names:** `terrain` (or `elevation`), `material`, `fluid`, `ice`, `ore`. No argument = all layers.
+**Layer names:** `terrain` (or `elevation`), `material`, `fluid`, `ice`, `ore`. No argument = those five. `slope` is **opt-in only** (`--dump=...,slope`) so a bare `--dump` stays byte-identical to historical output (the worldgen baselines + determinism/audit tools all drive a bare `--dump`).
 
 **Output format:** JSON array with one object per tile in the region. Region coordinates are **chunk coords** (not tile coords).
 
@@ -168,6 +168,7 @@ Per-tile fields (present when layer is enabled):
 | `fluidType`, `fluidSurf` | fluid | "ocean"/"lake"/"river"/"lava" or null |
 | `iceSurf`, `iceMode` | ice | Ice surface Z and "basin"/"drape" or null |
 | `oreId`, `oreTopZ`, `oreCount` | ore | Topmost ore band in the column: material id, its top z, cells of it (null/0 if none) |
+| `slope`, `hardness` | slope | Surface tile slope bitmask (bit0=N,1=E,2=S,3=W; 0=flat) and its surface-material hardness. Drives `tools/slope_report.py` (#224 sloping metric). |
 | `glacierZone`, `beyondGlacier` | always | World boundary flags |
 
 For cross-seed ore statistics (coverage, depth, deposit sizes) use

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -20,6 +20,8 @@ import World.Generate.Types (WorldGenParams(..))
 import World.Generate.Config (minimumWorldSize, normalizeWorldSize
                              , normalizePlateCount)
 import World.Geology.Ore (oreMaterialIds)
+import World.Material (getMaterialProps, MaterialProps(..)
+                      , MaterialId(..), MaterialRegistry)
 import World.Geology.Ore.Types (wodByChunk)
 import World.Geology.Timeline.Types (GeoTimeline(..))
 import World.Fluid.Lake.Types (WorldLakes(..), lkArea)
@@ -68,11 +70,16 @@ data DumpLayers = DumpLayers
     , dlFluid    ∷ !Bool
     , dlIce      ∷ !Bool
     , dlOre      ∷ !Bool
+    , dlSlope    ∷ !Bool
     } deriving (Show)
 
--- | All layers enabled (default when --dump has no =value).
+-- | Default layers (when --dump has no =value): the original five. The
+--   slope layer is OPT-IN only (--dump=...,slope) so a bare --dump stays
+--   byte-identical to historical output — the worldgen baselines and the
+--   determinism/audit tools all drive a bare --dump and must not see new
+--   fields.
 allLayers ∷ DumpLayers
-allLayers = DumpLayers True True True True True
+allLayers = DumpLayers True True True True True False
 
 -- | Parse --dump or --dump=layer1,layer2,... from args.
 --   Returns Nothing if --dump not present, Just layers otherwise.
@@ -88,6 +95,7 @@ parseDump (a:rest)
             , dlFluid    = "fluid"    `elem` flags
             , dlIce      = "ice"      `elem` flags
             , dlOre      = "ore"      `elem` flags
+            , dlSlope    = "slope"    `elem` flags
             }
     | otherwise = parseDump rest
 
@@ -402,7 +410,8 @@ runDump layers seed worldSize plateCount (cx1, cy1, cx2, cy2) = do
                     let climate = maybe (initClimateState worldSize)
                                      wgpClimateState mParams
                     td ← readIORef (wsTilesRef ws)
-                    let json = dumpTilesJSON layers worldSize climate td cx1 cy1 cx2 cy2
+                    registry ← readIORef (materialRegistryRef env')
+                    let json = dumpTilesJSON layers registry worldSize climate td cx1 cy1 cx2 cy2
                     -- Phase 1 sanity print: how many lakes did the
                     -- global flood produce, how many chunks they
                     -- touch.
@@ -537,9 +546,9 @@ pollsPerSecond = 1000000 `div` pollInterval
 -- | Dump per-tile data in a chunk region as JSON.
 --   Every tile in the region gets one object. Fields are included
 --   based on the DumpLayers whitelist.
-dumpTilesJSON ∷ DumpLayers → Int → ClimateState → WorldTileData
+dumpTilesJSON ∷ DumpLayers → MaterialRegistry → Int → ClimateState → WorldTileData
               → Int → Int → Int → Int → BS.ByteString
-dumpTilesJSON layers worldSize climate td cx1 cy1 cx2 cy2 =
+dumpTilesJSON layers registry worldSize climate td cx1 cy1 cx2 cy2 =
     let entries = concatMap dumpChunkTiles
             [ ChunkCoord x y | x ← [cx1..cx2], y ← [cy1..cy2] ]
     in BS.pack $ "[" ⧺ intercalate "," entries ⧺ "]\n"
@@ -614,11 +623,26 @@ dumpTilesJSON layers worldSize climate td cx1 cy1 cx2 cy2 =
                            ⧺ ",\"oreTopZ\":" ⧺ show (ctStartZ col + topOreIdx)
                            ⧺ ",\"oreCount\":" ⧺ show cnt
               | otherwise = ""
+            -- Slope layer: the rendered slope bitmask of the surface
+            -- tile (bit0=N,1=E,2=S,3=W; 0 = flat top). Lets headless
+            -- tools measure how often terrain slopes vs. steps (#224).
+            slopeFields
+              | dlSlope layers =
+                  let col = lcTiles lc V.! idx
+                      i   = surfZ - ctStartZ col
+                      sl  = if i ≥ 0 ∧ i < VU.length (ctSlopes col)
+                            then ctSlopes col VU.! i else 0
+                      smat = if i ≥ 0 ∧ i < VU.length (ctMats col)
+                             then ctMats col VU.! i else 0
+                      hard = mpHardness (getMaterialProps registry (MaterialId smat))
+                  in ",\"slope\":" ⧺ show sl
+                   ⧺ ",\"hardness\":" ⧺ show hard
+              | otherwise = ""
             zoneFields =
                   ",\"glacierZone\":" ⧺ boolStr (isGlacierZone worldSize gx gy)
                 ⧺ ",\"beyondGlacier\":" ⧺ boolStr (isBeyondGlacier worldSize gx gy)
         in base ⧺ terrainFields ⧺ matFields ⧺ fluidFields
-                ⧺ iceFields ⧺ oreFields ⧺ zoneFields ⧺ "}"
+                ⧺ iceFields ⧺ oreFields ⧺ slopeFields ⧺ zoneFields ⧺ "}"
 
     fluidTypeStr Ocean = "ocean"
     fluidTypeStr Lake  = "lake"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -626,10 +626,15 @@ dumpTilesJSON layers registry worldSize climate td cx1 cy1 cx2 cy2 =
             -- Slope layer: the rendered slope bitmask of the surface
             -- tile (bit0=N,1=E,2=S,3=W; 0 = flat top). Lets headless
             -- tools measure how often terrain slopes vs. steps (#224).
+            -- NB: index by terrainZ, not surfZ. The strata vectors
+            -- (ctSlopes/ctMats) are keyed to the TERRAIN surface; surfZ is
+            -- max(terrain, fluid), so on submerged tiles surfZ overshoots
+            -- the stored range and would report a spurious flat/empty bed.
+            -- terrainZ gives the real bed slope + bed material everywhere.
             slopeFields
               | dlSlope layers =
                   let col = lcTiles lc V.! idx
-                      i   = surfZ - ctStartZ col
+                      i   = terrainZ - ctStartZ col
                       sl  = if i ≥ 0 ∧ i < VU.length (ctSlopes col)
                             then ctSlopes col VU.! i else 0
                       smat = if i ≥ 0 ∧ i < VU.length (ctMats col)

--- a/src/World/Generate/Chunk.hs
+++ b/src/World/Generate/Chunk.hs
@@ -1210,8 +1210,15 @@ generateChunk registry catalog params coord =
         noNeighborLookup ∷ ChunkCoord → Maybe (VU.Vector Int)
         noNeighborLookup _ = Nothing
 
+        -- Initial single-chunk gen sees no neighbours; the cross-chunk
+        -- slope recompute (recomputeNeighborSlopes) re-slides the border
+        -- strip once neighbours load, supplying the real fluid lookup.
+        noFluidNeighborLookup ∷ ChunkCoord → Maybe (V.Vector (Maybe FluidCell))
+        noFluidNeighborLookup _ = Nothing
+
         slopedTiles = computeChunkSlopes seed coord terrainSurfaceMap registry
                                          fluidMap rawChunk noNeighborLookup
+                                         noFluidNeighborLookup
 
         -- Extract surface material and slope for vegetation computation
         surfaceMatsRaw = VU.generate chunkArea $ \idx →

--- a/src/World/Slope.hs
+++ b/src/World/Slope.hs
@@ -180,6 +180,15 @@ computeTileSlope seed coord lx ly z registry surfMap fluidMap tiles neighborLook
         bitS = slopeBit myHasFluid z neighS lx (ly + 1) coord fluidMap neighborLookup
         bitW = slopeBit myHasFluid z neighW (lx - 1) ly coord fluidMap neighborLookup
 
+        -- Is each cardinal neighbour a WET tile (in-chunk only, mirroring
+        -- 'slopeBit')? The dry-rock jagged path must honour the same bank
+        -- rule as dry land — never slope a dry tile into a water neighbour
+        -- (it would read as rock dipping into the river/lake/sea).
+        wetN = neighborHasFluidAt coord lx (ly - 1) fluidMap
+        wetE = neighborHasFluidAt coord (lx + 1) ly fluidMap
+        wetS = neighborHasFluidAt coord lx (ly + 1) fluidMap
+        wetW = neighborHasFluidAt coord (lx - 1) ly fluidMap
+
         rawSlope = (if bitN then 1 else 0)
                .|. (if bitE then 2 else 0)
                .|. (if bitS then 4 else 0)
@@ -209,7 +218,7 @@ computeTileSlope seed coord lx ly z registry surfMap fluidMap tiles neighborLook
             -- Exposed hard rock (the material the soft gate bars). #224:
             -- make mountain flanks slope and peaks read as jagged rock.
             else rockJaggedSlope seed coord lx ly hardness z maxDrop rawSlope
-                                 neighN neighE neighS neighW
+                                 neighN neighE neighS neighW wetN wetE wetS wetW
 
 -- | Slope rule for EXPOSED HARD ROCK — material at/above
 --   'slopeHardnessThreshold', which the soft-terrain gate in
@@ -232,13 +241,15 @@ computeTileSlope seed coord lx ly z registry surfMap fluidMap tiles neighborLook
 --        even where no neighbour is exactly one lower (steep multi-level
 --        faces) — the case the strict terrace rule leaves flat.
 --
---   The ramp only ever points at a strictly-lower neighbour, so it stays
---   a geometrically valid (and pathing-walkable) ramp — never a notch
---   into a higher wall.
+--   The ramp only ever points at a strictly-lower DRY neighbour, so it
+--   stays a geometrically valid (and pathing-walkable) ramp — never a
+--   notch into a higher wall, and never a dry tile dipping into water
+--   (the dry-land bank rule, honoured here via the @wet*@ flags).
 rockJaggedSlope ∷ Word64 → ChunkCoord → Int → Int → Float → Int → Int → Word8
-                → Int → Int → Int → Int → Word8
+                → Int → Int → Int → Int
+                → Bool → Bool → Bool → Bool → Word8
 rockJaggedSlope seed (ChunkCoord cx cy) lx ly hardness z maxDrop rawSlope
-                neighN neighE neighS neighW
+                neighN neighE neighS neighW wetN wetE wetS wetW
     | maxDrop < 1 = 0   -- no downhill neighbour: flat-topped rock, blocky
     | otherwise =
         let h    = tileHash seed cx cy lx ly
@@ -248,10 +259,15 @@ rockJaggedSlope seed (ChunkCoord cx cy) lx ly hardness z maxDrop rawSlope
                 + (hardness - slopeHardnessThreshold) * rockJaggedHardK
                 + reliefNorm * rockJaggedReliefK
             -- Candidate ramp directions: strictly-lower cardinal
-            -- neighbours. maxDrop ≥ 1 guarantees this list is non-empty.
-            cand = [ b | (b, nz) ← [ (1 ∷ Word8, neighN), (2, neighE)
-                                   , (4, neighS), (8, neighW) ]
-                       , nz ≠ minBound, nz < z ]
+            -- neighbours that are NOT wet (bank rule). May be empty if the
+            -- only downhill neighbour is water — then we fall through to
+            -- 'rawSlope', which already excludes wet neighbours, so a dry
+            -- rock at a water edge stays blocky.
+            cand = [ b | (b, nz, wet) ← [ (1 ∷ Word8, neighN, wetN)
+                                        , (2, neighE, wetE)
+                                        , (4, neighS, wetS)
+                                        , (8, neighW, wetW) ]
+                       , nz ≠ minBound, nz < z, not wet ]
         in if roll < jaggedChance ∧ not (null cand)
            then cand !! fromIntegral ((h `shiftR` 8) `mod`
                                       fromIntegral (length cand))
@@ -323,6 +339,20 @@ normalizeCoord ∷ ChunkCoord → Int → Int → (Int, Int, ChunkCoord)
 normalizeCoord coord lx ly =
     let (c, (lx', ly')) = normalizeToChunk coord lx ly
     in (lx', ly', c)
+
+-- | Does the cardinal neighbour at local (nlx, nly) hold a fluid cell?
+--   Only IN-CHUNK neighbours are inspected (cross-chunk fluid isn't
+--   visible from this chunk's 'fluidMap') — exactly the convention
+--   'slopeBit' already uses for its dry-land bank rule, so the jagged
+--   path stays consistent with it.
+neighborHasFluidAt ∷ ChunkCoord → Int → Int → V.Vector (Maybe FluidCell) → Bool
+neighborHasFluidAt coord nlx nly fluidMap =
+    let (normLx, normLy, neighborCoord) = normalizeCoord coord nlx nly
+    in case neighborCoord of
+        c | c ≡ coord → case fluidMap V.! columnIndex normLx normLy of
+                            Just _  → True
+                            Nothing → False
+        _ → False
 
 floorDiv' ∷ Int → Int → Int
 floorDiv' a b = floor (fromIntegral a / fromIntegral b ∷ Double)

--- a/src/World/Slope.hs
+++ b/src/World/Slope.hs
@@ -97,8 +97,10 @@ perimeterColumnSet = HS.fromList
 recomputeColumnSlope ∷ Word64 → ChunkCoord → VU.Vector Int → MaterialRegistry
                      → V.Vector (Maybe FluidCell) → Chunk
                      → (ChunkCoord → Maybe (VU.Vector Int))
+                     → (ChunkCoord → Maybe (V.Vector (Maybe FluidCell)))
                      → Int → ColumnTiles → ColumnTiles
-recomputeColumnSlope seed coord surfMap registry fluidMap chunk neighborLookup idx col =
+recomputeColumnSlope seed coord surfMap registry fluidMap chunk
+                     neighborLookup fluidNeighborLookup idx col =
     let lx = idx `mod` chunkSize
         ly = idx `div` chunkSize
         surfZ = surfMap VU.! idx
@@ -108,16 +110,19 @@ recomputeColumnSlope seed coord surfMap registry fluidMap chunk neighborLookup i
                                             surfZ registry
                                             surfMap fluidMap
                                             chunk neighborLookup
+                                            fluidNeighborLookup
             in col { ctSlopes = ctSlopes col VU.// [(i, newSlope)] }
        else col
 
 -- | Recompute every column's surface slope (initial chunk gen).
 computeChunkSlopes ∷ Word64 → ChunkCoord → VU.Vector Int → MaterialRegistry
                    → V.Vector (Maybe FluidCell) → Chunk
-                   → (ChunkCoord → Maybe (VU.Vector Int)) → Chunk
-computeChunkSlopes seed coord surfMap registry fluidMap chunk neighborLookup =
+                   → (ChunkCoord → Maybe (VU.Vector Int))
+                   → (ChunkCoord → Maybe (V.Vector (Maybe FluidCell))) → Chunk
+computeChunkSlopes seed coord surfMap registry fluidMap chunk
+                   neighborLookup fluidNeighborLookup =
     V.imap (recomputeColumnSlope seed coord surfMap registry fluidMap
-                                 chunk neighborLookup) chunk
+                                 chunk neighborLookup fluidNeighborLookup) chunk
 
 -- | Recompute slopes for ONLY the given column indices; all other
 --   columns pass through untouched. Used by 'recomputeNeighborSlopes' to
@@ -128,12 +133,14 @@ computeChunkSlopes seed coord surfMap registry fluidMap chunk neighborLookup =
 computeChunkSlopesCols ∷ Word64 → ChunkCoord → VU.Vector Int → MaterialRegistry
                        → V.Vector (Maybe FluidCell) → Chunk
                        → (ChunkCoord → Maybe (VU.Vector Int))
+                       → (ChunkCoord → Maybe (V.Vector (Maybe FluidCell)))
                        → HS.HashSet Int → Chunk
-computeChunkSlopesCols seed coord surfMap registry fluidMap chunk neighborLookup cols =
+computeChunkSlopesCols seed coord surfMap registry fluidMap chunk
+                       neighborLookup fluidNeighborLookup cols =
     V.imap (\idx col →
         if HS.member idx cols
         then recomputeColumnSlope seed coord surfMap registry fluidMap
-                                  chunk neighborLookup idx col
+                                  chunk neighborLookup fluidNeighborLookup idx col
         else col
     ) chunk
 
@@ -143,8 +150,10 @@ computeTileSlope ∷ Word64 → ChunkCoord
                 → V.Vector (Maybe FluidCell)
                 → Chunk
                 → (ChunkCoord → Maybe (VU.Vector Int))
+                → (ChunkCoord → Maybe (V.Vector (Maybe FluidCell)))
                 → Word8
-computeTileSlope seed coord lx ly z registry surfMap fluidMap tiles neighborLookup =
+computeTileSlope seed coord lx ly z registry surfMap fluidMap tiles
+                 neighborLookup fluidNeighborLookup =
     let col = tiles V.! columnIndex lx ly
         i = z - ctStartZ col
         matId = if i ≥ 0 ∧ i < VU.length (ctMats col)
@@ -180,14 +189,16 @@ computeTileSlope seed coord lx ly z registry surfMap fluidMap tiles neighborLook
         bitS = slopeBit myHasFluid z neighS lx (ly + 1) coord fluidMap neighborLookup
         bitW = slopeBit myHasFluid z neighW (lx - 1) ly coord fluidMap neighborLookup
 
-        -- Is each cardinal neighbour a WET tile (in-chunk only, mirroring
-        -- 'slopeBit')? The dry-rock jagged path must honour the same bank
-        -- rule as dry land — never slope a dry tile into a water neighbour
-        -- (it would read as rock dipping into the river/lake/sea).
-        wetN = neighborHasFluidAt coord lx (ly - 1) fluidMap
-        wetE = neighborHasFluidAt coord (lx + 1) ly fluidMap
-        wetS = neighborHasFluidAt coord lx (ly + 1) fluidMap
-        wetW = neighborHasFluidAt coord (lx - 1) ly fluidMap
+        -- Is each cardinal neighbour a WET tile? Resolves across chunk
+        -- boundaries via 'fluidNeighborLookup' (the jagged path can fire on
+        -- a multi-level drop, so it must check the bank rule at seams too,
+        -- not just in-chunk). The dry-rock jagged path must never slope a
+        -- dry tile into a water neighbour — it would read as rock dipping
+        -- into the river/lake/sea.
+        wetN = neighborHasFluidAt coord lx (ly - 1) fluidMap fluidNeighborLookup
+        wetE = neighborHasFluidAt coord (lx + 1) ly fluidMap fluidNeighborLookup
+        wetS = neighborHasFluidAt coord lx (ly + 1) fluidMap fluidNeighborLookup
+        wetW = neighborHasFluidAt coord (lx - 1) ly fluidMap fluidNeighborLookup
 
         rawSlope = (if bitN then 1 else 0)
                .|. (if bitE then 2 else 0)
@@ -341,18 +352,24 @@ normalizeCoord coord lx ly =
     in (lx', ly', c)
 
 -- | Does the cardinal neighbour at local (nlx, nly) hold a fluid cell?
---   Only IN-CHUNK neighbours are inspected (cross-chunk fluid isn't
---   visible from this chunk's 'fluidMap') — exactly the convention
---   'slopeBit' already uses for its dry-land bank rule, so the jagged
---   path stays consistent with it.
-neighborHasFluidAt ∷ ChunkCoord → Int → Int → V.Vector (Maybe FluidCell) → Bool
-neighborHasFluidAt coord nlx nly fluidMap =
-    let (normLx, normLy, neighborCoord) = normalizeCoord coord nlx nly
-    in case neighborCoord of
-        c | c ≡ coord → case fluidMap V.! columnIndex normLx normLy of
-                            Just _  → True
-                            Nothing → False
-        _ → False
+--   In-chunk neighbours read this chunk's 'fluidMap'; out-of-chunk
+--   neighbours resolve through 'fluidNeighborLookup' (the loaded
+--   neighbour's fluid map). A not-yet-loaded neighbour reads back as dry
+--   (Nothing) — exactly like the terrain 'neighborElev' minBound sentinel;
+--   the cross-chunk recompute re-runs this border strip once the neighbour
+--   loads, so the bank rule converges on the loaded set, not load order.
+neighborHasFluidAt ∷ ChunkCoord → Int → Int → V.Vector (Maybe FluidCell)
+                   → (ChunkCoord → Maybe (V.Vector (Maybe FluidCell))) → Bool
+neighborHasFluidAt coord nlx nly fluidMap fluidNeighborLookup
+    | nlx ≥ 0 ∧ nlx < chunkSize ∧ nly ≥ 0 ∧ nly < chunkSize
+        = isJustCell (fluidMap V.! columnIndex nlx nly)
+    | otherwise =
+        let (neighborCoord, (nlx', nly')) = normalizeToChunk coord nlx nly
+        in case fluidNeighborLookup neighborCoord of
+            Just nf → isJustCell (nf V.! columnIndex nlx' nly')
+            Nothing → False
+  where isJustCell (Just _) = True
+        isJustCell Nothing  = False
 
 floorDiv' ∷ Int → Int → Int
 floorDiv' a b = floor (fromIntegral a / fromIntegral b ∷ Double)
@@ -585,6 +602,11 @@ recomputeNeighborSlopes seed worldSize registry changedCoords wtd =
         neighborLookup coord = case HM.lookup (wrap coord) chunks of
             Just lc → Just (lcTerrainSurfaceMap lc)
             Nothing → Nothing
+        -- Parallel fluid lookup so the dry-rock bank rule (jagged path)
+        -- can see a wet neighbour ACROSS a chunk seam, not just in-chunk.
+        fluidNeighborLookup coord = case HM.lookup (wrap coord) chunks of
+            Just lc → Just (lcFluidMap lc)
+            Nothing → Nothing
         -- Only the boundary strip can change when a neighbour loads —
         -- interior columns read in-chunk data only, so recomputing them
         -- would reproduce their stored value. Restricting to the
@@ -595,7 +617,7 @@ recomputeNeighborSlopes seed worldSize registry changedCoords wtd =
                     let newTiles = computeChunkSlopesCols seed coord
                             (lcTerrainSurfaceMap lc) registry
                             (lcFluidMap lc) (lcTiles lc) neighborLookup
-                            perimeterColumnSet
+                            fluidNeighborLookup perimeterColumnSet
                     in HM.insert coord (lc { lcTiles = newTiles }) acc
                 Nothing → acc
             ) chunks affected

--- a/src/World/Slope.hs
+++ b/src/World/Slope.hs
@@ -269,21 +269,29 @@ rockJaggedSlope seed (ChunkCoord cx cy) lx ly hardness z maxDrop rawSlope
             jaggedChance = clamp01 $ rockJaggedBase
                 + (hardness - slopeHardnessThreshold) * rockJaggedHardK
                 + reliefNorm * rockJaggedReliefK
+            -- Wet-direction bitmask (seam-aware via the wet* flags).
+            wetMask = (if wetN then 1 else 0) .|. (if wetE then 2 else 0)
+                  .|. (if wetS then 4 else 0) .|. (if wetW then 8 else 0) ∷ Word8
             -- Candidate ramp directions: strictly-lower cardinal
             -- neighbours that are NOT wet (bank rule). May be empty if the
             -- only downhill neighbour is water — then we fall through to
-            -- 'rawSlope', which already excludes wet neighbours, so a dry
-            -- rock at a water edge stays blocky.
+            -- the dry clean-flank below.
             cand = [ b | (b, nz, wet) ← [ (1 ∷ Word8, neighN, wetN)
                                         , (2, neighE, wetE)
                                         , (4, neighS, wetS)
                                         , (8, neighW, wetW) ]
                        , nz ≠ minBound, nz < z, not wet ]
+            -- Clean-flank fallback: rawSlope with any wet directions
+            -- cleared. rawSlope is built by 'slopeBit', whose bank check is
+            -- IN-CHUNK only, so a 1-z lower wet neighbour across a chunk
+            -- seam would otherwise survive in rawSlope and ramp into water.
+            -- (15 `xor` wetMask) is the 4-bit complement of the wet mask.
+            dryFlank = rawSlope .&. (15 `xor` wetMask)
         in if roll < jaggedChance ∧ not (null cand)
            then cand !! fromIntegral ((h `shiftR` 8) `mod`
                                       fromIntegral (length cand))
-           else if rawSlope ≢ 0 ∧ rawSlope ≢ 15
-                then rawSlope   -- clean terrace flank, no jaggedness roll
+           else if dryFlank ≢ 0 ∧ dryFlank ≢ 15
+                then dryFlank   -- clean terrace flank (wet dirs masked out)
                 else 0
 
 slopeBit ∷ Bool → Int → Int → Int → Int → ChunkCoord

--- a/src/World/Slope.hs
+++ b/src/World/Slope.hs
@@ -37,6 +37,26 @@ import World.Material (getMaterialProps, MaterialProps(..), MaterialId(..)
 slopeHardnessThreshold ∷ Float
 slopeHardnessThreshold = 0.7
 
+-- | Jaggedness knobs for EXPOSED HARD ROCK (issue #224). The chance a
+--   bare-rock tile gets a semi-random jagged slope is
+--   @clamp01 (base + (hardness − threshold)·hardK + reliefNorm·reliefK)@,
+--   so the harder and steeper the rock, the more broken it reads. These
+--   are the inverse of the soft-terrain roughness taper in
+--   'applyRoughness' (which fades OUT as material softens). Tunable;
+--   render-only, so changing them never touches saved terrain.
+rockJaggedBase ∷ Float
+rockJaggedBase = 0.45
+
+rockJaggedHardK ∷ Float
+rockJaggedHardK = 1.0
+
+rockJaggedReliefK ∷ Float
+rockJaggedReliefK = 0.4
+
+-- | Local relief (in z-levels) at which rock jaggedness saturates.
+rockJaggedReliefMax ∷ Float
+rockJaggedReliefMax = 6.0
+
 tilePixelWidth ∷ Int
 tilePixelWidth = 96
 
@@ -164,9 +184,80 @@ computeTileSlope seed coord lx ly z registry surfMap fluidMap tiles neighborLook
                .|. (if bitE then 2 else 0)
                .|. (if bitS then 4 else 0)
                .|. (if bitW then 8 else 0) ∷ Word8
-    in if not passesHardness ∨ rawSlope ≡ 0 ∨ rawSlope ≡ 15
-       then 0
-       else applyRoughness seed coord lx ly hardness rawSlope
+
+        -- Local relief: the steepest single-neighbour DROP from this tile
+        -- (absent neighbours read back as the minBound sentinel and never
+        -- count). Drives both the bare-rock eligibility (a tile with no
+        -- downhill neighbour is flat-topped and stays blocky) and the
+        -- jaggedness intensity.
+        drops = [ z - nz | nz ← [neighN, neighE, neighS, neighW]
+                         , nz ≠ minBound, nz < z ]
+        maxDrop = if null drops then 0 else maximum drops
+    in if myHasFluid
+       -- Wet tiles (river bed / basin floor) keep the existing rule
+       -- unchanged: the bed slopes to match the water surface, gated the
+       -- same way it always was. Jaggedness is a DRY-rock feature only.
+       then if not passesHardness ∨ rawSlope ≡ 0 ∨ rawSlope ≡ 15
+            then 0
+            else applyRoughness seed coord lx ly hardness rawSlope
+       else if passesHardness
+            -- Soft dry terrain: unchanged terrace rule. Flat biomes have
+            -- no qualifying step and stay flat-topped.
+            then if rawSlope ≡ 0 ∨ rawSlope ≡ 15
+                 then 0
+                 else applyRoughness seed coord lx ly hardness rawSlope
+            -- Exposed hard rock (the material the soft gate bars). #224:
+            -- make mountain flanks slope and peaks read as jagged rock.
+            else rockJaggedSlope seed coord lx ly hardness z maxDrop rawSlope
+                                 neighN neighE neighS neighW
+
+-- | Slope rule for EXPOSED HARD ROCK — material at/above
+--   'slopeHardnessThreshold', which the soft-terrain gate in
+--   'computeTileSlope' otherwise forces flat. Bare rock on mountain
+--   flanks and peaks should read as jagged, broken rock rather than
+--   blocky prisms (issue #224). It dovetails with #225: gentle ground
+--   keeps its soil veneer (soft surface → soft path), so only steep,
+--   soil-shed faces reach this rock path.
+--
+--   Two effects, both gated on the tile having a downhill neighbour
+--   (@maxDrop ≥ 1@) so flat/low rocky ground — plateau tops, rocky flats
+--   — stays blocky and genuinely flat biomes are untouched:
+--
+--     1. Clean single-step flanks slope toward their lower neighbours
+--        ('rawSlope'), so rock mountainsides taper instead of stepping.
+--     2. JAGGEDNESS: with a probability that RISES with hardness and local
+--        relief (the inverse of 'applyRoughness'), override with a
+--        semi-random slope toward ONE strictly-lower neighbour. This
+--        breaks the regular terrace into irregular angular rock, and fires
+--        even where no neighbour is exactly one lower (steep multi-level
+--        faces) — the case the strict terrace rule leaves flat.
+--
+--   The ramp only ever points at a strictly-lower neighbour, so it stays
+--   a geometrically valid (and pathing-walkable) ramp — never a notch
+--   into a higher wall.
+rockJaggedSlope ∷ Word64 → ChunkCoord → Int → Int → Float → Int → Int → Word8
+                → Int → Int → Int → Int → Word8
+rockJaggedSlope seed (ChunkCoord cx cy) lx ly hardness z maxDrop rawSlope
+                neighN neighE neighS neighW
+    | maxDrop < 1 = 0   -- no downhill neighbour: flat-topped rock, blocky
+    | otherwise =
+        let h    = tileHash seed cx cy lx ly
+            roll = fromIntegral (h .&. 0xFF) / 255.0 ∷ Float
+            reliefNorm = min 1.0 (fromIntegral maxDrop / rockJaggedReliefMax)
+            jaggedChance = clamp01 $ rockJaggedBase
+                + (hardness - slopeHardnessThreshold) * rockJaggedHardK
+                + reliefNorm * rockJaggedReliefK
+            -- Candidate ramp directions: strictly-lower cardinal
+            -- neighbours. maxDrop ≥ 1 guarantees this list is non-empty.
+            cand = [ b | (b, nz) ← [ (1 ∷ Word8, neighN), (2, neighE)
+                                   , (4, neighS), (8, neighW) ]
+                       , nz ≠ minBound, nz < z ]
+        in if roll < jaggedChance ∧ not (null cand)
+           then cand !! fromIntegral ((h `shiftR` 8) `mod`
+                                      fromIntegral (length cand))
+           else if rawSlope ≢ 0 ∧ rawSlope ≢ 15
+                then rawSlope   -- clean terrace flank, no jaggedness roll
+                else 0
 
 slopeBit ∷ Bool → Int → Int → Int → Int → ChunkCoord
          → V.Vector (Maybe FluidCell)

--- a/tools/slope_report.py
+++ b/tools/slope_report.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""slope_report.py — headless metric for terrain sloping (issue #224).
+
+Drives the dump itself, then reports, per local-relief bin, what fraction
+of DRY surface tiles render a non-flat slope — split into soft terrain
+(hardness < 0.7, the unchanged terrace path) and exposed hard rock
+(hardness >= 0.7, the rock-jaggedness path #224 added). Before #224 the
+hard-rock column was 0% at every relief level (the hardness gate forced
+those tiles flat); this tool shows the new distribution and checks the
+two invariants the issue requires:
+
+  * flat ground (relief 0) never slopes  -> flat biomes stay flat-topped
+  * high-relief exposed rock slopes a lot -> mountains read as sloped/jagged
+
+Usage:
+  python3 tools/slope_report.py [--seed N] [--worldSize N] [--radius N]
+"""
+import argparse, json, subprocess, sys, os
+from collections import defaultdict
+
+HARD = 0.7  # slopeHardnessThreshold
+
+def run_dump(seed, size, radius):
+    r = radius
+    cmd = ["cabal", "run", "-v0", "exe:synarchy", "--",
+           "--dump=terrain,material,slope",
+           "--seed", str(seed), "--worldSize", str(size),
+           "--region", f"-{r},-{r},{r},{r}"]
+    out = subprocess.run(cmd, capture_output=True, timeout=400)
+    if out.returncode != 0:
+        sys.stderr.write(out.stderr.decode()[-2000:])
+        sys.exit(f"dump failed (exit {out.returncode})")
+    return json.loads(out.stdout)
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--seed", type=int, default=137)
+    ap.add_argument("--worldSize", type=int, default=128)
+    ap.add_argument("--radius", type=int, default=4)
+    a = ap.parse_args()
+
+    tiles = run_dump(a.seed, a.worldSize, a.radius)
+    by_xy = {(t["x"], t["y"]): t for t in tiles}
+
+    # local relief = steepest single-neighbour drop, mirrors Slope.hs
+    def relief(t):
+        z = t["terrainZ"]
+        best = 0
+        for dx, dy in ((0,-1),(1,0),(0,1),(-1,0)):
+            n = by_xy.get((t["x"]+dx, t["y"]+dy))
+            if n is not None:
+                best = max(best, z - n["terrainZ"])
+        return best
+
+    # bins: relief level -> [soft_total, soft_sloped, hard_total, hard_sloped]
+    bins = defaultdict(lambda: [0,0,0,0])
+    flat_violations = 0
+    considered = 0
+    for t in tiles:
+        # dry surface tiles only (slope/hardness fields require slope layer);
+        # skip world-edge tiles whose neighbours fall outside the dumped region
+        if "slope" not in t:
+            continue
+        # require full 4-neighbourhood inside the region for a valid relief
+        if any((t["x"]+dx, t["y"]+dy) not in by_xy
+               for dx,dy in ((0,-1),(1,0),(0,1),(-1,0))):
+            continue
+        considered += 1
+        rel = relief(t)
+        sloped = 1 if t["slope"] != 0 else 0
+        hard = t["hardness"] >= HARD
+        b = bins[min(rel, 8)]
+        if hard: b[2]+=1; b[3]+=sloped
+        else:    b[0]+=1; b[1]+=sloped
+        if rel == 0 and sloped:
+            flat_violations += 1
+
+    print(f"seed={a.seed} worldSize={a.worldSize} "
+          f"region=+/-{a.radius}  tiles_considered={considered}\n")
+    print(f"{'relief':>6} | {'soft n':>8} {'soft slope%':>11} | "
+          f"{'hard n':>8} {'hard slope%':>11}")
+    print("-"*56)
+    tot_hard=tot_hard_sl=0
+    for rel in sorted(bins):
+        st, ss, ht, hs = bins[rel]
+        sp = f"{100*ss/st:.1f}%" if st else "  -"
+        hp = f"{100*hs/ht:.1f}%" if ht else "  -"
+        label = f"{rel}" + ("+" if rel==8 else "")
+        print(f"{label:>6} | {st:>8} {sp:>11} | {ht:>8} {hp:>11}")
+        if rel>=3: tot_hard+=ht; tot_hard_sl+=hs
+    print("-"*56)
+
+    ok = True
+    # invariant 1: flat ground never slopes
+    if flat_violations:
+        print(f"FAIL: {flat_violations} relief-0 tiles are sloped "
+              f"(flat biomes must stay flat)")
+        ok = False
+    else:
+        print("PASS: no relief-0 (flat) tile is sloped")
+    # invariant 2: high-relief exposed rock slopes substantially
+    hi = (100*tot_hard_sl/tot_hard) if tot_hard else 0.0
+    if tot_hard == 0:
+        print("WARN: no high-relief (>=3) exposed rock in sample "
+              "(try a more mountainous seed)")
+    elif hi >= 50.0:
+        print(f"PASS: high-relief (>=3) exposed rock slopes {hi:.1f}% "
+              f"(n={tot_hard}); was 0% before #224")
+    else:
+        print(f"FAIL: high-relief exposed rock only {hi:.1f}% sloped "
+              f"(n={tot_hard}); expected >=50%")
+        ok = False
+
+    sys.exit(0 if ok else 1)
+
+if __name__ == "__main__":
+    main()

--- a/tools/slope_report.py
+++ b/tools/slope_report.py
@@ -23,7 +23,7 @@ HARD = 0.7  # slopeHardnessThreshold
 def run_dump(seed, size, radius):
     r = radius
     cmd = ["cabal", "run", "-v0", "exe:synarchy", "--",
-           "--dump=terrain,material,slope",
+           "--dump=terrain,material,fluid,slope",
            "--seed", str(seed), "--worldSize", str(size),
            "--region", f"-{r},-{r},{r},{r}"]
     out = subprocess.run(cmd, capture_output=True, timeout=400)
@@ -60,6 +60,10 @@ def main():
         # dry surface tiles only (slope/hardness fields require slope layer);
         # skip world-edge tiles whose neighbours fall outside the dumped region
         if "slope" not in t:
+            continue
+        # skip wet tiles: jaggedness is a dry-rock feature, and a submerged
+        # bed's slope is the wet-tile rule, not what #224 changed
+        if t.get("fluidType") is not None:
             continue
         # require full 4-neighbourhood inside the region for a valid relief
         if any((t["x"]+dx, t["y"]+dy) not in by_xy


### PR DESCRIPTION
Closes #224.

## Problem
Mountains rendered as blocky prisms because `World.Slope.computeTileSlope` bars rock from sloping: it only slopes a tile when `hardness < slopeHardnessThreshold` (0.7), but igneous (0.8–1.0) and metamorphic (0.65–0.95) rock — the bulk of bare mountain material — fail that gate and are forced flat. `applyRoughness` runs *after* the gate, so the "jagged bare rock" the issue asks for was impossible. This is the direct sequel to **#225** (just merged), which sheds soil off steep faces — that newly-exposed rock is exactly the hard, high-relief material the gate kept blocky.

## Fix
Split `computeTileSlope` by surface:
- **Wet beds** and **soft dry terrain** keep their existing rules verbatim → flat biomes stay flat-topped (no qualifying step).
- **Exposed hard dry rock** takes a new `rockJaggedSlope` path, gated on a downhill neighbour (`maxDrop ≥ 1`) so flat/low rocky ground stays blocky:
  1. clean single-step flanks slope toward lower neighbours (rock mountainsides taper instead of stepping);
  2. **jaggedness** — with probability rising with hardness and local relief (the inverse of `applyRoughness`), override with a semi-random slope toward one strictly-lower neighbour; fires even on steep multi-level faces the strict terrace rule leaves flat.

Ramps only point at strictly-lower neighbours → geometrically valid and pathing-walkable (minor gameplay effect: units can scramble up 1-z jagged rock steps). Slopes are a **render attribute** (`ctSlopes`, recomputed at gen, never saved) → no saved-terrain change, no save-version bump. Jaggedness constants are tunable at the top of `Slope.hs`.

## Verification (headless, metrics-only — no GPU)
New `tools/slope_report.py` + an **opt-in** `slope` dump layer (surface slope bitmask + hardness). Across seeds **137 / 42 / 13579 / 124907** (w128):

| | relief 0 (flat) | relief ≥3 exposed rock |
|---|---|---|
| sloped % | **0%** (incl. flat exposed rock) | **90–97%** (was 0% under the old gate) |

- Full hspec headless suite: **357 examples, 0 failures** (incl. slope specs). `test_audit`: **35/35**.
- The `slope` layer is opt-in, so a bare `--dump` (used by `world_check`/`world_baseline`/`world_determinism`) is **byte-identical** to before — this change touches only `ctSlopes`, never terrain/fluid/material.

### world_check note
`world_check` currently reports **18 pre-existing QUALITY failures (bugs=0)**. These are **stale baselines from #225** — terrain/fluid metrics (`elevationStats`, `WATER_CLIFF`, `DESERT_SOIL_ON_SLOPE`, …); baselines dated Jun 27, #225 merged Jun 28. They show **identical counts with this PR's dump additions toggled off**, are untouched by this render-only change, and are a #225 baseline-recapture follow-up (out of scope here).

Per the issue, this is a visual fix; headless metrics are provided, but final in-app eyeballing is recommended before merge (constants are easy to tune).

🤖 Generated with [Claude Code](https://claude.com/claude-code)