### PR TITLE
[locations][render] lift flora/veg in front of a structure wall over the whole wall (#418)

### DIFF
--- a/src/World/Render/Quads.hs
+++ b/src/World/Render/Quads.hs
@@ -20,7 +20,8 @@ import World.Fluids (FluidCell(..), FluidType(..))
 import World.Flora.Render (resolveFloraTexture)
 import World.Generate (chunkToGlobal, viewDepth)
 import World.Generate.Coordinates (globalToChunk)
-import World.Grid (gridToScreen, tileSideHeight, tileWidth)
+import World.Grid (gridToScreen, tileSideHeight, tileWidth, applyFacing)
+import Structure.Types (StructureSlot(..), spdGridZ)
 import World.Mine.Types (MineDesignation(..))
 import World.Construct.Types (ConstructDesignation(..), ConstructTarget(..))
 import World.Render.ViewBounds (ViewBounds, computeViewBounds, isTileVisible)
@@ -139,6 +140,44 @@ renderWorldQuads env worldState zoomAlpha snap = do
             Just lc' → Just (lcTerrainSurfaceMap lc')
             Nothing  → Nothing
 
+        -- #418: a flora/veg billboard sitting in front of a structure's FRONT
+        -- wall must draw over the WHOLE wall, not slice through the wall's
+        -- depth-sorted strips (#417). A single-depth sprite otherwise beats
+        -- the wall's back strips but loses its clamped south strips → the
+        -- "leaf over the wall / frond cut off" straddle. Here we find the
+        -- highest front-wall strip key the sprite at (gx,gy) is spatially IN
+        -- FRONT of, so the caller lifts the sprite's key just above it and it
+        -- clears the entire strip range as one unit. Returns Nothing when no
+        -- such wall is near (the sprite keeps its normal key).
+        --
+        -- The strip-key formula mirrors 'frontWallStrips'/'tieBreak' in
+        -- Structure.Render (SE 0.0006, SW 0.0005; the clamped south strip
+        -- anchors at the S vertex (wgx+1,wgy+1)) — keep them in sync. The
+        -- applyFacing depth test keeps it rotation-correct. Wall lookups cross
+        -- chunks; the per-chunk gate below keeps it free where there are none.
+        seTag = fromIntegral (fromEnum SWallSE) ∷ Word8
+        swTag = fromIntegral (fromEnum SWallSW) ∷ Word8
+        structureFrontWallClear gx gy =
+            let (fa, fb) = applyFacing facing gx gy
+                spriteDepth = fa + fb
+                wallKeyAt wgx wgy tag tieB = do
+                    let (cc, _) = globalToChunk wgx wgy
+                    lc' ← HM.lookup cc (wtdChunks tileData)
+                    spd ← HM.lookup (wgx, wgy, tag) (lcStructures lc')
+                    let (sa, sb) = applyFacing facing (wgx + 1) (wgy + 1)
+                        scDepth  = sa + sb
+                    if spriteDepth < scDepth   -- sprite is NOT fully in front
+                       then Nothing
+                       else Just (fromIntegral scDepth
+                                  + fromIntegral (spdGridZ spd - zSlice) * 0.001
+                                  + tieB)
+                cands = [ wallKeyAt (gx + dx) (gy + dy) tag tieB
+                        | dx ← [-2 .. 2], dy ← [-2 .. 2], (dx, dy) ≠ (0, 0)
+                        , (tag, tieB) ← [(seTag, 0.0006 ∷ Float), (swTag, 0.0005)] ]
+            in case [ k | Just k ← cands ] of
+                 [] → Nothing
+                 ks → Just (maximum ks)
+
         vb = computeViewBounds camera fbW fbH effectiveDepth
 
         visibleChunksWithOffset =
@@ -156,6 +195,19 @@ renderWorldQuads env worldState zoomAlpha snap = do
                 iceMap   = lcIceMap lc
                 chunkHasFluid = V.any isJust fluidMap
                 terrainSurfMap = lcTerrainSurfaceMap lc
+
+                -- #418: only pay the front-wall clearance lookup in chunks that
+                -- actually carry structures (rooms are localised — most chunks
+                -- have none, so this is a no-op there). A sprite whose own
+                -- chunk has structures gets lifted to sit fully in front of any
+                -- front wall it overlaps (structureFrontWallClear); everything
+                -- else is untouched.
+                chunkHasStructures = not (HM.null (lcStructures lc))
+                bump gx gy q
+                    | not chunkHasStructures = q
+                    | otherwise = case structureFrontWallClear gx gy of
+                        Just c  → q { sqSortKey = max (sqSortKey q) (c + 0.0001) }
+                        Nothing → q
 
                 !realQuads = V.ifoldl' (\acc idx col →
                         let lx = idx `mod` chunkSize
@@ -196,14 +248,14 @@ renderWorldQuads env worldState zoomAlpha snap = do
                                                    else Nothing
 
                                         in case vegQ of
-                                            Just vq → vq : tq : acc2
+                                            Just vq → bump gx gy vq : tq : acc2
                                             Nothing → tq : acc2
                                 ) acc [zLo .. zHi]
                     ) [] tileMap
                 -- Flora sprites
                 floraData = lcFlora lc
                 !floraQuads =
-                    [ fq
+                    [ bump gx gy fq
                     | inst ← fcdInstances floraData
                     , let tileX = fromIntegral (fiTileX inst)
                           tileY = fromIntegral (fiTileY inst)

--- a/src/World/Render/Quads.hs
+++ b/src/World/Render/Quads.hs
@@ -20,6 +20,7 @@ import World.Fluids (FluidCell(..), FluidType(..))
 import World.Flora.Render (resolveFloraTexture)
 import World.Generate (chunkToGlobal, viewDepth)
 import World.Generate.Coordinates (globalToChunk)
+import World.Chunk.Types (ChunkCoord(..))
 import World.Grid (gridToScreen, tileSideHeight, tileWidth, applyFacing)
 import Structure.Types (StructureSlot(..), spdGridZ)
 import World.Mine.Types (MineDesignation(..))
@@ -157,6 +158,14 @@ renderWorldQuads env worldState zoomAlpha snap = do
         -- chunks; the per-chunk gate below keeps it free where there are none.
         seTag = fromIntegral (fromEnum SWallSE) ∷ Word8
         swTag = fromIntegral (fromEnum SWallSW) ∷ Word8
+        -- Chunks that actually carry structures. A sprite is only considered
+        -- for the lift when its chunk is within ONE chunk of one of these, so
+        -- the check stays a no-op in structure-free areas — but, unlike a
+        -- same-chunk-only gate, it still fires for a sprite sitting across a
+        -- chunk seam from a wall on the next chunk (structureFrontWallClear
+        -- already resolves that wall cross-chunk).
+        structureChunkCoords =
+            [ lcCoord lc | lc ← chunks, not (HM.null (lcStructures lc)) ]
         structureFrontWallClear gx gy =
             let (fa, fb) = applyFacing facing gx gy
                 spriteDepth = fa + fb
@@ -196,15 +205,19 @@ renderWorldQuads env worldState zoomAlpha snap = do
                 chunkHasFluid = V.any isJust fluidMap
                 terrainSurfMap = lcTerrainSurfaceMap lc
 
-                -- #418: only pay the front-wall clearance lookup in chunks that
-                -- actually carry structures (rooms are localised — most chunks
-                -- have none, so this is a no-op there). A sprite whose own
-                -- chunk has structures gets lifted to sit fully in front of any
-                -- front wall it overlaps (structureFrontWallClear); everything
-                -- else is untouched.
-                chunkHasStructures = not (HM.null (lcStructures lc))
+                -- #418: only pay the front-wall clearance lookup in chunks at
+                -- or adjacent to one carrying structures (rooms are localised —
+                -- most chunks are nowhere near one, so this is a no-op there).
+                -- Adjacency (not same-chunk-only) is what lets a sprite across
+                -- a chunk seam from a wall still get lifted. A qualifying sprite
+                -- is raised to sit fully in front of any front wall it overlaps;
+                -- everything else is untouched.
+                ChunkCoord ccx ccy = coord
+                chunkNearStructures =
+                    any (\(ChunkCoord sx sy) → abs (sx - ccx) ≤ 1 ∧ abs (sy - ccy) ≤ 1)
+                        structureChunkCoords
                 bump gx gy q
-                    | not chunkHasStructures = q
+                    | not chunkNearStructures = q
                     | otherwise = case structureFrontWallClear gx gy of
                         Just c  → q { sqSortKey = max (sqSortKey q) (c + 0.0001) }
                         Nothing → q


### PR DESCRIPTION
## Problem

A flora/vegetation billboard sorts at its tile's **single** iso-depth, but #417 split front walls into 16 depth-sorted strips spanning `gx+gy+1 .. gx+gy+2`. A sprite on the tile just outside a front wall (depth `gx+gy+2`) therefore **beats the wall's back strips but loses its clamped south strips** — an exact 8/8 straddle: the sprite's canopy draws **over** the wall's back segment while the wall's front segment **cuts** the sprite. That's the "leaf over the wall / palm frond cut off" in the #418 screenshot. Pre-#417 the wall was one quad and the sprite sat cleanly behind it, so the strips regressed it.

## Numeric baseline (headless)

A sort-key model replicating the exact formulas (saved in scratchpad) confirms the mechanism deterministically:

```
scenario: SE wall on tile (0,0) z=1; flora/veg on diagonal-south tile (1,1) z=0; zSlice=20
  flora key = 1.98030
POST-#417 (16 strips): 8 strips draw OVER the flora, 8 draw UNDER it  ===> STRADDLE (the slice)
PRE-#417 (single wall quad): wall key 1.98160 > flora 1.98030 -> WALL over flora (cleanly BEHIND)
```

## Fix

A single billboard depth can't be *split*, but it **can be lifted as a unit**: when a sprite sits in front of a structure's front wall, raise its sort key just above that wall's highest strip key so it clears the **entire** strip range at once.

`renderWorldQuads` gains `structureFrontWallClear` — for a sprite at `(gx,gy)` it finds the highest `SWallSE`/`SWallSW` strip key it is spatially **in front of** (an `applyFacing` depth test, so it's rotation-correct; the strip-key formula mirrors `frontWallStrips`/`tieBreak` in `Structure.Render`), and the sprite's `sqSortKey` is lifted just above it. Gated per-chunk on the chunk actually carrying structures, so it's a **no-op everywhere else**. Sprites *behind* a wall, or with no wall near, are untouched. The same numeric model shows the 8/8 straddle collapses to "fully in front", and "behind"/"no wall" stay unchanged.

No signature changes to `FloraQuads`/`TileQuads` — the lift is a post-process on the emitted quad's sort key.

## Why not a depth buffer

Explored and rejected: a depth buffer needs a real per-pixel 3D depth, which a flat flora sprite's canopy/fronds don't have (they overhang neighbouring tiles), so it can't fix the overhang and mainly benefits future real-3D geometry. This is the entity-level ordering that actually addresses the symptom.

## Tested

- Numeric sort-key model — straddle → clean (both directions).
- `cabal build exe:synarchy` — clean compile + link.
- `python3 tools/location_overlay_probe.py` — 10/10 (structure data path intact).

**Render sort has no headless gate** — final confirmation is visual: a stamped room with flora at its south edge (the sapling should sit fully in front of the wall; the palm fronds should no longer be cut). Rotated views too, since the detection is rotation-aware but the wall *sprite* facing is a separate known limitation.

Closes #418