### PR TITLE
Fix #377: unit.list() scopes to the active world page

### DIFF
--- a/src/Engine/Scripting/Lua/API/Units.hs
+++ b/src/Engine/Scripting/Lua/API/Units.hs
@@ -2752,8 +2752,9 @@ unitGetAllIdsFn env = do
 unitListFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 unitListFn env = do
     result ← Lua.liftIO $ do
-        um ← readIORef (unitManagerRef env)
-        let entries = HM.toList (umInstances um)
+        -- Active world page only — consistent with unit.getAllIds, so a
+        -- unit on another world page never leaks into this listing (#377).
+        entries ← HM.toList <$> activeUnits env
         if null entries
         then return "No units spawned"
         else return $ T.unpack $ T.intercalate "\n" $


### PR DESCRIPTION
## Summary

`unit.list()` enumerated the raw global instance map (`HM.toList (umInstances um)`) instead of the active world page, unlike the primary enumeration API `unit.getAllIds()`, which filters through `activeUnits env`. With multiple live world pages (the all-worlds-save scenario, #214), `unit.list()` leaked units belonging to inactive pages into any script iterating it.

The fix routes `unitListFn` through the existing `activeUnits` helper — a one-call swap that makes the listing identical in scope to `unit.getAllIds()`.

```haskell
-     um ← readIORef (unitManagerRef env)
-     let entries = HM.toList (umInstances um)
+     entries ← HM.toList <$> activeUnits env
```

## Acceptance criteria

- [x] `unit.list()` returns only units on the active world page, consistent with `unit.getAllIds()`.
- [x] Implemented by routing through the existing `activeUnits env` helper.
- [x] Spot-checked with two live pages that `unit.list()` no longer returns the other page's units.

## Verification

Headless two-page (multiworld) probe — two pages, a unit on each, both registered in the global map:

```
[active=world_b] unit.list()=[2] getAllIds()=[2] (other unit exists globally: True)
[active=world_a] unit.list()=[1] getAllIds()=[1] (other unit exists globally: True)
PASS: unit.list() is active-page-scoped, equals getAllIds(), and never
      leaks an inactive page's (still-existing) units
```

The inactive page's unit is confirmed still present in the global instance map via `unit.getInfo` (which is *not* page-scoped) — so before this fix it would have appeared in `unit.list()`; now it doesn't.

- Full hspec headless suite: **400 examples, 0 failures**.
- No save-format change; no `currentSaveVersion` bump.

Closes #377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)