### PR TITLE
Fix #383: engine dead-export/field sweep

### DIFF
--- a/src/Engine/Asset/Manager.hs
+++ b/src/Engine/Asset/Manager.hs
@@ -279,7 +279,6 @@ loadTextureAtlasWithHandle texHandle name path arrayName = do
             , taName = name
             , taPath = T.pack path
             , taMetadata = AtlasMetadata (0, 0) Vk.FORMAT_R8G8B8A8_UNORM Map.empty
-            , taStatus = AssetLoaded
             , taInfo = Just $ TextureInfo
                 { tiImage = image
                 , tiView = imageView
@@ -434,9 +433,7 @@ cleanupResources device state = do
           [("name", taName atlas)
           ,("path", taPath atlas)
           ,("asset_id", T.pack $ show $ taId atlas)]
-        case taStatus atlas of
-            AssetLoaded → liftIO $ maybe (pure ()) id (taCleanup atlas)
-            _           → pure ()
+        liftIO $ maybe (pure ()) id (taCleanup atlas)
 
     liftIO $ writeIORef (apNextAssetId pool) 0
     liftIO $ atomicModifyIORef' poolRef $ \poolRef' →

--- a/src/Engine/Asset/Types.hs
+++ b/src/Engine/Asset/Types.hs
@@ -86,7 +86,6 @@ data TextureAtlas = TextureAtlas
   , taName         ∷ Text
   , taPath         ∷ Text
   , taMetadata     ∷ AtlasMetadata
-  , taStatus       ∷ AssetStatus
   , taInfo         ∷ Maybe TextureInfo   -- ^ Vulkan image\/view\/sampler; 'Nothing' until loaded
   , taRefCount     ∷ Word32
   , taCleanup      ∷ Maybe (IO ())       -- ^ Destroy Vulkan resources on unload

--- a/src/Engine/Core/Queue.hs
+++ b/src/Engine/Core/Queue.hs
@@ -37,17 +37,3 @@ readQueueTimeout micros q = do
 
 flushQueue ∷ Queue α → IO [α]
 flushQueue q = STM.atomically $ flushTQueue (queueTQueue q)
-
-type Channel α = STM.TChan α
-
-newChannel ∷ IO (Channel α)
-newChannel = STM.atomically STM.newTChan
-
-readChannel ∷ Channel α → STM.STM α
-readChannel = STM.readTChan
-
-writeChannel ∷ Channel α → α → STM.STM ()
-writeChannel = STM.writeTChan
-
-tryReadChannel ∷ Channel α → STM.STM (Maybe α)
-tryReadChannel = STM.tryReadTChan

--- a/src/Engine/Graphics/Vulkan/Init.hs
+++ b/src/Engine/Graphics/Vulkan/Init.hs
@@ -156,7 +156,6 @@ initializeVulkan window = do
   let texSystemConfig = TextureSystemConfig
         { tscMaxTextures   = 16384
         , tscReservedSlots = 1      -- Slot 0 = undefined texture
-        , tscForceBindless = False
         , tscForceLegacy   = False
         }
   texSystem ← createTextureSystem physicalDevice device cmdPool 

--- a/src/Engine/Graphics/Vulkan/Texture/Types.hs
+++ b/src/Engine/Graphics/Vulkan/Texture/Types.hs
@@ -71,6 +71,5 @@ data BindlessTextureSystem = BindlessTextureSystem
 data TextureSystemConfig = TextureSystemConfig
   { tscMaxTextures    ∷ Word32   -- ^ Max textures (for bindless)
   , tscReservedSlots  ∷ Word32   -- ^ Reserved slots (slot 0 = undefined)
-  , tscForceBindless  ∷ Bool     -- ^ Force bindless even if limits are low
   , tscForceLegacy    ∷ Bool     -- ^ Force legacy path (for testing)
   } deriving (Show, Eq)

--- a/src/Engine/Loop/Frame.hs
+++ b/src/Engine/Loop/Frame.hs
@@ -57,10 +57,6 @@ computeAmbientLight sunAngle =
        then 0.5 + 0.2 * sunHeight   -- day: 0.5 at horizon, 0.7 at noon
        else 0.15 + 0.35 * (1.0 + sunHeight)  -- night: 0.15 at midnight, 0.5 at horizon
 
--- | Sun cycle speed: full cycle every 600 seconds
-sunCycleSpeed ∷ Double
-sunCycleSpeed = 1.0 / 600.0
-
 -- | Draw a single frame
 drawFrame ∷ EngineM ε σ ()
 drawFrame = do

--- a/src/Engine/Scene/Batch/Update.hs
+++ b/src/Engine/Scene/Batch/Update.hs
@@ -4,7 +4,6 @@ module Engine.Scene.Batch.Update
   , updateTextBatches
   , createBatch
   , getSortedBatches
-  , buildLayeredBatches
   , groupByTextureAndLayer
   ) where
 
@@ -80,32 +79,3 @@ getSortedBatches manager =
     let batches = Map.elems (bmBatches manager)
         sorted = List.sortOn (\batch → (rbLayer batch, rbAvgZ batch)) batches
     in V.fromList sorted
-
--- | Build layered batches from sprite and text batches.
---   Accumulates into lists (O(1) cons) then converts to vectors once,
---   instead of using V.snoc which is O(n) per append.
-buildLayeredBatches ∷ BatchManager → BatchManager
-buildLayeredBatches manager =
-    let sortedSprites = getSortedBatches manager
-        sortedText = List.sortOn trbLayer $ Map.elems (bmTextBatches manager)
-        
-        -- Accumulate into lists with (:) — O(1) per item
-        spriteLists ∷ Map.Map LayerId [RenderItem]
-        spriteLists = V.foldl' (\acc batch →
-            let layer = rbLayer batch
-            in Map.insertWith (\_ old → SpriteItem batch : old)
-                layer [SpriteItem batch] acc
-          ) Map.empty sortedSprites
-        
-        textLists ∷ Map.Map LayerId [RenderItem]
-        textLists = foldl' (\acc batch →
-            let layer = trbLayer batch
-            in Map.insertWith (\_ old → TextItem batch : old)
-                layer [TextItem batch] acc
-          ) Map.empty sortedText
-        
-        -- Merge lists, then convert to vectors once
-        allLists = Map.unionWith (⧺) spriteLists textLists
-        allLayers = Map.map V.fromList allLists
-        
-    in manager { bmLayeredBatches = allLayers }

--- a/src/Engine/Scene/Render.hs
+++ b/src/Engine/Scene/Render.hs
@@ -66,7 +66,6 @@ updateSceneForRender = do
                     [("textBatches", T.pack $ show $ V.length textRenderBatches)]
 
                 let updatedBatchMgr = updateTextBatches textRenderBatches (smBatchManager updatedSceneMgr)
-                    finalBatchMgr = buildLayeredBatches updatedBatchMgr
                     spriteBatches = getCurrentBatches updatedSceneMgr
                     spriteCount = V.sum $ V.map (V.length . rbVertices) spriteBatches
                     drawCallCount = V.length spriteBatches + V.length textRenderBatches
@@ -78,7 +77,7 @@ updateSceneForRender = do
                     ,("totalDrawCalls", T.pack $ show drawCallCount)]
 
                 let finalSceneMgr = updatedSceneMgr
-                                        { smBatchManager = finalBatchMgr }
+                                        { smBatchManager = updatedBatchMgr }
                 modify $ \s → s { sceneManager = finalSceneMgr }
             Nothing → do
                 logDebugM CatScene "No scene graph found for active scene"

--- a/src/Engine/Scene/Types/Batch.hs
+++ b/src/Engine/Scene/Types/Batch.hs
@@ -135,7 +135,6 @@ data BatchManager = BatchManager
     , bmTextBatches    ∷ Map.Map (FontHandle, LayerId) TextRenderBatch
     , bmVisibleObjs    ∷ V.Vector DrawableObject
     , bmDirtyBatches   ∷ Set.Set (TextureHandle, LayerId)
-    , bmLayeredBatches ∷ Map.Map LayerId (V.Vector RenderItem)
     } deriving (Show)
 
 createBatchManager ∷ BatchManager
@@ -144,7 +143,6 @@ createBatchManager = BatchManager
     , bmTextBatches = Map.empty
     , bmVisibleObjs = V.empty
     , bmDirtyBatches = Set.empty
-    , bmLayeredBatches = Map.empty
     }
 
 data SceneDynamicBuffer = SceneDynamicBuffer

--- a/src/Engine/Scripting/Lua/Message.hs
+++ b/src/Engine/Scripting/Lua/Message.hs
@@ -16,7 +16,7 @@ import Foreign.Ptr (castPtr)
 import Foreign.Marshal.Utils (copyBytes)
 import System.FilePath (takeBaseName)
 import qualified Codec.Picture as JP
-import Engine.Asset.Base (AssetId, AssetStatus(AssetLoaded))
+import Engine.Asset.Base (AssetId)
 import Engine.Asset.Handle
 import Engine.Asset.Manager
 import Engine.Asset.Types
@@ -562,7 +562,6 @@ handleLoadTextureBatch requests = do
                                     (tupWidth prep, tupHeight prep)
                                     FORMAT_R8G8B8A8_UNORM
                                     Map.empty
-                                , taStatus = AssetLoaded
                                 , taInfo = Just TextureInfo
                                     { tiImage = image
                                     , tiView = imageView

--- a/test/Test/Engine/Core/Queue.hs
+++ b/test/Test/Engine/Core/Queue.hs
@@ -67,17 +67,3 @@ spec = do
               replicateM 3 (tryReadQueue queue)
         (_, results) ← concurrently writeItems readItems
         sequence results `shouldBe` Just ["1", "2", "3"]
-    describe "Channel Operations" $ do
-      it "can write and read from channel" $ do
-        chan ← newChannel ∷ IO (Channel T.Text)
-        atomically $ writeChannel chan "test"
-        result ← atomically $ tryReadChannel chan
-        result `shouldBe` Just "test"
-
-      it "returns Nothing when reading from empty channel" $ do
-        chan ← newChannel ∷ IO (Channel T.Text)
-        result ← atomically $ tryReadChannel chan
-        result `shouldBe` (Nothing ∷ Maybe T.Text)
-
-  where
-    atomically = STM.atomically


### PR DESCRIPTION
Closes #383.

Removes a cluster of dead exports/fields in the engine that generated `-Wall` noise and implied capabilities that don't exist. Each item was verified to be genuinely dead before removal.

## Changes

| Item | Finding | Action |
|------|---------|--------|
| `Engine.Core.Queue.Channel` (+ `new/read/write/tryReadChannel`) | Used only by its own hspec block | Removed type + helpers + the test block |
| `tscForceBindless` (Texture/Types) | Set `False` at construction, never read (only `tscForceLegacy` is checked) | Removed field + the one construction site |
| `buildLayeredBatches` + `bmLayeredBatches` (Scene.Batch) | Function fed a `BatchManager` field that is **written but never read** — `drawFrame` builds its layered batches independently | Removed function, field, and the dead call in `Scene.Render` (now threads `updatedBatchMgr` straight through) |
| `taStatus` (Asset TextureAtlas) | Always `AssetLoaded` on insert, so the `cleanupResources` guard never skipped | Removed field + 2 construction sites; cleanup is now unconditional |
| `sunCycleSpeed` (Loop.Frame) | Defined with doc comment, never referenced (`sunAngleRef` is Lua-driven) | Removed |

`RenderItem`/`SpriteItem`/`TextItem` and `AssetStatus`/`AssetLoaded` are still used elsewhere and were left intact; the now-orphaned `AssetStatus(AssetLoaded)` import in `Lua.Message` was trimmed to `AssetId`.

## Verification

- No behavioral change (no worldgen-output effect → no baseline re-runs needed).
- `cabal build all` + `cabal build synarchy-test-headless` build clean; force-recompile of every touched module surfaced **no new `-Wall` dead-binding/unused-import warnings**.
- `cabal test synarchy-test-headless` → **400 examples, 0 failures, 1 pending**.
- `--dump` smoke test runs and emits JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)