### PR TITLE
Fix #378: correct misnamed colors in Math.colorToVec4 (opaque, green/lime)

### DIFF
--- a/src/Math.hs
+++ b/src/Math.hs
@@ -21,7 +21,7 @@ colorToVec4 ('#':r1:r2:g1:g2:b1:b2:a1:a2:[]) =
       a = fromIntegral (readHex' ([a1, a2]) ∷ Int) / 255.0
   in Vec4 r g b a
 colorToVec4 ("red") = Vec4 1.0 0 0 1.0
-colorToVec4 ("green") = Vec4 0 1.0 0 1.0
+colorToVec4 ("green") = Vec4 0 0.5 0 1.0
 colorToVec4 ("blue") = Vec4 0 0 1.0 1.0
 colorToVec4 ("white") = Vec4 1.0 1.0 1.0 1.0
 colorToVec4 ("black") = Vec4 0 0 0 1.0
@@ -29,7 +29,10 @@ colorToVec4 ("yellow") = Vec4 1.0 1.0 0 1.0
 colorToVec4 ("cyan") = Vec4 0 1.0 1.0 1.0
 colorToVec4 ("magenta") = Vec4 1.0 0 1.0 1.0
 colorToVec4 ("transparent") = Vec4 0 0 0 0.0
-colorToVec4 ("opaque") = Vec4 0 0 0 0.5
+-- A dark translucent overlay (NOT alpha=1 — "opaque" was a misnomer for
+-- this 50%-alpha black; renamed per #378). Kept under an honest name so
+-- the dark-overlay value stays reachable; no caller used "opaque".
+colorToVec4 ("overlay") = Vec4 0 0 0 0.5
 colorToVec4 ("ghost") = Vec4 1.0 1.0 1.0 0.5
 colorToVec4 ("gray") = Vec4 0.5 0.5 0.5 1.0
 colorToVec4 ("orange") = Vec4 1.0 0.65 0 1.0

--- a/src/Math.hs
+++ b/src/Math.hs
@@ -29,10 +29,13 @@ colorToVec4 ("yellow") = Vec4 1.0 1.0 0 1.0
 colorToVec4 ("cyan") = Vec4 0 1.0 1.0 1.0
 colorToVec4 ("magenta") = Vec4 1.0 0 1.0 1.0
 colorToVec4 ("transparent") = Vec4 0 0 0 0.0
--- A dark translucent overlay (NOT alpha=1 — "opaque" was a misnomer for
--- this 50%-alpha black; renamed per #378). Kept under an honest name so
--- the dark-overlay value stays reachable; no caller used "opaque".
+-- A dark translucent overlay (50%-alpha black). "overlay" is the honest
+-- name (#378). "opaque" is a deprecated alias for the same value — it
+-- was always a misnomer (alpha != 1), but it's kept so any out-of-tree
+-- script still passing it gets the unchanged behaviour rather than
+-- silently falling through to the opaque-black default below.
 colorToVec4 ("overlay") = Vec4 0 0 0 0.5
+colorToVec4 ("opaque")  = Vec4 0 0 0 0.5
 colorToVec4 ("ghost") = Vec4 1.0 1.0 1.0 0.5
 colorToVec4 ("gray") = Vec4 0.5 0.5 0.5 1.0
 colorToVec4 ("orange") = Vec4 1.0 0.65 0 1.0


### PR DESCRIPTION
Closes #378.

## What
Two entries in the named-color table `Math.colorToVec4` were semantically wrong:

- **`"green"`** was `Vec4 0 1 0 1` — full-bright, identical to `"lime"`. Darkened to CSS green `Vec4 0 0.5 0 1` so the two names are now distinct (CSS: `green` = `#008000`, `lime` = `#00FF00`).
- **`"opaque"`** mapped to `Vec4 0 0 0 0.5` — a 50%-alpha (semi-transparent) black, the opposite of what "opaque" means. Renamed to **`"overlay"`**, which honestly describes the dark translucent value, keeping it reachable for the dark-overlay use case.

## Caller safety
Grepped the whole repo (`*.lua`, `*.hs`, `*.yaml`/`*.yml`) for `"opaque"`, `"green"`, `"lime"` as color strings — **no caller used any of them** (color strings reach `colorToVec4` dynamically from Lua via `Text.hs`/`Graphics.hs`, but none pass these names). So no callers needed updating and existing content renders unchanged.

Colors remain baked in the table (no tinting), per project convention.

## Acceptance criteria
- [x] `"opaque"` renamed to reflect its actual value (semi-transparent dark → `"overlay"`).
- [x] `"green"` darkened toward `(0, 0.5, 0, 1)`, distinct from `"lime"`.
- [x] Grepped Lua callers of `"opaque"`/`"green"`/`"lime"` — none rely on the old values.

## Testing
`cabal build all` — full library + executable compile and link clean. No test exercises this pure data table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)