### PR TITLE
Fix #367: tile select honours the picked z, not the column surface

### DIFF
--- a/scripts/hud.lua
+++ b/scripts/hud.lua
@@ -772,10 +772,13 @@ function hud.onMouseDown(button_num, mx, my)
             -- so a fast move-then-click selected the previously hovered
             -- tile; pickTile resolves the tile under the click NOW and
             -- world.selectTile sets it in one shot (also dropping any
-            -- chunk selection, #135) (#123).
-            local gx, gy = world.pickTile(cx, cy)
+            -- chunk selection, #135) (#123). Pass the picked z so a click
+            -- below the surface selects the clicked tile, not the column
+            -- top (#367) — pickTile resolves the tile at the active
+            -- z-slice, world.selectTile would otherwise snap to surface z.
+            local gx, gy, gz = world.pickTile(cx, cy)
             if gx and gy then
-                world.selectTile(hud.worldId, gx, gy)
+                world.selectTile(hud.worldId, gx, gy, gz)
                 -- Refresh the tile-editor popup at the just-selected
                 -- tile. Gated internally by arenaMode so non-arena worlds
                 -- silently no-op.

--- a/scripts/init.lua
+++ b/scripts/init.lua
@@ -817,8 +817,11 @@ function game.onMouseDown(button, x, y)
             -- this hardcoded list later.
             -- Capture the right-clicked tile with a live pick at the click
             -- coords (the cached hover lags a fast move, and once the menu
-            -- opens the cursor moves off the tile anyway) (#123).
-            local gx, gy = world.pickTile(x, y)
+            -- opens the cursor moves off the tile anyway) (#123). The pick
+            -- resolves the tile at the active z-slice, so stash its z too
+            -- and select that exact tile — a right-click on a cliff face /
+            -- below the surface must not snap to the column top (#367).
+            local gx, gy, gz = world.pickTile(x, y)
             if gx and gy then
                 local hud = require("scripts.hud")
                 local contextMenu = require("scripts.ui.context_menu")
@@ -829,7 +832,7 @@ function game.onMouseDown(button, x, y)
                     mx = x * (fbW / ww)
                     my = y * (fbH / wh)
                 end
-                local tileX, tileY = gx, gy
+                local tileX, tileY, tileZ = gx, gy, gz
                 contextMenu.show({
                     { label = "Info",
                       callback = function()
@@ -845,8 +848,10 @@ function game.onMouseDown(button, x, y)
                           -- select API — the cursor's pixel-hover state
                           -- has already moved to the menu, so the
                           -- usual hover+select would pick the wrong
-                          -- tile.
-                          world.selectTile(hud.worldId, tileX, tileY)
+                          -- tile. tileZ is the z captured at right-click
+                          -- time so the selection lands on the clicked
+                          -- tile, not the column surface (#367).
+                          world.selectTile(hud.worldId, tileX, tileY, tileZ)
                           local tileEditor =
                               require("scripts.tile_editor")
                           tileEditor.onTileSelected(tileX, tileY)

--- a/src/Engine/Scripting/Lua/API/World.hs
+++ b/src/Engine/Scripting/Lua/API/World.hs
@@ -654,23 +654,26 @@ worldClearWorldCursorSelectFn env = do
         _ → pure ()
     return 0
 
--- | world.selectTile(pageId, gx, gy) — atomically mark the column at
---   (gx, gy) as the world's selected tile, using the chunk's surface
---   z. Unlike setWorldCursorSelect (which races with per-tick mouse
---   hover updates), this is direct: a one-shot selection that doesn't
---   touch the cursor position. Used by the right-click → Info context
---   menu to highlight the right-clicked tile after the mouse has
---   already moved into the menu.
+-- | world.selectTile(pageId, gx, gy[, z]) — atomically mark the column
+--   at (gx, gy) as the world's selected tile. With @z@ (the live-picked
+--   z from @world.pickTile@) the exact clicked tile is selected — below
+--   the surface that is NOT the column top (issue #367). Omit @z@ to use
+--   the chunk's surface z (the right-click → Info context-menu path,
+--   which has no live pick). Unlike setWorldCursorSelect (which races
+--   with per-tick mouse hover updates), this is direct: a one-shot
+--   selection that doesn't touch the cursor position.
 worldSelectTileFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 worldSelectTileFn env = do
     pageIdArg ← Lua.tostring 1
     gxArg     ← Lua.tonumber 2
     gyArg     ← Lua.tonumber 3
+    zArg      ← Lua.tonumber 4
     case (pageIdArg, gxArg, gyArg) of
         (Just pageIdBS, Just gx, Just gy) → Lua.liftIO $ do
             let pageId = WorldPageId (TE.decodeUtf8 pageIdBS)
+                mz     = round ⊚ zArg
             Q.writeQueue (worldQueue env) $
-                WorldSelectTileByCoord pageId (round gx) (round gy)
+                WorldSelectTileByCoord pageId (round gx) (round gy) mz
         _ → pure ()
     return 0
 

--- a/src/Engine/Scripting/Lua/API/WorldQuery.hs
+++ b/src/Engine/Scripting/Lua/API/WorldQuery.hs
@@ -555,7 +555,7 @@ worldGetHoverPosFn env = do
             Lua.pushnil
             return 1
 
--- | world.pickTile(pixX, pixY) → gx, gy or nil
+-- | world.pickTile(pixX, pixY) → gx, gy, z or nil
 --   Synchronous screen-pixel → tile hit-test from the given click
 --   coordinates. Unlike getHoverTile (which reads the cached
 --   worldHoverTile the render thread resolves from the periodically
@@ -565,6 +565,12 @@ worldGetHoverPosFn env = do
 --   placement) where the async hover cache can lag a fast cursor move
 --   off-world and place on a stale tile. Returns nil when the pixel is
 --   off-world / over no solid tile.
+--
+--   The third result @z@ is the elevation of the resolved tile at the
+--   current z-slice — the actual tile under the cursor, which below the
+--   surface is NOT the column top. Pass it to @world.selectTile@ so a
+--   click selects the clicked tile, not the surface (issue #367).
+--   Existing callers that bind only @gx, gy@ are unaffected.
 worldPickTileFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 worldPickTileFn env = do
     -- Click coords arrive as Lua numbers (Doubles from GLFW.getCursorPos),
@@ -601,10 +607,11 @@ worldPickTileFn env = do
                         vb = computeViewBounds camera fbW fbH effectiveDepth
                     case pickWorldTile facing zoom zSlice camX camY fbW fbH winW winH
                                        worldSize effectiveDepth vb tileData px py of
-                        Just (gx, gy, _, _, _) → do
+                        Just (gx, gy, z, _, _) → do
                             Lua.pushinteger (fromIntegral gx)
                             Lua.pushinteger (fromIntegral gy)
-                            return 2
+                            Lua.pushinteger (fromIntegral z)
+                            return 3
                         Nothing → do
                             Lua.pushnil
                             return 1

--- a/src/World/Command/Types.hs
+++ b/src/World/Command/Types.hs
@@ -71,12 +71,16 @@ data WorldCommand
     | WorldSetWorldCursorHover WorldPageId Int Int
     | WorldSetWorldCursorSelect WorldPageId
     | WorldSetWorldCursorDeselect WorldPageId
-    | WorldSelectTileByCoord WorldPageId Int Int
-        -- ^ Atomically set worldSelectedTile to the column at (gx, gy)
-        --   using the loaded chunk's surface z. Bypasses the hover-
-        --   then-select dance so the caller doesn't have to fight the
-        --   continuous mouse-hover overwrites for one-shot selections
-        --   (e.g. context-menu "Info" on a tile).
+    | WorldSelectTileByCoord WorldPageId Int Int (Maybe Int)
+        -- ^ Atomically set worldSelectedTile to the column at (gx, gy).
+        --   The @Maybe Int@ is the z to select: @Just z@ pins the exact
+        --   tile (the live-picked z from a left-click, so a click below
+        --   the surface selects the clicked tile, not the column top —
+        --   issue #367); @Nothing@ falls back to the loaded chunk's
+        --   surface z (the right-click context-menu "Info" path, which
+        --   has no live pick). Bypasses the hover-then-select dance so
+        --   the caller doesn't have to fight the continuous mouse-hover
+        --   overwrites for one-shot selections.
     | WorldSetToolMode WorldPageId ToolMode
     | WorldSetMineAnchor WorldPageId Int Int
         -- ^ Mine tool: first click anchors the designation rectangle

--- a/src/World/Thread/Command.hs
+++ b/src/World/Thread/Command.hs
@@ -125,8 +125,8 @@ handleWorldCommand env logger (WorldSetWorldCursorSelect pageId)
   = handleWorldSetWorldCursorSelectCommand env logger pageId
 handleWorldCommand env logger (WorldSetWorldCursorDeselect pageId)
   = handleWorldSetWorldCursorDeselectCommand env logger pageId
-handleWorldCommand env logger (WorldSelectTileByCoord pageId gx gy)
-  = handleWorldSelectTileByCoordCommand env logger pageId gx gy
+handleWorldCommand env logger (WorldSelectTileByCoord pageId gx gy mz)
+  = handleWorldSelectTileByCoordCommand env logger pageId gx gy mz
 handleWorldCommand env logger (WorldSetMineAnchor pageId gx gy)
   = handleWorldSetMineAnchorCommand env logger pageId gx gy
 handleWorldCommand env logger (WorldClearMineAnchor pageId)

--- a/src/World/Thread/Command/Cursor.hs
+++ b/src/World/Thread/Command/Cursor.hs
@@ -397,14 +397,18 @@ handleWorldSetConstructDesignateTextureCommand env _logger pageId cat tid = do
                     _          → (cs { constructStructTexture = Just tid }, ())
         Nothing → pure ()
 
--- | Directly select the column at (gx, gy) on the given world, using
---   the loaded chunk's surface z. Used by the context-menu "Info" path
---   so a tile can be selected without going through the hover-then-
---   select cursor flow (which races with the per-tick mouse-hover
---   updates from hud.update). No-op if the chunk isn't loaded.
+-- | Directly select the column at (gx, gy) on the given world. The
+--   @Maybe Int@ picks the z: @Just z@ selects that exact tile (the
+--   live-picked z from a left-click, so clicking below the surface
+--   selects the clicked tile rather than the column top — issue #367);
+--   @Nothing@ falls back to the loaded chunk's surface z (the
+--   context-menu "Info" path, which has no live pick). Used so a tile
+--   can be selected without going through the hover-then-select cursor
+--   flow (which races with the per-tick mouse-hover updates from
+--   hud.update). No-op if the chunk isn't loaded.
 handleWorldSelectTileByCoordCommand ∷ EngineEnv → LoggerState → WorldPageId
-    → Int → Int → IO ()
-handleWorldSelectTileByCoordCommand env _logger pageId gx gy = do
+    → Int → Int → Maybe Int → IO ()
+handleWorldSelectTileByCoordCommand env _logger pageId gx gy mz = do
     mgr ← readIORef (worldManagerRef env)
     case lookup pageId (wmWorlds mgr) of
         Nothing → pure ()
@@ -414,7 +418,9 @@ handleWorldSelectTileByCoordCommand env _logger pageId gx gy = do
             case lookupChunk chunkCoord tileData of
                 Nothing → pure ()
                 Just lc → do
-                    let z = lcSurfaceMap lc VU.! columnIndex lx ly
+                    -- Use the live-picked z when supplied; otherwise
+                    -- default to the column surface.
+                    let z = fromMaybe (lcSurfaceMap lc VU.! columnIndex lx ly) mz
                     -- This path resolves the tile immediately (no hover
                     -- round-trip), so the set and the opposing-chunk clear
                     -- happen in the SAME write — no blank window. A new

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -158,6 +158,7 @@ test-suite synarchy-test-headless
                    Test.Headless.Unit.Stats
                    Test.Headless.World.Save.Sanitize
                    Test.Headless.World.CursorInfo
+                   Test.Headless.World.SelectTileZ
                    Test.Headless.World.Spoil
                    Test.Headless.Combat.Damage
                    Test.Headless.Combat.Severing

--- a/test-headless/Spec.hs
+++ b/test-headless/Spec.hs
@@ -23,6 +23,7 @@ import qualified Test.Headless.Unit.Fall as FallTest
 import qualified Test.Headless.Unit.Stats as StatsTest
 import qualified Test.Headless.World.Save.Sanitize as SaveSanitize
 import qualified Test.Headless.World.CursorInfo as CursorInfo
+import qualified Test.Headless.World.SelectTileZ as SelectTileZ
 import qualified Test.Headless.World.Spoil as Spoil
 import qualified Test.Headless.Combat.Damage as CombatDamage
 import qualified Test.Headless.Combat.Severing as CombatSevering
@@ -48,6 +49,7 @@ main = hspec $ do
     -- (was 16 generations / ~185 s; now ~6 / well under a minute).
     aroundAll withHeadlessEngine $ do
         describe "World Generation" WorldGen.spec
+        describe "World.SelectTileZ" SelectTileZ.spec
         describe "Geology" Geology.spec
         describe "Chunk/Fast Parity" Parity.spec
         describe "Biome Flatness" Flatness.spec

--- a/test-headless/Test/Headless/World/SelectTileZ.hs
+++ b/test-headless/Test/Headless/World/SelectTileZ.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE UnicodeSyntax, OverloadedStrings #-}
+-- | Regression for #367: a tile selection honours an explicit z.
+--
+--   The Info-tool left-click resolves the tile under the cursor at the
+--   active z-slice ('world.pickTile', which now returns that z) and
+--   passes it to 'world.selectTile'. Below the surface that z is NOT the
+--   column top, so dropping it — the old behaviour — silently selected
+--   the surface tile instead of the clicked one (the reported bug).
+--
+--   'WorldSelectTileByCoord' now carries a @Maybe Int@: @Just z@ pins the
+--   clicked tile; @Nothing@ keeps the surface-z default used by the
+--   right-click context-menu "Info" path (which has no live pick). This
+--   spec drives the real command handler against the shared 42/64/3
+--   world and asserts both arms. It only touches that world's cursor
+--   selection (not its tiles/edits), so sharing the read-only world is
+--   safe.
+module Test.Headless.World.SelectTileZ (spec) where
+
+import UPrelude
+import Test.Hspec
+import Data.IORef (readIORef)
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Vector.Unboxed as VU
+import Engine.Core.State (EngineEnv(..))
+import World.Tile.Types (WorldTileData(..))
+import World.Chunk.Types (LoadedChunk(..), columnIndex)
+import World.Generate.Coordinates (chunkToGlobal)
+import World.Cursor.Types (CursorState(..))
+import World.State.Types (WorldState(..))
+import World.Page.Types (WorldPageId(..))
+import World.Thread.Command.Cursor (handleWorldSelectTileByCoordCommand)
+import Test.Headless.Harness (sharedWorld, getWorldTileData)
+
+spec ∷ SpecWith EngineEnv
+spec = describe "tile selection z (#367)" $
+    it "Just z pins the clicked tile; Nothing falls back to surface z" $ \env → do
+        ws     ← sharedWorld env 42 64 3
+        -- The handler ignores the logger, but takes a real one.
+        logger ← readIORef (loggerRef env)
+        -- Reuse the shared world's page id (mirrors Harness.sharedWorld).
+        let pid = WorldPageId "shared_42_64_3"
+        tiles  ← getWorldTileData ws
+        case HM.toList (wtdChunks tiles) of
+            [] → expectationFailure "shared world has no loaded chunks"
+            ((coord, lc) : _) → do
+                let (gx, gy) = chunkToGlobal coord 0 0
+                    surfZ    = lcSurfaceMap lc VU.! columnIndex 0 0
+                    belowZ   = surfZ - 2   -- a distinct tile below the top
+
+                -- Nothing → surface z (right-click context-menu path).
+                handleWorldSelectTileByCoordCommand env logger pid gx gy Nothing
+                sel0 ← worldSelectedTile <$> readIORef (wsCursorRef ws)
+                sel0 `shouldBe` Just (gx, gy, surfZ)
+
+                -- Just z → the clicked tile, even below the surface. The
+                -- old code snapped this to surfZ — that is the #367 bug.
+                handleWorldSelectTileByCoordCommand env logger pid gx gy (Just belowZ)
+                sel1 ← worldSelectedTile <$> readIORef (wsCursorRef ws)
+                sel1 `shouldBe` Just (gx, gy, belowZ)


### PR DESCRIPTION
Closes #367.

## Symptom
In the zoomed-in world view, selecting a tile (Info tool left-click, or right-click → Info) selected the **top (surface) tile of the column** instead of the tile under the cursor — wrong in the info panel, not just visually. This broke selecting any tile below the surface (lowered z-slice, cliff faces, dug-out areas).

## Root cause
Both selection paths resolve the correct tile with `world.pickTile` (which hit-tests at the active z-slice and knows the clicked z), but then called `world.selectTile(gx, gy)` — **dropping the z**. `WorldSelectTileByCoord` forced `z = lcSurfaceMap` (the column surface), so the selection always snapped to the top.

The left-click case regressed with **#123**, which rerouted it from the hover-commit path (`World/Render/Quads.hs`, which committed the picked z) to `pickTile` + `selectTile`, losing the z.

## Fix
- `world.pickTile` now returns its `z` as a **third result**. This is an extra return value — existing callers that bind only `gx, gy` are unaffected (verified across `init.lua`, `build_tool.lua`, `construct_tool.lua`, `mine_tool.lua`).
- `WorldSelectTileByCoord` carries a `Maybe Int`; the handler uses `Just z` when supplied and falls back to surface z on `Nothing`.
- `world.selectTile(pageId, gx, gy[, z])` takes the optional z and threads it through.
- **Both** call sites now pass the picked z:
  - `hud.lua` — Info-tool left-click.
  - `init.lua` — right-click → Info. This path already does a live `world.pickTile` when the menu opens (the cursor leaves the tile once the menu is up), so it stashes the pick's z (`tileZ`) and passes it through.

`world.selectTile` with the z omitted still falls back to surface z, so any other caller keeps the old behavior.

## Tests
- New `Test.Headless.World.SelectTileZ`: drives the real command handler against the shared 42/64/3 world and asserts `Just z` pins the clicked tile while `Nothing` falls back to surface z. Both Lua call sites funnel through this handler.
- Full headless hspec suite green (**400 examples, 0 failures, 1 pending**); `test_audit.py` 35/35. No worldgen-output change, so baselines untouched.

Note: the render-based `pickTile` can't run headless (no window → degenerate viewport), so the end-to-end click can't be exercised in CI; the test covers the command/selection path that carried the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)