### PR TITLE
Restructure SaveData into per-world WorldPageSave + globals (#215)

### DIFF
--- a/src/World/Page/Types.hs
+++ b/src/World/Page/Types.hs
@@ -5,7 +5,11 @@ module World.Page.Types
 
 import UPrelude
 import Data.Hashable (Hashable)
+import Data.Serialize (Serialize)
 
+-- | 'Serialize' is derived from the underlying 'Text' (instance in
+--   UPrelude) so world-page ids can be persisted in saves — each page's
+--   id plus the active/visible-page lists land in 'SaveData' (#215).
 newtype WorldPageId = WorldPageId Text
     deriving (Show, Eq, Ord)
-    deriving newtype (Hashable)
+    deriving newtype (Hashable, Serialize)

--- a/src/World/Save/Serialize.hs
+++ b/src/World/Save/Serialize.hs
@@ -130,7 +130,16 @@ loadWorld rawName = case sanitizeSaveName rawName of
             fail $ "Save format incompatible: expected v"
                 <> show currentSaveVersion
                 <> ", got v" <> show (shVersion h)
-        S.get
+        sd ← S.get
+        -- A valid v59+ save always carries at least the active world page.
+        -- Reject an empty sdWorlds at DECODE time so the load API fails
+        -- cleanly (Left → engine.loadSave returns false) before it pauses
+        -- the engine, restores Lua blobs, or marks the head world loading.
+        -- Catching it only in the world-thread handler would wedge the
+        -- session on the loading screen after those side effects (#215).
+        when (null (sdWorlds sd)) $
+            fail "Save contains no world pages (corrupt or truncated file)"
+        pure sd
 
 mapLeft ∷ Either a b → (a → c) → Either c b
 mapLeft (Left a)  f = Left (f a)

--- a/src/World/Save/Serialize.hs
+++ b/src/World/Save/Serialize.hs
@@ -131,15 +131,27 @@ loadWorld rawName = case sanitizeSaveName rawName of
                 <> show currentSaveVersion
                 <> ", got v" <> show (shVersion h)
         sd ← S.get
-        -- A valid v59+ save always carries at least the active world page.
-        -- Reject an empty sdWorlds at DECODE time so the load API fails
-        -- cleanly (Left → engine.loadSave returns false) before it pauses
-        -- the engine, restores Lua blobs, or marks the head world loading.
-        -- Catching it only in the world-thread handler would wedge the
-        -- session on the loading screen after those side effects (#215).
-        when (null (sdWorlds sd)) $
-            fail "Save contains no world pages (corrupt or truncated file)"
-        pure sd
+        -- Validate sdWorlds cardinality at DECODE time so the load API
+        -- fails cleanly (Left → engine.loadSave returns false) before it
+        -- pauses the engine, restores Lua blobs, or marks the head world
+        -- loading. Catching it only in the world-thread handler would
+        -- wedge the session on the loading screen after those side effects.
+        --
+        -- This build's save command writes exactly one page and its load
+        -- handler restores only the active page (#215). The schema already
+        -- holds a list to make room for the all-pages save/load work
+        -- (#216/#217), but until that lands we must REFUSE a multi-page
+        -- v59 file rather than silently load just one and drop the rest —
+        -- a forward-compat hole if a later v59 writer emits many pages.
+        -- The all-pages loader will relax this to accept N pages.
+        case sdWorlds sd of
+          []  → fail "Save contains no world pages (corrupt or truncated file)"
+          [_] → pure sd
+          ws  → fail $ "Save contains " <> show (length ws)
+                    <> " world pages, but this build restores only the active"
+                    <> " page (multi-page save/load not yet implemented — see"
+                    <> " #214). Refusing to load to avoid silently dropping"
+                    <> " pages."
 
 mapLeft ∷ Either a b → (a → c) → Either c b
 mapLeft (Left a)  f = Left (f a)

--- a/src/World/Save/Serialize.hs
+++ b/src/World/Save/Serialize.hs
@@ -130,32 +130,39 @@ loadWorld rawName = case sanitizeSaveName rawName of
             fail $ "Save format incompatible: expected v"
                 <> show currentSaveVersion
                 <> ", got v" <> show (shVersion h)
-        sd ← S.get
         -- Validate sdWorlds cardinality at DECODE time so the load API
         -- fails cleanly (Left → engine.loadSave returns false) before it
         -- pauses the engine, restores Lua blobs, or marks the head world
         -- loading. Catching it only in the world-thread handler would
         -- wedge the session on the loading screen after those side effects.
-        --
-        -- This build's save command writes exactly one page and its load
-        -- handler restores only the active page (#215). The schema already
-        -- holds a list to make room for the all-pages save/load work
-        -- (#216/#217), but until that lands we must REFUSE a multi-page
-        -- v59 file rather than silently load just one and drop the rest —
-        -- a forward-compat hole if a later v59 writer emits many pages.
-        -- The all-pages loader will relax this to accept N pages.
-        case sdWorlds sd of
-          []  → fail "Save contains no world pages (corrupt or truncated file)"
-          [_] → pure sd
-          ws  → fail $ "Save contains " <> show (length ws)
-                    <> " world pages, but this build restores only the active"
-                    <> " page (multi-page save/load not yet implemented — see"
-                    <> " #214). Refusing to load to avoid silently dropping"
-                    <> " pages."
+        sd ← S.get
+        checkWorldCount sd
 
 mapLeft ∷ Either a b → (a → c) → Either c b
 mapLeft (Left a)  f = Left (f a)
 mapLeft (Right b) _ = Right b
+
+-- | Reject a decoded save whose 'sdWorlds' cardinality this build can't
+--   handle. A valid v59 save carries exactly one page (the active world):
+--   this build's save command writes one and its load handler restores
+--   only the active page (#215). The schema already holds a list to make
+--   room for the all-pages save/load work (#216/#217), but until that
+--   lands we must REFUSE a multi-page v59 file rather than silently load
+--   one page and drop the rest.
+--
+--   Shared by the load decoder ('decodeVersioned') and the listing decoder
+--   ('decodeListingMeta') so 'listSaves' never advertises a save that
+--   'loadWorld' would refuse — otherwise the menu's Continue list could
+--   offer an unloadable save. The all-pages loader (#217) will relax this
+--   to accept N pages.
+checkWorldCount ∷ SaveData → S.Get SaveData
+checkWorldCount sd = case sdWorlds sd of
+    []  → fail "Save contains no world pages (corrupt or truncated file)"
+    [_] → pure sd
+    ws  → fail $ "Save contains " <> show (length ws)
+              <> " world pages, but this build restores only the active"
+              <> " page (multi-page save/load not yet implemented — see"
+              <> " #214). Refusing to load to avoid silently dropping pages."
 
 -- | List available saves (returns metadata only).
 --   Checks both directory-based saves and legacy flat files.
@@ -207,7 +214,10 @@ listSaves logger = do
         h ← S.get
         when (shMagic h ≠ saveMagic) $ fail "bad magic"
         when (shVersion h ≠ currentSaveVersion) $ fail "version mismatch"
-        S.get
+        -- Same cardinality gate as loadWorld so listSaves never lists a
+        -- save engine.loadSave would refuse (empty / multi-page v59).
+        sd ← S.get
+        checkWorldCount sd
 
 -- | Canonicalize a save timestamp to the fixed-width microsecond ISO
 --   form (@%FT%T%6QZ@) used by the sort in 'listSaves' and by

--- a/src/World/Save/Serialize.hs
+++ b/src/World/Save/Serialize.hs
@@ -86,7 +86,13 @@ saveWorld rawName saveData = case sanitizeSaveName rawName of
                                     }
             encoded    = S.encode header <> S.encode saveData
         BS.writeFile binaryPath encoded
-        saveWorldGenYaml yamlPath (sdGenParams saveData)
+        -- The human-readable companion describes the primary (active)
+        -- world; per-world gen params now live in sdWorlds (#215). A
+        -- well-formed save always has an active page, but tolerate an
+        -- empty one by skipping the yaml rather than crashing the save.
+        case activeWorldPage saveData of
+            Just wps → saveWorldGenYaml yamlPath (wpsGenParams wps)
+            Nothing  → return ()
         return (Right ())
 
 -- | Load a world from disk.

--- a/src/World/Save/Types.hs
+++ b/src/World/Save/Types.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE Strict, UnicodeSyntax, DeriveGeneric, DeriveAnyClass #-}
 module World.Save.Types
     ( SaveData(..)
+    , WorldPageSave(..)
+    , activeWorldPage
     , SaveMetadata(..)
     , SaveHeader(..)
     , saveMagic
@@ -107,7 +109,12 @@ saveMagic = 0x53595241
 --       chunk-level ocean test so sub-sea tiles the coarse chunk-flood
 --       missed render ocean (sea-stops-at-chunk-boundary fix).
 currentSaveVersion ∷ Int
-currentSaveVersion = 58  -- v58: steep faces shed soil to bare rock in last-age erosion (#225)
+currentSaveVersion = 59  -- v59: SaveData restructured — per-world state moved off
+                         --      SaveData into a new WorldPageSave record;
+                         --      SaveData now holds globals + sdActivePage +
+                         --      sdVisiblePages + sdWorlds ([WorldPageSave]).
+                         --      Foundation for one-save-all-pages (#215, epic #214).
+                         -- v58: steep faces shed soil to bare rock in last-age erosion (#225)
                          -- v57: per-unit name (uisName) (#264)
                          -- v55: despike spike-only convergence pass (#254) — base
                          --      terrain output shifts on regen, so reject older saves
@@ -144,53 +151,86 @@ data SaveMetadata = SaveMetadata
     , smTimestamp  ∷ !Text        -- ^ ISO 8601 string
     } deriving (Show, Eq, Serialize, Generic)
 
--- | Everything needed to reconstruct a WorldState.
---   Schema is versioned via the file header — see saveMagic /
---   currentSaveVersion / SaveHeader above. Bump currentSaveVersion
---   whenever this record's layout changes (cereal's Generic encoding
---   is positional, so reordering or inserting a field is breaking).
-data SaveData = SaveData
-    { sdMetadata   ∷ !SaveMetadata
-    , sdGenParams  ∷ !WorldGenParams
-    , sdCameraX    ∷ !Float
-    , sdCameraY    ∷ !Float
-    , sdCameraZoom ∷ !Float
-    , sdCameraFacing ∷ !CameraFacing
-    , sdTimeHour   ∷ !Int
-    , sdTimeMinute ∷ !Int
-    , sdDateYear   ∷ !Int
-    , sdDateMonth  ∷ !Int
-    , sdDateDay    ∷ !Int
-    , sdTimeScale  ∷ !Float
-    , sdMapMode    ∷ !ZoomMapMode
-    , sdToolMode   ∷ !ToolMode
-    -- v2 fields (Phase 1):
-    , sdGameTime     ∷ !Double   -- ^ gameTimeRef value (game-clock seconds).
-    , sdEnginePaused ∷ !Bool     -- ^ enginePausedRef value. Auto-pause-on-save
-                                  --   means this is always True for v2+ saves.
-    -- v3 fields (Phase 2):
-    , sdEdits        ∷ !WorldEdits
+-- | Per-world-page save payload. Everything scoped to a single world
+--   page — terrain gen params, camera, clock, edits, and that page's
+--   buildings/units/sim-states — lives here. A 'SaveData' carries a list
+--   of these ('sdWorlds') plus the genuinely global fields.
+--
+--   Splitting per-world state into its own record is the foundation for
+--   persisting every live world page in one save (epic #214): today
+--   exactly one page (the active world) is written, but the shape already
+--   supports many. Like 'SaveData', this is encoded positionally by
+--   cereal's Generic instance, so any layout change bumps
+--   'currentSaveVersion'.
+data WorldPageSave = WorldPageSave
+    { wpsPageId       ∷ !WorldPageId
+        -- ^ The id this page had at save time. On load the active page
+        --   restores under @main_world@ (see 'sdActivePage'); additional
+        --   pages restore under this id.
+    , wpsGenParams    ∷ !WorldGenParams
+    , wpsCameraX      ∷ !Float
+    , wpsCameraY      ∷ !Float
+    , wpsCameraZoom   ∷ !Float
+    , wpsCameraFacing ∷ !CameraFacing
+    , wpsTimeHour     ∷ !Int
+    , wpsTimeMinute   ∷ !Int
+    , wpsDateYear     ∷ !Int
+    , wpsDateMonth    ∷ !Int
+    , wpsDateDay      ∷ !Int
+    , wpsTimeScale    ∷ !Float
+    , wpsMapMode      ∷ !ZoomMapMode
+    , wpsToolMode     ∷ !ToolMode
+    , wpsEdits        ∷ !WorldEdits
         -- ^ Per-chunk edit log. Restored before chunk regeneration on
         --   load; chunks then replay their edits to recover the player's
         --   modifications. Edits survive eviction during a play session.
-    -- v4 fields (Phase 3):
-    , sdBuildings    ∷ !BuildingSnapshot
-        -- ^ All placed buildings. Restored AFTER edits + center-chunk
-        --   regen so buildings landing on player-edited terrain end up
-        --   at the right z (their saved biGridZ already reflects the
-        --   post-edit terrain at place time, but the chunk needs to
-        --   have replayed its edits first for downstream queries to
-        --   agree).
-    -- v5 fields (Phase 4):
-    , sdUnits        ∷ !UnitSnapshot
-        -- ^ All live unit instances + their stats/skills/modifiers
-        --   /inventory. Restored alongside sim states below.
-    , sdUnitSimStates ∷ !(HM.HashMap UnitId UnitSimState)
+    , wpsMineDesignations ∷ !MineDesignations
+        -- ^ Mine designations incl. mid-dig corner progress. Restored
+        --   straight into wsMineDesignationsRef; markers re-render from
+        --   the stored z, so no chunk loading is required first.
+    , wpsGroundItems  ∷ !GroundItems
+        -- ^ Items lying in the world. Full ItemInstances + float
+        --   positions; resting height derives from terrain at render,
+        --   so restoration needs no chunk loading either.
+    , wpsSpoilPiles   ∷ !SpoilPiles
+        -- ^ Spoil mounds (vertex-keyed partial fills — see
+        --   World.Spoil.Types). Fills are relative to each tile's terrain
+        --   surface; promoted cells live in wpsEdits as WeAddTile, so
+        --   restoration is order-independent.
+    , wpsBuildings    ∷ !BuildingSnapshot
+        -- ^ This page's placed buildings. Restored AFTER edits +
+        --   center-chunk regen so buildings landing on player-edited
+        --   terrain end up at the right z (their saved biGridZ already
+        --   reflects the post-edit terrain at place time, but the chunk
+        --   needs to have replayed its edits first for downstream queries
+        --   to agree).
+    , wpsUnits        ∷ !UnitSnapshot
+        -- ^ This page's live unit instances + their stats/skills/
+        --   modifiers/inventory. Restored alongside the sim states below.
+    , wpsUnitSimStates ∷ !(HM.HashMap UnitId UnitSimState)
         -- ^ Per-unit sim state (position, pose, activity, target, path,
-        --   *Until timers). Saved straight; restored into utsRef on
-        --   EngineEnv (Phase 4 promoted utsRef from the unit-thread
-        --   local to engine-level).
-    -- v6 fields (Phase 5):
+        --   *Until timers) for this page's units. Restored into utsRef on
+        --   EngineEnv.
+    } deriving (Show, Serialize, Generic)
+
+-- | Everything needed to reconstruct the saved game. Per-world state is
+--   carried in 'sdWorlds' (one 'WorldPageSave' per saved page — today
+--   just the active world); the remaining fields are genuinely global,
+--   shared by every page or describing the save as a whole.
+--
+--   Schema is versioned via the file header — see saveMagic /
+--   currentSaveVersion / SaveHeader above. Bump currentSaveVersion
+--   whenever this record's layout (or 'WorldPageSave''s) changes
+--   (cereal's Generic encoding is positional, so reordering or inserting
+--   a field is breaking).
+data SaveData = SaveData
+    { sdMetadata   ∷ !SaveMetadata
+        -- ^ Save-listing metadata (name/seed/size/plates/timestamp),
+        --   describing the primary (active) world.
+    -- Global fields (one per save, shared across all pages):
+    , sdGameTime     ∷ !Double   -- ^ gameTimeRef value (game-clock seconds).
+    , sdEnginePaused ∷ !Bool     -- ^ enginePausedRef value. Auto-pause-on-save
+                                  --   means this is always True for v2+ saves.
     , sdLuaModules   ∷ !(HM.HashMap Text Text)
         -- ^ Per-Lua-module opaque blobs. Each registered module
         --   serializes its state to a string via the Lua
@@ -199,36 +239,39 @@ data SaveData = SaveData
         --   `saveModules.deserializeAll(blobs)` BEFORE the engine-side
         --   restore happens, so AI memory + spawn-sequencer state
         --   line up with the units/buildings the engine then writes.
-    -- v31 fields (mining):
-    , sdMineDesignations ∷ !MineDesignations
-        -- ^ Mine designations incl. mid-dig corner progress. Restored
-        --   straight into wsMineDesignationsRef; markers re-render
-        --   from the stored z, so no chunk loading is required first.
-    -- v32 fields (ground items):
-    , sdGroundItems ∷ !GroundItems
-        -- ^ Items lying in the world. Full ItemInstances + float
-        --   positions; resting height derives from terrain at render,
-        --   so restoration needs no chunk loading either.
-    -- v34 fields (dig yields):
-    , sdSpoilPiles ∷ !SpoilPiles
-        -- ^ Spoil mounds (vertex-keyed partial fills — see
-        --   World.Spoil.Types). Fills are relative to each tile's
-        --   terrain surface; promoted cells live in sdEdits as
-        --   WeAddTile, so restoration is order-independent.
-    -- v54 fields (structure persistence):
     , sdTexPalette ∷ !TexPalette
-        -- ^ Texture path↔id palette. Structure edits in sdEdits store
-        --   palette ids; this resolves them to paths → runtime handles
-        --   on load. Stable ids → no per-object remap. (Structures
-        --   themselves ride sdEdits as WeSetStructure — no separate
-        --   structure channel.)
-    -- v56 fields (item-instance identity, #67):
+        -- ^ Texture path↔id palette. Structure edits in each page's edits
+        --   store palette ids; this resolves them to paths → runtime
+        --   handles on load. Stable ids → no per-object remap.
     , sdNextItemInstanceId ∷ !Word64
         -- ^ Snapshot of 'nextItemInstanceIdRef' at save time. Restored
         --   (max'd, never lowered) on load so post-load item creation
         --   continues above every saved 'iiInstanceId' and can't reuse an
         --   id still held by a loaded item.
+    -- Multi-page fields (#215 / epic #214):
+    , sdActivePage   ∷ !WorldPageId
+        -- ^ The primary/active page at save time. Restores under id
+        --   @main_world@ (the documented convention that existing Lua /
+        --   headless code assumes) regardless of its original id.
+    , sdVisiblePages ∷ ![WorldPageId]
+        -- ^ Pages that were visible (wmVisible) at save time, so the
+        --   loaded game comes up showing what the player last saw.
+    , sdWorlds       ∷ ![WorldPageSave]
+        -- ^ Every saved world page. Today exactly one (the active world);
+        --   #216 will populate this from all of wmWorlds.
     } deriving (Show, Serialize, Generic)
+
+-- | The primary/active world page in a save — the one that restores as
+--   @main_world@. Falls back to the first page if 'sdActivePage' names no
+--   page in 'sdWorlds' (defensive; every real save records a valid active
+--   id). 'Nothing' only for a malformed empty-world save.
+activeWorldPage ∷ SaveData → Maybe WorldPageSave
+activeWorldPage sd =
+    case filter ((≡ sdActivePage sd) . wpsPageId) (sdWorlds sd) of
+        (w:_) → Just w
+        []    → case sdWorlds sd of
+                  (w:_) → Just w
+                  []    → Nothing
 
 -- | Persistable snapshot of `BuildingManager`. Drops `bmDefs`
 --   (regenerated from YAML at boot) and `bmSelected` (transient UI

--- a/src/World/Thread/Command/Save.hs
+++ b/src/World/Thread/Command/Save.hs
@@ -557,8 +557,9 @@ handleWorldLoadSaveCommand env logger pageId saveData
     sendSaveLoaded env uSurvivingIds bSurvivingIds
 
   | otherwise =
-      -- A well-formed save always records at least the active world page;
-      -- an empty sdWorlds means a corrupt or truncated file. Refuse rather
-      -- than crash the world thread.
+      -- Defense-in-depth: loadWorld already rejects an empty sdWorlds at
+      -- decode time (Serialize.hs), so engine.loadSave fails cleanly before
+      -- queueing this command and this branch is unreachable via the normal
+      -- path. Kept so a future direct caller can't crash the world thread.
       logError logger CatWorld
           "Cannot load save: save contains no world pages"

--- a/src/World/Thread/Command/Save.hs
+++ b/src/World/Thread/Command/Save.hs
@@ -129,33 +129,42 @@ handleWorldSaveCommand env logger pageId saveName timestampTxt luaBlobs = do
                             , smPlateCount = wgpPlateCount params
                             , smTimestamp  = timestampTxt
                             }
+                        -- Per-world payload for the active page. #216 will
+                        -- build one of these for every page in wmWorlds;
+                        -- today we snapshot only the saved (active) page.
+                        wps = WorldPageSave
+                            { wpsPageId     = pageId
+                            , wpsGenParams  = params
+                            , wpsCameraX    = cx
+                            , wpsCameraY    = cy
+                            , wpsCameraZoom = camZoom cam
+                            , wpsCameraFacing = camFacing cam
+                            , wpsTimeHour   = h
+                            , wpsTimeMinute = m
+                            , wpsDateYear   = y
+                            , wpsDateMonth  = mo
+                            , wpsDateDay    = d
+                            , wpsTimeScale  = tScale
+                            , wpsMapMode    = mapMode
+                            , wpsToolMode   = toolMode
+                            , wpsEdits      = edits
+                            , wpsMineDesignations = mineDesigs
+                            , wpsGroundItems = groundItems
+                            , wpsSpoilPiles  = spoilPiles
+                            , wpsBuildings   = buildings
+                            , wpsUnits       = units
+                            , wpsUnitSimStates = simStates
+                            }
                         sd = SaveData
                             { sdMetadata   = meta
-                            , sdGenParams  = params
-                            , sdCameraX    = cx
-                            , sdCameraY    = cy
-                            , sdCameraZoom = camZoom cam
-                            , sdCameraFacing = camFacing cam
-                            , sdTimeHour   = h
-                            , sdTimeMinute = m
-                            , sdDateYear   = y
-                            , sdDateMonth  = mo
-                            , sdDateDay    = d
-                            , sdTimeScale  = tScale
-                            , sdMapMode    = mapMode
-                            , sdToolMode   = toolMode
                             , sdGameTime     = gameTime
                             , sdEnginePaused = paused
-                            , sdEdits        = edits
-                            , sdBuildings    = buildings
-                            , sdUnits        = units
-                            , sdUnitSimStates = simStates
                             , sdLuaModules   = luaBlobs
-                            , sdMineDesignations = mineDesigs
-                            , sdGroundItems  = groundItems
-                            , sdSpoilPiles   = spoilPiles
                             , sdTexPalette   = texPalette
                             , sdNextItemInstanceId = nextItemId
+                            , sdActivePage   = pageId
+                            , sdVisiblePages = [pageId]
+                            , sdWorlds       = [wps]
                             }
                     result ← saveWorld saveName sd
                     case result of
@@ -175,11 +184,20 @@ handleWorldSaveCommand env logger pageId saveName timestampTxt luaBlobs = do
 --   buildTimeline / computeOceanMap / initEarlyClimate steps
 --   because those are already baked into sdGenParams.
 handleWorldLoadSaveCommand ∷ EngineEnv → LoggerState → WorldPageId → SaveData → IO ()
-handleWorldLoadSaveCommand env logger pageId saveData = do
+handleWorldLoadSaveCommand env logger pageId saveData
+  | (firstWps : _) ← sdWorlds saveData = do
     logInfo logger CatWorld $ "Loading save into world: "
         <> unWorldPageId pageId
 
-    let params    = sdGenParams saveData
+    -- #215: per-world state now lives in sdWorlds. Until the load handler
+    -- restores every page (#217), reconstruct only the active page — this
+    -- preserves the historical single-page load behaviour. The pattern
+    -- guard binds 'firstWps' as the fallback for a save whose recorded
+    -- active id is absent (activeWorldPage already prefers the active page).
+    let wps       = case activeWorldPage saveData of
+                      Just w  → w
+                      Nothing → firstWps
+        params    = wpsGenParams wps
         seed      = wgpSeed params
         worldSize = wgpWorldSize params
 
@@ -203,21 +221,21 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
 
     -- 2. Restore mutable game state from the save
     writeIORef (wsCameraRef worldState)
-        (WorldCamera (sdCameraX saveData) (sdCameraY saveData))
+        (WorldCamera (wpsCameraX wps) (wpsCameraY wps))
     writeIORef (wsTimeRef worldState)
-        (WorldTime (sdTimeHour saveData) (sdTimeMinute saveData))
+        (WorldTime (wpsTimeHour wps) (wpsTimeMinute wps))
     writeIORef (wsDateRef worldState)
-        (WorldDate (sdDateYear saveData)
-                   (sdDateMonth saveData)
-                   (sdDateDay saveData))
+        (WorldDate (wpsDateYear wps)
+                   (wpsDateMonth wps)
+                   (wpsDateDay wps))
     -- Keep wsTimeScaleRef synchronized with the restored pause flag: a
     -- paused save (the normal auto-pause-on-save case) must load with the
     -- live clock frozen, not running at the player's saved speed. The
     -- chosen speed is preserved in sdTimeScale and reapplied when the
     -- player resumes (scripts/pause.lua prevTimeScale) (#42).
     writeIORef (wsTimeScaleRef worldState)
-        (if sdEnginePaused saveData then 0 else sdTimeScale saveData)
-    writeIORef (wsMapModeRef worldState) (sdMapMode saveData)
+        (if sdEnginePaused saveData then 0 else wpsTimeScale wps)
+    writeIORef (wsMapModeRef worldState) (wpsMapMode wps)
     -- A loaded world starts on the default tool, NOT the tool that was
     -- active at save time. The HUD toolbar always comes up on the
     -- default slot after a load (fresh sessions rebuild it there;
@@ -238,17 +256,17 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
     -- v3 (Phase 2): restore edit log BEFORE chunk generation so the
     -- synchronous center chunk + every chunk pulled off the init queue
     -- replay any edits the player had made.
-    writeIORef (wsEditsRef worldState) (sdEdits saveData)
+    writeIORef (wsEditsRef worldState) (wpsEdits wps)
     -- v31 (mining): restore designations (incl. mid-dig corner
     -- progress). Markers render from the stored z, so this needs no
     -- chunk loading to be visible.
-    writeIORef (wsMineDesignationsRef worldState) (sdMineDesignations saveData)
+    writeIORef (wsMineDesignationsRef worldState) (wpsMineDesignations wps)
     -- v32 (ground items): heights derive from terrain at render, so
     -- restoration is position-only and needs no chunk loading.
-    writeIORef (wsGroundItemsRef worldState) (sdGroundItems saveData)
+    writeIORef (wsGroundItemsRef worldState) (wpsGroundItems wps)
     -- v34 (dig yields): spoil fills are relative to tile surfaces;
     -- promoted cells replay from sdEdits independently.
-    writeIORef (wsSpoilRef worldState) (sdSpoilPiles saveData)
+    writeIORef (wsSpoilRef worldState) (wpsSpoilPiles wps)
     -- v54 (structures): restore the texture palette BEFORE any chunk
     -- replays its WeSetStructure edits, so palette-id → path resolution
     -- is available. Structures themselves ride sdEdits (replayed per chunk).
@@ -305,9 +323,9 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
     -- wrong chunk for synchronous regen, producing a blank center tile
     -- on load until the async queue catches up.
     let centerCoord@(ChunkCoord camCX camCY) =
-            cameraChunkCoord (sdCameraFacing saveData)
-                             (sdCameraX saveData)
-                             (sdCameraY saveData)
+            cameraChunkCoord (wpsCameraFacing wps)
+                             (wpsCameraX wps)
+                             (wpsCameraY wps)
         (ct, cs, cterrain, cf, cice, cflora, cwt, cmagma) = generateChunk registry catalog params centerCoord
         seededSurf = VU.imap (\idx surfZ →
             case cf V.! idx of
@@ -357,7 +375,7 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
     bSurvivingIds ← do
         currentBm ← readIORef (buildingManagerRef env)
         let (restored, orphans) =
-                fromBuildingSnapshot pageId (bmDefs currentBm) (sdBuildings saveData)
+                fromBuildingSnapshot pageId (bmDefs currentBm) (wpsBuildings wps)
             -- #191: the snapshot owns only THIS page. Replace just this
             -- page's slice of the global manager and keep other live
             -- pages' buildings intact — a wholesale write dropped them.
@@ -427,11 +445,11 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
     uSurvivingIds ← do
         currentUm ← readIORef (unitManagerRef env)
         let (restoredUm, orphanUnits) =
-                fromUnitSnapshot pageId (umDefs currentUm) (sdUnits saveData)
+                fromUnitSnapshot pageId (umDefs currentUm) (wpsUnits wps)
             liveUids = HM.keysSet (umInstances restoredUm)
             -- Drop sim states whose owning unit was orphaned.
             simStates' = HM.filterWithKey (\uid _ → uid `HS.member` liveUids)
-                                          (sdUnitSimStates saveData)
+                                          (wpsUnitSimStates wps)
             -- #191: keep units (and their sim states) belonging to OTHER
             -- live pages; replace only this page's slice of the global
             -- manager. A wholesale write dropped off-page units.
@@ -486,9 +504,9 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
     -- takes grid coords (gx, gy), not world coords — go through
     -- worldToGrid so this matches the convention used everywhere else
     -- (Render.hs:136, Quads.hs:397, etc.).
-    let (camGX, camGY) = worldToGrid (sdCameraFacing saveData)
-                                     (sdCameraX saveData)
-                                     (sdCameraY saveData)
+    let (camGX, camGY) = worldToGrid (wpsCameraFacing wps)
+                                     (wpsCameraX wps)
+                                     (wpsCameraY wps)
         (surfaceElev, _mat) =
             elevationAtGlobal seed (wgpPlates params) worldSize camGX camGY
         startZSlice = surfaceElev + surfaceHeadroom
@@ -501,12 +519,12 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
     -- decision at load time.
     atomicModifyIORef' (cameraRef env) $ \_ →
         (Camera2D
-            { camPosition     = (sdCameraX saveData, sdCameraY saveData)
+            { camPosition     = (wpsCameraX wps, wpsCameraY wps)
             , camVelocity     = (0, 0)
-            , camZoom         = sdCameraZoom saveData
+            , camZoom         = wpsCameraZoom wps
             , camZoomVelocity = 0
             , camRotation     = 0
-            , camFacing       = sdCameraFacing saveData
+            , camFacing       = wpsCameraFacing wps
             , camDragging     = False
             , camDragOrigin   = (0, 0)
             , camZSlice       = startZSlice
@@ -537,3 +555,10 @@ handleWorldLoadSaveCommand env logger pageId saveData = do
     -- gone-before-save id that collides with a live off-page entity uses
     -- that entity's own state, never the blob's — no misattribution.
     sendSaveLoaded env uSurvivingIds bSurvivingIds
+
+  | otherwise =
+      -- A well-formed save always records at least the active world page;
+      -- an empty sdWorlds means a corrupt or truncated file. Refuse rather
+      -- than crash the world thread.
+      logError logger CatWorld
+          "Cannot load save: save contains no world pages"


### PR DESCRIPTION
Closes #215. Foundational schema sub-issue of the all-worlds-save epic (#214).

## What

Split the per-world fields off `SaveData` into a new `WorldPageSave` record. `SaveData` now holds the genuinely **global** fields plus the multi-page envelope:

```
data WorldPageSave = WorldPageSave   -- one per saved page
  { wpsPageId, wpsGenParams, wpsCamera*, wpsTime*/wpsDate*, wpsTimeScale
  , wpsMapMode, wpsToolMode, wpsEdits, wpsMineDesignations, wpsGroundItems
  , wpsSpoilPiles, wpsBuildings, wpsUnits, wpsUnitSimStates }

data SaveData = SaveData
  { sdMetadata
  , sdGameTime, sdEnginePaused, sdLuaModules, sdTexPalette, sdNextItemInstanceId  -- globals
  , sdActivePage :: WorldPageId
  , sdVisiblePages :: [WorldPageId]
  , sdWorlds :: [WorldPageSave] }
```

`sdNextItemInstanceId` (v56, #67) is kept as a global since the item-id allocator is engine-wide.

## Scope (intentionally minimal)

Per the epic decomposition, this PR only establishes the **shape**. The save command still snapshots just the active page (`sdWorlds = [wps]`), and the load handler reconstructs only the active page — so **single-world save/load behaviour is unchanged**. Iterating every page on save (#216) and restoring every page on load (#217) build on this without further schema churn.

- `activeWorldPage :: SaveData → Maybe WorldPageSave` resolves `sdActivePage` (falls back to the first page) for the `world_gen.yaml` writer and the single-page load path.
- `WorldPageId` gains a derived `Serialize` instance (newtype over `Text`, instance in UPrelude) so page ids persist.
- Load handler guards an empty `sdWorlds` (corrupt/truncated file) instead of crashing the world thread.
- `currentSaveVersion` 58 → 59 (old saves rejected with the existing clear version error).

## Camera duality note (#215)

For this single-page step the active page's camera fields come from the global `cameraRef` exactly as before — no behavioural change. Sourcing other pages' cameras from their `wsCameraRef` is deferred to #216/#217 where multiple pages are actually walked.

## Verification

- `cabal build all` — clean (no warnings).
- `cabal test synarchy-test-headless` — **369 examples, 0 failures**.
- Headless save→load round-trip on a fresh seed-42 w64 world: save writes a **v59** file (header magic `SYRA` + `0x3b`) with a correct `world_gen.yaml` (seed 42, plates 3); `engine.loadSave` decodes the new schema, extracts the active page, and reconstructs the world under `main_world` (terrain matches, 25 chunks, surface z=30) with no version-incompatible error.

This is a save-format change, not a worldgen-output change, so no baseline recapture / world_check tier is required — only the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)