### PR TITLE
Fix #389: dedup diverged helper copies (resolveTextureH hit-box bug + 3 cleanups)

### DIFF
--- a/src/Combat/Resolution.hs
+++ b/src/Combat/Resolution.hs
@@ -1123,7 +1123,7 @@ computeSeverity sm im atk tdef mEquipped natW tgt partId kind mode allocRoll kin
         -- skin/fat/muscle it crossed, the fracture over the bone, etc. (Not
         -- per-individual-layer — that double-counts a thin layer's tiny
         -- capacity and would let a graze "destroy" the skin.)
-        distOf layerSet _pmh =
+        distOf layerSet =
             let deps = penetrateDeposits layerSet budget wp kind
                 perKind = HM.fromListWith
                     (\(c1, h1) (c2, h2) → (c1 + c2, h1 + h2))
@@ -1144,7 +1144,6 @@ computeSeverity sm im atk tdef mEquipped natW tgt partId kind mode allocRoll kin
                           | (msub, th) ← scaledLayers pid ]
                 cap' = if cap ≤ 0 then defaultPartCapacity * sizeF else cap
             in max 0.5 (cap' * capacityHpScale)
-        hpOf pid = partHpId pid
 
         -- MACRO-part severity (the strike's reach + the death/wear scalar),
         -- on the macro-part's representative tissue stack.
@@ -1159,7 +1158,7 @@ computeSeverity sm im atk tdef mEquipped natW tgt partId kind mode allocRoll kin
                                         | (msub, _) ← macroLayers ])
         load = driver * clamp 0.0 2.0 (targetHardness / max 1.0 weaponHardness)
 
-        sev = sevDriver * kindSeverityFactor kind / (hpOf partId * perHp)
+        sev = sevDriver * kindSeverityFactor kind / (partHpId partId * perHp)
         -- Reach: how deep the strike penetrates (0 = surface, 1 = deepest
         -- subpart), from the macro severity. A solid hit reaches the deep
         -- structures; a glance only the shallow ones.
@@ -1177,12 +1176,12 @@ computeSeverity sm im atk tdef mEquipped natW tgt partId kind mode allocRoll kin
         selected = allocateSubparts kind reach allocRoll subparts
         subInjuries p =
             let sl = armorLayers ++ scaledLayers (bpId p)
-            in [ (bpId p, k, s) | (k, s) ← distOf sl (hpOf (bpId p)) ]
+            in [ (bpId p, k, s) | (k, s) ← distOf sl ]
         -- Scale a named layer's thickness the same way scalePair does.
         scaleNamed (nm, msub, th) =
             (nm, msub, th * layerThickScale (maybe "" sbsName msub))
         injuries = if null subparts
-                   then [ (partId, k, s) | (k, s) ← distOf macroLayers (hpOf partId) ]
+                   then [ (partId, k, s) | (k, s) ← distOf macroLayers ]
                    else concatMap subInjuries selected
 
         -- PER-LAYER log detail (for the combat-log narration): every named
@@ -1193,12 +1192,16 @@ computeSeverity sm im atk tdef mEquipped natW tgt partId kind mode allocRoll kin
         -- "lacerating the forearm's skin, fat, and muscle and breaking the
         -- radius".) Returns (subpartDisplayName, layerName, material, sev).
         bpNameOf pid = maybe pid bpName (HM.lookup pid (bodyPartIndex tdef))
-        layerDetailOf p =
-            let named = map scaleNamed (resolvePartLayersNamed sm tdef (bpId p))
+        -- One layer-detail path for both the per-subpart case (called with
+        -- each selected subpart's id) and the no-subpart macro fallback
+        -- (called with the macro part id). The two used to be structural
+        -- clones differing only in which part id they resolved.
+        layerDetailOfPart pid =
+            let named = map scaleNamed (resolvePartLayersNamed sm tdef pid)
                 armorNamed = [ ("armor", msub, th) | (msub, th) ← armorLayers ]
                 full  = armorNamed ++ named
                 deps  = penetrateDeposits [ (s, t) | (_, s, t) ← full ] budget wp kind
-                sub   = bpNameOf (bpId p)
+                sub   = bpNameOf pid
             in [ (sub, lname, lmat, capInjurySeverity k sv)
                | ((lname, _, th), (lmat, contrib)) ← zip full deps
                , Just k ← [tissueInjuryKind lmat kind]
@@ -1207,21 +1210,8 @@ computeSeverity sm im atk tdef mEquipped natW tgt partId kind mode allocRoll kin
                                / (layerHpMat lmat th * perHp))
                , sv ≥ injuryFloor ]
         logDetail = if null subparts
-                    then layerDetailOfMacro
-                    else concatMap layerDetailOf selected
-        layerDetailOfMacro =
-            let named = map scaleNamed (resolvePartLayersNamed sm tdef partId)
-                armorNamed = [ ("armor", msub, th) | (msub, th) ← armorLayers ]
-                full  = armorNamed ++ named
-                deps  = penetrateDeposits [ (s, t) | (_, s, t) ← full ] budget wp kind
-                sub   = bpNameOf partId
-            in [ (sub, lname, lmat, capInjurySeverity k sv)
-               | ((lname, _, th), (lmat, contrib)) ← zip full deps
-               , Just k ← [tissueInjuryKind lmat kind]
-               , let sv = capInjurySeverity k
-                            (contrib * kindSeverityFactor kind
-                               / (layerHpMat lmat th * perHp))
-               , sv ≥ injuryFloor ]
+                    then layerDetailOfPart partId
+                    else concatMap (layerDetailOfPart . bpId) selected
     in (clamp 0.0 1.0 sev, driver, sevDriver, load, weaponHardness, injuries, logDetail)
 
 -- ----- Event constructors -----

--- a/src/Engine/Scripting/Lua/API/Log.hs
+++ b/src/Engine/Scripting/Lua/API/Log.hs
@@ -20,6 +20,15 @@ import Data.IORef (IORef, readIORef, atomicModifyIORef')
 
 import Engine.Scripting.Lua.Debug (getSourceInfo, SourceInfo(..))
 
+-- | Strip the leading directory (and any "./" prefix) from a Lua chunk
+--   source path so the log prefix shows just the script segment, not the
+--   full on-disk path. Shared by all four log fns (info/warn/error/debug).
+dropDir ∷ String → String
+dropDir ('.':'/':ss) = dropDir ss
+dropDir ('/':ss)     = ss
+dropDir (_:ss)       = dropDir ss
+dropDir _            = ""
+
 logInfoFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 logInfoFn env = do
     msg ← Lua.tostring 1
@@ -29,10 +38,6 @@ logInfoFn env = do
             Just info → (siSource info, siCurrentLine info)
             Nothing   → ("<unknown>", 0)
         srcFileStripped = dropDir srcFile
-        dropDir ('.':'/':ss) = dropDir ss
-        dropDir ('/':ss)     = ss
-        dropDir (_:ss)       = dropDir ss
-        dropDir _            = ""
     case msg of
         Just msgBS → Lua.liftIO $ do
             logger ← readIORef (loggerRef env)
@@ -52,10 +57,6 @@ logWarnFn env = do
             Just info → (siSource info, siCurrentLine info)
             Nothing   → ("<unknown>", 0)
         srcFileStripped = dropDir srcFile
-        dropDir ('.':'/':ss) = dropDir ss
-        dropDir ('/':ss)     = ss
-        dropDir (_:ss)       = dropDir ss
-        dropDir _            = ""
     case msg of
         Just msgBS → Lua.liftIO $ do
             logger ← readIORef (loggerRef env)
@@ -75,10 +76,6 @@ logErrorFn env = do
             Just info → (siSource info, siCurrentLine info)
             Nothing   → ("<unknown>", 0)
         srcFileStripped = dropDir srcFile
-        dropDir ('.':'/':ss) = dropDir ss
-        dropDir ('/':ss)     = ss
-        dropDir (_:ss)       = dropDir ss
-        dropDir _            = ""
     case msg of
         Just msgBS → Lua.liftIO $ do
             logger ← readIORef (loggerRef env)
@@ -99,12 +96,13 @@ logDebugFn env = do
     let (srcFile, srcLine) = case mInfo of
             Just info → (siSource info, siCurrentLine info)
             Nothing   → ("<unknown>", 0)
-    
+        srcFileStripped = dropDir srcFile
+
     case msg of
         Just msgBS → Lua.liftIO $ do
             logger ← readIORef (loggerRef env)
             let msgText = TE.decodeUtf8 msgBS
-                fullMsg = "[" <> T.pack srcFile <> ":" <> T.pack (show srcLine) <> "] " <> msgText
+                fullMsg = "[" <> T.pack srcFileStripped <> ":" <> T.pack (show srcLine) <> "] " <> msgText
             logThreadDebug logger CatLua fullMsg
         Nothing → pure ()
     

--- a/src/Unit/HitTest.hs
+++ b/src/Unit/HitTest.hs
@@ -26,19 +26,14 @@ import World.Grid (tileWidth, tileHeight, tileSideHeight
                   , applyFacingF, GridConfig(..), defaultGridConfig)
 import World.Generate (viewDepth)
 import Unit.Types
-import Unit.Direction (Direction(..), dirIndex, indexToDir)
+import Unit.Direction (Direction)
+import Unit.Sprite (resolveTexture)
 
 baseTileW ∷ Float
 baseTileW = fromIntegral (gcTilePixelWidth defaultGridConfig)
 
 baseTileH ∷ Float
 baseTileH = fromIntegral (gcTilePixelHeight defaultGridConfig)
-
-cameraRotSteps ∷ CameraFacing → Int
-cameraRotSteps FaceSouth = 0
-cameraRotSteps FaceWest  = 2
-cameraRotSteps FaceNorth = 4
-cameraRotSteps FaceEast  = 6
 
 -- | Hit test at framebuffer-pixel coordinates. Returns the topmost
 --   (highest-Z) unit whose sprite quad contains the click, or Nothing.
@@ -215,19 +210,18 @@ hitTestUnitsInRect env x1d y1d x2d y2d = do
                 else [uid | (uid, inst) ← HM.toList instances, inRect inst]
 
 -- | Resolve which texture handle the unit displays for a given camera
---   facing. Duplicated from Unit.Render so HitTest doesn't import the
---   whole renderer.
+--   facing, for hit-box SIZING. Delegates to the shared
+--   'Unit.Sprite.resolveTexture' so the hit-box is sized from the same
+--   sprite the renderer draws — including the 'mirrorDir' fallback that
+--   produces W/SW/NW from their eastern counterparts. (A previous copy
+--   here omitted that fallback, so those units' hit-boxes were sized
+--   from the default texture instead — #389.) The flip flag doesn't
+--   affect sprite dimensions, so we drop it.
 resolveTextureH
     ∷ CameraFacing
     → Direction
     → Map.Map Direction TextureHandle
     → TextureHandle
     → TextureHandle
-resolveTextureH camFacing unitFacing dirSprites fallback
-    | Map.null dirSprites = fallback
-    | otherwise =
-        let screenIdx = (dirIndex unitFacing - cameraRotSteps camFacing) `mod` 8
-            screenDir = indexToDir screenIdx
-        in case Map.lookup screenDir dirSprites of
-            Just h  → h
-            Nothing → fallback
+resolveTextureH camFacing unitFacing dirSprites fallback =
+    fst (resolveTexture camFacing unitFacing dirSprites fallback)

--- a/src/Unit/Render.hs
+++ b/src/Unit/Render.hs
@@ -26,7 +26,8 @@ import World.Grid (tileWidth, tileHeight, tileSideHeight
                   , worldLayer, applyFacing, GridConfig(..), defaultGridConfig)
 import World.State.Types (wmVisible)
 import Unit.Types
-import Unit.Direction (Direction(..), dirIndex, indexToDir, mirrorDir)
+import Unit.Direction (mirrorDir)
+import Unit.Sprite (screenDirOf, resolveTexture)
 
 baseTileW ∷ Float
 baseTileW = fromIntegral (gcTilePixelWidth defaultGridConfig)
@@ -37,44 +38,8 @@ baseTileH = fromIntegral (gcTilePixelHeight defaultGridConfig)
 unitSortNudge ∷ Float
 unitSortNudge = 0.0003
 
--- | How many direction steps (in our 8-dir clockwise ring) the
---   camera rotation shifts.  Each 90 deg CW rotation = 2 steps.
-cameraRotSteps ∷ CameraFacing → Int
-cameraRotSteps FaceSouth = 0
-cameraRotSteps FaceWest  = 2
-cameraRotSteps FaceNorth = 4
-cameraRotSteps FaceEast  = 6
-
--- | Apply camera rotation to a world-space facing to get the screen-space
---   direction we should render. Used by both the T-pose picker and the
---   animation frame picker.
-screenDirOf ∷ CameraFacing → Direction → Direction
-screenDirOf camFacing unitFacing =
-    indexToDir ((dirIndex unitFacing - cameraRotSteps camFacing) `mod` 8)
-
--- | Pick the correct directional sprite for a unit given its world-space
---   facing and the current camera rotation.
---
---   Lookup order: requested screen direction → its `mirrorDir` (returned
---   with `flipX = True` so the renderer flips UVs) → fallback default
---   (no flip). The mirror step lets animations ship 5 directional
---   sprites (S/SE/E/NE/N) instead of 8 — SW/W/NW are produced by
---   horizontal mirror at draw time.
-resolveTexture
-    ∷ CameraFacing
-    → Direction                          -- ^ unit world facing
-    → Map.Map Direction TextureHandle    -- ^ directional sprites
-    → TextureHandle                      -- ^ fallback default
-    → (TextureHandle, Bool)              -- ^ (handle, flipX)
-resolveTexture camFacing unitFacing dirSprites fallback
-    | Map.null dirSprites = (fallback, False)
-    | otherwise =
-        let dir = screenDirOf camFacing unitFacing
-        in case Map.lookup dir dirSprites of
-            Just h  → (h, False)
-            Nothing → case mirrorDir dir >>= (`Map.lookup` dirSprites) of
-                Just h  → (h, True)
-                Nothing → (fallback, False)
+-- `cameraRotSteps`, `screenDirOf`, and `resolveTexture` now live in
+-- `Unit.Sprite` (shared with `Unit.HitTest`); re-exported above.
 
 -- | Choose a texture for a unit. If the unit has an active animation and
 --   the requested frames exist, pick by elapsed time; otherwise fall back

--- a/src/Unit/Sprite.hs
+++ b/src/Unit/Sprite.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE Strict, UnicodeSyntax #-}
+-- | Camera-rotation-aware directional sprite resolution, shared by the
+--   renderer ('Unit.Render') and the click/box hit-tester
+--   ('Unit.HitTest'). Both must resolve the SAME texture for a given
+--   unit facing + camera rotation: the renderer to draw it, the
+--   hit-tester to size the selection quad. Keeping the resolution in one
+--   place stops the two from diverging — historically 'Unit.HitTest'
+--   carried a stripped copy that omitted the 'mirrorDir' fallback, so
+--   the hit-box of W/SW/NW-facing units (drawn as the mirrored eastern
+--   sprite) was sized from the default texture instead (#389).
+--
+--   This module is deliberately light — Direction math + 'CameraFacing'
+--   + 'TextureHandle' only — so 'Unit.HitTest' can share it without
+--   pulling in the whole Vulkan renderer. 'Unit.Render' re-exports
+--   'screenDirOf' and 'resolveTexture' for existing callers.
+module Unit.Sprite
+    ( cameraRotSteps
+    , screenDirOf
+    , resolveTexture
+    ) where
+
+import UPrelude
+import qualified Data.Map.Strict as Map
+import Engine.Asset.Handle (TextureHandle(..))
+import Engine.Graphics.Camera (CameraFacing(..))
+import Unit.Direction (Direction(..), dirIndex, indexToDir, mirrorDir)
+
+-- | How many direction steps (in our 8-dir clockwise ring) the
+--   camera rotation shifts.  Each 90 deg CW rotation = 2 steps.
+cameraRotSteps ∷ CameraFacing → Int
+cameraRotSteps FaceSouth = 0
+cameraRotSteps FaceWest  = 2
+cameraRotSteps FaceNorth = 4
+cameraRotSteps FaceEast  = 6
+
+-- | Apply camera rotation to a world-space facing to get the screen-space
+--   direction we should render. Used by both the T-pose picker and the
+--   animation frame picker.
+screenDirOf ∷ CameraFacing → Direction → Direction
+screenDirOf camFacing unitFacing =
+    indexToDir ((dirIndex unitFacing - cameraRotSteps camFacing) `mod` 8)
+
+-- | Pick the correct directional sprite for a unit given its world-space
+--   facing and the current camera rotation.
+--
+--   Lookup order: requested screen direction → its `mirrorDir` (returned
+--   with `flipX = True` so the renderer flips UVs) → fallback default
+--   (no flip). The mirror step lets animations ship 5 directional
+--   sprites (S/SE/E/NE/N) instead of 8 — SW/W/NW are produced by
+--   horizontal mirror at draw time.
+resolveTexture
+    ∷ CameraFacing
+    → Direction                          -- ^ unit world facing
+    → Map.Map Direction TextureHandle    -- ^ directional sprites
+    → TextureHandle                      -- ^ fallback default
+    → (TextureHandle, Bool)              -- ^ (handle, flipX)
+resolveTexture camFacing unitFacing dirSprites fallback
+    | Map.null dirSprites = (fallback, False)
+    | otherwise =
+        let dir = screenDirOf camFacing unitFacing
+        in case Map.lookup dir dirSprites of
+            Just h  → (h, False)
+            Nothing → case mirrorDir dir >>= (`Map.lookup` dirSprites) of
+                Just h  → (h, True)
+                Nothing → (fallback, False)

--- a/src/World/Fluid/River/Identify.hs
+++ b/src/World/Fluid/River/Identify.hs
@@ -512,7 +512,7 @@ computeFlowAccumulation worldTiles terrain lakeIdAt dir spillwayOf
                         , let s = spillwayOf VU.! lid
                         , s ≥ 0
                         ]
-            spillDesc = sortDescByFst spillways
+            spillDesc = sortDescOn (\(z,_,_) → z) spillways
         forM_ spillDesc $ \(_, sw, lid) → do
             inject ← VUM.read lakeFlow lid
             when (inject > 0) $ do
@@ -550,14 +550,18 @@ walkInject worldTiles terrain lakeIdAt dir lakeFlow flow start inject =
                            when (terrain VU.! dn ≠ minBound) (go dn)
     in go start
 
--- | Sort a list of @(z, idx, lid)@ tuples by z descending.
-sortDescByFst ∷ [(Int, Int, Int)] → [(Int, Int, Int)]
-sortDescByFst xs = foldr insertDesc [] xs
+-- | Insertion sort, descending by a projected key. Insertion sort is
+--   fine for these — n is bounded by world area (spillway count /
+--   raw river count). Shared by the spillway-injection order
+--   (key = @(z,_,_)@) and the river-component keep order
+--   (key = @counts VU.! i@).
+sortDescOn ∷ Ord b ⇒ (a → b) → [a] → [a]
+sortDescOn key = foldr insertDesc []
   where
     insertDesc x [] = [x]
-    insertDesc x@(zx,_,_) (y@(zy,_,_):rest)
-        | zx ≥ zy   = x : y : rest
-        | otherwise = y : insertDesc x rest
+    insertDesc x (y:rest)
+        | key x ≥ key y = x : y : rest
+        | otherwise     = y : insertDesc x rest
 
 -- * River trace
 
@@ -926,7 +930,7 @@ cullByLength worldSize rawCompId rawNComps rawIsRiverTile =
                 when (cid ≥ 0) (VUM.modify v (+ 1) cid)
             pure v
         keepN      = min rawNComps (targetRiverCount worldSize)
-        ordered    = sortDescByKey rawNComps counts
+        ordered    = sortDescOn (counts VU.!) [0 .. rawNComps - 1]
         keptSet    = VU.create $ do
             v ← VUM.replicate rawNComps False
             forM_ (take keepN ordered) (\cid → VUM.write v cid True)
@@ -947,17 +951,6 @@ cullByLength worldSize rawCompId rawNComps rawIsRiverTile =
         newIsRiver  = VU.zipWith (\rt cid → rt ∧ cid ≥ 0)
                                  rawIsRiverTile newCompId
     in (newIsRiver, newCompId, newNComps)
-
--- | Sort component ids @[0 .. n - 1]@ by their per-id key value
---   (descending). Insertion sort is fine — n is the raw river count,
---   bounded by world area.
-sortDescByKey ∷ Int → VU.Vector Int → [Int]
-sortDescByKey n key = foldr insertDesc [] [0 .. n - 1]
-  where
-    insertDesc x [] = [x]
-    insertDesc x (y:rest)
-        | key VU.! x ≥ key VU.! y = x : y : rest
-        | otherwise               = y : insertDesc x rest
 
 -- | BFS label connected components of the river-tile mask. Edges are
 --   plain 4-adjacency over river tiles (E/W wrapped to mirror

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -407,6 +407,7 @@ library
                      Unit.Anim
                      Unit.Stats
                      Unit.Render
+                     Unit.Sprite
                      Unit.Selection
                      Unit.HitTest
                      Unit.LineOfSight

--- a/test-headless/Test/Headless/Unit/Render/PickFrame.hs
+++ b/test-headless/Test/Headless/Unit/Render/PickFrame.hs
@@ -12,7 +12,7 @@ import qualified Data.Vector as V
 import Engine.Asset.Handle (TextureHandle(..))
 import Engine.Graphics.Camera (CameraFacing(..))
 import Unit.Direction (Direction(..))
-import Unit.Render (pickFrame, screenDirOf)
+import Unit.Render (pickFrame, screenDirOf, resolveTexture)
 import Unit.Types
 import World.Page.Types (WorldPageId(..))
 
@@ -120,6 +120,33 @@ spec = do
             screenDirOf FaceWest DirS `shouldBe` DirE
         it "is its own inverse for full rotation" $
             screenDirOf FaceSouth (screenDirOf FaceSouth DirNE) `shouldBe` DirNE
+
+    -- resolveTexture is the single direction→sprite path shared by the
+    -- renderer (Unit.Render) and the hit-tester (Unit.HitTest). The
+    -- mirror fallback below is the #389 regression: a unit facing
+    -- W/SW/NW is DRAWN as the mirrored eastern sprite, so its hit-box
+    -- must be SIZED from that same sprite (not the default texture).
+    describe "resolveTexture — mirror fallback (#389)" $ do
+        -- The 5-sprite convention: only S/SE/E/NE/N authored; the
+        -- western half is produced by horizontal mirror of the east.
+        let east = Map.fromList
+                [ (DirS, h 1), (DirSE, h 2), (DirE, h 3)
+                , (DirNE, h 4), (DirN, h 5) ]
+            fb   = h 0
+        it "returns the directional sprite (no flip) when present" $
+            resolveTexture FaceSouth DirE east fb `shouldBe` (h 3, False)
+        it "W falls back to the mirrored E sprite with flipX" $
+            resolveTexture FaceSouth DirW east fb `shouldBe` (h 3, True)
+        it "SW falls back to the mirrored SE sprite with flipX" $
+            resolveTexture FaceSouth DirSW east fb `shouldBe` (h 2, True)
+        it "NW falls back to the mirrored NE sprite with flipX" $
+            resolveTexture FaceSouth DirNW east fb `shouldBe` (h 4, True)
+        it "uses the fallback only when neither dir nor its mirror exist" $
+            -- N is its own canonical (no mirror); drop it → fallback.
+            let noN = Map.delete DirN east
+            in resolveTexture FaceSouth DirN noN fb `shouldBe` (h 0, False)
+        it "uses the fallback when there are no directional sprites" $
+            resolveTexture FaceSouth DirW Map.empty fb `shouldBe` (h 0, False)
 
     describe "pickFrame — T-pose fallbacks" $ do
         it "returns directional T-pose when uiCurrentAnim is empty" $


### PR DESCRIPTION
Closes #389.

Four copy-pasted-then-diverged helpers — one a latent user-visible bug, three cleanups.

## 1. `resolveTextureH` hit-box bug (the user-visible one)
`Unit.HitTest.resolveTextureH` was a stripped copy of `Unit.Render.resolveTexture` that **omitted the `mirrorDir` fallback**. The hit-box quad is sized from the resolved texture's dimensions, so for **W/SW/NW-facing units** — which are *drawn* as the horizontally-mirrored eastern sprite (the 5-sprite S/SE/E/NE/N convention) — the hit-box was sized from the unit's **default texture** instead of the sprite actually on screen. Whenever those differ in size, click/box selection used the wrong hit-box.

**Fix:** extracted the camera-rotation + direction resolution (`cameraRotSteps` / `screenDirOf` / `resolveTexture`) into a new lightweight **`Unit.Sprite`** module shared by both the renderer and the hit-tester. `HitTest` now delegates to it (dropping only the flip flag, which doesn't affect sprite size). `Unit.Render` re-exports `screenDirOf` / `resolveTexture` so existing callers are unaffected. `Unit.Sprite` stays light (Direction math + `CameraFacing` + `TextureHandle` only) so `HitTest` doesn't pull in the Vulkan renderer — the original reason for the duplication.

## 2. `dropDir` (Lua API Log)
Inlined verbatim in `logInfoFn`/`logWarnFn`/`logErrorFn` and **omitted from `logDebugFn`** (which logged the unstripped on-disk path). Hoisted to one module-level definition used by all four.

## 3. River sort helpers (`World.Fluid.River.Identify`)
`sortDescByFst` / `sortDescByKey` were two identical insertion sorts; unified into one generic `sortDescOn`.

## 4. Combat layer-detail (`Combat.Resolution`)
`layerDetailOf` / `layerDetailOfMacro` were structural clones differing only in the part id resolved; merged into `layerDetailOfPart`. Also removed the trivial `hpOf` alias (→ `partHpId`) and `distOf`'s dead `_pmh` parameter (call sites computed `hpOf` only to discard it).

## Verification
- **Build:** library + exe + headless test suite compile clean; **zero `-Wall` warnings** on all changed modules (force-recompiled to confirm).
- **hspec:** 406 examples, 0 failures — including **6 new `Unit.Sprite.resolveTexture` mirror-fallback cases** that lock in the bug fix (W/SW/NW → mirrored eastern sprite + flip; fallback only when neither dir nor mirror exists), plus `Combat.Wounds` and `River.Graph`.
- **Worldgen byte-identical vs master** across 9 seeds (size 32 + 64) — the river-sort refactor is provably output-neutral.
- **`tools/test_audit.py`:** 35/35 groups pass.

No save-format change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)