### PR TITLE
Keep location placements clear of water (#414)

### DIFF
--- a/src/Location/Overlay.hs
+++ b/src/Location/Overlay.hs
@@ -38,7 +38,7 @@ import qualified Data.Text as T
 import qualified Data.Vector as V
 import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
-import World.Chunk.Types (ChunkCoord(..), chunkSize)
+import World.Chunk.Types (ChunkCoord(..), chunkSize, wrapChunkCoordU)
 import World.Plate (TectonicPlate, elevationAtGlobal, isBeyondGlacier)
 import World.Material (MaterialId, matGlacier)
 import World.Ocean.Types (OceanMap, OceanDistMap, oceanDistAt)
@@ -142,15 +142,22 @@ computeLocationOverlay seed worldSize plates oceanMap oceanDist lakes rivers def
     -- Locations avoid those: flattening a footprint next to water leaves
     -- the water overhanging the carved rim (#414). A def opts back IN via
     -- a coast anchor.
+    --
+    -- Every coord is canonicalised through 'wrapChunkCoordU' first, because
+    -- the ocean / lake / river tables are keyed by the wrapped coord (see
+    -- 'World.Generate.Chunk') — a seam-crossing neighbour read raw would
+    -- otherwise miss the water on the far side of the wrap.
     dryEnough ∷ ChunkCoord → Bool
     dryEnough coord@(ChunkCoord cx cy) =
-        oceanDistAt oceanDist coord ≥ 2
+        oceanDistAt oceanDist (wrap coord) ≥ 2
         ∧ all noStandingWater
             [ ChunkCoord (cx + dx) (cy + dy)
             | dx ← [-1, 0, 1], dy ← [-1, 0, 1] ]
       where
+        wrap = wrapChunkCoordU worldSize
         noStandingWater c =
-            V.null (lakesInChunk lakes c) ∧ V.null (riversInChunk rivers c)
+            let cc = wrap c
+            in V.null (lakesInChunk lakes cc) ∧ V.null (riversInChunk rivers cc)
 
     defsSorted = sortOn ldId defs
 

--- a/src/Location/Overlay.hs
+++ b/src/Location/Overlay.hs
@@ -35,12 +35,15 @@ import Data.Bits (xor, shiftR, (.&.))
 import Data.Word (Word64)
 import Data.List (sort, sortOn, foldl')
 import qualified Data.Text as T
+import qualified Data.Vector as V
 import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
 import World.Chunk.Types (ChunkCoord(..), chunkSize)
 import World.Plate (TectonicPlate, elevationAtGlobal, isBeyondGlacier)
 import World.Material (MaterialId, matGlacier)
 import World.Ocean.Types (OceanMap, OceanDistMap, oceanDistAt)
+import World.Fluid.Lake.Types (WorldLakes, lakesInChunk)
+import World.Fluid.River.Types (WorldRivers, riversInChunk)
 import World.Constants (seaLevel)
 import Location.Types (LocationDef(..))
 import Location.Overlay.Types (LocationOverlay, emptyLocationOverlay)
@@ -95,9 +98,11 @@ computeLocationOverlay
     → [TectonicPlate] -- ^ pre-generated plates
     → OceanMap        -- ^ submerged-chunk set
     → OceanDistMap    -- ^ distance-from-ocean per chunk
+    → WorldLakes      -- ^ per-chunk lakes
+    → WorldRivers     -- ^ per-chunk rivers
     → [LocationDef]   -- ^ registered location defs
     → LocationOverlay
-computeLocationOverlay seed worldSize plates oceanMap oceanDist defs
+computeLocationOverlay seed worldSize plates oceanMap oceanDist lakes rivers defs
     | null defs = emptyLocationOverlay
     | otherwise = fst (foldl' placeDef (emptyLocationOverlay, HS.empty) defsSorted)
   where
@@ -132,6 +137,21 @@ computeLocationOverlay seed worldSize plates oceanMap oceanDist defs
       where elevList  = sort (map (cmMedianElev . snd) landMetrics)
             rangeList = sort (map (cmElevRange  . snd) landMetrics)
 
+    -- A chunk is too close to water if it (or any of its 8 neighbours)
+    -- holds a lake or river, or it sits within one chunk of the ocean.
+    -- Locations avoid those: flattening a footprint next to water leaves
+    -- the water overhanging the carved rim (#414). A def opts back IN via
+    -- a coast anchor.
+    dryEnough ∷ ChunkCoord → Bool
+    dryEnough coord@(ChunkCoord cx cy) =
+        oceanDistAt oceanDist coord ≥ 2
+        ∧ all noStandingWater
+            [ ChunkCoord (cx + dx) (cy + dy)
+            | dx ← [-1, 0, 1], dy ← [-1, 0, 1] ]
+      where
+        noStandingWater c =
+            V.null (lakesInChunk lakes c) ∧ V.null (riversInChunk rivers c)
+
     defsSorted = sortOn ldId defs
 
     -- Place one def, threading the accumulating overlay + the set of
@@ -148,10 +168,12 @@ computeLocationOverlay seed worldSize plates oceanMap oceanDist defs
         -- Suitable land chunks, ordered by a deterministic per-chunk
         -- hash so the distribution is semi-random (not a grid) yet
         -- stable for a given seed.
+        wantWater = wantsWater (ldAnchor def)
         scored = sortOn snd
             [ (coord, scoreFor lid coord)
             | (coord, cm) ← landMetrics
-            , anchorOk cuts (ldAnchor def) cm ]
+            , anchorOk cuts (ldAnchor def) cm
+            , wantWater ∨ dryEnough coord ]
 
         greedy _      ov' occ [] = (ov', occ)
         greedy placed ov' occ ((coord, _) : rest)
@@ -180,6 +202,14 @@ computeLocationOverlay seed worldSize plates oceanMap oceanDist defs
 idSalt ∷ Text → Word64
 idSalt = T.foldl' (\acc c → (acc `xor` fromIntegral (fromEnum c)) * 0x100000001b3)
                   0xcbf29ce484222325
+
+-- | True if a def's anchors opt it INTO water proximity (a coast / shore /
+--   waterside location), so the dry-ground filter (#414) is skipped for it.
+--   @coast@/@coastal@ also constrain to the ocean shore; @waterside@ just
+--   tolerates nearby water without any other terrain requirement. Every
+--   other location keeps clear of lakes / rivers / the ocean shore.
+wantsWater ∷ [Text] → Bool
+wantsWater = any (`elem` (["coast", "coastal", "waterside"] ∷ [Text]))
 
 -- | Does a chunk satisfy ALL of a def's anchor tags? Unknown tags
 --   impose no constraint (a soft no-op; #88 only ships the "flat" tag,

--- a/src/World/Thread/Command/Init.hs
+++ b/src/World/Thread/Command/Init.hs
@@ -192,12 +192,14 @@ handleWorldInitCommand env logger pageId seed rawWorldSize rawPlaceCount = do
 
     -- Location overlay (#89): deterministically choose which chunks
     -- host the registered locations, from the just-finalised plates +
-    -- ocean data. Empty (and skipped) when no defs are loaded — the
-    -- common headless-dump path stays byte-identical and zero-cost.
+    -- ocean + lake/river data (locations keep clear of water, #414).
+    -- Empty (and skipped) when no defs are loaded — the common
+    -- headless-dump path stays byte-identical and zero-cost.
     locDefs ← allLocations <$> readIORef (locationDefsRef env)
     let params = params0
             { wgpLocationOverlay =
-                computeLocationOverlay seed worldSize plates oceanMap oceanDist locDefs
+                computeLocationOverlay seed worldSize plates oceanMap oceanDist
+                    (gtWorldLakes timeline) (gtWorldRivers timeline) locDefs
             }
     _ ← evaluate (force (wgpLocationOverlay params))
 

--- a/test-headless/Test/Headless/WorldGen.hs
+++ b/test-headless/Test/Headless/WorldGen.hs
@@ -179,10 +179,12 @@ spec = do
             Just p ← getWorldGenParams ws
             let lakes  = gtWorldLakes  (wgpGeoTimeline p)
                 rivers = gtWorldRivers (wgpGeoTimeline p)
+                wrap   = wrapChunkCoordU (wgpWorldSize p)
                 dry coord@(ChunkCoord cx cy) =
-                    oceanDistAt (wgpOceanDist p) coord ≥ 2
-                    ∧ all (\c → V.null (lakesInChunk lakes c)
-                              ∧ V.null (riversInChunk rivers c))
+                    oceanDistAt (wgpOceanDist p) (wrap coord) ≥ 2
+                    ∧ all (\c → let cc = wrap c
+                                in V.null (lakesInChunk lakes cc)
+                                 ∧ V.null (riversInChunk rivers cc))
                           [ ChunkCoord (cx + dx) (cy + dy)
                           | dx ← [-1, 0, 1], dy ← [-1, 0, 1] ]
             HM.keys (overlayFor p [flatDef, mtnDef]) `shouldSatisfy` all dry

--- a/test-headless/Test/Headless/WorldGen.hs
+++ b/test-headless/Test/Headless/WorldGen.hs
@@ -24,6 +24,10 @@ import World.Generate.Config
     )
 import World.Plate (generatePlates)
 import World.Types
+import qualified Data.Vector as V
+import World.Ocean.Types (oceanDistAt)
+import World.Fluid.Lake.Types (lakesInChunk)
+import World.Fluid.River.Types (riversInChunk)
 import Location.Types (LocationDef(..))
 import Location.Overlay (computeLocationOverlay, chunkMetricsAt, ChunkMetrics(..))
 
@@ -135,7 +139,9 @@ spec = do
             mtnDef  = mkDef "mountain_test" ["mountain"]
             overlayFor p defs = computeLocationOverlay
                 (wgpSeed p) (wgpWorldSize p) (wgpPlates p)
-                (wgpOceanMap p) (wgpOceanDist p) defs
+                (wgpOceanMap p) (wgpOceanDist p)
+                (gtWorldLakes (wgpGeoTimeline p)) (gtWorldRivers (wgpGeoTimeline p))
+                defs
 
         it "world init wires a serializable overlay field" $ \env → do
             ws ← sharedWorld env 42 64 3
@@ -157,6 +163,8 @@ spec = do
             let plates2 = generatePlates (wgpSeed p) (wgpWorldSize p) (wgpPlateCount p)
                 ov2 = computeLocationOverlay (wgpSeed p) (wgpWorldSize p) plates2
                                              (wgpOceanMap p) (wgpOceanDist p)
+                                             (gtWorldLakes (wgpGeoTimeline p))
+                                             (gtWorldRivers (wgpGeoTimeline p))
                                              [flatDef, mtnDef]
             ov2 `shouldBe` overlayFor p [flatDef, mtnDef]
 
@@ -165,6 +173,19 @@ spec = do
             Just p ← getWorldGenParams ws
             HM.keys (overlayFor p [flatDef, mtnDef])
                 `shouldSatisfy` all (\c → not (HS.member c (wgpOceanMap p)))
+
+        it "keeps locations clear of lakes, rivers, and the ocean shore (#414)" $ \env → do
+            ws ← sharedWorld env 42 64 3
+            Just p ← getWorldGenParams ws
+            let lakes  = gtWorldLakes  (wgpGeoTimeline p)
+                rivers = gtWorldRivers (wgpGeoTimeline p)
+                dry coord@(ChunkCoord cx cy) =
+                    oceanDistAt (wgpOceanDist p) coord ≥ 2
+                    ∧ all (\c → V.null (lakesInChunk lakes c)
+                              ∧ V.null (riversInChunk rivers c))
+                          [ ChunkCoord (cx + dx) (cy + dy)
+                          | dx ← [-1, 0, 1], dy ← [-1, 0, 1] ]
+            HM.keys (overlayFor p [flatDef, mtnDef]) `shouldSatisfy` all dry
 
         it "respects anchor tags — mountain picks higher ground than flat" $ \env → do
             ws ← sharedWorld env 42 64 3

--- a/tools/location_overlay_probe.py
+++ b/tools/location_overlay_probe.py
@@ -13,7 +13,8 @@ This drives the full integration headless and checks #89 end to end:
      somewhere (via listPlacedLocations).
   2. Same seed -> same overlay (two independent generations match).
   3. Suitability respects anchor tags: every ruin_small (anchor [flat])
-     sits on a land chunk, never an ocean one.
+     sits on a land chunk, never an ocean one, and its footprint is clear
+     of lakes / rivers / ocean (#414 — no carving a room next to water).
   4. Lazy stamping: loading a ruin's chunk materializes its geometry
      (engine chunk-load dispatch -> stamper -> the #88 builder).
   5. The overlay survives save -> quit -> fresh restart -> load; checked
@@ -147,6 +148,16 @@ def is_ocean(port: int, gx: int, gy: int) -> bool:
     return r.strip('"') == "ocean"
 
 
+def footprint_water(port: int, gx: int, gy: int, r: int = 3) -> str:
+    """Scan the room footprint + margin around (gx,gy) for any fluid tile
+    (lake/river/ocean/lava). Returns 'x,y,type' for the first wet tile, or
+    'dry'. One server-side call; the region stays inside the ruin's chunk."""
+    lua = (f"return (function() for y={gy - r},{gy + r} do for x={gx - r},{gx + r} do "
+           f"local f = world.getFluidAt(x, y); if f then return x..','..y..','..f end "
+           f"end end return 'dry' end)()")
+    return send(port, lua).strip('"')
+
+
 def has_floor(port: int, gx: int, gy: int, page: str | None = None) -> bool:
     """True if a 'floor' structure piece exists at (gx,gy) on the given page
     (or the active world) — i.e. room_small has stamped its room there."""
@@ -183,11 +194,13 @@ def wait_floor(port: int, gx: int, gy: int, page: str | None = None, tries: int 
     return False
 
 
-# A dense location def (no anchor, no spacing, unbounded count) places a
-# location on EVERY land chunk — so the centre chunk (0,0), land for our
-# seed, is guaranteed one. (0,0) is only ever loaded synchronously (Init /
-# Save regenerate it directly and exclude it from the chunk-load queue), so
-# a floor there can only come from the synchronous-centre stamp hooks.
+# A dense location def places a location on EVERY land chunk — so the centre
+# chunk (0,0), land for our seed, is guaranteed one. (0,0) is only ever loaded
+# synchronously (Init / Save regenerate it directly and exclude it from the
+# chunk-load queue), so a floor there can only come from the synchronous-centre
+# stamp hooks. The `waterside` anchor opts out of the #414 dry-ground filter
+# (without any terrain constraint), so (0,0) is covered even when it sits near
+# water — what we need to exercise the centre-chunk hooks regardless of seed.
 DENSE_YAML = "/tmp/loc_overlay_probe_dense.yaml"
 DENSE_BODY = (
     "locations:\n"
@@ -195,7 +208,7 @@ DENSE_BODY = (
     "    label: Small Ruin\n"
     "    type: ruin\n"
     "    builder: room_small\n"
-    "    anchor: []\n"
+    "    anchor: [waterside]\n"
     "    max_count: 100000\n"
     "    min_spacing: 1\n"
     "    contents: []\n"
@@ -280,14 +293,22 @@ def main() -> int:
         # geometry (engine dispatch -> stamper -> #88 builder). Doubles as
         # the on-land / anchor check.
         ocean_hits = []
+        wet = []
         for e in ruins:
             load_chunk(args.port, e["cx"], e["cy"])
             if is_ocean(args.port, e["gx"], e["gy"]):
                 ocean_hits.append(e)
+            w = footprint_water(args.port, e["gx"], e["gy"])
+            if w != "dry":
+                wet.append((e["cx"], e["cy"], w))
         if ruins and not ocean_hits:
             print(f"PASS: all {len(ruins)} ruin(s) on land (anchor [flat] respected)")
         elif ocean_hits:
             failures.append(f"{len(ocean_hits)} ruin(s) placed on ocean tiles")
+        if ruins and not wet:
+            print(f"PASS: all {len(ruins)} ruin footprint(s) clear of water (#414)")
+        elif wet:
+            failures.append(f"water in/near {len(wet)} ruin footprint(s): {wet[:3]}")
         n = wait_stamped(args.port, ruins)
         if ruins and n == len(ruins):
             print(f"PASS: lazy stamping materialized all {n} ruin(s) as their chunks loaded")


### PR DESCRIPTION
Closes #414

## Problem
A world-gen location could be placed right next to a lake/river/ocean shore. The footprint-flatten (#413) then carved the ground down to the lowest level, leaving the neighbouring water tile **overhanging the carved rim** — an "infinity pool". Root cause: the placement pass `computeLocationOverlay` only knew about the **ocean** (`oceanMap`/`oceanDist`); it was blind to **lakes and rivers** and had no "stay away from water" requirement, so a flat lakeside chunk passed the `[flat]` anchor.

## Fix
- `computeLocationOverlay` now also receives the world's **lakes + rivers** and rejects any candidate chunk that (or whose 8 neighbours) holds a lake or river, or that sits within one chunk of the ocean (`dryEnough`).
- A def can **opt back in** to water proximity via a `coast` / `coastal` / `waterside` anchor (`wantsWater`) — `coast`/`coastal` also constrain to the ocean shore, `waterside` just tolerates nearby water. Everything else (including `ruin_small`, anchor `[flat]`) stays dry.
- `World.Thread.Command.Init` threads `gtWorldLakes` / `gtWorldRivers` from the finalised timeline. The no-defs `--dump` path still short-circuits, so dumps are unaffected.

Conservative by design (chunk-granularity exclusion + neighbour margin); locations are sparse, so the dry requirement doesn't starve placement — they simply land on inland/dry chunks now.

## Tested
- **hspec** (`Test.Headless.WorldGen`): new spec "keeps locations clear of lakes, rivers, and the ocean shore (#414)" asserts every placement has `oceanDist >= 2` and no lake/river in its 3×3 chunk neighbourhood. Full suite **416/0**.
- **`--dump` byte-identical to master** (b61062cc) — the overlay short-circuits with no defs.
- **`tools/location_overlay_probe.py`**: new per-ruin footprint-fluid scan — `all 6 ruin footprint(s) clear of water (#414)`. All **10** checks pass. (The dense centre-chunk probe def now uses the `waterside` opt-out so the Init/Save/multiworld centre-chunk hooks still exercise `(0,0)` regardless of seed/water.)

Doesn't touch #415 (the wall z-layering bug), which is a separate render-order issue.