### PR TITLE
Fix #317: clamp chemical-erosion intensity to [0,1]

### DIFF
--- a/src/World/Geology/Timeline/Helpers.hs
+++ b/src/World/Geology/Timeline/Helpers.hs
@@ -144,10 +144,19 @@ isSourceNew worldSize existingRivers (sx, sy, _, _) =
 
 -- * Erosion
 
+-- | Chemical-weathering intensity from atmospheric CO2, clamped to [0, 1].
+--   The lower clamp is defensive: the raw formula goes negative for
+--   @co2 < 0.333@, which today the CO2 floor (max 0.4 in Timeline.hs)
+--   keeps out of reach — but that is an implicit cross-module coupling, so
+--   we guard locally rather than rely on it (see #317). Shared by
+--   'erosionFromGeoState' and 'regionalErosionMap' to keep them from drifting.
+chemicalErosion ∷ Float → Float
+chemicalErosion co2 = max 0.0 (min 1.0 (0.2 + (co2 - 1.0) * 0.3))
+
 erosionFromGeoState ∷ Float → GeoState → ClimateState → Word64 → Int → Bool → ErosionParams
 erosionFromGeoState intensity gs climate seed ageIdx isLastAge =
     let co2 = gsCO2 gs
-        chemical = min 1.0 (0.2 + (co2 - 1.0) * 0.3)
+        chemical = chemicalErosion co2
 
         globalTemp = csGlobalTemp climate
         regions = cgRegions (csClimate climate)
@@ -201,7 +210,7 @@ regionalErosionMap ∷ Float → GeoState → ClimateState → Word64 → Int �
                    → HM.HashMap ClimateCoord ErosionParams
 regionalErosionMap intensity gs climate seed ageIdx isLastAge =
     let co2 = gsCO2 gs
-        chemical = min 1.0 (0.2 + (co2 - 1.0) * 0.3)
+        chemical = chemicalErosion co2
         regions = cgRegions (csClimate climate)
     in HM.map (buildRegionErosion co2 chemical) regions
   where


### PR DESCRIPTION
## What

Closes #317.

`chemical` erosion intensity was computed with a one-sided clamp:

```haskell
chemical = min 1.0 (0.2 + (co2 - 1.0) * 0.3)
```

This goes **negative** for `co2 < 0.333`, which would invert the `epChemical`
weathering term. It stays non-negative today only because the CO2 floor
(`max 0.4` in `Timeline.hs:703`) keeps it at `>= 0.02` — non-negativity depends
on two separately-tuned constants staying aligned, with no local guard. Lower
the CO2 floor (e.g. to model deeper ice-age drawdown) and `epChemical` silently
goes negative.

## Change

- Add the defensive lower clamp: `max 0.0 (min 1.0 (...))`.
- Factor the expression into a shared `chemicalErosion :: Float -> Float` helper,
  replacing the two divergent copies (`erosionFromGeoState` and
  `regionalErosionMap`) so they can't drift.

## Verification

- `cabal build all` clean.
- **No output change** — `--dump` is byte-identical between the master binary and
  this build for seeds 42 and 1337 (`worldSize 128`, region `-4,-4,4,4`). The
  clamp is a no-op given the current CO2 floor, so the change is purely a
  robustness guard + dedup.
- No worldgen baseline rebaseline or save-version bump needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)