### PR TITLE
Fix #385: worldgen dead-code sweep (BoundarySide, plateAt, foldlM, wrapChunkX/Y, meander seed, dup isRiverCarveEvent)

### DIFF
--- a/src/World/Generate/Timeline.hs
+++ b/src/World/Generate/Timeline.hs
@@ -18,8 +18,7 @@ import World.Material (MaterialId(..), matGlacier, MaterialRegistry(..)
 import World.Plate (wrapGlobalU, TectonicPlate, elevationAtGlobal)
 import World.Geology.Types (GeoModification(..))
 import World.Geology.Event (applyGeoEvent)
-import World.Geology.Timeline.Types (GeoEvent(..))
-import World.Hydrology.Types (HydroFeature(..))
+import World.Geology.Timeline.Types (isRiverCarveEvent)
 import World.Geology.Erosion
     (applyErosion, applyErosionLerp4, lookupRegionalErosion
     , erosionCornerLookup)
@@ -457,13 +456,6 @@ applyTimelineChunk timeline worldSize registry wsc coord (baseElevVec, baseMatVe
                 pure (elevF, matF)
 
         in (finalElev, finalMat)
-
-    isRiverCarveEvent ∷ GeoEvent → Bool
-    isRiverCarveEvent (HydroEvent (RiverFeature _)) = True
-    isRiverCarveEvent (HydroEvent (GlacierFeature _)) = True
-    isRiverCarveEvent (RiverSegmentEvent _) = True
-    isRiverCarveEvent (RiverDeltaEvent _) = True
-    isRiverCarveEvent _ = False
 
     applyOneEvent ws gx gy (elev, mat) event =
         let hardness = mpHardness (getMaterialProps registry mat)

--- a/src/World/Geology/Event.hs
+++ b/src/World/Geology/Event.hs
@@ -35,8 +35,7 @@ applyGeoEvent (HydroEvent feature) worldSize gx gy baseElev _ =
 applyGeoEvent (HydroModify _fid evolution) worldSize gx gy baseElev _ =
     applyHydroEvolution evolution worldSize gx gy baseElev
 applyGeoEvent (RiverSegmentEvent rsc) worldSize gx gy baseElev _ =
-    carveFromSegment worldSize gx gy
-                            (rscMeanderSeed rsc) (rscSegment rsc) baseElev
+    carveFromSegment worldSize gx gy (rscSegment rsc) baseElev
 applyGeoEvent (RiverDeltaEvent rdp) worldSize gx gy baseElev _ =
     computeDeltaDeposit' (rdpLastSegment rdp) (rdpFlowRate rdp)
                          worldSize gx gy baseElev

--- a/src/World/Geology/Timeline.hs
+++ b/src/World/Geology/Timeline.hs
@@ -21,7 +21,7 @@ import World.Hydrology.Types (RiverSegment(..))
 import World.Fluid.River (fixupSegmentContinuity)
 import World.Generate.Timeline.Fast (applyTimelineFastFrom)
 import World.Geology.Types
-import World.Geology.Timeline.Types (TimelineParams(..))
+import World.Geology.Timeline.Types (TimelineParams(..), isRiverCarveEvent)
 import World.Geology.Hash
 import World.Geology.Crater (generateCraters)
 import World.Hydrology.Types (HydroFeature(..), RiverParams(..)
@@ -154,7 +154,7 @@ buildTimeline registry seed worldSize plateCount erosionIntensity volcanicActivi
         -- This is cached on GeoTimeline so applyTimeline/Fast don't
         -- recompute it per-tile (was 35% of CPU in profiling).
         riverExploded = V.concat
-            [ V.filter (\(evt, _) → isRiverCarveEvtCached evt)
+            [ V.filter (\(evt, _) → isRiverCarveEvent evt)
                        (gpExplodedEvents p)
             | p ← periods
             ]
@@ -399,13 +399,6 @@ stitchWorldTerrain worldSize cache =
                     ∧ gyOff ≥ 0 ∧ gyOff < worldTiles) $
                     VUM.write v wIdx (interior VU.! i)
         pure v
-
-isRiverCarveEvtCached ∷ GeoEvent → Bool
-isRiverCarveEvtCached (HydroEvent (RiverFeature _)) = True
-isRiverCarveEvtCached (HydroEvent (GlacierFeature _)) = True
-isRiverCarveEvtCached (RiverSegmentEvent _) = True
-isRiverCarveEvtCached (RiverDeltaEvent _) = True
-isRiverCarveEvtCached _ = False
 
 -- * Primordial Bombardment
 

--- a/src/World/Geology/Timeline/River.hs
+++ b/src/World/Geology/Timeline/River.hs
@@ -223,7 +223,6 @@ evolveExistingRiver seed ageIdx periodIdx worldSize pf tbs =
                     , rpMouthRegion  = GeoCoord bx by
                     , rpSegments     = tribSegs
                     , rpFlowRate     = rsFlowRate branchSeg * 0.4
-                    , rpMeanderSeed  = fromIntegral (hashGeo seed fidInt (925 + ageIdx))
                     }
 
                 childPf = PersistentFeature

--- a/src/World/Geology/Timeline/RiverTrace.hs
+++ b/src/World/Geology/Timeline/RiverTrace.hs
@@ -536,7 +536,6 @@ buildRiverFromPath seed worldSize gridSpacing riverIdx baseFlow climate path =
                         , rpMouthRegion  = GeoCoord mouthX mouthY
                         , rpSegments     = segments
                         , rpFlowRate     = totalFlow
-                        , rpMeanderSeed  = fromIntegral (hashGeo seed riverIdx 1150)
                         }
 
 -- | Keep every Nth point from the path, always preserving

--- a/src/World/Geology/Timeline/Types.hs
+++ b/src/World/Geology/Timeline/Types.hs
@@ -18,6 +18,7 @@ module World.Geology.Timeline.Types
     , bboxOverlapsChunk
     , tagEventsWithBBox
     , GeoEvent(..)
+    , isRiverCarveEvent
     , OreSheetParams(..)
     , RiverSegmentCarve(..)
     , RiverDeltaParams(..)
@@ -212,7 +213,6 @@ noBBox = EventBBox minBound minBound maxBound maxBound
 --   at the event level. Each segment gets its own tight bbox.
 data RiverSegmentCarve = RiverSegmentCarve
     { rscSegment     ∷ !RiverSegment
-    , rscMeanderSeed ∷ !Word64
     } deriving (Show, Eq, Generic, Serialize, Hashable, NFData)
 
 -- | Delta deposit at the river mouth. Extracted from the last
@@ -253,6 +253,20 @@ data GeoEvent
 --   simultaneously, producing gap-free valleys.
 explodeRiverEvent ∷ GeoEvent → [GeoEvent]
 explodeRiverEvent evt = [evt]
+
+-- * River-carve event predicate
+
+-- | True for events that carve river/glacier valleys into terrain.
+--   Single source shared by the timeline build (cache pre-filter,
+--   "World.Geology.Timeline") and the chunk apply pass (final river
+--   re-carve, "World.Generate.Timeline") so the two consumers can't
+--   diverge as 'GeoEvent' grows.
+isRiverCarveEvent ∷ GeoEvent → Bool
+isRiverCarveEvent (HydroEvent (RiverFeature _))   = True
+isRiverCarveEvent (HydroEvent (GlacierFeature _)) = True
+isRiverCarveEvent (RiverSegmentEvent _)           = True
+isRiverCarveEvent (RiverDeltaEvent _)             = True
+isRiverCarveEvent _                               = False
 
 -- * Bounding boxes
 

--- a/src/World/Hydrology/Glacier/Spawn.hs
+++ b/src/World/Hydrology/Glacier/Spawn.hs
@@ -121,7 +121,6 @@ spawnMeltwaterRiver seed periodIdx parentFid pf (events, tbs) =
             , rpMouthRegion  = GeoCoord endX endY
             , rpSegments     = segments
             , rpFlowRate     = 0.4
-            , rpMeanderSeed  = fromIntegral (hashGeo seed fidInt 975)
             }
 
         childPf = PersistentFeature

--- a/src/World/Hydrology/River/Carving.hs
+++ b/src/World/Hydrology/River/Carving.hs
@@ -8,7 +8,6 @@ module World.Hydrology.River.Carving
     ) where
 
 import UPrelude
-import Data.Word (Word64)
 import qualified Data.Vector as V
 import World.Base (GeoCoord(..))
 import World.Geology.Hash (wrappedDeltaUV)
@@ -33,10 +32,7 @@ import World.Geology.Hash
 applyRiverCarve ∷ RiverParams → Int → Int → Int → Int → GeoModification
 -- DEBUG STEP 1: carving only, no delta deposit
 applyRiverCarve river worldSize gx gy baseElev =
-    let mSeed = rpMeanderSeed river
-        bestCarve = findDeepestCarve worldSize gx gy mSeed baseElev
-                                     (rpSegments river)
-    in bestCarve
+    findDeepestCarve worldSize gx gy baseElev (rpSegments river)
 
 -- | Walk the segment list with an explicit recursive loop.
 --   This avoids the foldl' closure overhead and lets GHC
@@ -45,9 +41,9 @@ applyRiverCarve river worldSize gx gy baseElev =
 --   Early-out: skip segments whose bounding box (padded by
 --   valley width) doesn't contain the query point.
 {-# INLINE findDeepestCarve #-}
-findDeepestCarve ∷ Int → Int → Int → Word64 → Int
+findDeepestCarve ∷ Int → Int → Int → Int
                  → V.Vector RiverSegment → GeoModification
-findDeepestCarve worldSize gx gy mSeed baseElev segs = go noModification 0
+findDeepestCarve worldSize gx gy baseElev segs = go noModification 0
   where
     !len = V.length segs
     go !acc !i
@@ -65,7 +61,7 @@ findDeepestCarve worldSize gx gy mSeed baseElev segs = go noModification 0
         = go acc (i + 1)
         | otherwise
         = let seg = V.unsafeIndex segs i
-              carve = carveFromSegment worldSize gx gy mSeed seg baseElev
+              carve = carveFromSegment worldSize gx gy seg baseElev
           in go (pickDeepest acc carve) (i + 1)
 
 -- * Target-Based Segment Carving (sloped banks)
@@ -92,8 +88,8 @@ findDeepestCarve worldSize gx gy mSeed baseElev segs = go noModification 0
 --
 --   refSurface = lerp(rsStartElev, rsEndElev, clampedT) and
 --   channelFloor = max(seaLevel − 1, floor(refSurface − rsDepth)).
-carveFromSegment ∷ Int → Int → Int → Word64 → RiverSegment → Int → GeoModification
-carveFromSegment worldSize gx gy _meanderSeed seg baseElev =
+carveFromSegment ∷ Int → Int → Int → RiverSegment → Int → GeoModification
+carveFromSegment worldSize gx gy seg baseElev =
     let GeoCoord sx sy = rsStart seg
         GeoCoord ex ey = rsEnd seg
 

--- a/src/World/Hydrology/Simulation.hs
+++ b/src/World/Hydrology/Simulation.hs
@@ -582,12 +582,6 @@ computeOceanDistance totalSamples gridW landVec maxDist = runST $ do
 
     VU.unsafeFreeze distM
 
-foldlM ∷ Monad m ⇒ (a → b → m a) → a → [b] → m a
-foldlM _ acc [] = return acc
-foldlM f acc (x:xs) = do
-    acc' ← f acc x
-    foldlM f acc' xs
-
 -- * Flow Simulation
 
 simulateHydrology ∷ Word64 → Int → Int → ElevGrid → ClimateState → FlowResult

--- a/src/World/Hydrology/Types.hs
+++ b/src/World/Hydrology/Types.hs
@@ -38,7 +38,6 @@ data RiverParams = RiverParams
     , rpMouthRegion   ∷ !GeoCoord       -- ^ Where it reaches ocean/lake/basin
     , rpSegments      ∷ !(V.Vector RiverSegment) -- ^ Ordered list of path segments
     , rpFlowRate      ∷ !Float          -- ^ Accumulated precipitation along path
-    , rpMeanderSeed   ∷ !Word64         -- ^ Sub-seed for meander noise
     } deriving (Show, Eq, Generic, Serialize, Hashable)
 instance (Serialize a, Eq a, Hashable a)
     ⇒ Serialize (V.Vector a) where
@@ -49,8 +48,8 @@ instance (Serialize a, Eq a, Hashable a)
     hashWithSalt s v = hashWithSalt s (V.toList v)
 
 instance NFData RiverParams where
-    rnf (RiverParams s m segs f ms) =
-        rnf s `seq` rnf m `seq` rnf segs `seq` rnf f `seq` rnf ms `seq` ()
+    rnf (RiverParams s m segs f) =
+        rnf s `seq` rnf m `seq` rnf segs `seq` rnf f `seq` ()
 
 -- | A single segment of a river between two waypoints.
 --

--- a/src/World/Plate.hs
+++ b/src/World/Plate.hs
@@ -6,7 +6,6 @@ module World.Plate
     , generatePlates
     , defaultPlatesFor
       -- * Queries
-    , plateAt
     , twoNearestPlates
     , elevationAtGlobal
       -- * Boundary classification
@@ -25,8 +24,6 @@ module World.Plate
 import UPrelude
 import Data.Bits (xor, shiftR, (.&.))
 import Data.Word (Word32, Word64)
-import Data.List (sortBy)
-import Data.Ord (comparing)
 import World.Material (MaterialId(..), matGranite, matDiorite, matGabbro, matGlacier)
 import World.Scale (WorldScale(..), computeWorldScale, scaleElev, scaleDist, scaleElevI)
 import World.Constants (seaLevel)
@@ -40,9 +37,6 @@ data BoundaryType
     | Divergent  !Float
     | Transform  !Float
     deriving (Show)
-
-data BoundarySide = SidePlateA | SidePlateB
-    deriving (Show, Eq)
 
 -- * Plate Generation
 
@@ -127,12 +121,6 @@ generateOnePlate seed worldSize plateIndex =
 
 -- * Plate Queries
 
-plateAt ∷ Word64 → Int → [TectonicPlate] → Int → Int → (TectonicPlate, Float)
-plateAt seed worldSize plates gx gy =
-    case rankPlates seed worldSize plates gx gy of
-      (x:_) → x
-      []    → error "plateAt: no plates"
-
 twoNearestPlates ∷ Word64 → Int → [TectonicPlate] → Int → Int
                  → ((TectonicPlate, Float), (TectonicPlate, Float))
 twoNearestPlates seed worldSize plates gx gy =
@@ -185,16 +173,6 @@ twoNearestPlates seed worldSize plates gx gy =
                 second = (p, maxDist)
             in go first second False ps
         _ → error "no plates"
-
-rankPlates seed worldSize plates gx gy =
-    let withDist plate =
-            let du = fromIntegral (wrappedDeltaU worldSize gx gy
-                        (plateCenterX plate) (plateCenterY plate)) ∷ Float
-                dv = fromIntegral ((gx + gy) - (plateCenterX plate + plateCenterY plate)) ∷ Float
-                jitter = plateJitter seed worldSize gx gy
-                             (plateCenterX plate) (plateCenterY plate)
-            in (plate, sqrt (du * du + dv * dv) + jitter)
-    in sortBy (comparing snd) (map withDist plates)
 
 -- * Boundary Classification
 
@@ -453,8 +431,7 @@ elevationAtGlobal seed plates worldSize gx gy =
             baseElev = plateBaseElev myPlate
             boundaryDist = (distB - distA) / 2.0
             boundary = classifyBoundary worldSize plateA plateB
-            side = SidePlateA
-            boundaryEffect = boundaryElevation wsc boundary side plateA plateB boundaryDist
+            boundaryEffect = boundaryElevation wsc boundary plateA plateB boundaryDist
             shelfEffect = continentalShelf wsc plateA plateB boundaryDist
             mness = mountainness wsc boundaryDist
             ridge = ridgeContribution seed worldSize gx' gy' wsc mness
@@ -476,8 +453,7 @@ elevationAtGlobal seed plates worldSize gx gy =
 
         boundaryDist = (distB - distA) / 2.0
         boundary = classifyBoundary worldSize plateA plateB
-        side = SidePlateA
-        boundaryEffect = boundaryElevation wsc boundary side
+        boundaryEffect = boundaryElevation wsc boundary
                            plateA plateB boundaryDist
         shelfEffect = continentalShelf wsc plateA plateB boundaryDist
 
@@ -499,10 +475,10 @@ elevationAtGlobal seed plates worldSize gx gy =
 
 -- * Boundary Elevation Profiles
 
-boundaryElevation ∷ WorldScale → BoundaryType → BoundarySide
+boundaryElevation ∷ WorldScale → BoundaryType
                   → TectonicPlate → TectonicPlate
                   → Float → Int
-boundaryElevation wsc boundary _side plateA plateB boundaryDist =
+boundaryElevation wsc boundary plateA plateB boundaryDist =
     let bothLand  = plateIsLand plateA ∧ plateIsLand plateB
         bothOcean = not (plateIsLand plateA) ∧ not (plateIsLand plateB)
         aIsLand   = plateIsLand plateA

--- a/src/World/Save/Types.hs
+++ b/src/World/Save/Types.hs
@@ -109,8 +109,15 @@ saveMagic = 0x53595241
 --       bitmask) to GeoTimeline — composeFluidMap ORs it into the
 --       chunk-level ocean test so sub-sea tiles the coarse chunk-flood
 --       missed render ocean (sea-stops-at-chunk-boundary fix).
+--   v62 removes the dead 'rpMeanderSeed' (RiverParams) and
+--       'rscMeanderSeed' (RiverSegmentCarve) fields. Both rode along in
+--       the serialized 'wgpGeoTimeline' (GeoTimeline → gtPeriods →
+--       gpEvents → GeoEvent, e.g. HydroEvent (RiverFeature _)) but were
+--       never read — the meander noise they seeded was discarded by the
+--       river carve. Positional Generic Serialize drops the trailing
+--       field, incompatible with v61 (#385).
 currentSaveVersion ∷ Int
-currentSaveVersion = 61  -- v61: UnitSimState drops vestigial usFallImpact
+currentSaveVersion = 62  -- v62: drop dead rpMeanderSeed/rscMeanderSeed from the serialized GeoTimeline
                          --      (write-only scalar, never read; #386). Falls
                          --      route through usPendingFallDrop + Unit.Fall.
                          -- v60: WorldPageSave gains wpsConstructDesignations

--- a/src/World/ZoomMap/Cache.hs
+++ b/src/World/ZoomMap/Cache.hs
@@ -6,8 +6,6 @@ module World.ZoomMap.Cache
     ( buildZoomCache
     , buildZoomCacheWithPixels
     , majorityMaterial
-    , wrapChunkX
-    , wrapChunkY
     ) where
 
 import UPrelude
@@ -682,14 +680,6 @@ smoothZoomContour iters cs elev =
     in smoothZoomContour (iters - 1) cs smoothed
 
 -- * Helpers
-
-wrapChunkX ∷ Int → Int → Int
-wrapChunkX halfSize cx =
-    let w = halfSize * 2
-    in ((cx + halfSize) `mod` w + w) `mod` w - halfSize
-
-wrapChunkY ∷ Int → Int → Int
-wrapChunkY halfSize cy = max (-halfSize) (min (halfSize - 1) cy)
 
 majorityMaterial ∷ [(Int, Word8)] → Word8
 majorityMaterial samples =


### PR DESCRIPTION
Closes #385.

A grouped dead-code sweep across the worldgen modules. Every item below was traced to confirm it is genuinely dead (no callers anywhere) before removal.

## Changes

- **`World/Plate.hs`** — removed the unused `BoundarySide` type (`SidePlateB` never referenced) and `boundaryElevation`'s discarded `_side` parameter (both call sites bound `SidePlateA`). Removed the exported-but-uncalled `plateAt`; this cascaded to its **only** caller `rankPlates` and the then-orphaned `Data.List.sortBy` / `Data.Ord.comparing` imports. `elevationAtGlobal` uses the `twoNearestPlates` fast path and is untouched.
- **`World/Hydrology/Simulation.hs`** — removed the local `foldlM` (a reimplementation of `Control.Monad.foldM` with zero call sites).
- **`World/ZoomMap/Cache.hs`** — removed the exported-but-uncalled `wrapChunkX` / `wrapChunkY` (`wrapChunkX` duplicated the canonical `wrapChunkCoordU` from the #316 single-source fix).
- **Meander seed** — the seed was threaded `applyRiverCarve → findDeepestCarve → carveFromSegment` and immediately wildcarded. Removed the dead param everywhere, then dropped the resulting dead payload: `rpMeanderSeed` (`RiverParams`) + its 3 write sites, and `rscMeanderSeed` (`RiverSegmentCarve`, read only by the now-simplified `applyGeoEvent`), plus the now-unused `Word64` import in `Carving.hs`. **`heMeanderSeed`** on the `RiverMeander` evolution event is intentionally **left intact** — it's a separate, still-constructed field outside this checklist.
- **Predicate unification** — `isRiverCarveEvent` (`Generate/Timeline.hs`, local `where`) and `isRiverCarveEvtCached` (`Geology/Timeline.hs`, top-level) were identical 4-clause predicates. Unified into one exported `isRiverCarveEvent` in `World.Geology.Timeline.Types` (which owns `GeoEvent`); both consumers now import it.

## Save format — bumped to v62

**`currentSaveVersion` 61 → 62.** `RiverParams` and `RiverSegmentCarve` are serialized inside `wgpGeoTimeline` (`WorldGenParams`' manual `Serialize`, `src/World/Generate/Types.hs:81`), which is persisted in `WorldPageSave` — so dropping `rpMeanderSeed` / `rscMeanderSeed` changes the positional `Serialize` layout and pre-v62 saves must be rejected rather than mis-decoded. This matches the v23–v27 GeoTimeline-shape precedent in the version-history comment. _(Worldgen **output** is still byte-identical — the meander seed was discarded during generation; only the serialized save shape changed.)_

## Verification

- **Worldgen output byte-identical vs `master`** — direct A/B `--dump` diff against the master binary across 5 configs: w64 seeds 42/1337/7 and w128 region `-8,-8,8,8` seeds 42/99 (the seed-42 region contains **14,485 river/lake tiles**, exercising the river-carve path the meander-seed removal touches). All byte-identical.
- **Save round-trip at v62** — `tools/multiworld_save_probe.py` (save → quit → fresh restart → load across two generated world pages) → **10/10 checks pass**.
- `cabal test synarchy-test-headless` → **406 examples, 0 failures** (includes the worldgen determinism + shape specs).
- `python3 tools/test_audit.py` → **35/35 groups passed**.
- `-Wall` clean — no new warnings on any changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)