### PR TITLE
[docs] Fix misnumbered algorithm-walkthrough comments

### DIFF
--- a/src/Engine/Loop/Frame.hs
+++ b/src/Engine/Loop/Frame.hs
@@ -136,7 +136,7 @@ drawFrame = do
             -- 6. Render UI
             (_uiBatches, uiLayeredBatches) ← renderUIPages
             
-            -- 6. Final merge: world + UI
+            -- 7. Final merge: world + UI
             let layeredBatches = Map.unionsWith (<>)
                     [worldLayeredBatches, uiLayeredBatches]
 

--- a/src/World/Hydrology/Simulation.hs
+++ b/src/World/Hydrology/Simulation.hs
@@ -621,7 +621,7 @@ simulateHydrology seed worldSize ageIdx grid climate =
         (filledElev, flowDirVec) = fillDepressions grid
 
         ---------------------------------------------------
-        -- Step 3: Flow accumulation
+        -- Step 2: Flow accumulation
         ---------------------------------------------------
         -- Sort indices by descending filled elevation using in-place
         -- vector sort. Much faster than list sort on 262K elements
@@ -671,7 +671,7 @@ simulateHydrology seed worldSize ageIdx grid climate =
             VU.unsafeFreeze mv
 
         ---------------------------------------------------
-        -- Step 4: Lakes
+        -- Step 3: Lakes
         ---------------------------------------------------
         -- Raw lake candidates — sorted deepest-first so large basins
         -- get priority during dedup (they "claim" more territory).
@@ -702,7 +702,7 @@ simulateHydrology seed worldSize ageIdx grid climate =
         dedupedLakes = dedupLakes worldSize lakes
 
         ---------------------------------------------------
-        -- Step 5: River sources
+        -- Step 4: River sources
         -- A cell is a headwater if:
         --   1. It's land
         --   2. It has accumulation >= riverThreshold


### PR DESCRIPTION
## Summary
- `Engine/Loop/Frame.hs`: `drawFrame` had two consecutive `-- 6.` comments (Render UI, Final merge). Renumbered the final merge to `-- 7.`.
- `World/Hydrology/Simulation.hs`: `simulateHydrology` labeled `fillDepressions` as Step 1 then jumped to Step 3 with no Step 2. Renumbered flow accumulation → Step 2, lakes → Step 3, river sources → Step 4, so the walkthrough is sequential.

Docs-only comment renumbering, no logic changes.

Closes #381

## Test plan
- [x] `cabal build lib:synarchy` — clean build, no warnings/errors introduced
- [x] `git diff` reviewed — confirms only comment text changed, no code touched