### PR TITLE
World-gen location overlay (#89)

### DIFF
--- a/data/locations/ruin_small.yaml
+++ b/data/locations/ruin_small.yaml
@@ -18,6 +18,12 @@ locations:
     # Terrain placement constraint tags read by the world-gen overlay
     # (#89) to filter candidate chunks. The room wants flat ground.
     anchor: [flat]
+    # World-gen overlay (#89) placement controls. Per-type, not global:
+    # at most `max_count` instances, each at least `min_spacing` chunks
+    # from another ruin (jittered, deterministic from the seed). Both are
+    # optional (defaults: max_count 4, min_spacing 4).
+    max_count: 6
+    min_spacing: 5
     # Reference content entry (raw ids, resolved later in #90).
     contents:
       - { kind: building, id: cargo_hold_S, count: 1 }

--- a/scripts/init.lua
+++ b/scripts/init.lua
@@ -80,6 +80,12 @@ function game.init(scriptId)
     -- broadcasts (onSetInfoText) reach the module.
     tileEditorScriptId = engine.loadScript("scripts/tile_editor.lua", 0.1)
 
+    -- Location stamper (#89): on the engine's onWorldReady broadcast it
+    -- materializes the placed-location overlay into geometry via the #88
+    -- builders, stamping each as its chunk loads. Loaded so onWorldReady +
+    -- update() reach it.
+    locationStamperScriptId = engine.loadScript("scripts/location_stamper.lua", 0.1)
+
     -- Pause: owns the engine.setPaused flag + world.setTimeScale
     -- snapshot. No per-tick work; loaded so engine broadcasts (none
     -- needed today) and require()s from game scripts share state.

--- a/scripts/location_stamper.lua
+++ b/scripts/location_stamper.lua
@@ -29,9 +29,12 @@ local locations = require("scripts.locations")
 -- Fired by the engine for a just-loaded chunk that hosts a placed location.
 function stamper.onStampLocation(pageId, locId, gx, gy)
     gx, gy = math.floor(gx), math.floor(gy)
-    -- Already materialized (stamped earlier this session, or its edits
-    -- replayed on reload)? Then this is a repeat load — nothing to do.
-    if structure.hasAt(gx, gy, "floor") then return end
+    -- Already materialized ON THIS PAGE (stamped earlier this session, or
+    -- its edits replayed on reload)? Then this is a repeat load — skip.
+    -- The pageId is essential: without it the check resolves to the active
+    -- world, so unrelated geometry there could suppress a valid stamp on a
+    -- hidden secondary page.
+    if structure.hasAt(gx, gy, "floor", pageId) then return end
     locations.stamp(locId, gx, gy, pageId)
 end
 

--- a/scripts/location_stamper.lua
+++ b/scripts/location_stamper.lua
@@ -1,0 +1,73 @@
+-- Location stamper (#89)
+--
+-- The engine places data-driven locations (#88) into chunks during world
+-- generation and carries the resulting overlay in the world's gen params.
+-- This module materializes that overlay into actual geometry: on the
+-- engine's onWorldReady broadcast (fired ONLY for a freshly generated
+-- world, never a save-load) it records the world's placements and, as each
+-- location's chunk loads, calls the #88 Lua builder through locations.stamp.
+--
+-- The stamps land in the edit log (world.setCell / structure.place), so they
+-- persist with the save and replay on chunk reload — which is exactly why a
+-- loaded world must NOT be re-stamped: the engine never fires onWorldReady
+-- for the save-load path, so its restored edits are the single source.
+--
+-- Stamping needs the location's chunk loaded — the builders read the terrain
+-- surface for the floor height — so this runs from update(): force-load each
+-- pending chunk, then stamp once it reports loaded. We only act on the world
+-- that is currently ACTIVE, because the per-tile reads the builders use
+-- (getTerrainAt / getChunkInfo) resolve the active page.
+
+local stamper = {}
+
+local locations = require("scripts.locations")
+
+-- Pending stamps: list of { id, gx, gy, cx, cy, worldId, requested }.
+stamper.pending = {}
+
+-- Fired by the engine when a fresh world finishes generating.
+function stamper.onWorldReady(worldId)
+    local placed = world.listPlacedLocations(worldId) or {}
+    for _, e in ipairs(placed) do
+        stamper.pending[#stamper.pending + 1] = {
+            id = e.id, gx = e.gx, gy = e.gy, cx = e.cx, cy = e.cy,
+            worldId = worldId, requested = false,
+        }
+    end
+    if #placed > 0 then
+        engine.logInfo("location_stamper: queued " .. #placed
+            .. " location(s) for " .. tostring(worldId))
+    end
+end
+
+function stamper.update(dt)
+    if #stamper.pending == 0 then return end
+    local active = world.getActiveWorldId()
+    local still = {}
+    for _, p in ipairs(stamper.pending) do
+        if p.worldId ~= active then
+            -- Not the active page; per-tile reads would hit the wrong
+            -- world. Wait until this page is shown.
+            still[#still + 1] = p
+        else
+            local info = world.getChunkInfo(p.cx, p.cy)
+            if info and info.loaded then
+                locations.stamp(p.id, p.gx, p.gy, p.worldId)
+            else
+                if not p.requested then
+                    world.loadChunksInRegion(p.cx, p.cy, p.cx, p.cy)
+                    p.requested = true
+                end
+                still[#still + 1] = p   -- still loading; retry next tick
+            end
+        end
+    end
+    stamper.pending = still
+end
+
+-- Count of locations still waiting to stamp (used by the headless probe).
+function stamper.pendingCount()
+    return #stamper.pending
+end
+
+return stamper

--- a/scripts/location_stamper.lua
+++ b/scripts/location_stamper.lua
@@ -1,73 +1,36 @@
 -- Location stamper (#89)
 --
 -- The engine places data-driven locations (#88) into chunks during world
--- generation and carries the resulting overlay in the world's gen params.
--- This module materializes that overlay into actual geometry: on the
--- engine's onWorldReady broadcast (fired ONLY for a freshly generated
--- world, never a save-load) it records the world's placements and, as each
--- location's chunk loads, calls the #88 Lua builder through locations.stamp.
+-- generation and carries the resulting overlay in the world's gen params
+-- (which serializes into the save). This module materializes that overlay
+-- into geometry: the engine dispatches onStampLocation for every load of a
+-- chunk that hosts a placed location, so locations stamp lazily as their
+-- chunks load, in any session, driven only by the persisted overlay.
 --
--- The stamps land in the edit log (world.setCell / structure.place), so they
--- persist with the save and replay on chunk reload — which is exactly why a
--- loaded world must NOT be re-stamped: the engine never fires onWorldReady
--- for the save-load path, so its restored edits are the single source.
+-- That is what makes a location robust to save timing: there is no async
+-- queue to drain. Even a world saved before a chunk was ever stamped
+-- re-materializes that location when its chunk next loads — the overlay
+-- always rides the save, and the chunk-load trigger always consults it.
 --
--- Stamping needs the location's chunk loaded — the builders read the terrain
--- surface for the floor height — so this runs from update(): force-load each
--- pending chunk, then stamp once it reports loaded. We only act on the world
--- that is currently ACTIVE, because the per-tile reads the builders use
--- (getTerrainAt / getChunkInfo) resolve the active page.
+-- Idempotency: stamping lands in the edit log (structure.place / setCell),
+-- which replays on chunk reload. So a chunk that loads again already carries
+-- its geometry; we detect that with structure.hasAt and skip — never
+-- stamping twice, and never clobbering a location the player has edited.
 
 local stamper = {}
 
 local locations = require("scripts.locations")
 
--- Pending stamps: list of { id, gx, gy, cx, cy, worldId, requested }.
-stamper.pending = {}
-
--- Fired by the engine when a fresh world finishes generating.
-function stamper.onWorldReady(worldId)
-    local placed = world.listPlacedLocations(worldId) or {}
-    for _, e in ipairs(placed) do
-        stamper.pending[#stamper.pending + 1] = {
-            id = e.id, gx = e.gx, gy = e.gy, cx = e.cx, cy = e.cy,
-            worldId = worldId, requested = false,
-        }
-    end
-    if #placed > 0 then
-        engine.logInfo("location_stamper: queued " .. #placed
-            .. " location(s) for " .. tostring(worldId))
-    end
-end
-
-function stamper.update(dt)
-    if #stamper.pending == 0 then return end
-    local active = world.getActiveWorldId()
-    local still = {}
-    for _, p in ipairs(stamper.pending) do
-        if p.worldId ~= active then
-            -- Not the active page; per-tile reads would hit the wrong
-            -- world. Wait until this page is shown.
-            still[#still + 1] = p
-        else
-            local info = world.getChunkInfo(p.cx, p.cy)
-            if info and info.loaded then
-                locations.stamp(p.id, p.gx, p.gy, p.worldId)
-            else
-                if not p.requested then
-                    world.loadChunksInRegion(p.cx, p.cy, p.cx, p.cy)
-                    p.requested = true
-                end
-                still[#still + 1] = p   -- still loading; retry next tick
-            end
-        end
-    end
-    stamper.pending = still
-end
-
--- Count of locations still waiting to stamp (used by the headless probe).
-function stamper.pendingCount()
-    return #stamper.pending
+-- Fired by the engine for a just-loaded chunk that hosts a placed location.
+function stamper.onStampLocation(pageId, locId, gx, gy)
+    gx, gy = math.floor(gx), math.floor(gy)
+    -- The #88 builders read the ACTIVE world's terrain for the floor
+    -- height, so only stamp the world that is currently active.
+    if pageId ~= world.getActiveWorldId() then return end
+    -- Already materialized (stamped earlier this session, or its edits
+    -- replayed on reload)? Then this is a repeat load — nothing to do.
+    if structure.hasAt(gx, gy, "floor") then return end
+    locations.stamp(locId, gx, gy, pageId)
 end
 
 return stamper

--- a/scripts/location_stamper.lua
+++ b/scripts/location_stamper.lua
@@ -16,6 +16,11 @@
 -- which replays on chunk reload. So a chunk that loads again already carries
 -- its geometry; we detect that with structure.hasAt and skip — never
 -- stamping twice, and never clobbering a location the player has edited.
+--
+-- Multiworld: the builders read terrain with an explicit page id
+-- (locations.stamp -> the #88 builder -> world.getTerrainAt(gx,gy,pageId)),
+-- so a location materializes on its own page even when that page is hidden /
+-- not the active one — there is no active-page gate here.
 
 local stamper = {}
 
@@ -24,9 +29,6 @@ local locations = require("scripts.locations")
 -- Fired by the engine for a just-loaded chunk that hosts a placed location.
 function stamper.onStampLocation(pageId, locId, gx, gy)
     gx, gy = math.floor(gx), math.floor(gy)
-    -- The #88 builders read the ACTIVE world's terrain for the floor
-    -- height, so only stamp the world that is currently active.
-    if pageId ~= world.getActiveWorldId() then return end
     -- Already materialized (stamped earlier this session, or its edits
     -- replayed on reload)? Then this is a repeat load — nothing to do.
     if structure.hasAt(gx, gy, "floor") then return end

--- a/scripts/locations.lua
+++ b/scripts/locations.lua
@@ -51,9 +51,10 @@ end
 --     gx, gy,    -- chunk-centre tile (anchor for stamping)
 --     id }       -- LocationDef id (join with locations.getDef for
 --                --   label/type/builder)
--- Returns {} when no world is active or nothing was placed.
-function locations.listPlaced()
-    return world.listPlacedLocations() or {}
+-- With no argument the active world is read; pass a page id to read a
+-- specific world's overlay. Returns {} when no such world or nothing placed.
+function locations.listPlaced(worldId)
+    return world.listPlacedLocations(worldId) or {}
 end
 
 -- Debug-overlay list shape: { name=id, label, note }. The overlay keys

--- a/scripts/locations.lua
+++ b/scripts/locations.lua
@@ -149,31 +149,33 @@ function builders.room_small(worldId, gx, gy, withCeiling)
     local x0, x1 = gx - r, gx + r
     local y0, y1 = gy - r, gy + r
 
-    -- 1. floor across the whole footprint
+    -- 1. floor across the whole footprint. worldId threads through so a
+    --    location stamped on a hidden/non-active page reads THAT page's
+    --    terrain height, not the active world's (#89 multiworld).
     for x = x0, x1 do
-        for y = y0, y1 do S.floor(x, y) end
+        for y = y0, y1 do S.floor(x, y, worldId) end
     end
 
     -- 2. corner posts (cap the two perimeter walls that meet at each)
-    S.post(x0, y0, "n")   -- nw + ne meet
-    S.post(x1, y0, "e")   -- ne + se meet
-    S.post(x1, y1, "s")   -- se + sw meet
-    S.post(x0, y1, "w")   -- sw + nw meet
+    S.post(x0, y0, "n", worldId)   -- nw + ne meet
+    S.post(x1, y0, "e", worldId)   -- ne + se meet
+    S.post(x1, y1, "s", worldId)   -- se + sw meet
+    S.post(x0, y1, "w", worldId)   -- sw + nw meet
 
     -- 3. perimeter walls (after posts so they cap to them)
     for y = y0, y1 do
-        S.wall(x0, y, "nw")   -- −gx side
-        S.wall(x1, y, "se")   -- +gx side
+        S.wall(x0, y, "nw", worldId)   -- −gx side
+        S.wall(x1, y, "se", worldId)   -- +gx side
     end
     for x = x0, x1 do
-        S.wall(x, y0, "ne")   -- −gy side
-        S.wall(x, y1, "sw")   -- +gy side
+        S.wall(x, y0, "ne", worldId)   -- −gy side
+        S.wall(x, y1, "sw", worldId)   -- +gy side
     end
 
     -- 4. ceiling (optional)
     if withCeiling then
         for x = x0, x1 do
-            for y = y0, y1 do S.ceiling(x, y) end
+            for y = y0, y1 do S.ceiling(x, y, worldId) end
         end
     end
 

--- a/scripts/locations.lua
+++ b/scripts/locations.lua
@@ -40,6 +40,22 @@ function locations.getDef(id)
     return nil
 end
 
+-----------------------------------------------------------
+-- World-gen placement overlay (#89)
+-----------------------------------------------------------
+-- The engine places locations into chunks during world generation
+-- (deterministic from the seed) and carries the result in the world's
+-- gen params, so it survives save/load. listPlaced() reads back that
+-- overlay for the ACTIVE world. Each entry:
+--   { cx, cy,    -- chunk coordinate
+--     gx, gy,    -- chunk-centre tile (anchor for stamping)
+--     id }       -- LocationDef id (join with locations.getDef for
+--                --   label/type/builder)
+-- Returns {} when no world is active or nothing was placed.
+function locations.listPlaced()
+    return world.listPlacedLocations() or {}
+end
+
 -- Debug-overlay list shape: { name=id, label, note }. The overlay keys
 -- armed locations + stamp() on `name`, so name carries the def id.
 function locations.list()

--- a/scripts/structures.lua
+++ b/scripts/structures.lua
@@ -98,9 +98,12 @@ local CORNER_WALLS = { n = {"ne","nw"}, e = {"ne","se"},
 -- from THIS tile's own corner post — a post on a neighbouring tile (which
 -- shares the end node) must NOT cap this wall, else a post placed for the next
 -- segment bleeds across a gap onto this wall's clean end.
-local function placeWall(gx, gy, e)
+-- worldId (optional) targets a specific world page's terrain — locations
+-- stamped on a hidden/non-active page must read THAT page's height, not the
+-- active world's (#89). nil → the active world (the click-placement path).
+local function placeWall(gx, gy, e, worldId)
     local h = handles()
-    local z = (world.getTerrainAt(gx, gy) or 0) + 1
+    local z = (world.getTerrainAt(gx, gy, worldId) or 0) + 1
     local ends = WALL_ENDS[e]   -- {leftCorner, rightCorner}
     local capL = structure.hasAt(gx, gy, "post_" .. ends[1])
     local capR = structure.hasAt(gx, gy, "post_" .. ends[2])
@@ -116,10 +119,10 @@ end
 
 -- A post just changed at tile (gx,gy)'s `corner`: re-cap that tile's own two
 -- walls touching the corner, so wall-then-post and post-then-wall converge.
-local function recapTileCorner(gx, gy, corner)
+local function recapTileCorner(gx, gy, corner, worldId)
     for _, e in ipairs(CORNER_WALLS[corner]) do
         if structure.hasAt(gx, gy, "wall_" .. e) then
-            placeWall(gx, gy, e)
+            placeWall(gx, gy, e, worldId)
         end
     end
 end
@@ -168,35 +171,39 @@ end
 -- These name the exact slot/edge/corner instead of deriving it from a click.
 -----------------------------------------------------------
 
-function M.floor(gx, gy)
+-- The programmatic builders take an optional trailing `worldId` (the page
+-- to author on / read terrain from); nil → the active world. Location
+-- stamping passes it so a hidden page's room reads that page's terrain.
+function M.floor(gx, gy, worldId)
     local h = handles()
-    local z = (world.getTerrainAt(gx, gy) or 0) + 1
+    local z = (world.getTerrainAt(gx, gy, worldId) or 0) + 1
     structure.place(gx, gy, "floor", h.floor.tex, h.floor.face, z,
                     h.floor.texPath, h.floor.facePath)
 end
 
-function M.ceiling(gx, gy)
+function M.ceiling(gx, gy, worldId)
     local h = handles()
-    local z = (world.getTerrainAt(gx, gy) or 0) + 2   -- one level above the floor
+    local z = (world.getTerrainAt(gx, gy, worldId) or 0) + 2   -- one level above the floor
     structure.place(gx, gy, "ceiling", h.ceiling.tex, h.ceiling.face, z,
                     h.ceiling.texPath, h.ceiling.facePath)
 end
 
 -- corner ∈ "n"/"e"/"s"/"w". Gated to a floor (like click placement); re-caps
--- this tile's walls touching the corner. Returns true if placed.
-function M.post(gx, gy, corner)
+-- this tile's walls touching the corner. Returns true if placed. The post z
+-- comes from the existing floor (global store), so it needs no terrain read.
+function M.post(gx, gy, corner, worldId)
     local fz = structure.floorZAt(gx, gy)
     if not fz then return false end
     local h = handles()
     structure.place(gx, gy, "post_" .. corner, h.post.tex, h.post.face, fz,
                     h.post.texPath, h.post.facePath)
-    recapTileCorner(gx, gy, corner)
+    recapTileCorner(gx, gy, corner, worldId)
     return true
 end
 
 -- edge ∈ "ne"/"nw"/"se"/"sw". Caps to existing posts on this tile.
-function M.wall(gx, gy, edge)
-    placeWall(gx, gy, edge)
+function M.wall(gx, gy, edge, worldId)
+    placeWall(gx, gy, edge, worldId)
 end
 
 function M.clear() structure.clearAll() end

--- a/scripts/structures.lua
+++ b/scripts/structures.lua
@@ -105,8 +105,8 @@ local function placeWall(gx, gy, e, worldId)
     local h = handles()
     local z = (world.getTerrainAt(gx, gy, worldId) or 0) + 1
     local ends = WALL_ENDS[e]   -- {leftCorner, rightCorner}
-    local capL = structure.hasAt(gx, gy, "post_" .. ends[1])
-    local capR = structure.hasAt(gx, gy, "post_" .. ends[2])
+    local capL = structure.hasAt(gx, gy, "post_" .. ends[1], worldId)
+    local capR = structure.hasAt(gx, gy, "post_" .. ends[2], worldId)
     local suffix = (capL and "1" or "0") .. (capR and "1" or "0")
     if M.debug then
         engine.logInfo(string.format("[wall] tile %d,%d %s -> _%s  (L=%s post_%s  R=%s post_%s)",
@@ -114,14 +114,14 @@ local function placeWall(gx, gy, e, worldId)
     end
     local w = h.walls[e]
     structure.place(gx, gy, "wall_" .. e, w.tex, w.face[suffix], z,
-                    w.texPath, w.facePath[suffix])
+                    w.texPath, w.facePath[suffix], worldId)
 end
 
 -- A post just changed at tile (gx,gy)'s `corner`: re-cap that tile's own two
 -- walls touching the corner, so wall-then-post and post-then-wall converge.
 local function recapTileCorner(gx, gy, corner, worldId)
     for _, e in ipairs(CORNER_WALLS[corner]) do
-        if structure.hasAt(gx, gy, "wall_" .. e) then
+        if structure.hasAt(gx, gy, "wall_" .. e, worldId) then
             placeWall(gx, gy, e, worldId)
         end
     end
@@ -178,25 +178,26 @@ function M.floor(gx, gy, worldId)
     local h = handles()
     local z = (world.getTerrainAt(gx, gy, worldId) or 0) + 1
     structure.place(gx, gy, "floor", h.floor.tex, h.floor.face, z,
-                    h.floor.texPath, h.floor.facePath)
+                    h.floor.texPath, h.floor.facePath, worldId)
 end
 
 function M.ceiling(gx, gy, worldId)
     local h = handles()
     local z = (world.getTerrainAt(gx, gy, worldId) or 0) + 2   -- one level above the floor
     structure.place(gx, gy, "ceiling", h.ceiling.tex, h.ceiling.face, z,
-                    h.ceiling.texPath, h.ceiling.facePath)
+                    h.ceiling.texPath, h.ceiling.facePath, worldId)
 end
 
 -- corner ∈ "n"/"e"/"s"/"w". Gated to a floor (like click placement); re-caps
 -- this tile's walls touching the corner. Returns true if placed. The post z
--- comes from the existing floor (global store), so it needs no terrain read.
+-- comes from the existing floor (read from the same page), so it needs no
+-- terrain read.
 function M.post(gx, gy, corner, worldId)
-    local fz = structure.floorZAt(gx, gy)
+    local fz = structure.floorZAt(gx, gy, worldId)
     if not fz then return false end
     local h = handles()
     structure.place(gx, gy, "post_" .. corner, h.post.tex, h.post.face, fz,
-                    h.post.texPath, h.post.facePath)
+                    h.post.texPath, h.post.facePath, worldId)
     recapTileCorner(gx, gy, corner, worldId)
     return true
 end

--- a/src/Engine/Asset/YamlLocations.hs
+++ b/src/Engine/Asset/YamlLocations.hs
@@ -29,22 +29,26 @@ instance FromJSON LocationYamlContent where
 -- | The YAML shape of a location definition. Converted to
 --   'Location.Types.LocationDef' by the API loader.
 data LocationYamlDef = LocationYamlDef
-    { lydId       ∷ !Text
-    , lydLabel    ∷ !Text
-    , lydType     ∷ !Text
-    , lydBuilder  ∷ !Text
-    , lydAnchor   ∷ ![Text]
-    , lydContents ∷ ![LocationYamlContent]
+    { lydId         ∷ !Text
+    , lydLabel      ∷ !Text
+    , lydType       ∷ !Text
+    , lydBuilder    ∷ !Text
+    , lydAnchor     ∷ ![Text]
+    , lydMaxCount   ∷ !Int   -- ^ max placements (#89); default 4
+    , lydMinSpacing ∷ !Int   -- ^ min chunk separation (#89); default 4
+    , lydContents   ∷ ![LocationYamlContent]
     } deriving (Show, Eq, Generic)
 
 instance FromJSON LocationYamlDef where
     parseJSON = withObject "LocationYamlDef" $ \v → LocationYamlDef
         ⊚ v .:  "id"
-        ⊛ v .:? "label"    .!= ""
-        ⊛ v .:? "type"     .!= "natural"
+        ⊛ v .:? "label"       .!= ""
+        ⊛ v .:? "type"        .!= "natural"
         ⊛ v .:  "builder"
-        ⊛ v .:? "anchor"   .!= []
-        ⊛ v .:? "contents" .!= []
+        ⊛ v .:? "anchor"      .!= []
+        ⊛ v .:? "max_count"   .!= 4
+        ⊛ v .:? "min_spacing" .!= 4
+        ⊛ v .:? "contents"    .!= []
 
 newtype LocationYamlFile = LocationYamlFile
     { lyfLocations ∷ [LocationYamlDef]

--- a/src/Engine/Scripting/Lua/API.hs
+++ b/src/Engine/Scripting/Lua/API.hs
@@ -571,6 +571,7 @@ registerLuaAPI lst env backendState = Lua.runWith lst $ do
   registerLuaFunction "pickPos"      (worldPickPosFn env)
   registerLuaFunction "getClimateAt" (worldGetClimateAtFn env)
   registerLuaFunction "getAmbientAt" (worldGetAmbientAtFn env)
+  registerLuaFunction "listPlacedLocations" (worldListPlacedLocationsFn env)
 
   Lua.setglobal (Lua.Name "world")
 

--- a/src/Engine/Scripting/Lua/API/Locations.hs
+++ b/src/Engine/Scripting/Lua/API/Locations.hs
@@ -34,13 +34,15 @@ loadLocationYamlFn env = do
                 defs ← loadLocationYaml logger filePath
                 total ← foldM (\acc d → do
                     let def = LocationDef
-                            { ldId       = lydId d
-                            , ldLabel    = if T.null (lydLabel d)
-                                           then lydId d else lydLabel d
-                            , ldType     = lydType d
-                            , ldBuilder  = lydBuilder d
-                            , ldAnchor   = lydAnchor d
-                            , ldContents = map toContent (lydContents d)
+                            { ldId         = lydId d
+                            , ldLabel      = if T.null (lydLabel d)
+                                             then lydId d else lydLabel d
+                            , ldType       = lydType d
+                            , ldBuilder    = lydBuilder d
+                            , ldAnchor     = lydAnchor d
+                            , ldMaxCount   = lydMaxCount d
+                            , ldMinSpacing = lydMinSpacing d
+                            , ldContents   = map toContent (lydContents d)
                             }
                     atomicModifyIORef' (locationDefsRef env) $ \reg →
                         (registerLocation def reg, ())

--- a/src/Engine/Scripting/Lua/API/Structure.hs
+++ b/src/Engine/Scripting/Lua/API/Structure.hs
@@ -39,11 +39,22 @@ import Engine.Asset.Handle (TextureHandle(..))
 import Structure.Types
 import Structure.Palette (internPath, TexPalette(..))
 import Control.Monad (forM_)
-import World.Types (wsTilesRef, wsStructureStageRef)
+import World.Types (wsTilesRef, wsStructureStageRef, wmWorlds, WorldPageId(..), WorldState)
 import World.Chunk.Types (LoadedChunk(..))
 import World.Tile.Types (WorldTileData(..), lookupChunk)
 import World.Generate.Coordinates (globalToChunk)
 import World.Command.Types (WorldCommand(..))
+
+-- | Resolve which world page a structure op targets: a named page (any in
+--   wmWorlds, even hidden / non-active) when a page-id string is given,
+--   else the active world. Location stamping (#89) passes the page id so a
+--   room authored on a hidden secondary page writes onto THAT page — not
+--   whichever page happens to be active when its chunk loaded.
+resolveStructurePage ∷ EngineEnv → Maybe Text → IO (Maybe (WorldPageId, WorldState))
+resolveStructurePage env (Just pid) = do
+    mgr ← readIORef (worldManagerRef env)
+    pure $ (\ws → (WorldPageId pid, ws)) <$> lookup (WorldPageId pid) (wmWorlds mgr)
+resolveStructurePage env Nothing = activeWorldPage env
 
 -- | structure.place(gx, gy, slot, texHandle, faceHandle, z, texPath, facePath)
 --   → bool. slot ∈ "floor"/"ceiling"/"post_n…w"/"wall_ne…sw".
@@ -66,6 +77,7 @@ structurePlaceFn env = do
     zA    ← Lua.tointeger 6
     texPathA  ← Lua.tostring 7
     facePathA ← Lua.tostring 8
+    pageA     ← Lua.tostring 9
     case (gxA, gyA, slotA, texA, faceA) of
         (Just gx, Just gy, Just slotBS, Just tex, Just face) →
             case slotFromText (TE.decodeUtf8 slotBS) of
@@ -96,7 +108,7 @@ structurePlaceFn env = do
                                     ( HM.insert texId  (TextureHandle (fromIntegral tex))
                                     $ HM.insert faceId (TextureHandle (fromIntegral face)) m
                                     , () )
-                                mActive ← activeWorldPage env
+                                mActive ← resolveStructurePage env (TE.decodeUtf8 <$> pageA)
                                 case mActive of
                                     Just (pageId, ws) → do
                                         -- Only stage + queue when the target chunk
@@ -262,10 +274,12 @@ structureFloorZAtFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 structureFloorZAtFn env = do
     gxA ← Lua.tointeger 1
     gyA ← Lua.tointeger 2
+    pageA ← Lua.tostring 3
     case (gxA, gyA) of
         (Just gx, Just gy) → do
             mSpd ← Lua.liftIO $
-                lookupStructure env (fromIntegral gx) (fromIntegral gy) SFloor
+                lookupStructure env (TE.decodeUtf8 <$> pageA)
+                                (fromIntegral gx) (fromIntegral gy) SFloor
             case mSpd of
                 Just spd → Lua.pushinteger (fromIntegral (spdGridZ spd)) >> return 1
                 Nothing  → Lua.pushnil >> return 1
@@ -279,13 +293,15 @@ structureHasAtFn env = do
     gxA   ← Lua.tointeger 1
     gyA   ← Lua.tointeger 2
     slotA ← Lua.tostring 3
+    pageA ← Lua.tostring 4
     case (gxA, gyA, slotA) of
         (Just gx, Just gy, Just slotBS) →
             case slotFromText (TE.decodeUtf8 slotBS) of
                 Nothing → Lua.pushboolean False >> return 1
                 Just slot → do
                     mSpd ← Lua.liftIO $
-                        lookupStructure env (fromIntegral gx) (fromIntegral gy) slot
+                        lookupStructure env (TE.decodeUtf8 <$> pageA)
+                                        (fromIntegral gx) (fromIntegral gy) slot
                     Lua.pushboolean (maybe False (const True) mSpd)
                     return 1
         _ → Lua.pushboolean False >> return 1
@@ -297,10 +313,10 @@ structureHasAtFn env = do
 --   persistence read, and what's left after a save/load replay (when the cache
 --   is empty). Nothing if it's in neither: no staged add, and either no active
 --   world, the chunk holding (gx,gy) isn't loaded, or no piece there.
-lookupStructure ∷ EngineEnv → Int → Int → StructureSlot
+lookupStructure ∷ EngineEnv → Maybe Text → Int → Int → StructureSlot
                 → IO (Maybe StructurePieceData)
-lookupStructure env gx gy slot = do
-    mWs ← activeWorldState env
+lookupStructure env mPage gx gy slot = do
+    mWs ← fmap snd <$> resolveStructurePage env mPage
     case mWs of
         Nothing → pure Nothing
         Just ws → do

--- a/src/Engine/Scripting/Lua/API/WorldQuery.hs
+++ b/src/Engine/Scripting/Lua/API/WorldQuery.hs
@@ -65,19 +65,30 @@ worldStateByPage env pidText = do
     mgr ← readIORef (worldManagerRef env)
     pure (lookup (WorldPageId pidText) (wmWorlds mgr))
 
--- | world.getTerrainAt(gx, gy) → surfaceZ, terrainSurfaceZ or nil
---   Returns the surface elevation and terrain-only surface elevation.
+-- | world.getTerrainAt(gx, gy [, pageId]) → surfaceZ, terrainSurfaceZ or nil
+--   Returns the surface elevation and terrain-only surface elevation. With
+--   a page-id string argument it reads that page's tiles instead of the
+--   active world's — so the location stamper can author geometry against a
+--   specific (possibly hidden, non-active) page and still read its real
+--   terrain height (#89 multiworld).
 worldGetTerrainAtFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 worldGetTerrainAtFn env = do
     mGx ← Lua.tointeger 1
     mGy ← Lua.tointeger 2
+    mPage ← Lua.tostring 3
     case (mGx, mGy) of
         (Just gx', Just gy') → do
             let gx = fromIntegral gx'
                 gy = fromIntegral gy'
                 (coord, (lx, ly)) = globalToChunk gx gy
                 idx = ly * chunkSize + lx
-            mTd ← Lua.liftIO $ getWorldTileData env
+            mTd ← Lua.liftIO $ case mPage of
+                Just pidBS → do
+                    mWs ← worldStateByPage env (TE.decodeUtf8 pidBS)
+                    case mWs of
+                        Just ws → Just <$> readIORef (wsTilesRef ws)
+                        Nothing → pure Nothing
+                Nothing → getWorldTileData env
             case mTd >>= lookupChunk coord of
                 Nothing → do
                     Lua.pushnil

--- a/src/Engine/Scripting/Lua/API/WorldQuery.hs
+++ b/src/Engine/Scripting/Lua/API/WorldQuery.hs
@@ -14,6 +14,7 @@ module Engine.Scripting.Lua.API.WorldQuery
     , worldPickPosFn
     , worldGetClimateAtFn
     , worldGetAmbientAtFn
+    , worldListPlacedLocationsFn
     ) where
 
 import UPrelude
@@ -22,6 +23,8 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU
 import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
+import qualified Data.Text.Encoding as TE
+import Control.Monad (forM_)
 import Data.IORef (readIORef, atomicModifyIORef')
 import Control.Concurrent (threadDelay)
 import Engine.Core.State (EngineEnv(..), activeWorldState)
@@ -30,6 +33,7 @@ import World.Geology.Timeline.Types
 import World.Hydrology.Types
 import World.Cursor.Types (CursorState(..))
 import World.Generate.Types (WorldGenParams(..))
+import Location.Overlay.Types (overlayToList)
 import World.Weather.Lookup (lookupLocalClimate, LocalClimate(..))
 import World.Weather.Ambient (ambientTempAt)
 import Engine.Graphics.Camera (Camera2D(..))
@@ -678,4 +682,42 @@ worldPickPosFn env = do
                     return 1
         _ → do
             Lua.pushnil
+            return 1
+
+-- | world.listPlacedLocations() → array of placed-location tables for
+--   the active world, each:
+--     { cx, cy,    -- chunk coordinate hosting the location
+--       gx, gy,    -- the chunk's centre tile (anchor for stamping)
+--       id }       -- the LocationDef id (#88) placed there
+--   Reads the deterministic overlay computed at world init and carried
+--   in the world's gen params (#89). The Lua `locations` module wraps
+--   this as locations.listPlaced(); join `id` against locations.getDef
+--   for label/type/builder. Returns an empty table when no world is
+--   active or none were placed.
+worldListPlacedLocationsFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+worldListPlacedLocationsFn env = do
+    mParams ← Lua.liftIO $ do
+        mWs ← activeWorldState env
+        case mWs of
+            Just ws → readIORef (wsGenParamsRef ws)
+            Nothing → pure Nothing
+    Lua.newtable
+    case mParams of
+        Nothing → return 1
+        Just params → do
+            let placed = overlayToList (wgpLocationOverlay params)
+                half   = chunkSize `div` 2
+            forM_ (zip [1 ..] placed) $ \(i, (ChunkCoord cx cy, lid)) → do
+                Lua.newtable
+                Lua.pushinteger (fromIntegral cx)
+                Lua.setfield (-2) "cx"
+                Lua.pushinteger (fromIntegral cy)
+                Lua.setfield (-2) "cy"
+                Lua.pushinteger (fromIntegral (cx * chunkSize + half))
+                Lua.setfield (-2) "gx"
+                Lua.pushinteger (fromIntegral (cy * chunkSize + half))
+                Lua.setfield (-2) "gy"
+                Lua.pushstring (TE.encodeUtf8 lid)
+                Lua.setfield (-2) "id"
+                Lua.rawseti (-2) i
             return 1

--- a/src/Engine/Scripting/Lua/API/WorldQuery.hs
+++ b/src/Engine/Scripting/Lua/API/WorldQuery.hs
@@ -59,6 +59,12 @@ mVisibleWorldState manager = case wmVisible manager of
     (pageId:_) → lookup pageId (wmWorlds manager)
     []         → Nothing
 
+-- | The 'WorldState' of a named page (any page in wmWorlds), or Nothing.
+worldStateByPage ∷ EngineEnv → Text → IO (Maybe WorldState)
+worldStateByPage env pidText = do
+    mgr ← readIORef (worldManagerRef env)
+    pure (lookup (WorldPageId pidText) (wmWorlds mgr))
+
 -- | world.getTerrainAt(gx, gy) → surfaceZ, terrainSurfaceZ or nil
 --   Returns the surface elevation and terrain-only surface elevation.
 worldGetTerrainAtFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
@@ -684,20 +690,26 @@ worldPickPosFn env = do
             Lua.pushnil
             return 1
 
--- | world.listPlacedLocations() → array of placed-location tables for
---   the active world, each:
+-- | world.listPlacedLocations([pageId]) → array of placed-location
+--   tables, each:
 --     { cx, cy,    -- chunk coordinate hosting the location
 --       gx, gy,    -- the chunk's centre tile (anchor for stamping)
 --       id }       -- the LocationDef id (#88) placed there
---   Reads the deterministic overlay computed at world init and carried
---   in the world's gen params (#89). The Lua `locations` module wraps
---   this as locations.listPlaced(); join `id` against locations.getDef
---   for label/type/builder. Returns an empty table when no world is
---   active or none were placed.
+--   With a page-id string argument the named page's overlay is read
+--   (the location stamper needs a specific world's placements even
+--   before it becomes the active page); with no argument the active
+--   world is used. Reads the deterministic overlay computed at world
+--   init and carried in the world's gen params (#89). The Lua
+--   `locations` module wraps this as locations.listPlaced(); join `id`
+--   against locations.getDef for label/type/builder. Returns an empty
+--   table when no such world exists or none were placed.
 worldListPlacedLocationsFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 worldListPlacedLocationsFn env = do
+    mPage ← Lua.tostring 1
     mParams ← Lua.liftIO $ do
-        mWs ← activeWorldState env
+        mWs ← case mPage of
+            Just pidBS → worldStateByPage env (TE.decodeUtf8 pidBS)
+            Nothing    → activeWorldState env
         case mWs of
             Just ws → readIORef (wsGenParamsRef ws)
             Nothing → pure Nothing

--- a/src/Engine/Scripting/Lua/Thread.hs
+++ b/src/Engine/Scripting/Lua/Thread.hs
@@ -498,6 +498,8 @@ processLuaMsg env ls stateRef msg = case msg of
     broadcastToModules ls "onShellToggle" []
   LuaArenaReady pageId →
     broadcastToModules ls "onArenaReady" [ScriptString pageId]
+  LuaWorldReady pageId →
+    broadcastToModules ls "onWorldReady" [ScriptString pageId]
   LuaOpenArena →
     broadcastToModules ls "onOpenArena" []
   LuaDebugToggle → do

--- a/src/Engine/Scripting/Lua/Thread.hs
+++ b/src/Engine/Scripting/Lua/Thread.hs
@@ -498,8 +498,10 @@ processLuaMsg env ls stateRef msg = case msg of
     broadcastToModules ls "onShellToggle" []
   LuaArenaReady pageId →
     broadcastToModules ls "onArenaReady" [ScriptString pageId]
-  LuaWorldReady pageId →
-    broadcastToModules ls "onWorldReady" [ScriptString pageId]
+  LuaStampLocation pageId locId gx gy →
+    broadcastToModules ls "onStampLocation"
+        [ ScriptString pageId, ScriptString locId
+        , ScriptNumber (fromIntegral gx), ScriptNumber (fromIntegral gy) ]
   LuaOpenArena →
     broadcastToModules ls "onOpenArena" []
   LuaDebugToggle → do

--- a/src/Engine/Scripting/Lua/Types.hs
+++ b/src/Engine/Scripting/Lua/Types.hs
@@ -107,11 +107,14 @@ data LuaMsg = LuaTextureLoaded TextureHandle AssetId
             | LuaFramebufferResize Int Int
             | LuaAssetLoaded Text Int Text
             | LuaArenaReady Text
-            | LuaWorldReady Text
-              -- ^ A full world page finished FRESH generation (not a
-              --   save-load). Carries the page id; broadcast to Lua as
-              --   onWorldReady so the location stamper (#89) materializes
-              --   the placed-location geometry once each chunk loads.
+            | LuaStampLocation Text Text Int Int
+              -- ^ A just-loaded chunk hosts a placed location (#89):
+              --   (pageId, locationId, anchorGx, anchorGy). Broadcast to
+              --   Lua as onStampLocation so the stamper materializes the
+              --   geometry via the #88 builder — issued on every load of
+              --   the chunk (the stamper skips it if already stamped), so
+              --   a location always materializes from the persisted
+              --   overlay, even after a save/load that preceded stamping.
             | LuaOpenArena
             | LuaFocusLost Word32
             | LuaCharInput Word32 Char

--- a/src/Engine/Scripting/Lua/Types.hs
+++ b/src/Engine/Scripting/Lua/Types.hs
@@ -107,6 +107,11 @@ data LuaMsg = LuaTextureLoaded TextureHandle AssetId
             | LuaFramebufferResize Int Int
             | LuaAssetLoaded Text Int Text
             | LuaArenaReady Text
+            | LuaWorldReady Text
+              -- ^ A full world page finished FRESH generation (not a
+              --   save-load). Carries the page id; broadcast to Lua as
+              --   onWorldReady so the location stamper (#89) materializes
+              --   the placed-location geometry once each chunk loads.
             | LuaOpenArena
             | LuaFocusLost Word32
             | LuaCharInput Word32 Char

--- a/src/Location/Overlay.hs
+++ b/src/Location/Overlay.hs
@@ -1,0 +1,206 @@
+{-# LANGUAGE Strict, UnicodeSyntax #-}
+-- | World-gen location overlay placement pass (#89).
+--
+--   Given the finalised generation params (seed, plates, ocean map)
+--   and the loaded 'LocationDef's, deterministically chooses which
+--   chunks host which locations. The result is a sparse
+--   'LocationOverlay' (chunk → location id) stored in
+--   'World.Generate.Types.WorldGenParams', so it rides the save and a
+--   loaded world keeps its layout.
+--
+--   Design notes:
+--
+--     * /Coarse pass./ Suitability is judged from the plate-based
+--       elevation function ('elevationAtGlobal') sampled at five points
+--       per chunk — the same cheap, chunk-independent signal the ocean
+--       flood fill uses ('World.Fluid.Ocean'). No chunk needs to exist
+--       yet, so the pass fits naturally at the end of world init.
+--
+--     * /Adaptive thresholds./ "flat" / "mountain" / "highland" /
+--       "lowland" are resolved against percentiles of the world's own
+--       land elevations, so the same anchor tags behave sensibly at any
+--       world size without hand-tuned absolute constants.
+--
+--     * /Deterministic./ Candidate ordering is a pure hash of
+--       (seed, location id, chunk) — same seed always yields the same
+--       overlay. Spacing is enforced greedily in that hashed order.
+module Location.Overlay
+    ( computeLocationOverlay
+    , ChunkMetrics(..)
+    , chunkMetricsAt
+    ) where
+
+import UPrelude
+import Data.Bits (xor, shiftR, (.&.))
+import Data.Word (Word64)
+import Data.List (sort, sortOn, foldl')
+import qualified Data.Text as T
+import qualified Data.HashMap.Strict as HM
+import qualified Data.HashSet as HS
+import World.Chunk.Types (ChunkCoord(..), chunkSize)
+import World.Plate (TectonicPlate, elevationAtGlobal, isBeyondGlacier)
+import World.Material (MaterialId, matGlacier)
+import World.Ocean.Types (OceanMap, OceanDistMap, oceanDistAt)
+import World.Constants (seaLevel)
+import Location.Types (LocationDef(..))
+import Location.Overlay.Types (LocationOverlay, emptyLocationOverlay)
+
+-- | Coarse per-chunk terrain summary used for anchor matching.
+data ChunkMetrics = ChunkMetrics
+    { cmMedianElev ∷ !Int  -- ^ median of the 5 sampled elevations
+    , cmElevRange  ∷ !Int  -- ^ max − min sampled elevation (flatness)
+    , cmOceanDist  ∷ !Int  -- ^ BFS distance from ocean (0 = ocean)
+    } deriving (Show, Eq)
+
+-- | Elevation at a chunk's centre + 4 corners (median-stable sampling,
+--   mirroring 'World.Fluid.Ocean'\'s @chunkElev@).
+sampleElevs ∷ Word64 → [TectonicPlate] → Int → ChunkCoord → [(Int, MaterialId)]
+sampleElevs seed plates worldSize (ChunkCoord cx cy) =
+    let bx = cx * chunkSize
+        by = cy * chunkSize
+        c  = chunkSize `div` 2
+        pts = [ (bx + c, by + c)
+              , (bx, by)
+              , (bx + chunkSize - 1, by)
+              , (bx, by + chunkSize - 1)
+              , (bx + chunkSize - 1, by + chunkSize - 1) ]
+    in map (\(gx, gy) → elevationAtGlobal seed plates worldSize gx gy) pts
+
+-- | Coarse terrain metrics for one chunk — the plate-based elevation
+--   summary the suitability scan reads. Pure and chunk-independent.
+chunkMetricsAt ∷ Word64 → [TectonicPlate] → Int → OceanDistMap → ChunkCoord → ChunkMetrics
+chunkMetricsAt seed plates worldSize oceanDist coord =
+    let elevs  = map fst (sampleElevs seed plates worldSize coord)
+        sorted = sort elevs
+    in ChunkMetrics
+         { cmMedianElev = sorted !! 2
+         , cmElevRange  = last sorted - head sorted
+         , cmOceanDist  = oceanDistAt oceanDist coord
+         }
+
+-- | Elevation percentile cut-offs derived from the world's land chunks.
+data Cuts = Cuts
+    { flatCut     ∷ !Int  -- ^ elev-range at/below this reads as "flat"
+    , mountainCut ∷ !Int  -- ^ median elev at/above this reads as "mountain"
+    , highlandCut ∷ !Int
+    , lowlandCut  ∷ !Int
+    }
+
+-- | Place every location def into the world. Returns the sparse
+--   chunk→id overlay. Empty when no defs are registered (the common
+--   headless-dump path), which also short-circuits the per-chunk scan.
+computeLocationOverlay
+    ∷ Word64          -- ^ world seed
+    → Int             -- ^ world size in chunks
+    → [TectonicPlate] -- ^ pre-generated plates
+    → OceanMap        -- ^ submerged-chunk set
+    → OceanDistMap    -- ^ distance-from-ocean per chunk
+    → [LocationDef]   -- ^ registered location defs
+    → LocationOverlay
+computeLocationOverlay seed worldSize plates oceanMap oceanDist defs
+    | null defs = emptyLocationOverlay
+    | otherwise = fst (foldl' placeDef (emptyLocationOverlay, HS.empty) defsSorted)
+  where
+    half = worldSize `div` 2
+    allCoords = [ ChunkCoord cx cy | cx ← [-half .. half - 1], cy ← [-half .. half - 1] ]
+
+    -- Land chunks (not ocean, not glacier, above sea level) with metrics.
+    landMetrics ∷ [(ChunkCoord, ChunkMetrics)]
+    landMetrics = [ (coord, cm) | coord ← allCoords
+                                , let (isLand, cm) = classify coord
+                                , isLand ]
+
+    classify ∷ ChunkCoord → (Bool, ChunkMetrics)
+    classify coord@(ChunkCoord cx cy) =
+        let cxg = cx * chunkSize + chunkSize `div` 2
+            cyg = cy * chunkSize + chunkSize `div` 2
+            (_, centerMat) = elevationAtGlobal seed plates worldSize cxg cyg
+            cm = chunkMetricsAt seed plates worldSize oceanDist coord
+            isLand = centerMat /= matGlacier
+                   ∧ not (isBeyondGlacier worldSize cxg cyg)
+                   ∧ not (HS.member coord oceanMap)
+                   ∧ cmMedianElev cm > seaLevel
+        in (isLand, cm)
+
+    cuts ∷ Cuts
+    cuts = Cuts
+        { flatCut     = pctl rangeList 0.5
+        , mountainCut = pctl elevList  0.75
+        , highlandCut = pctl elevList  0.6
+        , lowlandCut  = pctl elevList  0.4
+        }
+      where elevList  = sort (map (cmMedianElev . snd) landMetrics)
+            rangeList = sort (map (cmElevRange  . snd) landMetrics)
+
+    defsSorted = sortOn ldId defs
+
+    -- Place one def, threading the accumulating overlay + the set of
+    -- chunks already taken by any def (so two locations never collide
+    -- on one chunk).
+    placeDef ∷ (LocationOverlay, HS.HashSet ChunkCoord)
+             → LocationDef
+             → (LocationOverlay, HS.HashSet ChunkCoord)
+    placeDef (ov, occupied) def = greedy [] ov occupied scored
+      where
+        lid        = ldId def
+        maxCount   = max 0 (ldMaxCount def)
+        minSpacing = max 1 (ldMinSpacing def)
+        -- Suitable land chunks, ordered by a deterministic per-chunk
+        -- hash so the distribution is semi-random (not a grid) yet
+        -- stable for a given seed.
+        scored = sortOn snd
+            [ (coord, scoreFor lid coord)
+            | (coord, cm) ← landMetrics
+            , anchorOk cuts (ldAnchor def) cm ]
+
+        greedy _      ov' occ [] = (ov', occ)
+        greedy placed ov' occ ((coord, _) : rest)
+            | length placed ≥ maxCount        = (ov', occ)
+            | HS.member coord occ             = greedy placed ov' occ rest
+            | any (tooClose coord) placed     = greedy placed ov' occ rest
+            | otherwise = greedy (coord : placed)
+                                 (HM.insert coord lid ov')
+                                 (HS.insert coord occ)
+                                 rest
+        tooClose (ChunkCoord ax ay) (ChunkCoord bx by) =
+            max (abs (ax - bx)) (abs (ay - by)) < minSpacing
+
+    scoreFor ∷ Text → ChunkCoord → Word64
+    scoreFor lid (ChunkCoord cx cy) =
+        let s0 = seed `xor` idSalt lid
+            h1 = s0 `xor` (fromIntegral cx * 0x517cc1b727220a95)
+            h2 = h1 `xor` (fromIntegral cy * 0x6c62272e07bb0142)
+            h3 = (h2 `xor` (h2 `shiftR` 33)) * 0xff51afd7ed558ccd
+            h4 = (h3 `xor` (h3 `shiftR` 33)) * 0xc4ceb9fe1a85ec53
+        in  h4 `xor` (h4 `shiftR` 33)
+
+-- | FNV-1a hash of a location id — a fully deterministic salt (no
+--   dependence on hashable's per-run seed) so the overlay is identical
+--   across runs and machines.
+idSalt ∷ Text → Word64
+idSalt = T.foldl' (\acc c → (acc `xor` fromIntegral (fromEnum c)) * 0x100000001b3)
+                  0xcbf29ce484222325
+
+-- | Does a chunk satisfy ALL of a def's anchor tags? Unknown tags
+--   impose no constraint (a soft no-op; #88 only ships the "flat" tag,
+--   and removing this would let one typo'd tag suppress all placement).
+anchorOk ∷ Cuts → [Text] → ChunkMetrics → Bool
+anchorOk cuts tags cm = all ok tags
+  where
+    ok tag = case tag of
+        "flat"     → cmElevRange  cm ≤ flatCut cuts
+        "mountain" → cmMedianElev cm ≥ mountainCut cuts
+        "highland" → cmMedianElev cm ≥ highlandCut cuts
+        "lowland"  → cmMedianElev cm ≤ lowlandCut cuts
+        "coast"    → cmOceanDist  cm ≡ 1
+        "coastal"  → cmOceanDist  cm ≡ 1
+        "inland"   → cmOceanDist  cm ≥ 4
+        _          → True
+
+-- | p-quantile of a pre-sorted list (0 for the empty list).
+pctl ∷ [Int] → Double → Int
+pctl [] _ = 0
+pctl xs p =
+    let n = length xs
+        i = min (n - 1) (max 0 (floor (p * fromIntegral n)))
+    in xs !! i

--- a/src/Location/Overlay/Types.hs
+++ b/src/Location/Overlay/Types.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE Strict, UnicodeSyntax #-}
+module Location.Overlay.Types
+    ( LocationOverlay
+    , emptyLocationOverlay
+    , overlayLookup
+    , overlayToList
+    ) where
+
+import UPrelude
+import qualified Data.HashMap.Strict as HM
+import Data.List (sortOn)
+import World.Chunk.Types (ChunkCoord(..))
+
+-- | Sparse map: chunk coordinate → placed location id (the
+--   'Location.Types.ldId' of a 'LocationDef'). Computed once at world
+--   init by the deterministic placement pass ('Location.Overlay') and
+--   carried in 'World.Generate.Types.WorldGenParams', so it serializes
+--   into the save and a loaded world keeps the exact layout it was
+--   generated with — never recomputed (#89).
+--
+--   A plain 'HM.HashMap' keyed by 'ChunkCoord' (same shape as
+--   'World.Ocean.Types.OceanDistMap') so it reuses the existing
+--   'Serialize' / 'NFData' instances WorldGenParams already relies on.
+type LocationOverlay = HM.HashMap ChunkCoord Text
+
+emptyLocationOverlay ∷ LocationOverlay
+emptyLocationOverlay = HM.empty
+
+-- | The location id placed in a chunk, if any.
+overlayLookup ∷ ChunkCoord → LocationOverlay → Maybe Text
+overlayLookup = HM.lookup
+
+-- | All placed entries, sorted by (cx, cy). 'HM.HashMap' iteration
+--   order is unspecified, so callers that surface the overlay (the
+--   @world.listPlacedLocations@ query) sort through this for stable,
+--   deterministic output across runs and machines.
+overlayToList ∷ LocationOverlay → [(ChunkCoord, Text)]
+overlayToList = sortOn (\(ChunkCoord cx cy, _) → (cx, cy)) . HM.toList

--- a/src/Location/Types.hs
+++ b/src/Location/Types.hs
@@ -38,6 +38,11 @@ data LocationDef = LocationDef
     , ldAnchor   ∷ ![Text]            -- ^ terrain placement constraint tags
                                       --   (e.g. ["mountain","flat"]); the
                                       --   generator (#89) filters on these.
+    , ldMaxCount ∷ !Int               -- ^ max instances the world-gen
+                                      --   overlay (#89) places (per type).
+    , ldMinSpacing ∷ !Int             -- ^ min chunk separation between two
+                                      --   instances of this type (jittered
+                                      --   distribution; #89).
     , ldContents ∷ ![LocationContent] -- ^ content to spawn (raw ids; #90)
     } deriving (Show, Eq, Generic)
 

--- a/src/World/Generate/Types.hs
+++ b/src/World/Generate/Types.hs
@@ -31,6 +31,7 @@ import World.Weather.Types (ClimateParams, ClimateState
                            , defaultClimateParams, initClimateState)
 import World.Magma.Types (VolcanoCtx, emptyVolcanoCtx)
 import World.Magma.Init (buildVolcanoCtx)
+import Location.Overlay.Types (LocationOverlay, emptyLocationOverlay)
 
 -- | Pure, serializable world generation parameters.
 --   Same params + same ChunkCoord = same Chunk, always.
@@ -60,6 +61,11 @@ data WorldGenParams = WorldGenParams
     , wgpWaterfallQuantum ∷ !Int          -- ^ Max water-surface drop between adjacent river tiles before a stepped gorge is carved
     , wgpOreLevers ∷ !OreLevers           -- ^ Resource-abundance levers for the ore deposition pass
     , wgpTimelineParams ∷ !TimelineParams -- ^ Player-configured timeline depth (eon/era/period/epoch/age counts)
+    , wgpLocationOverlay ∷ !LocationOverlay
+      -- ^ Sparse chunk→location-id map placed at world init by the
+      --   deterministic overlay pass (#89). Serialized (appended to the
+      --   manual instance below) so a loaded world keeps its layout
+      --   without recomputation.
     , wgpVolcanoCtx ∷ !VolcanoCtx
       -- ^ Pure-function lava system context. Transient: NOT serialized;
       --   rebuilt from gtFeatures + wgpSeed + wgpWorldSize on load.
@@ -90,6 +96,7 @@ instance Serialize WorldGenParams where
         put (wgpWaterfallQuantum p)
         put (wgpOreLevers p)
         put (wgpTimelineParams p)
+        put (wgpLocationOverlay p)
     get = do
         seed       ← get
         ws         ← get
@@ -110,6 +117,7 @@ instance Serialize WorldGenParams where
         waterfallQ ← get
         oreLevers  ← get
         timelineP  ← get
+        locOverlay ← get
         let vc = buildVolcanoCtx seed ws plates (gtFeatures timeline)
         pure WorldGenParams
             { wgpSeed             = seed
@@ -131,6 +139,7 @@ instance Serialize WorldGenParams where
             , wgpWaterfallQuantum = waterfallQ
             , wgpOreLevers        = oreLevers
             , wgpTimelineParams   = timelineP
+            , wgpLocationOverlay  = locOverlay
             , wgpVolcanoCtx       = vc
             }
 
@@ -160,6 +169,7 @@ defaultWorldGenParams = WorldGenParams
     , wgpWaterfallQuantum = 12
     , wgpOreLevers = defaultOreLevers
     , wgpTimelineParams = defaultTimelineParams
+    , wgpLocationOverlay = emptyLocationOverlay
     , wgpVolcanoCtx = emptyVolcanoCtx
     }
 

--- a/src/World/Save/Types.hs
+++ b/src/World/Save/Types.hs
@@ -117,7 +117,11 @@ saveMagic = 0x53595241
 --       river carve. Positional Generic Serialize drops the trailing
 --       field, incompatible with v61 (#385).
 currentSaveVersion ∷ Int
-currentSaveVersion = 62  -- v62: drop dead rpMeanderSeed/rscMeanderSeed from the serialized GeoTimeline
+currentSaveVersion = 63  -- v63: WorldGenParams gains trailing 'wgpLocationOverlay'
+                         --      (sparse chunk→location-id map placed at world
+                         --      init; serialized so a loaded world keeps its
+                         --      layout without recomputation; #89).
+                         -- v62: drop dead rpMeanderSeed/rscMeanderSeed from the serialized GeoTimeline
                          --      (write-only scalar, never read; #386). Falls
                          --      route through usPendingFallDrop + Unit.Fall.
                          -- v60: WorldPageSave gains wpsConstructDesignations

--- a/src/World/Thread/ChunkLoading.hs
+++ b/src/World/Thread/ChunkLoading.hs
@@ -31,6 +31,7 @@ import World.Slope (recomputeNeighborSlopes, slopeRecomputeAffected, wrapChunkCo
 import World.SideFace.Compute (computeChunkSideDecos)
 import World.Thread.Helpers (unWorldPageId)
 import World.Generate.Types (WorldGenParams(..), isArenaParams)
+import Engine.Scripting.Lua.Types (LuaMsg(..))
 import World.Edit.Apply (replayEdits)
 import World.Mine.Apply (applyDigSlopesTd)
 import Sim.Command.Types (SimCommand(..))
@@ -140,6 +141,9 @@ updateChunkLoading env logger = do
                                         SimChunkLoaded pageId (lcCoord lc)
                                             (lcFluidMap lc)
                                             (lcTerrainSurfaceMap lc)
+                                -- Stamp any placed locations on the loaded
+                                -- chunks (#89).
+                                dispatchLocationStamps env params pageId newChunks'
                                 -- Notify sim thread of evicted chunks
                                 forM_ evicted $ \cc →
                                     Q.writeQueue (simQueue env)
@@ -147,6 +151,28 @@ updateChunkLoading env logger = do
                                 bumpQuadCacheGen worldState
                                 writeIORef (wsZoomQuadCacheRef worldState) Nothing
                                 writeIORef (wsBgQuadCacheRef worldState) Nothing
+
+-- | Dispatch a location-stamp request to the Lua thread for any
+--   just-loaded chunk the overlay (#89) places a location on. Issued on
+--   EVERY load of the chunk (fresh gen, eviction reload, or after a
+--   save/load) — the Lua stamper skips it when the geometry is already
+--   present (structure.hasAt), so repeats are cheap no-ops. Consulting
+--   the persisted overlay on every chunk load is what makes a location
+--   materialize even if the world was saved before it was first stamped:
+--   there is no async queue to drain, only the overlay (which always
+--   rides the save) and the chunk-load trigger.
+dispatchLocationStamps ∷ EngineEnv → WorldGenParams → WorldPageId
+                       → [LoadedChunk] → IO ()
+dispatchLocationStamps env params pageId chunks =
+    forM_ chunks $ \lc →
+        case HM.lookup (lcCoord lc) (wgpLocationOverlay params) of
+            Nothing  → return ()
+            Just lid →
+                let ChunkCoord cx cy = lcCoord lc
+                    gx = cx * chunkSize + chunkSize `div` 2
+                    gy = cy * chunkSize + chunkSize `div` 2
+                in Q.writeQueue (luaQueue env)
+                       (LuaStampLocation (unWorldPageId pageId) lid gx gy)
 
 partitionChunks ∷ [ChunkCoord] → WorldTileData → ([ChunkCoord], [ChunkCoord])
 partitionChunks coords tileData =
@@ -244,6 +270,8 @@ drainInitQueues env logger = do
                                 SimChunkLoaded pageId (lcCoord lc)
                                     (lcFluidMap lc)
                                     (lcTerrainSurfaceMap lc)
+                        -- Stamp any placed locations on the loaded chunks (#89).
+                        dispatchLocationStamps env params pageId newChunks'
 
                         -- The batch is now in wsTilesRef AND the sim has been
                         -- notified, so drop it from the init queue — by coord,

--- a/src/World/Thread/ChunkLoading.hs
+++ b/src/World/Thread/ChunkLoading.hs
@@ -3,6 +3,7 @@
 module World.Thread.ChunkLoading
     ( updateChunkLoading
     , drainInitQueues
+    , dispatchLocationStamps
     , maxChunksPerTick
     ) where
 

--- a/src/World/Thread/Command/Init.hs
+++ b/src/World/Thread/Command/Init.hs
@@ -33,6 +33,8 @@ import World.Geology (buildTimeline)
 import World.Geology.Log (formatTimeline, formatPlatesSummary)
 import World.Fluids (computeOceanMap, isOceanChunk)
 import World.Plate (generatePlates, elevationAtGlobal)
+import Location.Types (allLocations)
+import Location.Overlay (computeLocationOverlay)
 import World.Preview (buildPreviewFromPixels, PreviewImage(..))
 import World.Render (surfaceHeadroom)
 import World.ZoomMap (buildZoomCacheWithPixels)
@@ -177,7 +179,7 @@ handleWorldInitCommand env logger pageId seed rawWorldSize rawPlaceCount = do
     -- 'withVolcanoCtx' populates the Magma context now that
     -- gtFeatures is final, so chunk-gen sees a built spatial index.
     let baseParams = applyConfigToParams worldGenCfg0
-        params = withVolcanoCtx $ baseParams
+        params0 = withVolcanoCtx $ baseParams
             { wgpSeed        = seed
             , wgpWorldSize   = worldSize
             , wgpPlateCount  = placeCount
@@ -187,6 +189,17 @@ handleWorldInitCommand env logger pageId seed rawWorldSize rawPlaceCount = do
             , wgpOceanDist   = oceanDist
             , wgpClimateState = climateState'
             }
+
+    -- Location overlay (#89): deterministically choose which chunks
+    -- host the registered locations, from the just-finalised plates +
+    -- ocean data. Empty (and skipped) when no defs are loaded — the
+    -- common headless-dump path stays byte-identical and zero-cost.
+    locDefs ← allLocations <$> readIORef (locationDefsRef env)
+    let params = params0
+            { wgpLocationOverlay =
+                computeLocationOverlay seed worldSize plates oceanMap oceanDist locDefs
+            }
+    _ ← evaluate (force (wgpLocationOverlay params))
 
     writeIORef (wsGenParamsRef worldState) (Just params)
     

--- a/src/World/Thread/Command/Init.hs
+++ b/src/World/Thread/Command/Init.hs
@@ -299,13 +299,6 @@ handleWorldInitCommand env logger pageId seed rawWorldSize rawPlaceCount = do
         <> "surface at z=" <> T.pack (show surfaceElev)
         <> ": " <> unWorldPageId pageId
 
-    -- Notify Lua that a fresh world is ready, so the location stamper
-    -- (#89) materializes the placed-location geometry as their chunks
-    -- load. Fired only on FRESH gen — the save-load path
-    -- (handleWorldLoadSaveCommand) replays the location edits instead, so
-    -- loaded worlds are never re-stamped.
-    Q.writeQueue (luaQueue env) (LuaWorldReady (unWorldPageId pageId))
-
 handleWorldInitArenaCommand ∷ EngineEnv → LoggerState → WorldPageId → IO ()
 handleWorldInitArenaCommand env logger pageId = do
     logInfo logger CatWorld $ "Initializing test arena: " <> unWorldPageId pageId

--- a/src/World/Thread/Command/Init.hs
+++ b/src/World/Thread/Command/Init.hs
@@ -49,7 +49,7 @@ import World.Generate.Config (WorldGenConfig(..), ClimateYaml(..)
                              , minimumWorldSize, normalizeWorldGenInputs)
 import World.Geology.Ore.Types (OreLevers(..))
 import World.Thread.Helpers (sendGenLog, unWorldPageId)
-import World.Thread.ChunkLoading (maxChunksPerTick)
+import World.Thread.ChunkLoading (maxChunksPerTick, dispatchLocationStamps)
 
 handleWorldInitCommand ∷ EngineEnv → LoggerState → WorldPageId
     → Word64 → Int → Int → IO ()
@@ -271,6 +271,11 @@ handleWorldInitCommand env logger pageId seed rawWorldSize rawPlaceCount = do
     atomicModifyIORef' (wsTilesRef worldState) $ \_ →
         (WorldTileData { wtdChunks = HM.singleton centerCoord centerChunk
                        , wtdMaxChunks = 200 }, ())
+
+    -- Stamp any placed location on the synchronously-generated centre
+    -- chunk (#89). It is written straight to wsTilesRef and excluded from
+    -- the init queue, so the chunk-loading dispatch never sees it.
+    dispatchLocationStamps env params pageId [centerChunk]
 
     -- Step 7: Queue remaining chunks
     writeIORef phaseRef (LoadPhase1 7 totalSteps)

--- a/src/World/Thread/Command/Init.hs
+++ b/src/World/Thread/Command/Init.hs
@@ -294,10 +294,17 @@ handleWorldInitCommand env logger pageId seed rawWorldSize rawPlaceCount = do
     sendGenLog env $ "World initialized: "
         <> T.pack (show totalInitialChunks) <> " chunks queued"
     
-    logInfo logger CatWorld $ "World initialized: " 
+    logInfo logger CatWorld $ "World initialized: "
         <> T.pack (show totalInitialChunks) <> " chunks, "
         <> "surface at z=" <> T.pack (show surfaceElev)
         <> ": " <> unWorldPageId pageId
+
+    -- Notify Lua that a fresh world is ready, so the location stamper
+    -- (#89) materializes the placed-location geometry as their chunks
+    -- load. Fired only on FRESH gen — the save-load path
+    -- (handleWorldLoadSaveCommand) replays the location edits instead, so
+    -- loaded worlds are never re-stamped.
+    Q.writeQueue (luaQueue env) (LuaWorldReady (unWorldPageId pageId))
 
 handleWorldInitArenaCommand ∷ EngineEnv → LoggerState → WorldPageId → IO ()
 handleWorldInitArenaCommand env logger pageId = do

--- a/src/World/Thread/Command/Save.hs
+++ b/src/World/Thread/Command/Save.hs
@@ -49,7 +49,7 @@ import Unit.Sim.Types (UnitThreadState(..))
 import World.Weather (initEarlyClimate, formatWeather, defaultClimateParams)
 import World.Thread.Helpers (sendGenLog, sendSaveLoaded, unWorldPageId)
 import Engine.PlayerEvent.Emit (emitEvent)
-import World.Thread.ChunkLoading (maxChunksPerTick)
+import World.Thread.ChunkLoading (maxChunksPerTick, dispatchLocationStamps)
 
 
 -- | Order-preserving de-duplication of a page-id list (keeps the first
@@ -512,6 +512,13 @@ handleWorldLoadSaveCommand env logger pageId saveData
         Q.writeQueue (simQueue env) $
             SimChunkLoaded rid centerCoord
                 (lcFluidMap centerChunk) (lcTerrainSurfaceMap centerChunk)
+
+        -- Stamp any placed location on the synchronously-regenerated centre
+        -- chunk (#89). Like Init's centre chunk it is written straight to
+        -- wsTilesRef and excluded from the init queue, so the chunk-loading
+        -- dispatch never sees it. A location saved un-stamped on the camera
+        -- chunk thus still materializes on load.
+        dispatchLocationStamps env params rid [centerChunk]
 
         -- 1d. Queue the remaining initial chunks for progressive loading.
         when isActive $ writeIORef phaseRef (LoadPhase1 4 totalSteps)

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -202,6 +202,7 @@ test-suite synarchy-test-headless
                 , random
                 , linear
                 , bytestring
+                , cereal
                 , yaml
     default-language: GHC2024
     if flag(dev)
@@ -448,6 +449,8 @@ library
                      Engine.Asset.YamlInfection
                      Engine.Scripting.Lua.API.Infection
                      Location.Types
+                     Location.Overlay.Types
+                     Location.Overlay
                      Engine.Asset.YamlLocations
                      Engine.Scripting.Lua.API.Locations
                      Sim.Thread

--- a/test-headless/Test/Headless/WorldGen.hs
+++ b/test-headless/Test/Headless/WorldGen.hs
@@ -9,6 +9,8 @@ module Test.Headless.WorldGen (spec) where
 import UPrelude
 import Test.Hspec
 import qualified Data.HashMap.Strict as HM
+import qualified Data.HashSet as HS
+import qualified Data.Serialize as Cereal
 import Control.Concurrent (threadDelay)
 import Engine.Core.State (EngineEnv)
 import Test.Headless.Harness
@@ -22,6 +24,8 @@ import World.Generate.Config
     )
 import World.Plate (generatePlates)
 import World.Types
+import Location.Types (LocationDef(..))
+import Location.Overlay (computeLocationOverlay, chunkMetricsAt, ChunkMetrics(..))
 
 spec ∷ SpecWith EngineEnv
 spec = do
@@ -114,3 +118,70 @@ spec = do
             threadDelay 500000
             mWs ← getWorldState env (WorldPageId "destroy")
             isNothing mWs `shouldBe` True
+
+    describe "Location overlay (#89)" $ do
+
+        -- The headless harness boots no Lua, so the location registry is
+        -- empty and the stored overlay is empty — these specs exercise
+        -- the pure placement pass directly against the shared world's
+        -- real plates / ocean data, with synthetic defs. The full
+        -- load-defs → init → listPlaced integration lives in the python
+        -- probe (tools/location_overlay_probe.py).
+        let mkDef lid anchors = LocationDef
+                { ldId = lid, ldLabel = lid, ldType = "test"
+                , ldBuilder = "noop", ldAnchor = anchors
+                , ldMaxCount = 8, ldMinSpacing = 3, ldContents = [] }
+            flatDef = mkDef "flat_test"     ["flat"]
+            mtnDef  = mkDef "mountain_test" ["mountain"]
+            overlayFor p defs = computeLocationOverlay
+                (wgpSeed p) (wgpWorldSize p) (wgpPlates p)
+                (wgpOceanMap p) (wgpOceanDist p) defs
+
+        it "world init wires a serializable overlay field" $ \env → do
+            ws ← sharedWorld env 42 64 3
+            mp ← getWorldGenParams ws
+            case mp of
+                Just p  → HM.size (wgpLocationOverlay p) `shouldSatisfy` (≥ 0)
+                Nothing → expectationFailure "params should exist"
+
+        it "places flat-anchored locations on land" $ \env → do
+            ws ← sharedWorld env 42 64 3
+            Just p ← getWorldGenParams ws
+            HM.size (overlayFor p [flatDef]) `shouldSatisfy` (> 0)
+
+        it "is deterministic — same seed yields the same overlay" $ \env → do
+            ws ← sharedWorld env 42 64 3
+            Just p ← getWorldGenParams ws
+            -- recompute the plates independently from the seed: a fresh
+            -- plate list with the same seed must give the same overlay.
+            let plates2 = generatePlates (wgpSeed p) (wgpWorldSize p) (wgpPlateCount p)
+                ov2 = computeLocationOverlay (wgpSeed p) (wgpWorldSize p) plates2
+                                             (wgpOceanMap p) (wgpOceanDist p)
+                                             [flatDef, mtnDef]
+            ov2 `shouldBe` overlayFor p [flatDef, mtnDef]
+
+        it "never places a location on an ocean chunk" $ \env → do
+            ws ← sharedWorld env 42 64 3
+            Just p ← getWorldGenParams ws
+            HM.keys (overlayFor p [flatDef, mtnDef])
+                `shouldSatisfy` all (\c → not (HS.member c (wgpOceanMap p)))
+
+        it "respects anchor tags — mountain picks higher ground than flat" $ \env → do
+            ws ← sharedWorld env 42 64 3
+            Just p ← getWorldGenParams ws
+            let med c = cmMedianElev
+                    (chunkMetricsAt (wgpSeed p) (wgpPlates p) (wgpWorldSize p)
+                                    (wgpOceanDist p) c)
+                mtn  = HM.keys (overlayFor p [mtnDef])
+                flat = HM.keys (overlayFor p [flatDef])
+                avg xs = sum xs `div` max 1 (length xs)
+            mtn  `shouldSatisfy` (not . null)
+            flat `shouldSatisfy` (not . null)
+            avg (map med mtn) `shouldSatisfy` (> avg (map med flat))
+
+        it "overlay survives a WorldGenParams serialize round-trip" $ \_env → do
+            let sample = HM.fromList [ (ChunkCoord 1 2, "ruin_small" ∷ Text)
+                                     , (ChunkCoord (-3) 4, "camp") ]
+                p = defaultWorldGenParams { wgpLocationOverlay = sample }
+                back = Cereal.decode (Cereal.encode p) ∷ Either String WorldGenParams
+            fmap wgpLocationOverlay back `shouldBe` Right sample

--- a/tools/location_overlay_probe.py
+++ b/tools/location_overlay_probe.py
@@ -130,6 +130,33 @@ def is_ocean(port: int, gx: int, gy: int) -> bool:
     return r.strip('"') == "ocean"
 
 
+def has_floor(port: int, gx: int, gy: int) -> bool:
+    """True if a 'floor' structure piece exists at (gx,gy) — i.e. the
+    ruin_small builder (room_small) has stamped its room there."""
+    r = send(port, f"return structure.hasAt({gx},{gy},'floor') and 'yes' or 'no'")
+    return r.strip('"') == "yes"
+
+
+def load_chunk(port: int, cx: int, cy: int) -> None:
+    send(port, f"return world.loadChunksInRegion({cx},{cy},{cx},{cy})")
+    send(port, "return world.waitForChunks(30)", timeout=35)
+
+
+def count_stamped(port: int, ruins: list[dict]) -> int:
+    return sum(1 for e in ruins if has_floor(port, e["gx"], e["gy"]))
+
+
+def wait_stamped(port: int, ruins: list[dict], tries: int = 80) -> int:
+    """Poll until every ruin has been stamped (or the cap)."""
+    want, n = len(ruins), 0
+    for _ in range(tries):
+        n = count_stamped(port, ruins)
+        if n >= want:
+            return n
+        time.sleep(0.5)
+    return n
+
+
 def gen_world(port: int, page: str, seed: int, size: int) -> None:
     send(port, f"world.init('{page}', {seed}, {size}, 3); return 'ok'")
     send(port, "return world.waitForInit(240)", timeout=250)
@@ -151,10 +178,13 @@ def main() -> int:
 
     failures: list[str] = []
 
-    # ---- Phase 1: placement + determinism + anchor (one engine) ----
+    # ---- Phase 1: placement + determinism + anchor + stamping ----
     proc = boot(args.port)
     try:
         send(args.port, "engine.loadLocationYaml('data/locations/ruin_small.yaml'); return 'ok'")
+        # Load the stamper so the engine's onWorldReady broadcast drives it
+        # (the loading screen that normally loads it is GUI-only).
+        send(args.port, "engine.loadScript('scripts/location_stamper.lua', 0.1); return 'ok'")
 
         gen_world(args.port, "wa", args.seed, args.size)
         la = placed_ready(args.port)
@@ -192,6 +222,14 @@ def main() -> int:
         elif ocean_hits:
             failures.append(f"{len(ocean_hits)} ruin(s) placed on ocean tiles")
 
+        # Stamping: the location_stamper materializes each ruin's geometry
+        # (the #88 room_small builder) into the world as its chunk loads.
+        n = wait_stamped(args.port, ruins)
+        if ruins and n == len(ruins):
+            print(f"PASS: all {n} ruin(s) stamped into the world (geometry present)")
+        else:
+            failures.append(f"only {n}/{len(ruins)} ruin(s) stamped into the world")
+
         # Save world A for the reload phase.
         send(args.port, "engine.saveWorld('wa', 'loc_overlay_probe'); return 'saved'")
         time.sleep(1.0)
@@ -199,8 +237,10 @@ def main() -> int:
         shutdown(args.port, proc)
 
     # ---- Phase 2: save survives a fresh restart + load ----
-    # Deliberately do NOT load the location YAML on this engine: if the
-    # placements still appear, they came from the save, not a recompute.
+    # Deliberately load NEITHER the location YAML NOR the stamper on this
+    # engine: if the placements AND their geometry still appear, they came
+    # from the save (overlay in gen params + stamped edits), not a recompute
+    # or a re-stamp.
     proc = boot(args.port)
     try:
         send(args.port, "engine.loadSave('loc_overlay_probe'); return 'queued'")
@@ -214,6 +254,18 @@ def main() -> int:
             print(f"PASS: overlay survived save/load ({len(lc)} placements, no YAML reload)")
         else:
             failures.append(f"overlay lost/changed across save-load: before={key(la)} after={key(lc)}")
+
+        # Stamped geometry must replay from the saved per-chunk edits (with
+        # no stamper loaded). Load each ruin's chunk so its edits replay,
+        # then confirm the floor is back.
+        ruins_after = [e for e in lc if e["id"] == "ruin_small"]
+        for e in ruins_after:
+            load_chunk(args.port, e["cx"], e["cy"])
+        m = count_stamped(args.port, ruins_after)
+        if ruins_after and m == len(ruins_after):
+            print(f"PASS: stamped geometry replayed after load ({m} ruin(s), no re-stamp)")
+        else:
+            failures.append(f"geometry lost across save/load: {m}/{len(ruins_after)} ruins have floors")
     finally:
         shutdown(args.port, proc)
 

--- a/tools/location_overlay_probe.py
+++ b/tools/location_overlay_probe.py
@@ -26,6 +26,10 @@ This drives the full integration headless and checks #89 end to end:
   7. The SYNCHRONOUS centre chunk (0,0) — which Init/Save regenerate
      directly and exclude from the chunk-load queue — also stamps, both
      on first generation (Init hook) and on first load (Save hook).
+  8. Multiworld: a location on a HIDDEN, non-active page still stamps
+     (page-targeted terrain reads, no active-page gate) — checked with a
+     locationless arena as the active world so the hidden page's stamp is
+     observable.
 
 The location stamper is auto-loaded at boot by scripts/init.lua, exactly
 as in the real game, so this only registers the location defs by hand
@@ -196,14 +200,17 @@ DENSE_BODY = (
 )
 
 
-def has_loc_on(port: int, cx: int, cy: int, tries: int = 20) -> bool:
-    """Whether the active overlay places a location on chunk (cx,cy).
+def has_loc_on(port: int, cx: int, cy: int, page: str | None = None, tries: int = 20) -> bool:
+    """Whether the overlay places a location on chunk (cx,cy). With `page`
+    it reads that page's overlay (so a hidden, non-active world works);
+    otherwise the active world.
 
-    Polls until the overlay is readable (the world is active), so it does
-    not race world.show. The server-side scan returns just a flag, never
-    the (huge, dense) full list.
+    Polls until the overlay is readable (genParams written / world active),
+    so it does not race init or world.show. The server-side scan returns
+    just a flag, never the (huge, dense) full list.
     """
-    lua = (f"local t = world.listPlacedLocations(); "
+    arg = f"'{page}'" if page else ""
+    lua = (f"local t = world.listPlacedLocations({arg}); "
            f"for _, e in ipairs(t) do if e.cx == {cx} and e.cy == {cy} then return 'yes' end end; "
            f"return (#t > 0) and 'no' or 'empty'")
     for _ in range(tries):
@@ -392,6 +399,49 @@ def main() -> int:
                 failures.append("saved-camera centre chunk (0,0) NOT present on first load (Save hook)")
         finally:
             shutdown(args.port, proc)
+
+    # ---- Phase 5: a location on a HIDDEN, non-active page still stamps
+    #      (multiworld). A flat, locationless ARENA is the active world, so a
+    #      separately generated page's centre chunk loads while hidden — and
+    #      a floor at (8,8) can then only come from that hidden page. With the
+    #      old active-page gate it would be skipped forever; page-targeted
+    #      terrain reads let it stamp against its own page regardless. ----
+    proc = boot(args.port)
+    try:
+        send(args.port, f"engine.loadLocationYaml('{DENSE_YAML}'); return 'ok'")
+        send(args.port, "world.initArena('arena'); world.initArenaDone('arena'); world.show('arena'); return 'ok'")
+        arena_ok = False
+        for _ in range(40):
+            r = send(args.port, "local i=world.getChunkInfo(0,0); return i and i.loaded and 'y' or 'n'").strip('"')
+            if r == "y":
+                arena_ok = True
+                break
+            time.sleep(0.25)
+        if not arena_ok:
+            failures.append("phase 5: arena never became ready")
+        else:
+            # Generate a second world but DO NOT show it — arena stays active.
+            send(args.port, f"world.init('sw', {args.seed}, {args.size}, 3); return 'ok'")
+            send(args.port, "return world.waitForInit(240)", timeout=250)
+            active = "?"
+            for _ in range(10):
+                active = send(args.port, "return world.getActiveWorldId()").strip('"')
+                if active == "arena":
+                    break
+                time.sleep(0.3)
+            if active != "arena":
+                failures.append(f"phase 5: expected 'arena' active, got '{active}'")
+            elif not has_loc_on(args.port, 0, 0, page="sw"):
+                failures.append("phase 5: hidden world 'sw' has no location on (0,0)")
+            elif wait_floor(args.port, 8, 8):
+                swz = send(args.port, "return world.getTerrainAt(8,8,'sw')").split("\t")[0].strip()
+                fz = send(args.port, "return structure.floorZAt(8,8)").strip()
+                print(f"PASS: hidden non-active page stamped its centre while '{active}' active "
+                      f"(floor z={fz} matches sw terrain {swz}, not the arena's 0)")
+            else:
+                failures.append("hidden non-active page did NOT stamp its centre (multiworld)")
+    finally:
+        shutdown(args.port, proc)
 
     print("-" * 56)
     if failures:

--- a/tools/location_overlay_probe.py
+++ b/tools/location_overlay_probe.py
@@ -26,10 +26,11 @@ This drives the full integration headless and checks #89 end to end:
   7. The SYNCHRONOUS centre chunk (0,0) — which Init/Save regenerate
      directly and exclude from the chunk-load queue — also stamps, both
      on first generation (Init hook) and on first load (Save hook).
-  8. Multiworld: a location on a HIDDEN, non-active page still stamps
-     (page-targeted terrain reads, no active-page gate) — checked with a
-     locationless arena as the active world so the hidden page's stamp is
-     observable.
+  8. Multiworld: a location on a HIDDEN, non-active page still stamps onto
+     its OWN page, even when the active page already has a floor at the same
+     tile (page-targeted writes + reads + idempotency guard). Checked with
+     an arena as the active world that is given a room at (8,8); the hidden
+     page must still stamp there, at its own terrain z, not the arena's.
 
 The location stamper is auto-loaded at boot by scripts/init.lua, exactly
 as in the real game, so this only registers the location defs by hand
@@ -401,12 +402,14 @@ def main() -> int:
         finally:
             shutdown(args.port, proc)
 
-    # ---- Phase 5: a location on a HIDDEN, non-active page still stamps
-    #      (multiworld). A flat, locationless ARENA is the active world, so a
-    #      separately generated page's centre chunk loads while hidden — and
-    #      a floor at (8,8) can then only come from that hidden page. With the
-    #      old active-page gate it would be skipped forever; page-targeted
-    #      terrain reads let it stamp against its own page regardless. ----
+    # ---- Phase 5: a location on a HIDDEN, non-active page still stamps,
+    #      EVEN when the active page already has a floor at the same tile
+    #      (multiworld). The active world is an arena that we deliberately
+    #      give a room at (8,8); a second page is then generated hidden, also
+    #      with a location at (8,8). The page-targeted hasAt guard must not
+    #      let the arena's floor suppress the hidden page's stamp, and the
+    #      write must land on the hidden page at ITS terrain z, not the
+    #      arena's. ----
     proc = boot(args.port)
     try:
         send(args.port, f"engine.loadLocationYaml('{DENSE_YAML}'); return 'ok'")
@@ -421,31 +424,41 @@ def main() -> int:
         if not arena_ok:
             failures.append("phase 5: arena never became ready")
         else:
-            # Generate a second world but DO NOT show it — arena stays active.
-            send(args.port, f"world.init('sw', {args.seed}, {args.size}, 3); return 'ok'")
-            send(args.port, "return world.waitForInit(240)", timeout=250)
-            active = "?"
-            for _ in range(10):
-                active = send(args.port, "return world.getActiveWorldId()").strip('"')
-                if active == "arena":
-                    break
-                time.sleep(0.3)
-            if active != "arena":
-                failures.append(f"phase 5: expected 'arena' active, got '{active}'")
-            elif not has_loc_on(args.port, 0, 0, page="sw"):
-                failures.append("phase 5: hidden world 'sw' has no location on (0,0)")
-            elif wait_floor(args.port, 8, 8, page="sw"):
-                # The structure must be on 'sw', NOT the active arena.
-                on_arena = has_floor(args.port, 8, 8, page="arena")
-                swz = send(args.port, "return world.getTerrainAt(8,8,'sw')").split("\t")[0].strip()
-                fz = send(args.port, "return structure.floorZAt(8,8,'sw')").strip()
-                if on_arena:
-                    failures.append("phase 5: structure leaked onto the active arena page")
-                else:
-                    print(f"PASS: hidden non-active page 'sw' stamped its OWN centre while "
-                          f"'{active}' active (floor z={fz}=sw terrain {swz}+1; nothing on arena)")
+            # Put a room on the ACTIVE arena at (8,8) (arena terrain z=0 ->
+            # floor z=1). This is the unrelated geometry that must NOT
+            # suppress the hidden page's stamp at the same tile.
+            send(args.port, "require('scripts.locations').stamp('ruin_small', 8, 8, 'arena'); return 'ok'")
+            if not wait_floor(args.port, 8, 8, page="arena"):
+                failures.append("phase 5 setup: could not place a floor on the active arena")
             else:
-                failures.append("hidden non-active page did NOT stamp its centre (multiworld)")
+                # Generate a second world but DO NOT show it — arena stays active.
+                send(args.port, f"world.init('sw', {args.seed}, {args.size}, 3); return 'ok'")
+                send(args.port, "return world.waitForInit(240)", timeout=250)
+                active = "?"
+                for _ in range(10):
+                    active = send(args.port, "return world.getActiveWorldId()").strip('"')
+                    if active == "arena":
+                        break
+                    time.sleep(0.3)
+                if active != "arena":
+                    failures.append(f"phase 5: expected 'arena' active, got '{active}'")
+                elif not has_loc_on(args.port, 0, 0, page="sw"):
+                    failures.append("phase 5: hidden world 'sw' has no location on (0,0)")
+                elif wait_floor(args.port, 8, 8, page="sw"):
+                    # sw stamped despite arena already having a floor at (8,8).
+                    # Confirm it's sw's own room at sw's terrain z (29), not
+                    # the arena's (1) — proving page-targeted write + guard.
+                    swz = send(args.port, "return world.getTerrainAt(8,8,'sw')").split("\t")[0].strip()
+                    fz_sw = send(args.port, "return structure.floorZAt(8,8,'sw')").strip()
+                    fz_ar = send(args.port, "return structure.floorZAt(8,8,'arena')").strip()
+                    if fz_sw == fz_ar:
+                        failures.append(f"phase 5: sw floor z ({fz_sw}) == arena floor z ({fz_ar}) — pages not isolated")
+                    else:
+                        print(f"PASS: hidden page 'sw' stamped at (8,8) despite the active "
+                              f"'arena' already having a floor there (sw floor z={fz_sw}=sw "
+                              f"terrain {swz}+1; arena floor z={fz_ar})")
+                else:
+                    failures.append("hidden page suppressed by active-world geometry at same tile (multiworld)")
     finally:
         shutdown(args.port, proc)
 

--- a/tools/location_overlay_probe.py
+++ b/tools/location_overlay_probe.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Headless world-gen location-overlay probe (#89).
+
+The engine places data-driven locations (#88) into chunks during world
+generation: a deterministic pass, run from the seed + plate/ocean data,
+produces a sparse chunk -> location-id overlay that is carried in the
+world's gen params and serialized into the save. `world.listPlaced-
+Locations()` (Lua `locations.listPlaced()`) reads that overlay back.
+
+This drives the full integration headless and checks the four
+acceptance criteria of #89:
+
+  1. Generating a world with `ruin_small` defined produces >= 1 ruin
+     somewhere (via listPlacedLocations).
+  2. Same seed -> same overlay (two independent generations match).
+  3. Overlay survives save -> quit -> fresh restart -> load, WITHOUT the
+     reload engine re-loading the location YAML (so the placements can
+     only have come from the save, never a recompute).
+  4. Suitability respects anchor tags: every ruin_small (anchor [flat])
+     sits on a land chunk, never an ocean one.
+
+Usage:
+  python3 tools/location_overlay_probe.py
+  python3 tools/location_overlay_probe.py --seed 7 --size 64 --port 9189
+
+Exit code 0 = all checks passed.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+import subprocess
+import sys
+import time
+
+LOG = "/tmp/location_overlay_engine.log"
+
+
+def send(port: int, lua: str, timeout: float = 10.0) -> str:
+    """Run one line of Lua in the debug console, return the result text."""
+    with socket.create_connection(("localhost", port), timeout=timeout) as s:
+        s.sendall((lua + "\n").encode())
+        chunks: list[bytes] = []
+        s.settimeout(0.3)
+        try:
+            while True:
+                b = s.recv(4096)
+                if not b:
+                    break
+                chunks.append(b)
+        except socket.timeout:
+            pass
+    out = b"".join(chunks).decode(errors="replace")
+    results = [ln[2:].strip() for ln in out.splitlines() if ln.startswith("> ")]
+    results = [r for r in results if r]
+    return results[-1] if results else out.strip()
+
+
+def boot(port: int) -> subprocess.Popen:
+    log = open(LOG, "w")
+    proc = subprocess.Popen(
+        ["cabal", "run", "-v0", "exe:synarchy", "--",
+         "--headless", "--port", str(port)],
+        stdout=log, stderr=subprocess.STDOUT,
+    )
+    deadline = time.time() + 240
+    while time.time() < deadline:
+        try:
+            if "READY" in open(LOG).read():
+                return proc
+        except FileNotFoundError:
+            pass
+        if proc.poll() is not None:
+            sys.exit(f"engine exited before READY; see {LOG}")
+        time.sleep(0.4)
+    proc.kill()
+    sys.exit("engine never printed READY")
+
+
+def shutdown(port: int, proc: subprocess.Popen) -> None:
+    try:
+        send(port, "engine.quit(); return 'bye'", timeout=3.0)
+    except OSError:
+        pass
+    try:
+        proc.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def placed(port: int) -> list[dict]:
+    """The active world's placed-location list, parsed from JSON."""
+    raw = send(port, "return world.listPlacedLocations()").strip()
+    if not raw or raw in ("nil", "{}", "[]"):
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    return data if isinstance(data, list) else []
+
+
+def placed_ready(port: int, tries: int = 30) -> list[dict]:
+    """Read the overlay once the shown world is actually active.
+
+    world.show queues a command processed by the world thread; the
+    active-world query can race ahead of it and read the previous (or no)
+    active page. Poll until a non-empty result settles. The test inputs
+    (ruin_small, max_count 6) always place several, so non-empty is the
+    ready signal; fall through after the cap so a genuinely empty world
+    still returns rather than hanging.
+    """
+    last: list[dict] = []
+    for _ in range(tries):
+        last = placed(port)
+        if last:
+            return last
+        time.sleep(0.5)
+    return last
+
+
+def key(entries: list[dict]) -> list[tuple]:
+    """Stable, comparable signature of a placement set."""
+    return sorted((e["cx"], e["cy"], e["id"]) for e in entries)
+
+
+def is_ocean(port: int, gx: int, gy: int) -> bool:
+    r = send(port, f"local f=world.getFluidAt({gx},{gy}); return f or 'dry'")
+    return r.strip('"') == "ocean"
+
+
+def gen_world(port: int, page: str, seed: int, size: int) -> None:
+    send(port, f"world.init('{page}', {seed}, {size}, 3); return 'ok'")
+    send(port, "return world.waitForInit(240)", timeout=250)
+    send(port, f"world.show('{page}'); return 'ok'")
+    # world.show queues a command processed by the world thread; load the
+    # centre region and wait so the page is the active one before we read
+    # the overlay (the overlay is in gen params, not the chunks, but this
+    # is a reliable sync point that the show has taken effect).
+    send(port, "return world.loadChunksInRegion(-1,-1,1,1)")
+    send(port, "return world.waitForChunks(60)", timeout=65)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--size", type=int, default=64)
+    ap.add_argument("--port", type=int, default=9189)
+    args = ap.parse_args()
+
+    failures: list[str] = []
+
+    # ---- Phase 1: placement + determinism + anchor (one engine) ----
+    proc = boot(args.port)
+    try:
+        send(args.port, "engine.loadLocationYaml('data/locations/ruin_small.yaml'); return 'ok'")
+
+        gen_world(args.port, "wa", args.seed, args.size)
+        la = placed_ready(args.port)
+        print(f"world A (seed {args.seed}): {len(la)} placed location(s)")
+        for e in la:
+            print(f"  {e['id']:14s} chunk ({e['cx']},{e['cy']})  tile ({e['gx']},{e['gy']})")
+
+        ruins = [e for e in la if e["id"] == "ruin_small"]
+        if ruins:
+            print(f"PASS: {len(ruins)} ruin_small placed (>= 1)")
+        else:
+            failures.append("no ruin_small placed in world A")
+
+        # Determinism: a second independent generation with the same seed.
+        gen_world(args.port, "wb", args.seed, args.size)
+        lb = placed_ready(args.port)
+        if key(la) == key(lb) and la:
+            print("PASS: same seed -> identical overlay (A == B)")
+        else:
+            failures.append(f"overlay not deterministic: A={key(la)} B={key(lb)}")
+
+        # Anchor: flat-anchored ruins must never sit on an ocean tile.
+        # Load each ruin's own chunk on demand (cheaper than the whole
+        # world) and read the fluid at its anchor tile.
+        send(args.port, "world.show('wa'); return 'ok'")
+        ocean_hits = []
+        for e in ruins:
+            cx, cy = e["cx"], e["cy"]
+            send(args.port, f"return world.loadChunksInRegion({cx},{cy},{cx},{cy})")
+            send(args.port, "return world.waitForChunks(30)", timeout=35)
+            if is_ocean(args.port, e["gx"], e["gy"]):
+                ocean_hits.append(e)
+        if ruins and not ocean_hits:
+            print(f"PASS: all {len(ruins)} ruin(s) on land (anchor [flat] respected)")
+        elif ocean_hits:
+            failures.append(f"{len(ocean_hits)} ruin(s) placed on ocean tiles")
+
+        # Save world A for the reload phase.
+        send(args.port, "engine.saveWorld('wa', 'loc_overlay_probe'); return 'saved'")
+        time.sleep(1.0)
+    finally:
+        shutdown(args.port, proc)
+
+    # ---- Phase 2: save survives a fresh restart + load ----
+    # Deliberately do NOT load the location YAML on this engine: if the
+    # placements still appear, they came from the save, not a recompute.
+    proc = boot(args.port)
+    try:
+        send(args.port, "engine.loadSave('loc_overlay_probe'); return 'queued'")
+        # The overlay rides gen params, restored immediately on load — no
+        # need to wait for chunks. A short settle covers the load queue.
+        time.sleep(6.0)
+        send(args.port, "world.show('main_world'); return 'ok'")
+        time.sleep(1.0)
+        lc = placed_ready(args.port)
+        if key(lc) == key(la) and lc:
+            print(f"PASS: overlay survived save/load ({len(lc)} placements, no YAML reload)")
+        else:
+            failures.append(f"overlay lost/changed across save-load: before={key(la)} after={key(lc)}")
+    finally:
+        shutdown(args.port, proc)
+
+    print("-" * 56)
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}", file=sys.stderr)
+        return 1
+    print("ALL CHECKS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/location_overlay_probe.py
+++ b/tools/location_overlay_probe.py
@@ -7,17 +7,22 @@ produces a sparse chunk -> location-id overlay that is carried in the
 world's gen params and serialized into the save. `world.listPlaced-
 Locations()` (Lua `locations.listPlaced()`) reads that overlay back.
 
-This drives the full integration headless and checks the four
-acceptance criteria of #89:
+This drives the full integration headless and checks #89 end to end:
 
   1. Generating a world with `ruin_small` defined produces >= 1 ruin
      somewhere (via listPlacedLocations).
   2. Same seed -> same overlay (two independent generations match).
-  3. Overlay survives save -> quit -> fresh restart -> load, WITHOUT the
-     reload engine re-loading the location YAML (so the placements can
-     only have come from the save, never a recompute).
-  4. Suitability respects anchor tags: every ruin_small (anchor [flat])
+  3. Suitability respects anchor tags: every ruin_small (anchor [flat])
      sits on a land chunk, never an ocean one.
+  4. Lazy stamping: loading a ruin's chunk materializes its geometry
+     (engine chunk-load dispatch -> stamper -> the #88 builder).
+  5. The overlay survives save -> quit -> fresh restart -> load; checked
+     before any location YAML is reloaded, so it can only have come from
+     the save (a recompute is impossible with no defs registered).
+  6. No location is lost to save timing: the world is saved with its
+     ruins still UN-STAMPED (right after gen, before their far chunks
+     load); after a fresh restart + load, visiting each ruin's chunk
+     materializes it from the persisted overlay anyway.
 
 Usage:
   python3 tools/location_overlay_probe.py
@@ -178,12 +183,13 @@ def main() -> int:
 
     failures: list[str] = []
 
-    # ---- Phase 1: placement + determinism + anchor + stamping ----
+    # ---- Phase 1: placement, determinism, lazy stamping; then save the
+    #      world with its locations still UN-STAMPED (saved right after gen,
+    #      before any far ruin chunk has loaded) so phase 2 can prove they
+    #      are not lost. ----
     proc = boot(args.port)
     try:
         send(args.port, "engine.loadLocationYaml('data/locations/ruin_small.yaml'); return 'ok'")
-        # Load the stamper so the engine's onWorldReady broadcast drives it
-        # (the loading screen that normally loads it is GUI-only).
         send(args.port, "engine.loadScript('scripts/location_stamper.lua', 0.1); return 'ok'")
 
         gen_world(args.port, "wa", args.seed, args.size)
@@ -198,6 +204,32 @@ def main() -> int:
         else:
             failures.append("no ruin_small placed in world A")
 
+        # The ruins sit on far chunks not loaded at gen, so none are stamped
+        # yet. Confirm, then SAVE in that un-stamped state — the race the
+        # reviewer flagged (saved before stamping drains).
+        unstamped = sum(1 for e in ruins if not has_floor(args.port, e["gx"], e["gy"]))
+        print(f"  {unstamped}/{len(ruins)} ruin(s) un-stamped at save time")
+        send(args.port, "engine.saveWorld('wa', 'loc_overlay_probe'); return 'saved'")
+        time.sleep(1.0)
+
+        # In-session lazy stamping: loading a ruin's chunk materializes its
+        # geometry (engine dispatch -> stamper -> #88 builder). Doubles as
+        # the on-land / anchor check.
+        ocean_hits = []
+        for e in ruins:
+            load_chunk(args.port, e["cx"], e["cy"])
+            if is_ocean(args.port, e["gx"], e["gy"]):
+                ocean_hits.append(e)
+        if ruins and not ocean_hits:
+            print(f"PASS: all {len(ruins)} ruin(s) on land (anchor [flat] respected)")
+        elif ocean_hits:
+            failures.append(f"{len(ocean_hits)} ruin(s) placed on ocean tiles")
+        n = wait_stamped(args.port, ruins)
+        if ruins and n == len(ruins):
+            print(f"PASS: lazy stamping materialized all {n} ruin(s) as their chunks loaded")
+        else:
+            failures.append(f"only {n}/{len(ruins)} ruin(s) stamped in-session")
+
         # Determinism: a second independent generation with the same seed.
         gen_world(args.port, "wb", args.seed, args.size)
         lb = placed_ready(args.port)
@@ -205,67 +237,42 @@ def main() -> int:
             print("PASS: same seed -> identical overlay (A == B)")
         else:
             failures.append(f"overlay not deterministic: A={key(la)} B={key(lb)}")
-
-        # Anchor: flat-anchored ruins must never sit on an ocean tile.
-        # Load each ruin's own chunk on demand (cheaper than the whole
-        # world) and read the fluid at its anchor tile.
-        send(args.port, "world.show('wa'); return 'ok'")
-        ocean_hits = []
-        for e in ruins:
-            cx, cy = e["cx"], e["cy"]
-            send(args.port, f"return world.loadChunksInRegion({cx},{cy},{cx},{cy})")
-            send(args.port, "return world.waitForChunks(30)", timeout=35)
-            if is_ocean(args.port, e["gx"], e["gy"]):
-                ocean_hits.append(e)
-        if ruins and not ocean_hits:
-            print(f"PASS: all {len(ruins)} ruin(s) on land (anchor [flat] respected)")
-        elif ocean_hits:
-            failures.append(f"{len(ocean_hits)} ruin(s) placed on ocean tiles")
-
-        # Stamping: the location_stamper materializes each ruin's geometry
-        # (the #88 room_small builder) into the world as its chunk loads.
-        n = wait_stamped(args.port, ruins)
-        if ruins and n == len(ruins):
-            print(f"PASS: all {n} ruin(s) stamped into the world (geometry present)")
-        else:
-            failures.append(f"only {n}/{len(ruins)} ruin(s) stamped into the world")
-
-        # Save world A for the reload phase.
-        send(args.port, "engine.saveWorld('wa', 'loc_overlay_probe'); return 'saved'")
-        time.sleep(1.0)
     finally:
         shutdown(args.port, proc)
 
-    # ---- Phase 2: save survives a fresh restart + load ----
-    # Deliberately load NEITHER the location YAML NOR the stamper on this
-    # engine: if the placements AND their geometry still appear, they came
-    # from the save (overlay in gen params + stamped edits), not a recompute
-    # or a re-stamp.
+    # ---- Phase 2: a world saved with UN-STAMPED locations still
+    #      materializes them after a fresh restart + load (the reviewer's
+    #      option 2: chunk-load after a save consults the persisted overlay
+    #      and stamps any not-yet-materialized entry). ----
     proc = boot(args.port)
     try:
         send(args.port, "engine.loadSave('loc_overlay_probe'); return 'queued'")
-        # The overlay rides gen params, restored immediately on load — no
-        # need to wait for chunks. A short settle covers the load queue.
         time.sleep(6.0)
         send(args.port, "world.show('main_world'); return 'ok'")
         time.sleep(1.0)
+
+        # Overlay persisted: no location YAML loaded yet, so this CANNOT be a
+        # recompute (computeLocationOverlay short-circuits with no defs) — it
+        # came from the save.
         lc = placed_ready(args.port)
         if key(lc) == key(la) and lc:
             print(f"PASS: overlay survived save/load ({len(lc)} placements, no YAML reload)")
         else:
             failures.append(f"overlay lost/changed across save-load: before={key(la)} after={key(lc)}")
 
-        # Stamped geometry must replay from the saved per-chunk edits (with
-        # no stamper loaded). Load each ruin's chunk so its edits replay,
-        # then confirm the floor is back.
+        # Load the defs + stamper as the game does at boot, then visit each
+        # ruin's chunk. Each must materialize from the persisted overlay even
+        # though the save contained no stamped geometry for it.
+        send(args.port, "engine.loadLocationYaml('data/locations/ruin_small.yaml'); return 'ok'")
+        send(args.port, "engine.loadScript('scripts/location_stamper.lua', 0.1); return 'ok'")
         ruins_after = [e for e in lc if e["id"] == "ruin_small"]
         for e in ruins_after:
             load_chunk(args.port, e["cx"], e["cy"])
-        m = count_stamped(args.port, ruins_after)
+        m = wait_stamped(args.port, ruins_after)
         if ruins_after and m == len(ruins_after):
-            print(f"PASS: stamped geometry replayed after load ({m} ruin(s), no re-stamp)")
+            print(f"PASS: all {m} ruin(s) materialized after load despite being saved un-stamped")
         else:
-            failures.append(f"geometry lost across save/load: {m}/{len(ruins_after)} ruins have floors")
+            failures.append(f"only {m}/{len(ruins_after)} ruin(s) materialized after load")
     finally:
         shutdown(args.port, proc)
 

--- a/tools/location_overlay_probe.py
+++ b/tools/location_overlay_probe.py
@@ -146,10 +146,11 @@ def is_ocean(port: int, gx: int, gy: int) -> bool:
     return r.strip('"') == "ocean"
 
 
-def has_floor(port: int, gx: int, gy: int) -> bool:
-    """True if a 'floor' structure piece exists at (gx,gy) — i.e. the
-    ruin_small builder (room_small) has stamped its room there."""
-    r = send(port, f"return structure.hasAt({gx},{gy},'floor') and 'yes' or 'no'")
+def has_floor(port: int, gx: int, gy: int, page: str | None = None) -> bool:
+    """True if a 'floor' structure piece exists at (gx,gy) on the given page
+    (or the active world) — i.e. room_small has stamped its room there."""
+    arg = f",'{page}'" if page else ""
+    r = send(port, f"return structure.hasAt({gx},{gy},'floor'{arg}) and 'yes' or 'no'")
     return r.strip('"') == "yes"
 
 
@@ -173,9 +174,9 @@ def wait_stamped(port: int, ruins: list[dict], tries: int = 80) -> int:
     return n
 
 
-def wait_floor(port: int, gx: int, gy: int, tries: int = 40) -> bool:
+def wait_floor(port: int, gx: int, gy: int, page: str | None = None, tries: int = 40) -> bool:
     for _ in range(tries):
-        if has_floor(port, gx, gy):
+        if has_floor(port, gx, gy, page):
             return True
         time.sleep(0.5)
     return False
@@ -433,11 +434,16 @@ def main() -> int:
                 failures.append(f"phase 5: expected 'arena' active, got '{active}'")
             elif not has_loc_on(args.port, 0, 0, page="sw"):
                 failures.append("phase 5: hidden world 'sw' has no location on (0,0)")
-            elif wait_floor(args.port, 8, 8):
+            elif wait_floor(args.port, 8, 8, page="sw"):
+                # The structure must be on 'sw', NOT the active arena.
+                on_arena = has_floor(args.port, 8, 8, page="arena")
                 swz = send(args.port, "return world.getTerrainAt(8,8,'sw')").split("\t")[0].strip()
-                fz = send(args.port, "return structure.floorZAt(8,8)").strip()
-                print(f"PASS: hidden non-active page stamped its centre while '{active}' active "
-                      f"(floor z={fz} matches sw terrain {swz}, not the arena's 0)")
+                fz = send(args.port, "return structure.floorZAt(8,8,'sw')").strip()
+                if on_arena:
+                    failures.append("phase 5: structure leaked onto the active arena page")
+                else:
+                    print(f"PASS: hidden non-active page 'sw' stamped its OWN centre while "
+                          f"'{active}' active (floor z={fz}=sw terrain {swz}+1; nothing on arena)")
             else:
                 failures.append("hidden non-active page did NOT stamp its centre (multiworld)")
     finally:

--- a/tools/location_overlay_probe.py
+++ b/tools/location_overlay_probe.py
@@ -23,6 +23,13 @@ This drives the full integration headless and checks #89 end to end:
      ruins still UN-STAMPED (right after gen, before their far chunks
      load); after a fresh restart + load, visiting each ruin's chunk
      materializes it from the persisted overlay anyway.
+  7. The SYNCHRONOUS centre chunk (0,0) — which Init/Save regenerate
+     directly and exclude from the chunk-load queue — also stamps, both
+     on first generation (Init hook) and on first load (Save hook).
+
+The location stamper is auto-loaded at boot by scripts/init.lua, exactly
+as in the real game, so this only registers the location defs by hand
+(headless skips the GUI data-loading step).
 
 Usage:
   python3 tools/location_overlay_probe.py
@@ -162,6 +169,53 @@ def wait_stamped(port: int, ruins: list[dict], tries: int = 80) -> int:
     return n
 
 
+def wait_floor(port: int, gx: int, gy: int, tries: int = 40) -> bool:
+    for _ in range(tries):
+        if has_floor(port, gx, gy):
+            return True
+        time.sleep(0.5)
+    return False
+
+
+# A dense location def (no anchor, no spacing, unbounded count) places a
+# location on EVERY land chunk — so the centre chunk (0,0), land for our
+# seed, is guaranteed one. (0,0) is only ever loaded synchronously (Init /
+# Save regenerate it directly and exclude it from the chunk-load queue), so
+# a floor there can only come from the synchronous-centre stamp hooks.
+DENSE_YAML = "/tmp/loc_overlay_probe_dense.yaml"
+DENSE_BODY = (
+    "locations:\n"
+    "  - id: ruin_small\n"
+    "    label: Small Ruin\n"
+    "    type: ruin\n"
+    "    builder: room_small\n"
+    "    anchor: []\n"
+    "    max_count: 100000\n"
+    "    min_spacing: 1\n"
+    "    contents: []\n"
+)
+
+
+def has_loc_on(port: int, cx: int, cy: int, tries: int = 20) -> bool:
+    """Whether the active overlay places a location on chunk (cx,cy).
+
+    Polls until the overlay is readable (the world is active), so it does
+    not race world.show. The server-side scan returns just a flag, never
+    the (huge, dense) full list.
+    """
+    lua = (f"local t = world.listPlacedLocations(); "
+           f"for _, e in ipairs(t) do if e.cx == {cx} and e.cy == {cy} then return 'yes' end end; "
+           f"return (#t > 0) and 'no' or 'empty'")
+    for _ in range(tries):
+        r = send(port, lua).strip('"')
+        if r == "yes":
+            return True
+        if r == "no":
+            return False
+        time.sleep(0.5)
+    return False
+
+
 def gen_world(port: int, page: str, seed: int, size: int) -> None:
     send(port, f"world.init('{page}', {seed}, {size}, 3); return 'ok'")
     send(port, "return world.waitForInit(240)", timeout=250)
@@ -190,7 +244,8 @@ def main() -> int:
     proc = boot(args.port)
     try:
         send(args.port, "engine.loadLocationYaml('data/locations/ruin_small.yaml'); return 'ok'")
-        send(args.port, "engine.loadScript('scripts/location_stamper.lua', 0.1); return 'ok'")
+        # The stamper is auto-loaded at boot by scripts/init.lua (as in the
+        # real game), so we only have to register the location defs here.
 
         gen_world(args.port, "wa", args.seed, args.size)
         la = placed_ready(args.port)
@@ -264,7 +319,8 @@ def main() -> int:
         # ruin's chunk. Each must materialize from the persisted overlay even
         # though the save contained no stamped geometry for it.
         send(args.port, "engine.loadLocationYaml('data/locations/ruin_small.yaml'); return 'ok'")
-        send(args.port, "engine.loadScript('scripts/location_stamper.lua', 0.1); return 'ok'")
+        # The stamper is auto-loaded at boot by scripts/init.lua (as in the
+        # real game), so we only have to register the location defs here.
         ruins_after = [e for e in lc if e["id"] == "ruin_small"]
         for e in ruins_after:
             load_chunk(args.port, e["cx"], e["cy"])
@@ -275,6 +331,67 @@ def main() -> int:
             failures.append(f"only {m}/{len(ruins_after)} ruin(s) materialized after load")
     finally:
         shutdown(args.port, proc)
+
+    # A dense def places a location on EVERY land chunk, so the centre
+    # chunk (0,0) — land for our seed, and the only chunk that is ever
+    # loaded SYNCHRONOUSLY (Init and Save regenerate it directly and
+    # exclude it from the chunk-load queue) — is guaranteed one. A floor at
+    # its anchor (8,8) can therefore only come from the synchronous-centre
+    # stamp hooks, not the chunk-load dispatch.
+    with open(DENSE_YAML, "w") as fh:
+        fh.write(DENSE_BODY)
+
+    # ---- Phase 3: the SYNCHRONOUS centre chunk (0,0) stamps on fresh gen
+    #      (Init hook). ----
+    proc = boot(args.port)
+    try:
+        send(args.port, f"engine.loadLocationYaml('{DENSE_YAML}'); return 'ok'")
+        gen_world(args.port, "wc", args.seed, args.size)
+        if not has_loc_on(args.port, 0, 0):
+            failures.append(f"seed {args.seed}: no location on centre chunk (0,0) — cannot test Init hook")
+        elif wait_floor(args.port, 8, 8):
+            print("PASS: synchronous centre chunk (0,0) stamped on first gen (Init hook)")
+        else:
+            failures.append("centre chunk (0,0) NOT stamped on first gen (Init hook)")
+    finally:
+        shutdown(args.port, proc)
+
+    # ---- Phase 4: a location on the SAVED CAMERA CHUNK is present on the
+    #      FIRST load. The default camera sits on (0,0); save a world whose
+    #      (0,0) hosts a location, then on a fresh restart confirm it is back
+    #      WITHOUT force-loading (0,0) — Save regenerates that chunk
+    #      synchronously and excludes it from the queue, so its presence
+    #      exercises the Save centre hook. ----
+    proc = boot(args.port)
+    saved_centre = False
+    try:
+        send(args.port, f"engine.loadLocationYaml('{DENSE_YAML}'); return 'ok'")
+        gen_world(args.port, "wd", args.seed, args.size)
+        if not has_loc_on(args.port, 0, 0):
+            failures.append(f"seed {args.seed}: no location on centre chunk (0,0) — cannot test Save hook")
+        elif not wait_floor(args.port, 8, 8):
+            failures.append("phase 4 setup: centre (0,0) did not stamp at gen")
+        else:
+            send(args.port, "engine.saveWorld('wd', 'loc_centre_probe'); return 'saved'")
+            time.sleep(1.0)
+            saved_centre = True
+    finally:
+        shutdown(args.port, proc)
+
+    if saved_centre:
+        proc = boot(args.port)
+        try:
+            send(args.port, f"engine.loadLocationYaml('{DENSE_YAML}'); return 'ok'")
+            send(args.port, "engine.loadSave('loc_centre_probe'); return 'queued'")
+            time.sleep(6.0)
+            send(args.port, "world.show('main_world'); return 'ok'")
+            # Do NOT force-load (0,0) — it is the synchronous centre chunk.
+            if wait_floor(args.port, 8, 8):
+                print("PASS: saved-camera centre chunk (0,0) present on first load (Save hook)")
+            else:
+                failures.append("saved-camera centre chunk (0,0) NOT present on first load (Save hook)")
+        finally:
+            shutdown(args.port, proc)
 
     print("-" * 56)
     if failures:


### PR DESCRIPTION
Closes #89

## Approach

A placement pass runs at the end of world init (`World.Thread.Command.Init`), after the geological timeline + ocean map + climate are finalised, and produces a sparse **chunk → location-id overlay**. It is stored in `WorldGenParams` (`wgpLocationOverlay`) — the same place the geo timeline lives — so it **serializes into the save and survives load without being recomputed**, keeping a world's layout stable across sessions.

**Placement** (`Location.Overlay.computeLocationOverlay`) is the *coarse pass* the issue's open question recommends:
- Suitability is judged from the plate-based elevation function (`elevationAtGlobal`), sampled at 5 points per chunk — exactly the cheap, chunk-independent signal the ocean flood fill (`World.Fluid.Ocean`) already uses. No chunk needs to exist yet.
- Anchor tags (`flat` / `mountain` / `highland` / `lowland` / `coast` / `inland`) resolve against **percentiles of the world's own land elevations**, so the same tags behave sensibly at any world size with no hand-tuned constants. Ocean and glacier chunks are always excluded.
- Candidate order is a pure FNV-salted hash of `(seed, location-id, chunk)` → a jittered, **deterministic**, non-grid distribution. Per-type `max_count` + `min_spacing` (new optional YAML fields) bound count and spread; two locations never share a chunk.
- Short-circuits to empty when no location defs are loaded, so the bare-`--dump` worldgen path stays byte-identical and zero-cost.

**Query:** `world.listPlacedLocations()` (Lua `locations.listPlaced()`) returns the active world's overlay as `{cx, cy, gx, gy, id}` records.

Save version bumped 62 → 63 (trailing `wgpLocationOverlay`).

### Scope note
This PR delivers the **overlay** — placement, persistence, anchor suitability, and the query. The issue's four acceptance criteria are all explicitly verifiable via `listPlaced()` and are met. Stamping the actual location *geometry* (invoking the #88 Lua builder per chunk) is a Haskell→Lua-thread concern that naturally pairs with **#90 (location content spawning)**, which also walks this overlay; `listPlaced()` is the seam it builds on.

## What I tested

**hspec** (`Test.Headless.WorldGen`, against the shared seed-42 world's real plates/ocean data) — full suite **416 examples, 0 failures**:
- deterministic — same seed (independently regenerated plates) → identical overlay
- never places on an ocean chunk
- respects anchor tags — `mountain` selects higher ground than `flat`
- places ≥1 flat-anchored location on land
- `WorldGenParams` serialize round-trip preserves the overlay

**Integration probe** `tools/location_overlay_probe.py` — boots a real headless engine and checks all four acceptance criteria end-to-end:
1. world with `ruin_small` defined → 6 ruins placed (≥1) ✓
2. same seed → identical overlay (two independent generations) ✓
3. overlay survives **save → quit → fresh restart → load**, with the reload engine **not** re-loading the location YAML (so the placements can only have come from the save) ✓
4. every flat-anchored ruin sits on a land tile, never ocean ✓

**Determinism guard:** two bare `--dump`s (seed 42, w64) are byte-identical, and the dump JSON carries no location keys — confirming the worldgen baselines are unaffected.