### PR TITLE
Fix #319: debug-console JSON serializer emits valid JSON for inf/nan + control chars

### DIFF
--- a/src/Engine/Scripting/Lua/API/Shell.hs
+++ b/src/Engine/Scripting/Lua/API/Shell.hs
@@ -11,6 +11,7 @@ import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Read as T
 import qualified Data.ByteString.Char8 as BS
 import Data.List (sortBy, sort)
+import Numeric (showHex)
 
 shellExecuteFn ∷ Lua.LuaE Lua.Exception Lua.NumResults
 shellExecuteFn = do
@@ -178,10 +179,21 @@ luaValueToText depth idx
                 b ← Lua.toboolean idx
                 return $ if b then "true" else "false"
             Lua.TypeNumber  → do
-                Lua.pushvalue idx
-                mStr ← Lua.tostring (-1)
-                Lua.pop 1
-                return $ maybe "0" TE.decodeUtf8 mStr
+                -- Non-finite numbers (inf/-inf/nan) are not valid JSON, and
+                -- math.huge is a live sentinel in game code. Emit a quoted
+                -- stand-in so the headless → JSON → python pipeline still parses.
+                -- NB: unwrap the constructor rather than realToFrac — the
+                -- latter routes through toRational, which mangles inf/nan.
+                mNum ← Lua.tonumber idx
+                case mNum of
+                    Just (Lua.Number d)
+                        | isInfinite d → return $ if d > 0 then "\"inf\"" else "\"-inf\""
+                        | isNaN d      → return "\"nan\""
+                    _ → do
+                        Lua.pushvalue idx
+                        mStr ← Lua.tostring (-1)
+                        Lua.pop 1
+                        return $ maybe "0" TE.decodeUtf8 mStr
             Lua.TypeString  → do
                 mStr ← Lua.tostring idx
                 return $ case mStr of
@@ -254,6 +266,8 @@ collectTablePairs depth tableIdx acc = do
             collectTablePairs depth tableIdx ((keyText, valText) : acc)
 
 -- | Escape special characters for JSON string values.
+--   All C0 control chars (U+0000–U+001F) must be escaped per the JSON spec;
+--   the common ones get named escapes, the rest a \\u00XX form.
 escapeJsonText ∷ Text → Text
 escapeJsonText = T.concatMap $ \c → case c of
     '"'  → "\\\""
@@ -261,4 +275,8 @@ escapeJsonText = T.concatMap $ \c → case c of
     '\n' → "\\n"
     '\r' → "\\r"
     '\t' → "\\t"
-    _    → T.singleton c
+    '\b' → "\\b"
+    '\f' → "\\f"
+    _ | c < '\x20' → "\\u" <> T.pack (let h = showHex (fromEnum c) ""
+                                      in replicate (4 - length h) '0' <> h)
+      | otherwise  → T.singleton c


### PR DESCRIPTION
Closes #319.

## Problem

The debug console auto-serializes Lua return values to JSON (`luaValueToText` / `escapeJsonText` in `src/Engine/Scripting/Lua/API/Shell.hs`), and the headless workflow pipes that straight into `python3` tools. Two value classes produced **invalid JSON** that breaks `json.loads`:

1. **Non-finite numbers** — the number path used `Lua.tostring`, rendering `math.huge` to `inf`, `0/0` to `nan`, `-math.huge` to `-inf`. None are valid JSON. `math.huge` is a live sentinel in game code (e.g. `unit.getStat(uid,"carrying_capacity") or math.huge`), so a stat dump could emit `inf` and the consuming python tool throws an opaque `JSONDecodeError`.
2. **Control chars in strings** — `escapeJsonText` only escaped `" \ \n \r \t`; all other C0 control chars (U+0000 to U+001F) passed through raw, which the JSON spec forbids and strict parsers reject.

## Fix

- **Numbers:** intercept via `Lua.tonumber`; if `isInfinite`/`isNaN`, emit a quoted stand-in `"inf"`/`"-inf"`/`"nan"` (preserves diagnostic value, valid JSON). Finite numbers fall through to the unchanged `tostring` path, so integer formatting (`42`, not `42.0`) is preserved.
  - Subtlety: unwrap the `Lua.Number` constructor directly rather than `realToFrac` — `realToFrac` routes through `toRational`, which mangles `nan`/`inf` (an early version of this fix rendered `nan` as `"inf"` because of exactly that).
- **Strings:** extend `escapeJsonText` with named `\b`/`\f` escapes and a `\u00XX` fallback for any remaining char below U+0020.

## Testing

Built (production) and verified end-to-end via the headless TCP console to JSON to `python3 json.loads` pipeline:

| input | payload | parses |
|---|---|---|
| `{a=math.huge, b=-math.huge, c=0/0}` | `{"a":"inf","b":"-inf","c":"nan"}` | yes |
| `0/0` | `"nan"` | yes |
| string with embedded ctrl chars (\1 \8 \31) | ``, `\b`, `` escaped | yes |
| `{n=42, f=3.14, big=2^53}` | `{"n":42,"f":3.14,"big":9.007...e+15}` | yes |

Before the fix these emitted `inf`/`nan`/raw control chars and failed `json.loads`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
