### PR TITLE
Flatten location room footprint to the lowest ground level

### DIFF
--- a/scripts/locations.lua
+++ b/scripts/locations.lua
@@ -122,6 +122,39 @@ function locations.wallRing(worldId, x0, y0, x1, y1, z0, z1, mat)
     end
 end
 
+-- Level the terrain across the box [x0..x1]×[y0..y1] to the LOWEST base
+-- elevation in it, so a stamped room sits flat instead of following the bumps
+-- under it. The base elevation is the terrain-only surface (getTerrainAt's 2nd
+-- value), so sub-tile slopes ON TOP are excluded from the min; every cell
+-- above the target level is carved to air and any surface slope is dropped.
+-- Returns the level it flattened to — the structure floor then sits one above.
+--
+-- NB the tile edits are async (queued to the world thread), so getTerrainAt
+-- still reads the OLD heights for the rest of THIS call. Builders must place
+-- their pieces at the returned level explicitly rather than re-reading terrain.
+function locations.flattenFootprint(worldId, x0, y0, x1, y1)
+    local lo, hi
+    for gx = x0, x1 do
+        for gy = y0, y1 do
+            local _, tz = world.getTerrainAt(gx, gy, worldId)
+            tz = tz or 0
+            if lo == nil or tz < lo then lo = tz end
+            if hi == nil or tz > hi then hi = tz end
+        end
+    end
+    lo = lo or 0
+    hi = hi or lo
+    for gx = x0, x1 do
+        for gy = y0, y1 do
+            for z = lo + 1, hi do
+                world.setCell(worldId, gx, gy, z, "air")
+            end
+            world.setSlope(worldId, gx, gy, lo, 0)   -- 0 bits = flat
+        end
+    end
+    return lo
+end
+
 -----------------------------------------------------------
 -- Builders
 -----------------------------------------------------------
@@ -139,8 +172,9 @@ local builders = {}
 -- then the inward-facing perimeter walls (which cap to those posts).
 --
 -- Perimeter edge per side: −gx = nw, +gx = se, −gy = ne, +gy = sw.
--- worldId is unused for now — the structure store is global (Stage-1 limit).
--- Ceiling is OFF by default so the interior stays visible while iterating.
+-- worldId selects the page; baseZ (from flattenFootprint) is the levelled
+-- ground the pieces sit on. Ceiling is OFF by default so the interior stays
+-- visible while iterating.
 local ROOM_SMALL_RADIUS = 2   -- → 5×5 footprint
 
 function builders.room_small(worldId, gx, gy, withCeiling)
@@ -149,33 +183,37 @@ function builders.room_small(worldId, gx, gy, withCeiling)
     local x0, x1 = gx - r, gx + r
     local y0, y1 = gy - r, gy + r
 
-    -- 1. floor across the whole footprint. worldId threads through so a
-    --    location stamped on a hidden/non-active page reads THAT page's
-    --    terrain height, not the active world's (#89 multiworld).
+    -- 0. level the ground so the room is flat: flatten the footprint to its
+    --    lowest base elevation and build every piece at that explicit z. (The
+    --    flatten edits are async, so re-reading terrain this call would still
+    --    see the old bumps — hence baseZ is threaded through, not re-read.)
+    local baseZ = locations.flattenFootprint(worldId, x0, y0, x1, y1)
+
+    -- 1. floor across the whole footprint at the levelled height
     for x = x0, x1 do
-        for y = y0, y1 do S.floor(x, y, worldId) end
+        for y = y0, y1 do S.floor(x, y, worldId, baseZ) end
     end
 
     -- 2. corner posts (cap the two perimeter walls that meet at each)
-    S.post(x0, y0, "n", worldId)   -- nw + ne meet
-    S.post(x1, y0, "e", worldId)   -- ne + se meet
-    S.post(x1, y1, "s", worldId)   -- se + sw meet
-    S.post(x0, y1, "w", worldId)   -- sw + nw meet
+    S.post(x0, y0, "n", worldId, baseZ)   -- nw + ne meet
+    S.post(x1, y0, "e", worldId, baseZ)   -- ne + se meet
+    S.post(x1, y1, "s", worldId, baseZ)   -- se + sw meet
+    S.post(x0, y1, "w", worldId, baseZ)   -- sw + nw meet
 
     -- 3. perimeter walls (after posts so they cap to them)
     for y = y0, y1 do
-        S.wall(x0, y, "nw", worldId)   -- −gx side
-        S.wall(x1, y, "se", worldId)   -- +gx side
+        S.wall(x0, y, "nw", worldId, baseZ)   -- −gx side
+        S.wall(x1, y, "se", worldId, baseZ)   -- +gx side
     end
     for x = x0, x1 do
-        S.wall(x, y0, "ne", worldId)   -- −gy side
-        S.wall(x, y1, "sw", worldId)   -- +gy side
+        S.wall(x, y0, "ne", worldId, baseZ)   -- −gy side
+        S.wall(x, y1, "sw", worldId, baseZ)   -- +gy side
     end
 
     -- 4. ceiling (optional)
     if withCeiling then
         for x = x0, x1 do
-            for y = y0, y1 do S.ceiling(x, y, worldId) end
+            for y = y0, y1 do S.ceiling(x, y, worldId, baseZ) end
         end
     end
 

--- a/scripts/structures.lua
+++ b/scripts/structures.lua
@@ -101,9 +101,9 @@ local CORNER_WALLS = { n = {"ne","nw"}, e = {"ne","se"},
 -- worldId (optional) targets a specific world page's terrain — locations
 -- stamped on a hidden/non-active page must read THAT page's height, not the
 -- active world's (#89). nil → the active world (the click-placement path).
-local function placeWall(gx, gy, e, worldId)
+local function placeWall(gx, gy, e, worldId, baseZ)
     local h = handles()
-    local z = (world.getTerrainAt(gx, gy, worldId) or 0) + 1
+    local z = (baseZ or world.getTerrainAt(gx, gy, worldId) or 0) + 1
     local ends = WALL_ENDS[e]   -- {leftCorner, rightCorner}
     local capL = structure.hasAt(gx, gy, "post_" .. ends[1], worldId)
     local capR = structure.hasAt(gx, gy, "post_" .. ends[2], worldId)
@@ -117,12 +117,15 @@ local function placeWall(gx, gy, e, worldId)
                     w.texPath, w.facePath[suffix], worldId)
 end
 
+-- (M.wall / recapTileCorner pass the levelled baseZ through; the
+-- click-placement path omits it and reads the active world's terrain.)
+
 -- A post just changed at tile (gx,gy)'s `corner`: re-cap that tile's own two
 -- walls touching the corner, so wall-then-post and post-then-wall converge.
-local function recapTileCorner(gx, gy, corner, worldId)
+local function recapTileCorner(gx, gy, corner, worldId, baseZ)
     for _, e in ipairs(CORNER_WALLS[corner]) do
         if structure.hasAt(gx, gy, "wall_" .. e, worldId) then
-            placeWall(gx, gy, e, worldId)
+            placeWall(gx, gy, e, worldId, baseZ)
         end
     end
 end
@@ -174,16 +177,20 @@ end
 -- The programmatic builders take an optional trailing `worldId` (the page
 -- to author on / read terrain from); nil → the active world. Location
 -- stamping passes it so a hidden page's room reads that page's terrain.
-function M.floor(gx, gy, worldId)
+-- The programmatic builders take an optional trailing baseZ — the levelled
+-- ground a stamped room sits on (locations.flattenFootprint). When given, the
+-- piece is placed at that explicit z instead of re-reading terrain (which,
+-- right after the async flatten edits, would still report the old bumps).
+function M.floor(gx, gy, worldId, baseZ)
     local h = handles()
-    local z = (world.getTerrainAt(gx, gy, worldId) or 0) + 1
+    local z = (baseZ or world.getTerrainAt(gx, gy, worldId) or 0) + 1
     structure.place(gx, gy, "floor", h.floor.tex, h.floor.face, z,
                     h.floor.texPath, h.floor.facePath, worldId)
 end
 
-function M.ceiling(gx, gy, worldId)
+function M.ceiling(gx, gy, worldId, baseZ)
     local h = handles()
-    local z = (world.getTerrainAt(gx, gy, worldId) or 0) + 2   -- one level above the floor
+    local z = (baseZ or world.getTerrainAt(gx, gy, worldId) or 0) + 2   -- one level above the floor
     structure.place(gx, gy, "ceiling", h.ceiling.tex, h.ceiling.face, z,
                     h.ceiling.texPath, h.ceiling.facePath, worldId)
 end
@@ -192,19 +199,19 @@ end
 -- this tile's walls touching the corner. Returns true if placed. The post z
 -- comes from the existing floor (read from the same page), so it needs no
 -- terrain read.
-function M.post(gx, gy, corner, worldId)
+function M.post(gx, gy, corner, worldId, baseZ)
     local fz = structure.floorZAt(gx, gy, worldId)
     if not fz then return false end
     local h = handles()
     structure.place(gx, gy, "post_" .. corner, h.post.tex, h.post.face, fz,
                     h.post.texPath, h.post.facePath, worldId)
-    recapTileCorner(gx, gy, corner, worldId)
+    recapTileCorner(gx, gy, corner, worldId, baseZ)
     return true
 end
 
 -- edge ∈ "ne"/"nw"/"se"/"sw". Caps to existing posts on this tile.
-function M.wall(gx, gy, edge, worldId)
-    placeWall(gx, gy, edge, worldId)
+function M.wall(gx, gy, edge, worldId, baseZ)
+    placeWall(gx, gy, edge, worldId, baseZ)
 end
 
 function M.clear() structure.clearAll() end


### PR DESCRIPTION
Follow-up to #89 (location overlay). Reported in testing: stamped rooms come out at different levels on uneven ground instead of flat.

## Problem
`room_small` placed each floor/wall piece at its own tile's `terrain + 1`. On bumpy ground the room therefore followed the terrain — the floor sat at different heights and the room wasn't flat.

## Fix
`room_small` now levels the footprint before building (`locations.flattenFootprint`):
- **target = the lowest terrain-only surface z** across the footprint. Using `getTerrainAt`'s 2nd return (the base integer height) means sub-tile **slopes on top are excluded** from the minimum.
- every cell above that level is carved to air, and each surface slope is dropped (`setSlope … 0`), so the ground is genuinely flat.
- the room pieces are placed at that explicit level. The tile edits are async (queued to the world thread), so re-reading terrain in the same call would still see the old bumps — the `structures.lua` programmatic builders take an optional `baseZ` and place at it. Omitting `baseZ` keeps the click-placement build tool reading the active world's terrain exactly as before (backward compatible).

## Tested (headless, Lua-only — no engine rebuild)
- A footprint bumped to z=1/2/3 **and** a sloped tile flattens to its lowest level (0) after stamping, with a uniform floor at z=1:
  ```
  BEFORE:  0 0 0 0 0 / 0 1 0 0 0 / 0 0 1 0 0 / 0 0 0 2 0 / 0 0 0 0 3
  AFTER:   0 0 0 0 0 / 0 0 0 0 0 / 0 0 0 0 0 / 0 0 0 0 0 / 0 0 0 0 0   (floor z uniformly 1)
  ```
  A sloped tile reads `terrainSurfaceZ = base` (excluded from the min), confirming "excluding the slopes on top".
- Same on a real generated world (seed 42): a placed ruin's 5×5 footprint is a single level, floor uniform.
- `tools/location_overlay_probe.py` (the #89 9-phase gate) still passes — the flatten is additive; its assertions are existence/page-isolation based.

The structure store is per-page (#89), so this flattens the correct world's terrain via the threaded `worldId`.