### PR TITLE
Fix #298: world-thread heap overflow loading glacier-rim chunks

### DIFF
--- a/src/World/Generate/Chunk.hs
+++ b/src/World/Generate/Chunk.hs
@@ -1111,11 +1111,27 @@ generateChunk registry catalog params coord =
                     -- pre-smoothing bordered terrain, because
                     -- 'smoothIslandColumns' may lower a lake-adjacent tile
                     -- after 'finalElevVec' is computed.
-                    finalSelf = terrainSurfaceMap VU.! idx
+                    --
+                    -- A beyond-glacier neighbour reads back as the
+                    -- 'minBound' sentinel (its column is empty / unrendered);
+                    -- it must NOT pull 'exposeFrom' down toward minBound, or
+                    -- 'buildColumnStrata' below would size a ~2^63-tall column
+                    -- (depth = rawSurfZ - exposeFrom) and overflow the heap.
+                    -- Treat it like an absent neighbour (fall back to this
+                    -- column's own surface — no downward exposure), the same
+                    -- way the slope / edge-strata passes special-case the
+                    -- sentinel. This is the world-edge case behind the
+                    -- glacier-rim chunk-load crash (#298): a chunk straddling
+                    -- the glacier diagonal has real columns bordering empty
+                    -- ones in-chunk.
+                    finalSelf0 = terrainSurfaceMap VU.! idx
+                    finalSelf = if finalSelf0 ≡ minBound then rawSurfZ
+                                else finalSelf0
                     visibleTerrainOr olx oly fallback =
                         if olx ≥ 0 ∧ olx < chunkSize
                            ∧ oly ≥ 0 ∧ oly < chunkSize
-                        then terrainSurfaceMap VU.! columnIndex olx oly
+                        then let z = terrainSurfaceMap VU.! columnIndex olx oly
+                             in if z ≡ minBound then fallback else z
                         else lookupElevOr olx oly fallback
                     exposeN = visibleTerrainOr lx (ly - 1) rawSurfZ
                     exposeS = visibleTerrainOr lx (ly + 1) rawSurfZ

--- a/test-headless/Test/Headless/WorldGen/Exposure.hs
+++ b/test-headless/Test/Headless/WorldGen/Exposure.hs
@@ -141,11 +141,18 @@ spec = do
             -- exact load shape that crashed.
             queueChunks ws [ ChunkCoord cx cy
                            | cx ← [-4 .. 0], cy ← [-4 .. 0] ]
-            -- (-4,-1) is a MIXED rim chunk (some real, some beyond). If
-            -- the world thread heap-overflowed mid-batch it never lands,
-            -- so this load IS the regression assertion.
-            loaded ← waitForChunksAt ws (ChunkCoord (-4) (-1)) 60
-            loaded `shouldBe` True
+            -- The MIXED rim chunks (real columns bordering beyond-glacier
+            -- columns in-chunk) are the crashers — the full glacier
+            -- anti-diagonal across this corner. They span more than one
+            -- load batch (drainInitQueues does maxChunksPerTick = 8), and
+            -- a heap overflow on any batch kills the world thread so that
+            -- batch's chunks AND every later one never land. Wait for
+            -- EVERY mixed chunk, not just the first, or a later-batch
+            -- crash would slip through.
+            let mixedRim = [ ChunkCoord (-4) (-1), ChunkCoord (-3) (-2)
+                           , ChunkCoord (-2) (-3), ChunkCoord (-1) (-4) ]
+            loaded ← mapM (\c → waitForChunksAt ws c 60) mixedRim
+            loaded `shouldBe` map (const True) mixedRim
             -- The rim chunks must also store sane, bounded strata
             -- (exposure invariant) rather than voids.
             tiles ← getWorldTileData ws

--- a/test-headless/Test/Headless/WorldGen/Exposure.hs
+++ b/test-headless/Test/Headless/WorldGen/Exposure.hs
@@ -28,6 +28,7 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU
 import Engine.Core.State (EngineEnv)
 import System.Environment (lookupEnv)
+import qualified Data.Text as T
 import Test.Headless.Harness
 import World.Types
 
@@ -116,6 +117,37 @@ spec = do
 
         it "holds across a w64 world (seed 42)" $ \env → do
             ws ← sharedWorld env 42 64 3
+            tiles ← getWorldTileData ws
+            reportViolations (worldViolations (wtdChunks tiles))
+
+        -- Regression for #298 (glacier-rim chunk-load heap overflow).
+        -- A chunk straddling the glacier diagonal has REAL columns
+        -- bordering BEYOND-GLACIER (empty) columns in-chunk. Reading
+        -- such an empty in-chunk neighbour's terrain surface returns the
+        -- minBound sentinel, which used to drag the column build's
+        -- 'exposeFrom' down to minBound — sizing a ~2^63-tall strata
+        -- column ('buildColumnStrata' depth = surfZ − exposeFrom) and
+        -- heap-overflowing (killing) the world thread the instant such a
+        -- chunk loaded. A private w8 world (half-size 4 chunks) puts the
+        -- v-edge rim two chunks from centre, so it reproduces fast and
+        -- in isolation without perturbing the shared worlds.
+        it "loads glacier-rim chunks straddling the v-edge without\
+           \ heap-overflowing the world thread (#298)" $ \env → do
+            let pid = WorldPageId (T.pack "rim_298_w8")
+            sendWorldCommand env (WorldInit pid 7 8 3)
+            ws ← waitForWorldInit env pid 120
+            -- Queue the whole (-4..0)² corner at once: interior, mixed
+            -- (glacier-diagonal) and fully-beyond chunks together — the
+            -- exact load shape that crashed.
+            queueChunks ws [ ChunkCoord cx cy
+                           | cx ← [-4 .. 0], cy ← [-4 .. 0] ]
+            -- (-4,-1) is a MIXED rim chunk (some real, some beyond). If
+            -- the world thread heap-overflowed mid-batch it never lands,
+            -- so this load IS the regression assertion.
+            loaded ← waitForChunksAt ws (ChunkCoord (-4) (-1)) 60
+            loaded `shouldBe` True
+            -- The rim chunks must also store sane, bounded strata
+            -- (exposure invariant) rather than voids.
             tiles ← getWorldTileData ws
             reportViolations (worldViolations (wtdChunks tiles))
 


### PR DESCRIPTION
Fixes #298.

## Root cause

A chunk straddling the world's **glacier diagonal** (the v-edge rim) has REAL columns bordering BEYOND-GLACIER columns *within the same chunk*. Beyond-glacier columns are empty and store the `minBound` sentinel in `terrainSurfaceMap`.

The detail column build's `exposeFrom` (how far down to expose strata for a cliff face, `src/World/Generate/Chunk.hs`) read those in-chunk neighbour surfaces **without guarding the sentinel**. A real edge column therefore got `exposeFrom = minBound`, and `buildColumnStrata` sized it as `depth = rawSurfZ - exposeFrom ≈ 2^63`, so `VUM.replicate depth` blew the heap and killed the world thread (`"World thread crashed: heap overflow"`) the instant such a chunk loaded.

This is why a single *fully*-beyond chunk was fine but a *mixed* (glacier-diagonal) chunk crashed.

## Fix

Treat a `minBound` in-chunk neighbour (and self) like an *absent* neighbour in the exposure calc — fall back to the column's own surface (no downward exposure), exactly how the slope (`drops`, `nz ≠ minBound`) and edge-strata (`clampSentinel`) passes already special-case the sentinel.

- **Output-identical for interior chunks** — verified a w64 interior terrain dump is byte-identical before/after (interior chunks never hold the sentinel, so the new guards never fire). Only the world-edge rim — which previously *crashed* — changes, and its real tiles now carry sane elevations.
- Shares `generateLoadedChunk`, so this fixes **both** loaders: the init-queue path (`world.loadChunksInRegion` → `drainInitQueues`) and the camera-visible path (`updateChunkLoading`). The latter is the `camera.goToTile` rim crash that the #297 clamp was guarding around.

## Verification

- Minimal repro from the issue (`world.init("s",7,8,5)` + `loadChunksInRegion(-4,-4,4,4)`) no longer crashes; bisected to a single *mixed* chunk and confirmed fixed.
- `camera.goToTile` driven to/past the rim on w16 and w128 (incl. the headline `goToTile(500,500)`-equivalent) no longer crashes.
- Full-region worldgen dump completes across seeds 7/42/1234.
- New regression test in `Test.Headless.WorldGen.Exposure` (private w8 world, rim corner queued) — **verified it fails without the fix and passes with it**.
- Full headless suite green: **389 examples, 0 failures, 1 pending**.

No save-version bump (worldgen-only, no serialized-format change).