### PR TITLE
Fix #307: route lunge stamina gate through stats.get(max_stamina)

### DIFF
--- a/scripts/unit_ai.lua
+++ b/scripts/unit_ai.lua
@@ -1424,8 +1424,8 @@ local function shouldLunge(uid, s)
     -- Stamina gate — a leap is a big spend.
     local stam = unit.getStat(uid, "stamina")
     if stam then
-        local maxStam = (unit.getStat(uid, "endurance") or 1.0) * 10.0
-        if maxStam > 0 and stam / maxStam < LUNGE_MIN_STAMINA_FRAC then
+        local maxStam = require("scripts.unit_stats").get(uid, "max_stamina")
+        if maxStam and maxStam > 0 and stam / maxStam < LUNGE_MIN_STAMINA_FRAC then
             return false
         end
     end


### PR DESCRIPTION
## Summary

`shouldLunge` (`scripts/unit_ai.lua`) recomputed a unit's max stamina inline as `endurance × 10`, the lone outlier among the stamina-fraction sites — `wanderUtility`, the engage gate, attack pursuit, and the info panel all go through the canonical accessor `stats.get(uid, "max_stamina")`. The inline formula bypassed the YAML/runtime `max_stamina` override path that the rest of the codebase respects.

```lua
-- before
local maxStam = (unit.getStat(uid, "endurance") or 1.0) * 10.0
if maxStam > 0 and stam / maxStam < LUNGE_MIN_STAMINA_FRAC then
-- after
local maxStam = require("scripts.unit_stats").get(uid, "max_stamina")
if maxStam and maxStam > 0 and stam / maxStam < LUNGE_MIN_STAMINA_FRAC then
```

## Why it's safe / why it matters

- The `max_stamina` derived fallback in `unit_stats.lua` returns `endurance × 10`, so behaviour is **byte-identical today** (no unit currently declares an explicit `max_stamina` — the bug is latent).
- It diverges correctly the moment any unit gets an explicit pool — exactly the instinct-lungers (bear, technomule, squirrel) most likely to want a non-acolyte stamina pool. Without this, the lunge gate would silently use the wrong fraction.
- The `maxStam and` nil-guard matches the neighbouring canonical sites (e.g. line ~1670), which also skip the gate when the accessor returns nil.

## Testing

Pure Lua change; no engine rebuild needed. `luajit -bl scripts/unit_ai.lua` parses clean.

Closes #307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)