### PR TITLE
Fix #374: add diagnostic context to bare error partials on worker-thread paths

### DIFF
--- a/src/Unit/Injury.hs
+++ b/src/Unit/Injury.hs
@@ -320,7 +320,9 @@ allocateSubparts kind reach roll subs =
 
 -- | Pick one part weighted by area weight, from a roll in [0,1). Total.
 weightedPick ∷ Float → [BodyPart] → BodyPart
-weightedPick _ [] = error "weightedPick: empty list"   -- guarded by callers
+-- Guarded by callers: bands from groupBy are non-empty, and the stab /
+-- structural / soft paths case-match [] before calling.
+weightedPick roll [] = error $ "weightedPick: empty list (roll=" ⧺ show roll ⧺ ")"
 weightedPick roll ps@(p0 : _) =
     let total  = sum (map bpAreaWeight ps)
         target = roll * total

--- a/src/Unit/Injury.hs
+++ b/src/Unit/Injury.hs
@@ -302,28 +302,37 @@ allocateSubparts kind reach roll subs =
         deepSoft   p = any (\(_, m, _) → m ≡ "nerve" ∨ m ≡ "organ")     (bpLayers p)
         rollFor i = let x = roll * fromIntegral (i + 3) * 1.61803
                     in x - fromIntegral (floor x ∷ Int)
+        -- Context label threaded into weightedPick so a (caller-guarded,
+        -- so unreachable) empty-pool abort names the allocation path that
+        -- violated the invariant — kind, reach, and which sub-pool.
+        pick lbl = weightedPick (T.unpack kind ⧺ "/" ⧺ lbl
+                                 ⧺ " reach=" ⧺ show reach)
     in case kind of
-        "slash" → [ weightedPick (rollFor i) band | (i, band) ← zip [0 ..] bands ]
+        "slash" → [ pick ("slash-band" ⧺ show i) (rollFor i) band
+                  | (i, band) ← zip [0 ..] bands ]
         "stab"  → case reverse bands of
-            (deepest : _) → [ weightedPick roll deepest ]
+            (deepest : _) → [ pick "stab-deepest" roll deepest ]
             []            → []
         _       → let struct = filter structural pool
                       soft   = filter deepSoft pool
-                      sPick  = case struct of [] → []; _ → [weightedPick roll struct]
-                      tPick  = case soft   of [] → []; _ → [weightedPick (rollFor 1) soft]
+                      sPick  = case struct of [] → []; _ → [pick "blunt-struct" roll struct]
+                      tPick  = case soft   of [] → []; _ → [pick "blunt-soft" (rollFor 1) soft]
                       picks  = sPick ++ tPick
                   -- An all-soft part (no bone/cartilage, no nerve/organ —
                   -- e.g. a hand of skin+fat+muscle subparts) has neither a
                   -- structural nor a deep target; honour the "always ≥1"
                   -- contract by bruising one subpart from the pool.
-                  in if null picks then [ weightedPick roll pool ] else picks
+                  in if null picks then [ pick "blunt-allsoft" roll pool ] else picks
 
 -- | Pick one part weighted by area weight, from a roll in [0,1). Total.
-weightedPick ∷ Float → [BodyPart] → BodyPart
--- Guarded by callers: bands from groupBy are non-empty, and the stab /
--- structural / soft paths case-match [] before calling.
-weightedPick roll [] = error $ "weightedPick: empty list (roll=" ⧺ show roll ⧺ ")"
-weightedPick roll ps@(p0 : _) =
+--   The @ctx@ label identifies the allocation path for the abort message
+--   (the empty-list case is caller-guarded — bands from groupBy are
+--   non-empty, and the stab / structural / soft paths case-match []
+--   before calling — so it should never fire).
+weightedPick ∷ String → Float → [BodyPart] → BodyPart
+weightedPick ctx roll [] = error $ "weightedPick: empty list (ctx=" ⧺ ctx
+                                 ⧺ " roll=" ⧺ show roll ⧺ ")"
+weightedPick _ roll ps@(p0 : _) =
     let total  = sum (map bpAreaWeight ps)
         target = roll * total
         go _   []          = p0

--- a/src/World/Flora/Render.hs
+++ b/src/World/Flora/Render.hs
@@ -92,4 +92,6 @@ findActiveCycleStage stages dayOfYear =
 maximumByKey ∷ Ord b ⇒ (a → b) → [a] → a
 maximumByKey _ [x]    = x
 maximumByKey f (x:xs) = foldl' (\best y → if f y > f best then y else best) x xs
-maximumByKey _ []     = error "maximumByKey: empty list"
+-- Unreachable: the only caller (findActivePhase) matches [] → Nothing
+-- before reaching this, so the list is non-empty here by construction.
+maximumByKey _ []     = error "maximumByKey: empty list (caller failed to guard non-empty)"

--- a/src/World/Geology/Timeline/Helpers.hs
+++ b/src/World/Geology/Timeline/Helpers.hs
@@ -119,7 +119,9 @@ isSuperVolcano pf = case pfFeature pf of
 getRiverParamsFromPf ∷ PersistentFeature → RiverParams
 getRiverParamsFromPf pf = case pfFeature pf of
     HydroShape (RiverFeature r) → r
-    _ → error "getRiverParamsFromPf: not a river"
+    other → error $ "getRiverParamsFromPf: not a river (featureId=" ⧺ show (pfId pf)
+                  ⧺ " formationPeriod=" ⧺ show (pfFormationPeriod pf)
+                  ⧺ " actualShape=" ⧺ show other ⧺ ")"
 
 isSourceNew ∷ Int → [PersistentFeature] → (Int, Int, Int, Float) → Bool
 isSourceNew worldSize existingRivers (sx, sy, _, _) =

--- a/src/World/Geology/Timeline/Helpers.hs
+++ b/src/World/Geology/Timeline/Helpers.hs
@@ -121,7 +121,7 @@ getRiverParamsFromPf pf = case pfFeature pf of
     HydroShape (RiverFeature r) → r
     other → error $ "getRiverParamsFromPf: not a river (featureId=" ⧺ show (pfId pf)
                   ⧺ " formationPeriod=" ⧺ show (pfFormationPeriod pf)
-                  ⧺ " actualShape=" ⧺ show other ⧺ ")"
+                  ⧺ " actualShape=" ⧺ featureShapeTag other ⧺ ")"
 
 isSourceNew ∷ Int → [PersistentFeature] → (Int, Int, Int, Float) → Bool
 isSourceNew worldSize existingRivers (sx, sy, _, _) =

--- a/src/World/Geology/Timeline/River.hs
+++ b/src/World/Geology/Timeline/River.hs
@@ -423,7 +423,10 @@ performMerge worldSize periodIdx tributaryPf mainPf junctionCoord segIdx tbs =
         cutSeg   = if cutIdx < V.length tribSegs
                    then tribSegs V.! cutIdx
                    else if V.null tribSegs
-                        then error "performMerge: empty tributary"
+                        then error $ "performMerge: empty tributary (tribId="
+                                   ⧺ show tribId ⧺ " mainId=" ⧺ show mainId
+                                   ⧺ " period=" ⧺ show periodIdx
+                                   ⧺ " junction=(" ⧺ show jx ⧺ "," ⧺ show jy ⧺ "))"
                         else V.last tribSegs
 
         -- Junction segment's end elevation must put the tributary's

--- a/src/World/Geology/Timeline/Types.hs
+++ b/src/World/Geology/Timeline/Types.hs
@@ -22,6 +22,7 @@ module World.Geology.Timeline.Types
     , RiverSegmentCarve(..)
     , RiverDeltaParams(..)
     , FeatureShape(..)
+    , featureShapeTag
     , FeatureActivity(..)
     , FeatureEvolution(..)
     , CraterParams(..)
@@ -577,6 +578,25 @@ data FeatureShape
     = VolcanicShape !VolcanicFeature
     | HydroShape   !HydroFeature
     deriving (Show, Eq, Generic, Serialize, Hashable, NFData)
+
+-- | Compact constructor tag for a FeatureShape — the constructor name
+--   only, without the payload. Use this for diagnostics/abort messages:
+--   the derived Show of a RiverFeature drags in the full rpSegments
+--   geometry, which would dump an entire river into a crash log.
+featureShapeTag ∷ FeatureShape → String
+featureShapeTag (VolcanicShape v) = case v of
+    ShieldVolcano{}    → "VolcanicShape ShieldVolcano"
+    CinderCone{}       → "VolcanicShape CinderCone"
+    LavaDome{}         → "VolcanicShape LavaDome"
+    Caldera{}          → "VolcanicShape Caldera"
+    FissureVolcano{}   → "VolcanicShape FissureVolcano"
+    LavaTube{}         → "VolcanicShape LavaTube"
+    SuperVolcano{}     → "VolcanicShape SuperVolcano"
+    HydrothermalVent{} → "VolcanicShape HydrothermalVent"
+featureShapeTag (HydroShape h) = case h of
+    RiverFeature{}   → "HydroShape RiverFeature"
+    GlacierFeature{} → "HydroShape GlacierFeature"
+    LakeFeature{}    → "HydroShape LakeFeature"
 
 data FeatureActivity
     = FActive

--- a/src/World/Hydrology/Glacier/Common.hs
+++ b/src/World/Hydrology/Glacier/Common.hs
@@ -14,4 +14,4 @@ getGlacierParams pf = case pfFeature pf of
     (HydroShape (GlacierFeature g)) → g
     other → error $ "getGlacierParams: not a glacier (featureId=" ⧺ show (pfId pf)
                   ⧺ " formationPeriod=" ⧺ show (pfFormationPeriod pf)
-                  ⧺ " actualShape=" ⧺ show other ⧺ ")"
+                  ⧺ " actualShape=" ⧺ featureShapeTag other ⧺ ")"

--- a/src/World/Hydrology/Glacier/Common.hs
+++ b/src/World/Hydrology/Glacier/Common.hs
@@ -12,4 +12,6 @@ import World.Hydrology.Types
 getGlacierParams ∷ PersistentFeature → GlacierParams
 getGlacierParams pf = case pfFeature pf of
     (HydroShape (GlacierFeature g)) → g
-    _ → error "getGlacierParams: not a glacier"
+    other → error $ "getGlacierParams: not a glacier (featureId=" ⧺ show (pfId pf)
+                  ⧺ " formationPeriod=" ⧺ show (pfFormationPeriod pf)
+                  ⧺ " actualShape=" ⧺ show other ⧺ ")"

--- a/src/World/Hydrology/River/Common.hs
+++ b/src/World/Hydrology/River/Common.hs
@@ -14,4 +14,4 @@ getRiverParams pf = case pfFeature pf of
     (HydroShape (RiverFeature r)) → r
     other → error $ "getRiverParams: not a river (featureId=" ⧺ show (pfId pf)
                   ⧺ " formationPeriod=" ⧺ show (pfFormationPeriod pf)
-                  ⧺ " actualShape=" ⧺ show other ⧺ ")"
+                  ⧺ " actualShape=" ⧺ featureShapeTag other ⧺ ")"

--- a/src/World/Hydrology/River/Common.hs
+++ b/src/World/Hydrology/River/Common.hs
@@ -12,4 +12,6 @@ import World.Hydrology.Types
 getRiverParams ∷ PersistentFeature → RiverParams
 getRiverParams pf = case pfFeature pf of
     (HydroShape (RiverFeature r)) → r
-    _ → error "getRiverParams: not a river"
+    other → error $ "getRiverParams: not a river (featureId=" ⧺ show (pfId pf)
+                  ⧺ " formationPeriod=" ⧺ show (pfFormationPeriod pf)
+                  ⧺ " actualShape=" ⧺ show other ⧺ ")"

--- a/src/World/Plate.hs
+++ b/src/World/Plate.hs
@@ -131,7 +131,9 @@ plateAt ∷ Word64 → Int → [TectonicPlate] → Int → Int → (TectonicPlat
 plateAt seed worldSize plates gx gy =
     case rankPlates seed worldSize plates gx gy of
       (x:_) → x
-      []    → error "plateAt: no plates"
+      []    → error $ "plateAt: no plates (seed=" ⧺ show seed
+                    ⧺ " worldSize=" ⧺ show worldSize
+                    ⧺ " tile=(" ⧺ show gx ⧺ "," ⧺ show gy ⧺ "))"
 
 twoNearestPlates ∷ Word64 → Int → [TectonicPlate] → Int → Int
                  → ((TectonicPlate, Float), (TectonicPlate, Float))
@@ -184,7 +186,9 @@ twoNearestPlates seed worldSize plates gx gy =
                 first  = (p, d0)
                 second = (p, maxDist)
             in go first second False ps
-        _ → error "no plates"
+        _ → error $ "twoNearestPlates: no plates (seed=" ⧺ show seed
+                  ⧺ " worldSize=" ⧺ show worldSize
+                  ⧺ " tile=(" ⧺ show gx ⧺ "," ⧺ show gy ⧺ "))"
 
 rankPlates seed worldSize plates gx gy =
     let withDist plate =

--- a/src/World/Render/Zoom/Climate.hs
+++ b/src/World/Render/Zoom/Climate.hs
@@ -39,7 +39,8 @@ toClimateCoord facing worldSize x y =
   where
     floorDiv a b
       | b > 0     = if a >= 0 then a `div` b else -(((-a) + b - 1) `div` b)
-      | otherwise = error "floorDiv: non-positive divisor"
+      | otherwise = error $ "floorDiv: non-positive divisor (a=" ⧺ show a
+                          ⧺ " b=" ⧺ show b ⧺ ")"
 
 -- * Per-Mode Color Functions
 


### PR DESCRIPTION
Closes #374.

## What

Worker threads are **fail-stop by design**, so a bare `error "msg"` on a worldgen/unit hot path aborts the thread with no state to debug from. These partials are caller-guarded today, so this is **hardening, not a known crash** — the message just needed enough context (seed / tile coords / period / feature id / input shape) to diagnose a regression if a future change ever unguards one. Fail-stop semantics are **unchanged**.

## Changes

| Site | Context added |
|------|---------------|
| `World/Plate.hs` — `plateAt`, `twoNearestPlates` | seed, worldSize, tile coords |
| `World/Geology/Timeline/River.hs` — `performMerge` | tributary id, main id, period, junction coords |
| `World/Hydrology/River/Common.hs` — `getRiverParams` | feature id, formation period, actual shape |
| `World/Hydrology/Glacier/Common.hs` — `getGlacierParams` | feature id, formation period, actual shape |
| `World/Geology/Timeline/Helpers.hs` — `getRiverParamsFromPf` | feature id, formation period, actual shape |
| `World/Render/Zoom/Climate.hs` — `floorDiv` | dividend + divisor |
| `Unit/Injury.hs` — `weightedPick` | roll value + caller-guard comment |
| `World/Flora/Render.hs` — `maximumByKey` | structurally-unreachable invariant comment (polymorphic helper, no element data to surface) |

`maximumByKey` is the one genuinely-unreachable case (its sole caller `findActivePhase` matches `[] → Nothing` first), so per the acceptance criteria it gets an invariant comment rather than fabricated data.

## Verification

- ✅ Clean build (lib + exe + headless test target)
- ✅ `cabal test synarchy-test-headless` — 406 examples, 0 failures
- ✅ Worldgen dump (`--dump --seed 42 --worldSize 64 --region -2,-2,2,2`) **byte-identical** to master — only error-branch strings changed, happy paths untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)