### PR TITLE
Fix #323: correct building.getStorageWeight docstring

### DIFF
--- a/src/Engine/Asset/YamlUnits.hs
+++ b/src/Engine/Asset/YamlUnits.hs
@@ -109,7 +109,8 @@ instance FromJSON UnitYamlBody where
 --
 --   drop_priority feeds the spawn-time capacity check: a unit whose
 --   full loadout (inventory + equipment + accessories, fill counted
---   at 1 L = 1 kg) exceeds its rolled carrying_capacity sheds
+--   at each container's per-unit fill weight) exceeds its rolled
+--   carrying_capacity sheds
 --   droppable entries in DESCENDING priority until it fits. 0 (the
 --   default) = never shed — armor, weapons, and survival kit always
 --   arrive. Acolytes mark the pick (2) and shovel (1).

--- a/src/Engine/Scripting/Lua/API/Buildings.hs
+++ b/src/Engine/Scripting/Lua/API/Buildings.hs
@@ -679,10 +679,12 @@ buildingGetStorageCapacityFn env = do
                     return 1
 
 -- | building.getStorageWeight(bid) → Float kg currently stored. Sums
---   the def-declared weight of each ItemInstance in biStorage.
---   Doesn't account for container fills inside the storage (a stored
---   canteen counts as the empty canteen weight, not full weight) —
---   keep it simple for v1. nil if the bid is gone.
+--   the full weight of each ItemInstance in biStorage via
+--   'itemTotalWeight' (instance weight + container fill + nested
+--   contents) — so a stored canteen counts at its filled weight and a
+--   first-aid kit counts its contents, matching the unit-side
+--   'unit.getCarryingWeight' convention and the depositToCargo capacity
+--   gate. nil if the bid is gone.
 buildingGetStorageWeightFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 buildingGetStorageWeightFn env = do
     idArg ← Lua.tointeger 1

--- a/src/Engine/Scripting/Lua/API/Units.hs
+++ b/src/Engine/Scripting/Lua/API/Units.hs
@@ -2113,12 +2113,12 @@ unitWithdrawFromCargoFn env = do
             return 1
 
 -- | unit.getCarryingWeight(uid) → Float kg. Sum of full item weight
---   via 'itemTotalWeight' (instance weight + container fill, 1 L = 1 kg
---   water density, + nested container contents) across loose inventory
---   + equipped slot items + accessories. Worn gear counts the same as
---   carried gear by design: it's the same mass. Used by the auto-store
---   AI utility (fill_fraction = this / cap) and the pickup/fetch
---   capacity gates.
+--   via 'itemTotalWeight' (instance weight + container fill at the
+--   container's per-unit fill weight + nested container contents)
+--   across loose inventory + equipped slot items + accessories. Worn
+--   gear counts the same as carried gear by design: it's the same mass.
+--   Used by the auto-store AI utility (fill_fraction = this / cap) and
+--   the pickup/fetch capacity gates.
 unitGetCarryingWeightFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 unitGetCarryingWeightFn env = do
     uidArg ← Lua.tointeger 1

--- a/src/Engine/Scripting/Lua/API/Units.hs
+++ b/src/Engine/Scripting/Lua/API/Units.hs
@@ -2112,12 +2112,13 @@ unitWithdrawFromCargoFn env = do
             Lua.pushboolean False
             return 1
 
--- | unit.getCarryingWeight(uid) → Float kg. Sum of def-declared
---   weight PLUS current fill (1 L = 1 kg — water density) across
---   loose inventory + equipped slot items + accessories. Worn gear
---   counts the same as carried gear by design: it's the same mass.
---   Used by the auto-store AI utility (fill_fraction = this / cap)
---   and the pickup/fetch capacity gates.
+-- | unit.getCarryingWeight(uid) → Float kg. Sum of full item weight
+--   via 'itemTotalWeight' (instance weight + container fill, 1 L = 1 kg
+--   water density, + nested container contents) across loose inventory
+--   + equipped slot items + accessories. Worn gear counts the same as
+--   carried gear by design: it's the same mass. Used by the auto-store
+--   AI utility (fill_fraction = this / cap) and the pickup/fetch
+--   capacity gates.
 unitGetCarryingWeightFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 unitGetCarryingWeightFn env = do
     uidArg ← Lua.tointeger 1

--- a/src/Unit/Thread/Command.hs
+++ b/src/Unit/Thread/Command.hs
@@ -135,7 +135,8 @@ handleUnitCommand env utsRef (UnitSpawn uid defName gx gy gz factionId pageId) =
             -- priority shed (highest first — pick before shovel)
             -- until the loadout fits the rolled carrying_capacity.
             -- Weights mirror getCarryingWeight: instance weight + fill
-            -- (1 L = 1 kg) + container contents, worn gear at full mass.
+            -- (at the container's per-unit fill weight) + container
+            -- contents, worn gear at full mass.
             let itemW = itemTotalWeight itemMgr
                 fixedW = sum (map itemW (HM.elems initialEquipment))
                        + sum (map itemW initialAccessories)


### PR DESCRIPTION
## Summary

`buildingGetStorageWeightFn` (`src/Engine/Scripting/Lua/API/Buildings.hs`) had a docstring that contradicted its implementation. The doc claimed it summed only def-declared empty weights and "doesn't account for container fills inside the storage (a stored canteen counts as the empty canteen weight, not full weight) — keep it simple for v1", but the code sums `itemTotalWeight`, which includes `iiCurrentFill` and nested container contents.

Per the issue, the **code** is correct and stays — it matches `unit.getCarryingWeight` and the `depositToCargo` capacity gate, so storage weight, carry weight, and the deposit gate are all consistent. Only the stale docstring is updated.

## Change

Comment-only. Rewrote the docstring to describe the actual behavior (sums `itemTotalWeight` = instance weight + container fill + nested contents) and note the consistency with the unit-side convention and deposit gate.

## Testing

None needed — pure Haskell comment change, no code path affected. Verified no other stale references to the old "empty canteen" claim exist in docs/Lua/Haskell.

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)