### PR TITLE
Restore phase-3 structural rebind — fix magenta interior regression from #282

### DIFF
--- a/scripts/main_menu.lua
+++ b/scripts/main_menu.lua
@@ -374,10 +374,17 @@ function mainMenu.loadAndShowSave(saveName)
 
     worldView.sendTexturesToWorld("main_world")
 
-    -- sendTexturesToWorld binds the structural set (and so busts the quad
-    -- cache); the engine also self-heals the cache when any dependent
-    -- texture finishes loading (#35), so no Lua-side gen-complete rebind is
-    -- needed for the loaded-save magenta-interior case (#64) anymore.
+    -- Arm the one-shot gen-complete structural rebind, exactly as
+    -- worldView.createWorld does. The world's quad cache bakes each tile's
+    -- bindless texture slot in at build time; if the structural textures
+    -- (blank tile, facemaps) are still GPU-loading when that cache is first
+    -- built, it bakes the magenta "undefined" slot and the engine's load-time
+    -- invalidation doesn't reliably heal it in the live flow. worldView.update
+    -- re-binds the structural set once world generation reports done (phase 3)
+    -- — by then they've loaded — busting the stale cache. Without this a
+    -- loaded save renders a magenta interior / missing facemaps (#64).
+    worldView.structuralRebound = false
+
     world.show("main_world")
 
     -- Show loading screen instead of jumping straight to world_view.

--- a/scripts/world_view.lua
+++ b/scripts/world_view.lua
@@ -300,10 +300,18 @@ function worldView.createWorld()
         -- materials and vegetation textures sent via sendTexturesToWorld
     })
     worldManager.showWorld()
-    -- The engine now rebuilds a world's quad cache by itself when a texture
-    -- it depends on finishes loading (race-safe generation counter, covers
-    -- not-yet-visible worlds — #35), so the structural set no longer needs a
-    -- Lua-side post-gen re-bind to bust a stale cache.
+
+    -- Structural textures (blank, facemaps) can still be GPU-loading when
+    -- the world's quad cache is first built, baking the undefined/magenta
+    -- slot + empty facemaps. The engine's load-time invalidation alone does
+    -- NOT reliably heal this in the live flow (the cache settles at a point
+    -- the per-texture invalidation doesn't re-bump), so we still re-bind the
+    -- structural set ONCE when world generation reports done (worldView.update
+    -- polls for it): by the time chunk generation finishes the small
+    -- structural textures have loaded, and the world.setTexture re-bind busts
+    -- the stale quad cache so it rebuilds with valid slots. (The engine-side
+    -- generation counter from #35 still makes that invalidation race-safe.)
+    worldView.structuralRebound = false
 end
 
 -----------------------------------------------------------
@@ -371,6 +379,18 @@ end
 function worldView.update(dt)
     if not worldView.visible then return end
     worldManager.update(dt)
+
+    -- One-shot structural re-bind when world generation completes (phase 3).
+    -- Busts the stale quad cache so the interior + facemaps render with the
+    -- now-loaded textures. Polls only until it fires, then stops.
+    if worldView.structuralRebound == false and worldManager.isActive() then
+        local phase = world.getInitProgress()
+        if phase == 3 then
+            worldView.structuralRebound = true
+            local wid = worldManager.getCurrentWorld()
+            if wid then worldView.rebindStructural(wid) end
+        end
+    end
 end
 
 -----------------------------------------------------------


### PR DESCRIPTION
## Regression
#282 removed the Lua `structuralRebound` one-shot, on the bet that the engine-side render-cache invalidation it added (race-safe generation counter + all-worlds sweep on texture load) would heal the late-structural-texture magenta interior by itself. **It doesn't** in the live GUI flow: the terrain interior comes up **magenta underground and stays that way** — the world quad cache settles at a point where the `blank`/facemap bindless slots baked into the vertices aren't valid, and the per-texture-load invalidation doesn't land at the moment needed to rebuild it.

The original workaround dodged this by re-binding the structural set at a **guaranteed-late point — phase 3 (chunk generation complete)** — long after all the world-init texture churn settled.

## Fix
Restore the phase-3 rebind:
- `worldView.update` — the one-shot poll that calls `rebindStructural` when `world.getInitProgress()` reaches phase 3.
- `worldView.createWorld` and `mainMenu.loadAndShowSave` — re-arm the `structuralRebound` flag.

**The engine-side generation counter from #282 is kept** — it still makes this rebind (and every other cache invalidation, including the genuine world-thread/render-thread race) race-safe. This just puts back the late re-bind that actually busts the stale structural cache.

## Validation
- Lua-only, **no rebuild required** — restarting the game (or reloading scripts) picks it up.
- `luajit` syntax check passes on both files.
- ⚠️ Needs an in-app confirm that the mountainous-world interior now comes up grey with facemaps (no persistent magenta), same as before #282.

## Follow-up
Properly replacing the workaround with an engine-only fix needs the actual GUI-observable slot-timing chased down (likely: invalidate after the world-init transient-texture churn / preview disposal settles, or move slot resolution to draw time per #35's third suggestion). Tracking under #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)