### PR TITLE
#305: movement speed accounts for encumbrance (carried load ÷ capacity), eased by endurance

### DIFF
--- a/scripts/movement_speed.lua
+++ b/scripts/movement_speed.lua
@@ -19,6 +19,45 @@ local function clamp(x, lo, hi)
     return math.max(lo, math.min(hi, x))
 end
 
+-- Encumbrance speed band, keyed on the carried-weight / capacity ratio.
+--   FREE_FRAC  — load up to this fraction of capacity is "free" (a unit
+--                carrying a tool and a canteen isn't visibly slowed).
+--   IN_CAP_K   — gentle penalty slope from FREE_FRAC up to full capacity.
+--   OVER_K     — a much steeper slope once OVER capacity, so an overloaded
+--                unit slows hard. The hard pickup gate still holds (a unit
+--                only ends up over capacity from worn gear / a forced load),
+--                so this just makes that state visibly costly to move in.
+--   FLOOR      — never slower than this fraction of the base band, so a
+--                pinned-down unit still inches along rather than freezing.
+local ENC_FREE_FRAC = 0.25
+local ENC_IN_CAP_K  = 0.40
+local ENC_OVER_K    = 1.20
+local ENC_FLOOR     = 0.20
+
+-- Encumbrance multiplier on the whole speed band (mirrors
+-- injuries.speedMultiplier / salts.speedMultiplier). A light load is ~1.0;
+-- the penalty grows with the carried/capacity ratio and is EASED by the
+-- endurance stat — a fit unit (or a pack animal like the technomule, with
+-- both huge capacity and high endurance) shrugs off load that would crawl
+-- a weak one. Returns 1.0 when capacity data is missing so callers stay
+-- safe for defs without a carry stat.
+function M.encumbranceMultiplier(uid)
+    local cap = unit.getStat(uid, "carrying_capacity")
+    if not cap or cap <= 0 then return 1.0 end
+    local carried = unit.getCarryingWeight(uid) or 0
+    local r = carried / cap
+    -- Endurance 1.0 is nominal (acolyte); clamp so absurd stat data can't
+    -- zero the penalty or blow it up. Higher endurance divides the penalty.
+    local endur = clamp(unit.getStat(uid, "endurance") or 1.0, 0.3, 3.0)
+    -- Penalty accrues only above the free allowance: a gentle term within
+    -- capacity, plus a steep extra term once over it.
+    local penalty = 0.0
+    local inCap = math.min(r, 1.0) - ENC_FREE_FRAC
+    if inCap > 0 then penalty = penalty + ENC_IN_CAP_K * inCap end
+    if r > 1.0  then penalty = penalty + ENC_OVER_K * (r - 1.0) end
+    return clamp(1.0 - penalty / endur, ENC_FLOOR, 1.0)
+end
+
 -- Top (sprint) speed: max_speed × agility. Agility 1.0 → max_speed,
 -- 2.0 → double (a 20 km/h human, an exceptional 40 km/h one). Agility is
 -- clamped defensively so absurd stat data can't produce absurd speeds.
@@ -26,13 +65,15 @@ end
 -- injuries.speedMultiplier, so comfort/ordered/meander — all derived
 -- from sprint — slow together. A fully disabling break keeps the unit
 -- collapsed entirely (unit_resources), so this only ever limps a unit
--- that's still on its feet.
+-- that's still on its feet. Carried load slows the band the same way via
+-- encumbranceMultiplier — heavier = slower, eased by endurance.
 function M.sprint(uid)
     local maxsp = unit.getMaxSpeed(uid) or 0
     local agi   = unit.getStat(uid, "agility") or 1.0
     -- Salt cramps (hyponatremia) slow the whole speed band too, like a limp.
     return maxsp * clamp(agi, 0.3, 3.0)
          * injuries.speedMultiplier(uid) * salts.speedMultiplier(uid)
+         * M.encumbranceMultiplier(uid)
 end
 
 -- Comfort (stamina-neutral cruise): a fraction of sprint set by endurance,

--- a/scripts/movement_speed.lua
+++ b/scripts/movement_speed.lua
@@ -98,10 +98,17 @@ end
 -- regardless of how fast the unit *could* run — and capped under half
 -- comfort so even a low-comfort unit still meanders slower than it cruises.
 -- This is what keeps animals from sprinting around with no purpose.
+--
+-- Encumbrance DOES slow the amble (a loaded unit physically plods), so it
+-- multiplies the raw max_speed cap too. The comfort term already carries
+-- encumbrance via sprint, but on an agile unit the max_speed cap binds and
+-- would otherwise hide load from wander until it grew heavy — so apply the
+-- multiplier to both terms and the amble always responds to load.
 local MEANDER_FRAC = 0.25
 function M.meander(uid)
     local maxsp = unit.getMaxSpeed(uid) or 0
-    return math.min(maxsp * MEANDER_FRAC, M.comfort(uid) * 0.5)
+    return math.min(maxsp * MEANDER_FRAC * M.encumbranceMultiplier(uid),
+                    M.comfort(uid) * 0.5)
 end
 
 return M

--- a/tools/test_encumbrance_speed.lua
+++ b/tools/test_encumbrance_speed.lua
@@ -1,0 +1,129 @@
+-- Offline regression harness for the encumbrance speed multiplier (#305).
+--
+-- movement_speed.lua now scales the whole speed band by a carried-weight /
+-- capacity ratio, eased by the endurance stat. This test loads the module
+-- in isolation (stubbing injuries/salts so only the encumbrance term is
+-- exercised) and asserts the three properties the issue calls for:
+--
+--   1. Same unit, empty vs near-capacity vs over-capacity → strictly
+--      DECREASING speed.
+--   2. Same load ratio, high vs low endurance → the high-endurance unit is
+--      faster (endurance eases the curve).
+--   3. Unloaded behaviour unchanged — multiplier ≈ 1.0 at light load.
+--
+-- Run: luajit tools/test_encumbrance_speed.lua
+
+package.path = "./?.lua;" .. package.path
+
+-----------------------------------------------------------
+-- Stub the two sibling speed multipliers so this test isolates the
+-- encumbrance term (and doesn't drag in their real dependency trees).
+-----------------------------------------------------------
+package.loaded["scripts.injuries"] = { speedMultiplier = function() return 1.0 end }
+package.loaded["scripts.salts"]    = { speedMultiplier = function() return 1.0 end }
+
+-----------------------------------------------------------
+-- Unit-state the stubs serve: per-uid carrying_capacity, carried weight,
+-- endurance, plus a fixed max_speed / agility so sprint() is well-defined.
+-----------------------------------------------------------
+local U = {}  -- uid -> { cap, carried, endur }
+
+unit = {
+    getMaxSpeed = function() return 10.0 end,
+    getCarryingWeight = function(uid) return U[uid].carried end,
+    getStat = function(uid, name)
+        if name == "agility" then return 1.0 end
+        if name == "endurance" then return U[uid].endur end
+        if name == "carrying_capacity" then return U[uid].cap end
+        return nil
+    end,
+}
+
+local ms = require("scripts.movement_speed")
+
+-----------------------------------------------------------
+-- Assertion helpers
+-----------------------------------------------------------
+local failures = 0
+local function check(cond, msg)
+    if cond then
+        print("  PASS  " .. msg)
+    else
+        print("  FAIL  " .. msg)
+        failures = failures + 1
+    end
+end
+
+local function approx(a, b, eps)
+    return math.abs(a - b) <= (eps or 1e-6)
+end
+
+-- Configure a uid and return its encumbrance multiplier + sprint speed.
+local function setUnit(uid, cap, carried, endur)
+    U[uid] = { cap = cap, carried = carried, endur = endur }
+    return ms.encumbranceMultiplier(uid), ms.sprint(uid)
+end
+
+print("== #305 encumbrance speed multiplier ==")
+
+-----------------------------------------------------------
+-- 1. Strictly decreasing speed: empty < quarter < half < at-cap < over-cap.
+--    capacity 100 kg, endurance 1.0 (nominal acolyte).
+-----------------------------------------------------------
+print("[1] strictly-decreasing travel speed as load rises (endurance 1.0)")
+local mEmpty , sEmpty  = setUnit(1, 100,   0, 1.0)
+local mQtr   , _       = setUnit(1, 100,  25, 1.0)   -- at the free allowance
+local mHalf  , sHalf   = setUnit(1, 100,  50, 1.0)
+local mFull  , sFull   = setUnit(1, 100, 100, 1.0)   -- at capacity
+local mOver  , sOver   = setUnit(1, 100, 150, 1.0)   -- 1.5x over capacity
+
+check(approx(mEmpty, 1.0), string.format("empty  -> %.3f (≈1.0, light load free)", mEmpty))
+check(approx(mQtr,   1.0), string.format("25%%   -> %.3f (≈1.0, still within free allowance)", mQtr))
+check(mHalf  < mEmpty,     string.format("half   -> %.3f < empty %.3f", mHalf, mEmpty))
+check(mFull  < mHalf,      string.format("at-cap -> %.3f < half  %.3f", mFull, mHalf))
+check(mOver  < mFull,      string.format("over   -> %.3f < at-cap %.3f", mOver, mFull))
+-- Over-capacity slope must be visibly steeper than the in-capacity slope.
+check((mFull - mOver) > (mHalf - mFull),
+    string.format("over-cap drop (%.3f) steeper than in-cap drop (%.3f)",
+        mFull - mOver, mHalf - mFull))
+-- The band itself (sprint) tracks the multiplier.
+check(sOver < sFull and sFull < sHalf and sHalf < sEmpty,
+    "sprint speed strictly decreases with load")
+
+-----------------------------------------------------------
+-- 2. Endurance eases the curve: at the SAME ratio, higher endurance = faster.
+-----------------------------------------------------------
+print("[2] endurance eases the curve (same load ratio)")
+local mWeak,   _ = setUnit(1, 100, 100, 0.5)   -- at-capacity, weak
+local mNorm,   _ = setUnit(1, 100, 100, 1.0)   -- at-capacity, nominal
+local mStrong, _ = setUnit(1, 100, 100, 2.0)   -- at-capacity, strong
+check(mWeak < mNorm, string.format("at-cap: weak(0.5) %.3f < nominal(1.0) %.3f", mWeak, mNorm))
+check(mNorm < mStrong, string.format("at-cap: nominal(1.0) %.3f < strong(2.0) %.3f", mNorm, mStrong))
+-- Same comparison while over capacity (the steep regime) — ordering holds.
+local oWeak,   _ = setUnit(1, 100, 150, 0.5)
+local oStrong, _ = setUnit(1, 100, 150, 2.0)
+check(oWeak < oStrong, string.format("over-cap: weak %.3f < strong %.3f", oWeak, oStrong))
+
+-----------------------------------------------------------
+-- 3. Unloaded / missing-data safety.
+-----------------------------------------------------------
+print("[3] unloaded + missing-capacity safety")
+local mZero, _ = setUnit(1, 100, 0, 1.0)
+check(approx(mZero, 1.0), string.format("zero load -> %.3f (≈1.0)", mZero))
+-- No capacity stat (e.g. a def without a carry stat) -> neutral 1.0.
+U[2] = { cap = nil, carried = 5, endur = 1.0 }
+check(approx(ms.encumbranceMultiplier(2), 1.0), "nil capacity -> 1.0 (neutral)")
+U[3] = { cap = 0, carried = 5, endur = 1.0 }
+check(approx(ms.encumbranceMultiplier(3), 1.0), "zero capacity -> 1.0 (neutral, no divide-by-zero)")
+-- Floor holds for an absurd overload.
+local mCrush, _ = setUnit(1, 100, 1000, 0.3)
+check(mCrush >= 0.20 - 1e-9, string.format("crushing overload -> %.3f >= floor 0.20", mCrush))
+
+print("")
+if failures == 0 then
+    print("ALL CHECKS PASSED")
+    os.exit(0)
+else
+    print(string.format("%d CHECK(S) FAILED", failures))
+    os.exit(1)
+end

--- a/tools/test_encumbrance_speed.lua
+++ b/tools/test_encumbrance_speed.lua
@@ -32,7 +32,7 @@ unit = {
     getMaxSpeed = function() return 10.0 end,
     getCarryingWeight = function(uid) return U[uid].carried end,
     getStat = function(uid, name)
-        if name == "agility" then return 1.0 end
+        if name == "agility" then return U[uid].agi or 1.0 end
         if name == "endurance" then return U[uid].endur end
         if name == "carrying_capacity" then return U[uid].cap end
         return nil
@@ -59,8 +59,8 @@ local function approx(a, b, eps)
 end
 
 -- Configure a uid and return its encumbrance multiplier + sprint speed.
-local function setUnit(uid, cap, carried, endur)
-    U[uid] = { cap = cap, carried = carried, endur = endur }
+local function setUnit(uid, cap, carried, endur, agi)
+    U[uid] = { cap = cap, carried = carried, endur = endur, agi = agi }
     return ms.encumbranceMultiplier(uid), ms.sprint(uid)
 end
 
@@ -103,6 +103,23 @@ check(mNorm < mStrong, string.format("at-cap: nominal(1.0) %.3f < strong(2.0) %.
 local oWeak,   _ = setUnit(1, 100, 150, 0.5)
 local oStrong, _ = setUnit(1, 100, 150, 2.0)
 check(oWeak < oStrong, string.format("over-cap: weak %.3f < strong %.3f", oWeak, oStrong))
+
+-----------------------------------------------------------
+-- 2b. Ambient wander (meander) must respond to load too — including the
+--     case the review caught: an AGILE unit whose meander is pinned by the
+--     fixed max_speed cap, not by comfort. Agility 1.2 makes the raw cap
+--     bind when empty, so without the encumbrance term on that cap a 40%
+--     load would amble at exactly the same speed as empty.
+-----------------------------------------------------------
+print("[2b] meander (ambient wander) slows with load, even when the max_speed cap binds")
+setUnit(1, 100, 0,  1.0, 1.2)   -- agile, empty
+local wEmpty = ms.meander(1)
+setUnit(1, 100, 40, 1.0, 1.2)   -- agile, 40% load (within capacity)
+local wMid = ms.meander(1)
+setUnit(1, 100, 100, 1.0, 1.2)  -- agile, at capacity
+local wFull = ms.meander(1)
+check(wMid < wEmpty,  string.format("meander: 40%% load %.4f < empty %.4f", wMid, wEmpty))
+check(wFull < wMid,   string.format("meander: at-cap %.4f < 40%% load %.4f", wFull, wMid))
 
 -----------------------------------------------------------
 -- 3. Unloaded / missing-data safety.


### PR DESCRIPTION
Closes #305.

## Problem
Carried weight had **no effect on movement** — a unit at 99% of capacity
walked, cruised, and routed exactly like an empty one. The only consequence
of load was the hard over-capacity pickup gate. `movement_speed.lua` scaled
the band by `agility × injuries.speedMultiplier × salts.speedMultiplier`
only — no encumbrance term (confirmed: no `getCarryingWeight`/load reference
anywhere in the speed chain).

## Change
Adds `M.encumbranceMultiplier(uid)` to `scripts/movement_speed.lua` and
composes it into `M.sprint` alongside the existing injury/salt multipliers,
so the whole derived band (comfort/ordered/meander) — and the commanded
speed `unit_ai` hands to `unit.moveTo` — slows together.

The multiplier is keyed on the carried/capacity ratio (`unit.getCarryingWeight`
÷ `carrying_capacity`, the same data path as the unit-info Carry row) and
**eased by the `endurance` stat**:

| state (endurance 1.0) | multiplier |
|---|---|
| ≤25% of capacity (free allowance) | 1.00 |
| half load | 0.90 |
| at capacity | 0.70 |
| 1.25× over capacity | 0.40 |
| heavy overload | 0.20 (floor) |

- Endurance divides the penalty: at the same ratio a strong unit (or the
  high-endurance technomule) loses far less speed than a weak one.
- Light load is free; missing/zero capacity returns a neutral 1.0.
- The over-capacity slope is much steeper than the in-capacity one, but the
  **hard pickup gate is untouched** — the steep regime only bites worn-gear /
  forced overloads.

Out of scope (the issue's named follow-ups): coupling load into stamina
drain and feeding the `Unit.Pathing.Cost` per-unit modifier.

## Testing
`luajit tools/test_encumbrance_speed.lua` — new offline harness (mirrors
`test_mule_sourcing.lua`), all 16 checks pass, covering the issue's three
asserts:

1. same unit, empty → near-cap → over-cap = strictly decreasing speed,
2. same load ratio, high vs low endurance = high-endurance faster,
3. unloaded ≈ 1.0 + missing/zero-capacity neutrality + floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)