### PR TITLE
Fix #396: dedupe broken-equipment overlay into scripts/ui/broken_overlay

### DIFF
--- a/scripts/cargo_inventory_panel.lua
+++ b/scripts/cargo_inventory_panel.lua
@@ -29,6 +29,7 @@ local panel       = require("scripts.ui.panel")
 local label       = require("scripts.ui.label")
 local scale       = require("scripts.ui.scale")
 local boxTextures = require("scripts.ui.box_textures")
+local brokenOverlay = require("scripts.ui.broken_overlay")
 
 -----------------------------------------------------------
 -- Layout constants. Mirrors unit_info_v2's inventory section so
@@ -412,23 +413,11 @@ local function buildRows(originX, originY, contentW, grouped)
             UI.setZIndex(iconId, 133)
             s.rowElements[#s.rowElements + 1] = { kind = "sprite", id = iconId }
             -- Broken (condition 0): overlay broken_equipment.png.
-            if g.condition and g.condition <= 0 then
-                local bt = cargoInventoryPanel.brokenTex
-                if not bt then
-                    local hh = engine.getTextureHandle("broken_equipment")
-                    if hh and hh >= 0 then
-                        cargoInventoryPanel.brokenTex = hh
-                        bt = hh
-                    end
-                end
-                if bt then
-                    local oid = UI.newSprite("cargo_inv_broken_" .. i,
-                        iconSz, iconSz, bt, 1.0, 1.0, 1.0, 1.0, h.page)
-                    UI.addToPage(h.page, oid, originX + txtPad, iconY)
-                    UI.setZIndex(oid, 134)
-                    s.rowElements[#s.rowElements + 1] =
-                        { kind = "sprite", id = oid }
-                end
+            local oid = brokenOverlay.add(h.page, "cargo_inv_broken_" .. i,
+                g.condition, originX + txtPad, iconY, iconSz, iconSz, 134)
+            if oid then
+                s.rowElements[#s.rowElements + 1] =
+                    { kind = "sprite", id = oid }
             end
         end
 

--- a/scripts/item_contents_panel.lua
+++ b/scripts/item_contents_panel.lua
@@ -36,6 +36,7 @@ package.loaded["scripts.item_contents_panel"] = itemContentsPanel
 local panel       = require("scripts.ui.panel")
 local label       = require("scripts.ui.label")
 local scale       = require("scripts.ui.scale")
+local brokenOverlay = require("scripts.ui.broken_overlay")
 
 -----------------------------------------------------------
 -- Layout constants. Mirrors cargo_inventory_panel so the two read the
@@ -80,7 +81,6 @@ itemContentsPanel.state = itemContentsPanel.state or {
 
 itemContentsPanel.hud           = nil   -- assets set by setup()
 itemContentsPanel.whitePixelTex = nil
-itemContentsPanel.brokenTex     = nil
 
 -----------------------------------------------------------
 -- HUD hookup
@@ -251,23 +251,12 @@ local function buildRows(originX, originY, contentW, rows)
             UI.addToPage(h.page, iconId, originX + txtPad, iconY)
             UI.setZIndex(iconId, 133)
             s.rowElements[#s.rowElements + 1] = { kind = "sprite", id = iconId }
-            if g.condition and g.condition <= 0 then
-                local bt = itemContentsPanel.brokenTex
-                if not bt then
-                    local hh = engine.getTextureHandle("broken_equipment")
-                    if hh and hh >= 0 then
-                        itemContentsPanel.brokenTex = hh
-                        bt = hh
-                    end
-                end
-                if bt then
-                    local oid = UI.newSprite("item_contents_broken_" .. i,
-                        iconSz, iconSz, bt, 1.0, 1.0, 1.0, 1.0, h.page)
-                    UI.addToPage(h.page, oid, originX + txtPad, iconY)
-                    UI.setZIndex(oid, 134)
-                    s.rowElements[#s.rowElements + 1] =
-                        { kind = "sprite", id = oid }
-                end
+            local oid = brokenOverlay.add(h.page,
+                "item_contents_broken_" .. i, g.condition,
+                originX + txtPad, iconY, iconSz, iconSz, 134)
+            if oid then
+                s.rowElements[#s.rowElements + 1] =
+                    { kind = "sprite", id = oid }
             end
         end
 

--- a/scripts/ui/broken_overlay.lua
+++ b/scripts/ui/broken_overlay.lua
@@ -1,0 +1,39 @@
+-- Shared "broken equipment" icon overlay.
+--
+-- Item-list panels (the unit-info inventory section, the cargo
+-- contents popup, the item-container contents popup) draw a
+-- broken_equipment.png badge over an item icon when the item is worn
+-- out (condition <= 0). The overlay texture is registered by name
+-- during item load (see Engine.Scripting.Lua.API.Items); we resolve
+-- its handle once and cache it module-wide so every panel shares one
+-- lookup instead of caching it three times.
+
+local brokenOverlay = {}
+
+local _tex = nil
+
+-- Resolve the broken_equipment overlay texture handle, cached once.
+-- Returns the handle, or nil if it isn't resident yet.
+function brokenOverlay.tex()
+    if _tex then return _tex end
+    local h = engine.getTextureHandle("broken_equipment")
+    if h and h >= 0 then _tex = h end
+    return _tex
+end
+
+-- Overlay broken_equipment.png over an item icon at (x, y, w, h) when
+-- `condition` marks the item broken (<= 0). `z` should sit just above
+-- the icon. Creates the sprite on `page` named `name` and returns its
+-- id so the caller can track it for teardown; returns nil (draws
+-- nothing) when the item isn't broken or the overlay texture is absent.
+function brokenOverlay.add(page, name, condition, x, y, w, h, z)
+    if not (condition and condition <= 0) then return nil end
+    local bt = brokenOverlay.tex()
+    if not bt then return nil end
+    local oid = UI.newSprite(name, w, h, bt, 1.0, 1.0, 1.0, 1.0, page)
+    UI.addToPage(page, oid, x, y)
+    UI.setZIndex(oid, z)
+    return oid
+end
+
+return brokenOverlay

--- a/scripts/unit_info_v2.lua
+++ b/scripts/unit_info_v2.lua
@@ -20,6 +20,7 @@ local label       = require("scripts.ui.label")
 local scale       = require("scripts.ui.scale")
 local boxTextures = require("scripts.ui.box_textures")
 local scrollbar   = require("scripts.ui.scrollbar")
+local brokenOverlay = require("scripts.ui.broken_overlay")
 local stats       = require("scripts.unit_stats")
 local injuries    = require("scripts.injuries")
 local knowledge   = require("scripts.knowledge")
@@ -735,28 +736,15 @@ local function loadIconFor(iconKey)
     return tex
 end
 
--- Broken-equipment overlay texture (registered by name during item
--- load; see Lua/API/Items). Cached once resolved.
-local _brokenTex = nil
-local function brokenOverlayTex()
-    if _brokenTex then return _brokenTex end
-    local h = engine.getTextureHandle("broken_equipment")
-    if h and h >= 0 then _brokenTex = h end
-    return _brokenTex
-end
-
 -- Overlay broken_equipment.png over an item icon at (x,y,w,h) when the
 -- item is broken (condition 0). z should sit just above the icon. The
 -- overlay sprite is tracked in `track` so it tears down with the panel.
+-- Cache + draw live in scripts.ui.broken_overlay (shared with the cargo
+-- and item-container contents panels).
 local function addBrokenOverlay(it, name, x, y, w, h, z, track)
-    if not (it and it.condition and it.condition <= 0) then return end
-    local bt = brokenOverlayTex()
-    if not bt then return end
-    local oid = UI.newSprite(name, w, h, bt, 1.0, 1.0, 1.0, 1.0,
-                             unitInfoV2.page)
-    UI.addToPage(unitInfoV2.page, oid, x, y)
-    UI.setZIndex(oid, z)
-    table.insert(track, { kind = "sprite", id = oid })
+    local oid = brokenOverlay.add(unitInfoV2.page, name,
+                                  it and it.condition, x, y, w, h, z)
+    if oid then table.insert(track, { kind = "sprite", id = oid }) end
 end
 
 -- Place a single content row: stat icon on the left, bright value on


### PR DESCRIPTION
Closes #396.

## Problem
The broken-equipment icon overlay (resolve the `broken_equipment` texture handle, cache it, draw it over an item icon when `condition <= 0`) was implemented three times:
- `scripts/unit_info_v2.lua` (extracted helpers `brokenOverlayTex()` + `addBrokenOverlay()`)
- `scripts/cargo_inventory_panel.lua:415` (inline)
- `scripts/item_contents_panel.lua:254` (inline)

A change to the overlay logic needed editing in three places.

## Change
New shared module `scripts/ui/broken_overlay.lua`:
- `brokenOverlay.tex()` — resolve + cache the handle once, **module-wide** (was cached three times).
- `brokenOverlay.add(page, name, condition, x, y, w, h, z)` — condition gate (`<= 0`) + sprite draw; returns the sprite id (or `nil`) so each panel tracks it for teardown exactly as before.

All three panels now call the shared helper. `unit_info_v2`'s `addBrokenOverlay` keeps its signature (thin wrapper, callers unchanged). The now-dead per-panel `brokenTex` caches are removed.

## Behaviour
Identical: same condition gate, same sprite params/z/tracking, same global `getTextureHandle("broken_equipment")` value.

## Testing
- Lua syntax check (luajit) on all four files.
- Stubbed-globals parity test of the shared module: non-broken (`nil`/`>0`) → no draw + `nil`; broken (`0`/negative) → correct sprite params + single cached handle lookup.
- GUI spot-check of the three panels still recommended (panels aren't headless-verifiable), per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)