### PR TITLE
Fix #321: round-trip non-finite numbers in the Lua save serializer

### DIFF
--- a/scripts/lib/serialize.lua
+++ b/scripts/lib/serialize.lua
@@ -56,11 +56,20 @@ function serializeLib.serialize(value)
     return ser(value)
 end
 
+-- Deserialize env. Kept minimal so the loaded chunk can't reach _G,
+-- io, os, etc. The two number constants exist only to decode LEGACY
+-- blobs: saves written before issue #321 emitted bare inf/-inf/nan
+-- tokens (from %.17g). Binding inf/nan here lets those resolve as
+-- numbers instead of nil-globals (inf/nan dropped to nil, -inf threw
+-- and lost the whole module), so existing v60 saves restore correctly.
+-- The current encoder writes 1/0 / -1/0 / 0/0, which need no globals.
+local deserializeEnv = { inf = math.huge, nan = 0/0 }
+
 function serializeLib.deserialize(str)
     if str == nil or str == "" then return nil end
-    -- "t" mode = text-only chunk (no bytecode). Empty env table
+    -- "t" mode = text-only chunk (no bytecode); the restricted env above
     -- prevents the chunk from reaching _G, io, os, etc.
-    local fn, err = load("return " .. str, "savedata", "t", {})
+    local fn, err = load("return " .. str, "savedata", "t", deserializeEnv)
     if not fn then
         error("deserialize: " .. tostring(err))
     end

--- a/scripts/lib/serialize.lua
+++ b/scripts/lib/serialize.lua
@@ -14,11 +14,23 @@
 
 local serializeLib = {}
 
+-- Format a number as a round-trippable Lua literal. %.17g does not
+-- emit a token that reloads in the empty deserialize env for the
+-- non-finite values (inf/-inf/nan → undefined globals → nil, or a
+-- "1.#INF"-style syntax error on some libc), so map those to bare
+-- arithmetic literals that need no globals. See issue #321.
+local function serNum(v)
+    if v ~= v then return "0/0"             -- nan (v ~= v only for nan)
+    elseif v == math.huge then return "1/0"
+    elseif v == -math.huge then return "-1/0"
+    else return string.format("%.17g", v) end
+end
+
 local function ser(v)
     local t = type(v)
     if t == "nil"     then return "nil"
     elseif t == "boolean" then return tostring(v)
-    elseif t == "number"  then return string.format("%.17g", v)
+    elseif t == "number"  then return serNum(v)
     elseif t == "string"  then return string.format("%q", v)
     elseif t == "table"   then
         local parts = {}
@@ -28,7 +40,7 @@ local function ser(v)
             if kt == "string" then
                 ks = string.format("[%q]", k)
             elseif kt == "number" then
-                ks = "[" .. string.format("%.17g", k) .. "]"
+                ks = "[" .. serNum(k) .. "]"
             else
                 error("serialize: unsupported key type " .. kt)
             end

--- a/tools/test_serialize_nonfinite.lua
+++ b/tools/test_serialize_nonfinite.lua
@@ -1,0 +1,64 @@
+-- Offline regression harness for issue #321: the save-state serializer
+-- (scripts/lib/serialize.lua) must round-trip non-finite numbers.
+--
+-- Before the fix, %.17g emitted "inf"/"-inf"/"nan", which on reload in
+-- the empty deserialize env became undefined globals: inf/nan silently
+-- dropped to nil, and "-inf" parsed as -(global inf) → an arithmetic
+-- error that lost the module's ENTIRE saved blob. PASS = every value
+-- round-trips and finite numbers are unchanged.
+
+package.path = "./?.lua;" .. package.path
+
+local s = require("scripts.lib.serialize")
+
+local failures = 0
+local function check(name, cond)
+    if cond then
+        print("PASS  " .. name)
+    else
+        print("FAIL  " .. name)
+        failures = failures + 1
+    end
+end
+
+local function roundtrip(v)
+    return s.deserialize(s.serialize(v))
+end
+
+-- Non-finite scalars survive the round-trip.
+check("+inf round-trips", roundtrip(math.huge) == math.huge)
+check("-inf round-trips", roundtrip(-math.huge) == -math.huge)
+local nan = roundtrip(0/0)
+check("nan round-trips", nan ~= nan)  -- nan is the only value ~= itself
+
+-- Finite numbers are byte-identical to the old %.17g output.
+for _, v in ipairs({ 0, -1, 3.5, 1234567.89, 1e-9, math.pi, -0.0 }) do
+    check("finite " .. tostring(v) .. " unchanged",
+          roundtrip(v) == v and s.serialize(v) == string.format("%.17g", v))
+end
+
+-- The real trigger: a saved table carrying math.huge sentinels (e.g.
+-- unit_ai AI memory) must not lose sibling fields. Pre-fix, the -inf
+-- field threw and the whole table failed to deserialize.
+local blob = { cooldown = math.huge, floor = -math.huge, bad = 0/0,
+               name = "acolyte", n = 42, nested = { t = math.huge } }
+local dec = roundtrip(blob)
+check("sentinel table: cooldown", dec.cooldown == math.huge)
+check("sentinel table: floor",    dec.floor == -math.huge)
+check("sentinel table: bad(nan)", dec.bad ~= dec.bad)
+check("sentinel table: name kept", dec.name == "acolyte")
+check("sentinel table: n kept",    dec.n == 42)
+check("sentinel table: nested",    dec.nested.t == math.huge)
+
+-- An infinite numeric KEY also round-trips (nan keys are illegal in Lua,
+-- so they can never reach the serializer from a key slot).
+local keyed = roundtrip({ [math.huge] = "topcap" })
+check("inf numeric key", keyed[math.huge] == "topcap")
+
+if failures == 0 then
+    print("ALL PASS")
+    os.exit(0)
+else
+    print(failures .. " FAILURE(S)")
+    os.exit(1)
+end

--- a/tools/test_serialize_nonfinite.lua
+++ b/tools/test_serialize_nonfinite.lua
@@ -55,6 +55,24 @@ check("sentinel table: nested",    dec.nested.t == math.huge)
 local keyed = roundtrip({ [math.huge] = "topcap" })
 check("inf numeric key", keyed[math.huge] == "topcap")
 
+-- Backward compatibility: LEGACY blobs written before the fix carry bare
+-- inf/-inf/nan tokens (what %.17g emitted). Existing v60 saves stay at
+-- v60, so deserialize must still decode them rather than dropping the
+-- field (inf/nan → nil) or losing the whole module (-inf threw).
+check("legacy inf decodes",  s.deserialize("inf") == math.huge)
+check("legacy -inf decodes", s.deserialize("-inf") == -math.huge)
+local lnan = s.deserialize("nan")
+check("legacy nan decodes",  lnan ~= lnan)
+local legacyBlob = s.deserialize('{["cooldown"]=inf,["floor"]=-inf,["name"]="acolyte"}')
+check("legacy table: cooldown", legacyBlob.cooldown == math.huge)
+check("legacy table: floor",    legacyBlob.floor == -math.huge)
+check("legacy table: name kept", legacyBlob.name == "acolyte")
+
+-- The restricted env must still block runtime/global access.
+check("env blocks globals", s.deserialize("type") == nil)
+check("env has no os", pcall(function() return s.deserialize("os") end) and
+                       s.deserialize("os") == nil)
+
 if failures == 0 then
     print("ALL PASS")
     os.exit(0)


### PR DESCRIPTION
## Problem

`scripts/lib/serialize.lua` formats numbers with `%.17g`, which emits `inf` / `-inf` / `nan` (or `1.#INF` on some libc) for non-finite values. Those are reloaded by `deserialize` via `load("return "..str, "t", env)` against a restricted environment — pre-fix, an **empty** one — so:

- `inf` / `nan` → undefined globals → **silently `nil`** (field dropped).
- `-inf` → parsed as `-(global inf)` → **arithmetic-on-nil error** → `deserialize` throws and the module's **entire saved blob is lost** (`save_modules.deserializeAll` catches and skips the module).

This writes **player saves** (unit_ai AI memory, building_spawn state, …) — the codebase uses `math.huge` / `-math.huge` as live sentinels, so any saved numeric field set to one corrupts silently.

## Fix (two halves)

**1. Encoder.** Factor number formatting into `serNum()` and special-case non-finite values to bare arithmetic literals that need no globals and round-trip exactly. Applied to **both** the value and numeric-key sites:

| value | literal |
|-------|---------|
| `nan` | `0/0` |
| `+inf` | `1/0` |
| `-inf` | `-1/0` |

Finite numbers are **byte-identical** to the old `%.17g` output.

**2. Decoder / backward compat.** Existing **v60 saves stay at v60** (no version bump, since finite output is unchanged), so they must still load. But those blobs were written by the old encoder and carry bare `inf`/`-inf`/`nan` tokens. The deserialize env now binds `inf = math.huge` and `nan = 0/0` so legacy tokens resolve as numbers instead of nil-globals — recovering the field (and, for `-inf`, the whole module) on load. The env stays restricted to those two **numbers** (no functions, no `_G`/`io`/`os`), preserving the sandbox; the new encoder's `1/0`-style output doesn't depend on them.

> Note: the `1.#INF`-style libc output is a syntax error and unrecoverable by env-binding, but that never occurs on the supported macOS/Linux (luajit) platforms, which emit `inf`/`nan`.

## Test

Adds `tools/test_serialize_nonfinite.lua` (offline luajit regression harness). All 25 checks pass — fresh round-trips, finite-unchanged, the `math.huge`-sentinel table, inf numeric keys, **legacy `inf`/`-inf`/`nan` token decoding**, and env-sandbox assertions:

```
$ luajit tools/test_serialize_nonfinite.lua
...
PASS  legacy inf decodes
PASS  legacy -inf decodes
PASS  legacy nan decodes
PASS  legacy table: cooldown / floor / name kept
PASS  env blocks globals
PASS  env has no os
ALL PASS
```

Closes #321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)