### PR TITLE
Fix #136: stop unit_info_v2 hiding the shared HUD info panel

### DIFF
--- a/scripts/unit_info_v2.lua
+++ b/scripts/unit_info_v2.lua
@@ -3414,12 +3414,16 @@ local function bootstrap()
     unitInfoV2.subTabUnselectedTexSet =
         boxTextures.load("assets/textures/ui/tabunselected", "tabunselected")
 
-    -- Take over the unit-info display: suppress the shared HUD info panel
-    -- entirely while v2 is alive. Tile / building info also stop showing
-    -- until those flows get migrated into v2 too. Suppression (not a bare
-    -- hide) also blocks background info watchers from re-opening the panel
-    -- behind v2, and lets shutdown restore from content (#134).
-    infoPanel.suppress("unit_info_v2")
+    -- Take over the unit-info display. The legacy unit watcher
+    -- (unit_info_panel.lua) already self-suppresses via the
+    -- __unit_info_v2_suppress sentinel, so it never pushes unit content
+    -- into the shared HUD info panel while v2 is loaded. We do NOT blanket-
+    -- suppress that shared panel here: it is still the renderer for tile /
+    -- building / ground-item info, which must keep showing (#136). Instead
+    -- suppression is driven dynamically in update() — the shared panel is
+    -- hidden only while v2's pane is actually on screen (a unit is
+    -- selected), so the two can never visually overlap, and released the
+    -- moment the pane hides so tile/building/item readouts reappear.
 end
 
 -----------------------------------------------------------
@@ -3657,8 +3661,16 @@ function unitInfoV2.update(dt)
     if want ~= unitInfoV2.lastWantVisible then
         if want then
             UI.showPage(unitInfoV2.page)
+            -- Pane is coming up over the right edge: hide the shared HUD
+            -- info panel so a lingering tile/building/item readout can't
+            -- overlap it (#136). Released again the moment the pane hides.
+            infoPanel.suppress("unit_info_v2")
         else
             UI.hidePage(unitInfoV2.page)
+            -- Pane gone: let the shared panel render tile/building/item
+            -- info again (refresh re-derives from content + any other
+            -- suppressors, so it only resurfaces if it has something).
+            infoPanel.unsuppress("unit_info_v2")
         end
         unitInfoV2.lastWantVisible = want
     end
@@ -3682,8 +3694,10 @@ function unitInfoV2.onFramebufferResize(width, height)
                      and hud.currentView == "zoomed_in"
         if want then
             UI.showPage(unitInfoV2.page)
+            infoPanel.suppress("unit_info_v2")
         else
             UI.hidePage(unitInfoV2.page)
+            infoPanel.unsuppress("unit_info_v2")
         end
         unitInfoV2.lastWantVisible = want
     end

--- a/scripts/unit_info_v2.lua
+++ b/scripts/unit_info_v2.lua
@@ -3562,6 +3562,15 @@ function unitInfoV2.update(dt)
     if key ~= unitInfoV2.lastSelKey then
         rebuildTabs(sel)
         unitInfoV2.lastSelKey = key
+        -- Selecting a unit takes ownership of the readout, so clear any
+        -- world-tile cursor selection — exactly as the legacy unit
+        -- watcher did (unit_info_panel.lua), which is suppressed under v2.
+        -- Without this the tile-info watcher keeps a stale tile readout
+        -- alive in the (suppressed) shared panel, which then resurfaces
+        -- the moment the v2 pane hides and we unsuppress it (#136).
+        if count > 0 and hud and hud.worldId then
+            world.clearWorldCursorSelect(hud.worldId)
+        end
     end
 
     -- Stats sub-panel: rebuild content when the active unit OR sub-tab


### PR DESCRIPTION
Closes #136.

## Problem
The shared HUD info panel (`scripts/hud/info_panel.lua`) is a single top-right panel with swappable schemas — it's the only renderer for **tile, building, and ground-item** info (as well as legacy unit info). `unit_info_v2.bootstrap()` called `infoPanel.suppress("unit_info_v2")`, which force-hid that panel for v2's entire lifetime. The tile/building/item watchers kept pushing updates, but into a permanently-hidden panel, so that info never appeared while `unit_info_v2` was loaded.

## Why the blanket suppress was unnecessary
- The legacy unit watcher (`unit_info_panel.lua`) already self-suppresses via the `__unit_info_v2_suppress` sentinel, so the shared panel **never carries unit content** while v2 is loaded.
- The v2 right-edge pane is shown **only when ≥1 unit is selected** (and zoomed-in + gameplay active). The only real reason to hide the shared panel was to stop a lingering tile/building readout from overlapping the v2 pane — which only matters *while the pane is on screen*.

## Fix
Drive the suppressor **dynamically** from the v2 pane's visibility instead of statically at bootstrap:
- pane shown (unit selected) → `infoPanel.suppress("unit_info_v2")` (no overlap)
- pane hidden (no unit → tile/building/item selected) → `infoPanel.unsuppress("unit_info_v2")` → tile/building/item info renders in the top-right again

Mirrored in both the `update()` visibility gate and the `onFramebufferResize()` gate so the invariant *"shared panel suppressed iff v2 pane visible"* always holds. `shutdown()` still releases on unload. The `#134` suppressor machinery (keyed suppressors, content-derived refresh) is preserved untouched.

## Scope / risk
Lua-only change to `scripts/unit_info_v2.lua` (no engine/Haskell, no schema/save changes). Syntax-checked with `luajit`.

## Verification
This is **GUI-only** behavior — the hspec suite and `world_check` cover engine core / worldgen and don't load these HUD scripts, and the loading screen / HUD don't run headless. Needs an in-app visual confirm:
- With `unit_info_v2` active, click a **tile** → tile info appears top-right.
- Click a **building** / **ground item** → its info appears top-right.
- Click a **unit** → the v2 right-edge pane shows and the top-right panel hides (no overlap).
- Deselect → top-right panel returns for any still-selected tile/building/item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)