### PR TITLE
Fix #380: correct inaccurate Lua API docstrings

### DIFF
--- a/src/Engine/Scripting/Lua/API/Units.hs
+++ b/src/Engine/Scripting/Lua/API/Units.hs
@@ -891,10 +891,11 @@ parsePose "climbing"  = Just Climbing
 parsePose "falling"   = Just Falling
 parsePose _           = Nothing
 
--- | unit.getPose(uid) — returns the unit's current pose as a string:
---   "standing" / "crouching" / "crawling" / "collapsed". nil if the
---   unit doesn't exist. Reads `uiPose`, mirrored from `usPose` by
---   Unit.Thread.publishToRender every tick.
+-- | unit.getPose(uid) — returns the unit's current pose as a string,
+--   one of: "standing" / "crouching" / "crawling" / "collapsed" /
+--   "dead" / "climbing" / "falling" (the full `Unit.Anim.poseTag`
+--   set). nil if the unit doesn't exist. Reads `uiPose`, mirrored from
+--   `usPose` by Unit.Thread.publishToRender every tick.
 unitGetPoseFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 unitGetPoseFn env = do
     idArg ← Lua.tointeger 1

--- a/src/Engine/Scripting/Lua/API/Units.hs
+++ b/src/Engine/Scripting/Lua/API/Units.hs
@@ -2678,9 +2678,12 @@ unitLungeImpactSpeedFn env = do
                 Nothing → Lua.pushnumber (Lua.Number 0) >> return 1
 
 -- | unit.getActivity(uid) — returns the unit's current sim-thread
---   activity as a string: "idle", "walking", or "collapsed". nil if
---   the unit doesn't exist. Reads `uiActivity`, which is mirrored
---   from `usState` by Unit.Thread.publishToRender every tick.
+--   activity as a string, one of: "idle", "walking", "running",
+--   "drinking", "eating", "pickup", "transitioning" (see
+--   `Unit.Thread.activityLabel`). nil if the unit doesn't exist. This
+--   is the activity, NOT the pose — collapse/death are poses, read via
+--   `unit.getPose`, and never appear here. Reads `uiActivity`, which is
+--   mirrored from `usState` by Unit.Thread.publishToRender every tick.
 unitGetActivityFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 unitGetActivityFn env = do
     idArg ← Lua.tointeger 1
@@ -3427,7 +3430,11 @@ unitRemoveModifierFn env = do
 
 -- | unit.getModifiers(id, name) — list every modifier on the named
 --   stat as a Lua array of @{delta, percent, source, expiry}@ tables. Expired
---   entries are NOT filtered — caller can compare expiry to os.time().
+--   entries are NOT filtered — caller can compare expiry to the game
+--   clock (e.g. `engine.gameTime()`). NB: @expiry@ is in game-clock
+--   seconds (stamped from `gameTimeRef` by `unit.addModifier`), NOT
+--   POSIX epoch, so comparing it to `os.time()` is wrong. @expiry@ is
+--   absent on permanent modifiers.
 --   nil if the unit doesn't exist; empty array if no modifiers.
 unitGetModifiersFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 unitGetModifiersFn env = do

--- a/src/Engine/Scripting/Lua/API/WorldQuery.hs
+++ b/src/Engine/Scripting/Lua/API/WorldQuery.hs
@@ -82,8 +82,13 @@ worldGetTerrainAtFn env = do
             Lua.pushnil
             return 1
 
--- | world.getFluidAt(gx, gy) → type, surface or nil
---   Returns fluid type string ("ocean","lake","river","lava") and surface Z.
+-- | world.getFluidAt(gx, gy) → type, surface | nil
+--   Arity is the contract: on dry tiles (and unloaded/out-of-range
+--   chunks) it pushes a single nil; on a fluid tile it pushes TWO
+--   values — the fluid type string ("ocean","lake","river","lava") and
+--   the fluid surface Z. So test `getFluidAt(x,y) ~= nil` (or capture
+--   the first return) to distinguish "no fluid" from a fluid sitting at
+--   surface 0 — never rely on the surface alone.
 worldGetFluidAtFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 worldGetFluidAtFn env = do
     mGx ← Lua.tointeger 1


### PR DESCRIPTION
Closes #380.

## Problem

Three Lua-API Haddock docstrings (which are effectively the Lua API reference) no longer matched behaviour, so scripts written against them carried latent bugs.

## Fixes

- **`unit.getActivity`** (`API/Units.hs`) — docstring listed only `"idle"`/`"walking"`/`"collapsed"`, but `Unit.Thread.activityLabel` emits `idle`/`walking`/`running`/`drinking`/`eating`/`pickup`/`transitioning` and never `"collapsed"`. Documented the full set and that collapse/death are **poses** (read via `unit.getPose`), not activities.
- **`unit.getModifiers`** (`API/Units.hs`) — docstring said to compare `expiry` to `os.time()`, but `smExpiry` is stamped from `gameTimeRef` (game-clock seconds) by `unit.addModifier`, not POSIX epoch. Now points callers at `engine.gameTime()` and notes permanent modifiers omit `expiry`. (The `addModifier` docstring already documented `gameTimeRef` correctly — this just makes the read side consistent.)
- **`world.getFluidAt`** (`API/WorldQuery.hs`) — `"type, surface or nil"` omitted the arity contract: dry/unloaded pushes **1** value (nil), a fluid tile pushes **2**. Documented so callers distinguish "no fluid" from a fluid at surface 0.

## Verification

- Confirmed all three claims against the implementation before editing.
- Grepped the Lua scripts: **no caller relies on the wrong contract** — the sole `getModifiers` caller (`unit_info_v2.lua`) sums `delta`/`percent` without touching `expiry`; no `getActivity` caller branches on `"collapsed"`; `os.time()` appears only in a `randomseed`. So no script fixes were needed.
- Comment-only; no logic change. `cabal build exe:synarchy` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)