### PR TITLE
[docs] Fix stale `.claude/scripts` references in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Procedural world with geological simulation in `World/`:
 - Chunk-based with zoom-level LOD system (`World.Render.Zoom.*`, `World.ZoomMap`)
 
 ### Lua scripting
-`Engine.Scripting.Lua.*` provides a Lua API for game logic. Lua scripts live in `.claude/scripts/` (UI, menus, HUD, world management). The API modules in `Engine.Scripting.Lua.API.*` expose engine functionality to Lua.
+`Engine.Scripting.Lua.*` provides a Lua API for game logic. Lua scripts live in the repo-root `scripts/` directory (UI, menus, HUD, world management); `engine.loadScript` paths are relative to the repo root (e.g. `engine.loadScript("scripts/ui_manager.lua")`). The API modules in `Engine.Scripting.Lua.API.*` expose engine functionality to Lua.
 
 ### UI system
 `UI.*` handles focus management, text input, and UI rendering. UI layout and behavior is driven from Lua scripts.
@@ -115,7 +115,7 @@ Procedural world with geological simulation in `World/`:
 - `config/` — YAML config (keybinds, video settings)
 - `data/` — Game data YAML (materials, vegetation, flora, units)
 - `assets/` — Images and graphical resources
-- `.claude/scripts/` — Lua scripts for game logic
+- `scripts/` — Lua scripts for game logic
 
 ## Headless Mode & Debug Console
 


### PR DESCRIPTION
Closes #369

## Summary

CLAUDE.md pointed the Lua game scripts at `.claude/scripts/` in two places, but that directory does not exist. All 63 game `.lua` files live in the repo-root `scripts/` directory, and `engine.loadScript` resolves paths relative to the repo root — which is what the headless docs in the same file already assume. This fixes the two stale references so the file no longer contradicts itself, and adds a one-line note that `engine.loadScript` paths are repo-root-relative (with a concrete `scripts/ui_manager.lua` example).

## Changes

- **Lua scripting section**: `.claude/scripts/` → repo-root `scripts/`, plus a note on repo-root-relative `engine.loadScript` paths.
- **Project Layout section**: `.claude/scripts/` → `scripts/`.

## Tested

- Confirmed repo-root `scripts/` exists (63 `.lua` files) and `.claude/scripts/` does not.
- `grep -rn ".claude/scripts"` across the repo (CLAUDE.md, `docs/`, everything) now returns no matches.
- Verified the example path `scripts/ui_manager.lua` exists.

Docs-only change, single file, no build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)