### PR TITLE
Location content spawning: units, items, buildings, structures, loot tables (#90)

### DIFF
--- a/data/locations/ruin_small.yaml
+++ b/data/locations/ruin_small.yaml
@@ -6,8 +6,8 @@
 # LocationDef; the `builder` names a Lua function in scripts/locations.lua
 # that authors the geometry when the location is stamped.
 #
-# `contents` ids are NOT validated or resolved in this issue (#88) — the
-# content-spawning pass (#90) resolves them at spawn time.
+# `contents` ids are resolved at spawn time (#90), not here — an unknown
+# id or kind logs a warning and is skipped rather than crashing.
 locations:
   - id: ruin_small
     label: "Small Ruin"
@@ -24,6 +24,11 @@ locations:
     # optional (defaults: max_count 4, min_spacing 4).
     max_count: 6
     min_spacing: 5
-    # Reference content entry (raw ids, resolved later in #90).
+    # Content spawned once, the first time this location's chunk loads
+    # (#90). Fixed-position entries land at that exact anchor offset;
+    # entries without `position` scatter randomly within the room.
     contents:
-      - { kind: building, id: cargo_hold_S, count: 1 }
+      - { kind: building, id: cargo_hold_S, count: 1, position: {x: 0, y: 0} }
+      - { kind: unit, id: acolyte, count: 1, faction: hostile, position: {x: 1, y: 1} }
+      - { kind: item, id: rations, count: 1, position: {x: -1, y: 1} }
+      - { kind: loot_table, id: ruin_common, rolls: 2 }

--- a/data/loot_tables/ruin_common.yaml
+++ b/data/loot_tables/ruin_common.yaml
@@ -1,0 +1,14 @@
+# Reference loot table (#90): common scavenge finds in a ruin. One
+# file IS one table — no wrapping list, unlike locations/items/units.
+#
+# `weight` is relative, not a percentage: rations is 3x as likely to
+# roll as steel_dagger. A `loot_table` location content entry rolls
+# this `rolls` times and spawns each result as a ground item.
+id: ruin_common
+entries:
+  - id: rations
+    weight: 3
+  - id: first_aid_kit
+    weight: 2
+  - id: steel_dagger
+    weight: 1

--- a/scripts/location_stamper.lua
+++ b/scripts/location_stamper.lua
@@ -21,6 +21,13 @@
 -- (locations.stamp -> the #88 builder -> world.getTerrainAt(gx,gy,pageId)),
 -- so a location materializes on its own page even when that page is hidden /
 -- not the active one — there is no active-page gate here.
+--
+-- Content spawning (#90): spawnContents is called EVERY time, regardless
+-- of whether stamp() ran this call — it has its own persisted one-time
+-- flag (world.hasSpawnedLocationContents), independent of structure.hasAt.
+-- A geometry-only skip does not imply contents already spawned: a
+-- floor-less location type never satisfies structure.hasAt, and a player
+-- demolishing the floor would otherwise re-trigger a full re-stamp.
 
 local stamper = {}
 
@@ -34,8 +41,10 @@ function stamper.onStampLocation(pageId, locId, gx, gy)
     -- The pageId is essential: without it the check resolves to the active
     -- world, so unrelated geometry there could suppress a valid stamp on a
     -- hidden secondary page.
-    if structure.hasAt(gx, gy, "floor", pageId) then return end
-    locations.stamp(locId, gx, gy, pageId)
+    if not structure.hasAt(gx, gy, "floor", pageId) then
+        locations.stamp(locId, gx, gy, pageId)
+    end
+    locations.spawnContents(locId, gx, gy, pageId)
 end
 
 return stamper

--- a/scripts/locations.lua
+++ b/scripts/locations.lua
@@ -324,30 +324,30 @@ end
 local function spawnLootTableContent(def, entry, gx, gy, worldId)
     for _ = 1, (entry.rolls or 1) do
         local itemId = loot.roll(entry.id)
-        if itemId then
-            local ox, oy = contentOffset(def, entry)
-            item.spawnGround(itemId, gx + ox, gy + oy, nil, worldId)
-        else
+        if not itemId then
             engine.logWarn("locations: unknown loot table '" ..
                 tostring(entry.id) .. "'")
+        else
+            local ox, oy = contentOffset(def, entry)
+            local gid = item.spawnGround(itemId, gx + ox, gy + oy, nil, worldId)
+            if not gid then
+                engine.logWarn("locations: loot table '" .. tostring(entry.id) ..
+                    "' rolled unknown item id '" .. tostring(itemId) .. "'")
+            end
         end
     end
 end
 
--- NB building.spawn does NOT take a pageId (it validates occupancy
--- against the snapshot of the VISIBLE worlds, not a named page) — a
--- building content entry only spawns correctly when its location's
--- page is the active/visible one. Pre-existing engine limitation, not
--- new to #90; a hidden-page location with building content logs the
--- "unknown/unplaceable" warning below instead of spawning.
+-- building.spawn takes an explicit pageId (#90) so this validates
+-- occupancy/terrain-Z against — and spawns onto — the location's own
+-- page, same as unit.spawn / item.spawnGround / structure.place.
 local function spawnBuildingContent(def, entry, gx, gy, worldId)
     for _ = 1, (entry.count or 1) do
         local ox, oy = contentOffset(def, entry)
-        local bid = building.spawn(entry.id, gx + ox, gy + oy)
+        local bid = building.spawn(entry.id, gx + ox, gy + oy, worldId)
         if not bid then
             engine.logWarn("locations: building content '" ..
-                tostring(entry.id) .. "' failed to spawn " ..
-                "(unknown id, unplaceable, or not on the active page)")
+                tostring(entry.id) .. "' failed to spawn (unknown id or unplaceable)")
         end
     end
 end

--- a/scripts/locations.lua
+++ b/scripts/locations.lua
@@ -14,6 +14,14 @@
 -- terrain primitives below. Definitions are now data-driven: they come
 -- from data/locations/*.yaml, loaded at boot via engine.loadLocationYaml
 -- and read back through engine.listLocationDefs (#88).
+--
+-- Content spawning (#90): scripts/location_stamper.lua calls
+-- locations.spawnContents(id, gx, gy, worldId) once per chunk load,
+-- independent of whether the geometry was (re)built this call. It
+-- dispatches each `contents` entry to unit.spawn / item.spawnGround /
+-- building.spawn / loot.roll / a builder (for nested "structure"
+-- content), gated by its own one-time engine flag
+-- (world.hasSpawnedLocationContents) so contents are never re-spawned.
 
 local locations = {}
 
@@ -158,10 +166,10 @@ end
 -----------------------------------------------------------
 -- Builders
 -----------------------------------------------------------
--- One function per location id. Authored on top of the primitives
--- above + content spawns (building.spawn / item.spawnGround /
--- unit.spawn). Anchor is the clicked tile (gx, gy); the builder decides
--- how the structure is laid out relative to it.
+-- One function per location id, authored on top of the primitives
+-- above. Anchor is the clicked tile (gx, gy); the builder decides how
+-- the structure is laid out relative to it. Content spawning (#90) is
+-- a separate concern — see locations.spawnContents below.
 
 local builders = {}
 
@@ -252,6 +260,146 @@ end
 -- `worldId`. The debug-overlay entry point (it knows the page).
 function locations.stamp(id, gx, gy, worldId)
     return buildAt(id, gx, gy, worldId)
+end
+
+-----------------------------------------------------------
+-- Content spawning (#90)
+-----------------------------------------------------------
+-- Each LocationDef.contents entry (see data/locations/*.yaml):
+--   { kind, id, count, rolls, position = {x,y} | nil, faction | nil }
+-- `position` is a fixed offset from the anchor; when absent the entry
+-- scatters randomly within the location's footprint instead (a fresh
+-- roll per instance). `count` is how many to place ("loot_table" uses
+-- `rolls` instead — how many times to roll the table). `faction` is
+-- unit-only and defaults to "hostile".
+--
+-- Called once per chunk load by scripts/location_stamper.lua,
+-- regardless of whether the geometry was (re)built this call — gated
+-- by its OWN one-time engine flag (world.hasSpawnedLocationContents),
+-- independent of the structure.hasAt check that gates re-stamping.
+-- That independence matters: a floor-less location type would
+-- otherwise re-run every load, and a player demolishing the floor
+-- would otherwise re-trigger every content spawn too.
+
+-- Scatter radius (tiles from anchor), keyed by LocationDef.builder,
+-- for content entries that omit `position`. Add an entry here for
+-- each new builder's footprint; unknown builders fall back to the
+-- default.
+local FOOTPRINT_RADIUS = { room_small = ROOM_SMALL_RADIUS }
+local DEFAULT_FOOTPRINT_RADIUS = 2
+
+local function contentOffset(def, entry)
+    if entry.position then
+        return entry.position.x or 0, entry.position.y or 0
+    end
+    local r = FOOTPRINT_RADIUS[def.builder] or DEFAULT_FOOTPRINT_RADIUS
+    return math.random(-r, r), math.random(-r, r)
+end
+
+local function spawnUnitContent(def, entry, gx, gy, worldId)
+    local faction = entry.faction or "hostile"
+    for _ = 1, (entry.count or 1) do
+        local ox, oy = contentOffset(def, entry)
+        local uid = unit.spawn(entry.id, gx + ox, gy + oy, nil, faction, worldId)
+        if uid == -1 then
+            engine.logWarn("locations: unknown unit content '" ..
+                tostring(entry.id) .. "'")
+        end
+    end
+end
+
+-- NB item.spawnGround takes an explicit pageId (#90) so this works on
+-- a hidden secondary page, same as unit.spawn / structure.place.
+local function spawnItemContent(def, entry, gx, gy, worldId)
+    for _ = 1, (entry.count or 1) do
+        local ox, oy = contentOffset(def, entry)
+        local gid = item.spawnGround(entry.id, gx + ox, gy + oy, nil, worldId)
+        if not gid then
+            engine.logWarn("locations: unknown item content '" ..
+                tostring(entry.id) .. "'")
+        end
+    end
+end
+
+local function spawnLootTableContent(def, entry, gx, gy, worldId)
+    for _ = 1, (entry.rolls or 1) do
+        local itemId = loot.roll(entry.id)
+        if itemId then
+            local ox, oy = contentOffset(def, entry)
+            item.spawnGround(itemId, gx + ox, gy + oy, nil, worldId)
+        else
+            engine.logWarn("locations: unknown loot table '" ..
+                tostring(entry.id) .. "'")
+        end
+    end
+end
+
+-- NB building.spawn does NOT take a pageId (it validates occupancy
+-- against the snapshot of the VISIBLE worlds, not a named page) — a
+-- building content entry only spawns correctly when its location's
+-- page is the active/visible one. Pre-existing engine limitation, not
+-- new to #90; a hidden-page location with building content logs the
+-- "unknown/unplaceable" warning below instead of spawning.
+local function spawnBuildingContent(def, entry, gx, gy, worldId)
+    for _ = 1, (entry.count or 1) do
+        local ox, oy = contentOffset(def, entry)
+        local bid = building.spawn(entry.id, gx + ox, gy + oy)
+        if not bid then
+            engine.logWarn("locations: building content '" ..
+                tostring(entry.id) .. "' failed to spawn " ..
+                "(unknown id, unplaceable, or not on the active page)")
+        end
+    end
+end
+
+-- A "structure" content entry nests another builder's geometry at an
+-- offset from the anchor — `id` names a scripts.locations builder
+-- (the same names LocationDef.builder uses), not a location id.
+local function spawnStructureContent(def, entry, gx, gy, worldId)
+    local b = builders[entry.id]
+    if not b then
+        engine.logWarn("locations: content structure names unknown builder '" ..
+            tostring(entry.id) .. "'")
+        return
+    end
+    local ox, oy = contentOffset(def, entry)
+    b(worldId, gx + ox, gy + oy)
+end
+
+local function dispatchContent(def, entry, gx, gy, worldId)
+    local kind = entry.kind
+    if kind == "unit" then
+        spawnUnitContent(def, entry, gx, gy, worldId)
+    elseif kind == "item" then
+        spawnItemContent(def, entry, gx, gy, worldId)
+    elseif kind == "loot_table" then
+        spawnLootTableContent(def, entry, gx, gy, worldId)
+    elseif kind == "building" then
+        spawnBuildingContent(def, entry, gx, gy, worldId)
+    elseif kind == "structure" then
+        spawnStructureContent(def, entry, gx, gy, worldId)
+    else
+        engine.logWarn("locations: unknown content kind '" ..
+            tostring(kind) .. "'")
+    end
+end
+
+-- Spawn location `id`'s contents, anchored at (gx, gy) on page
+-- `worldId` — once, ever, for this chunk. Safe to call on every chunk
+-- load: a no-op once world.hasSpawnedLocationContents is true.
+function locations.spawnContents(id, gx, gy, worldId)
+    gx, gy = math.floor(gx), math.floor(gy)
+    if world.hasSpawnedLocationContents(gx, gy, worldId) then return end
+    local def = locations.getDef(id)
+    if def then
+        for _, entry in ipairs(def.contents or {}) do
+            dispatchContent(def, entry, gx, gy, worldId)
+        end
+    else
+        engine.logWarn("locations: unknown location '" .. tostring(id) ..
+            "' (content spawn)")
+    end
+    world.markLocationContentsSpawned(gx, gy, worldId)
 end
 
 return locations

--- a/scripts/startup_loader.lua
+++ b/scripts/startup_loader.lua
@@ -148,8 +148,9 @@ local function queueNormalProfile()
     addYamlDir("data/equipment",  "Loading equipment...",  engine.loadEquipmentYaml)
     addYamlDir("data/buildings",  "Loading buildings...",  engine.loadBuildingYaml)
     addYamlDir("data/units",      "Loading units...",      engine.loadUnitYaml)
-    -- Locations load LAST (their content ids reference the registries
-    -- above; cross-registry resolution lands in #90).
+    addYamlDir("data/loot_tables", "Loading loot tables...", engine.loadLootTableYaml)
+    -- Locations load LAST (their content ids, incl. loot_table ids,
+    -- reference the registries above; resolved at spawn time, #90).
     addYamlDir("data/locations",  "Loading locations...",  engine.loadLocationYaml)
 
     -- Texture-only phases.
@@ -173,6 +174,7 @@ local function queueArenaProfile()
     addYamlDir("data/equipment",  "Loading equipment...",  engine.loadEquipmentYaml)
     addYamlDir("data/buildings",  "Loading buildings...",  engine.loadBuildingYaml)
     addYamlDir("data/units",      "Loading units...",      engine.loadUnitYaml)
+    addYamlDir("data/loot_tables", "Loading loot tables...", engine.loadLootTableYaml)
     addYamlDir("data/locations",  "Loading locations...",  engine.loadLocationYaml)
 end
 

--- a/src/Engine/Asset/YamlLocations.hs
+++ b/src/Engine/Asset/YamlLocations.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE Strict, UnicodeSyntax, DeriveGeneric, OverloadedStrings #-}
 module Engine.Asset.YamlLocations
-    ( LocationYamlContent(..)
+    ( LocationYamlPosition(..)
+    , LocationYamlContent(..)
     , LocationYamlDef(..)
     , LocationYamlFile(..)
     , loadLocationYaml
@@ -13,18 +14,37 @@ import qualified Data.Yaml as Yaml
 import Data.Aeson (FromJSON(..), (.:), (.:?), (.!=), withObject)
 import Engine.Core.Log (LoggerState, logDebug, logWarn, LogCategory(..))
 
--- | One `{kind, id, count}` content entry. `count` defaults to 1.
+-- | A fixed relative tile offset from a location's anchor (#90).
+data LocationYamlPosition = LocationYamlPosition
+    { lypX ∷ !Int
+    , lypY ∷ !Int
+    } deriving (Show, Eq, Generic)
+
+instance FromJSON LocationYamlPosition where
+    parseJSON = withObject "LocationYamlPosition" $ \v → LocationYamlPosition
+        ⊚ v .:? "x" .!= 0
+        ⊛ v .:? "y" .!= 0
+
+-- | One `{kind, id, count, position, faction, rolls}` content entry.
+--   `count` defaults to 1; `position`/`faction`/`rolls` are all
+--   optional (#90) — see 'Location.Types.LocationContent'.
 data LocationYamlContent = LocationYamlContent
-    { lycKind  ∷ !Text
-    , lycId    ∷ !Text
-    , lycCount ∷ !Int
+    { lycKind     ∷ !Text
+    , lycId       ∷ !Text
+    , lycCount    ∷ !Int
+    , lycPosition ∷ !(Maybe LocationYamlPosition)
+    , lycFaction  ∷ !(Maybe Text)
+    , lycRolls    ∷ !Int
     } deriving (Show, Eq, Generic)
 
 instance FromJSON LocationYamlContent where
     parseJSON = withObject "LocationYamlContent" $ \v → LocationYamlContent
         ⊚ v .:  "kind"
         ⊛ v .:  "id"
-        ⊛ v .:? "count" .!= 1
+        ⊛ v .:? "count"    .!= 1
+        ⊛ v .:? "position"
+        ⊛ v .:? "faction"
+        ⊛ v .:? "rolls"    .!= 1
 
 -- | The YAML shape of a location definition. Converted to
 --   'Location.Types.LocationDef' by the API loader.

--- a/src/Engine/Asset/YamlLootTables.hs
+++ b/src/Engine/Asset/YamlLootTables.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE Strict, UnicodeSyntax, DeriveGeneric, OverloadedStrings #-}
+module Engine.Asset.YamlLootTables
+    ( LootTableYamlEntry(..)
+    , LootTableYamlDef(..)
+    , loadLootTableYaml
+    ) where
+
+import UPrelude
+import GHC.Generics (Generic)
+import qualified Data.Text as T
+import qualified Data.Yaml as Yaml
+import Data.Aeson (FromJSON(..), (.:), withObject)
+import Engine.Core.Log (LoggerState, logDebug, logWarn, LogCategory(..))
+
+-- | One `{id, weight}` loot table entry.
+data LootTableYamlEntry = LootTableYamlEntry
+    { ltyeId     ∷ !Text
+    , ltyeWeight ∷ !Float
+    } deriving (Show, Eq, Generic)
+
+instance FromJSON LootTableYamlEntry where
+    parseJSON = withObject "LootTableYamlEntry" $ \v → LootTableYamlEntry
+        ⊚ v .: "id"
+        ⊛ v .: "weight"
+
+-- | The YAML shape of a loot table def. Unlike locations/items/units,
+--   one file IS one def — no wrapping list — so the top-level document
+--   parses directly into this type.
+data LootTableYamlDef = LootTableYamlDef
+    { ltydId      ∷ !Text
+    , ltydEntries ∷ ![LootTableYamlEntry]
+    } deriving (Show, Eq, Generic)
+
+instance FromJSON LootTableYamlDef where
+    parseJSON = withObject "LootTableYamlDef" $ \v → LootTableYamlDef
+        ⊚ v .: "id"
+        ⊛ v .: "entries"
+
+-- | Parse one loot table YAML file. Returns 'Nothing' (with a logged
+--   warning) on a parse failure — mirrors 'loadLocationYaml', except
+--   there is only ever at most one def per file.
+loadLootTableYaml ∷ LoggerState → FilePath → IO (Maybe LootTableYamlDef)
+loadLootTableYaml logger path = do
+    result ← Yaml.decodeFileEither path
+    case result of
+        Left err → do
+            logWarn logger CatAsset $ "Failed to parse loot table YAML "
+                <> T.pack path <> ": " <> T.pack (show err)
+            return Nothing
+        Right def → do
+            logDebug logger CatAsset $ "Loaded loot table '"
+                <> ltydId def <> "' from " <> T.pack path
+            return (Just def)

--- a/src/Engine/Core/Init.hs
+++ b/src/Engine/Core/Init.hs
@@ -48,6 +48,7 @@ import Equipment.Types (emptyEquipmentClassManager)
 import Substance.Types (emptySubstanceManager)
 import Infection.Types (emptyInfectionManager)
 import Location.Types (emptyLocationRegistry)
+import LootTable.Types (emptyLootTableRegistry)
 import World.Types (WorldCommand, emptyWorldManager, emptyFloraCatalog)
 import World.Material (emptyMaterialRegistry)
 import World.Generate.Config (loadWorldGenConfig)
@@ -151,6 +152,7 @@ initializeEngineWith logBackend = do
   substanceManagerRef ← newIORef emptySubstanceManager
   infectionManagerRef ← newIORef emptyInfectionManager
   locationDefsRef ← newIORef emptyLocationRegistry
+  lootTableRegistryRef ← newIORef emptyLootTableRegistry
   -- Player Events: load the notification registry (data/) merged
   -- with player overrides (config/), allocate the ring buffer and
   -- popup queue. Both TVars are multi-writer (world/unit/Lua threads
@@ -229,6 +231,7 @@ initializeEngineWith logBackend = do
         , substanceManagerRef      = substanceManagerRef
         , infectionManagerRef      = infectionManagerRef
         , locationDefsRef    = locationDefsRef
+        , lootTableRegistryRef = lootTableRegistryRef
         , eventStoreRef      = eventStoreRef
         , notificationCfgRef = notificationCfgRef
         , notificationOrder  = notificationOrder

--- a/src/Engine/Core/State.hs
+++ b/src/Engine/Core/State.hs
@@ -54,6 +54,7 @@ import Equipment.Types (EquipmentClassManager)
 import Substance.Types (SubstanceManager)
 import Infection.Types (InfectionManager)
 import Location.Types (LocationRegistry)
+import LootTable.Types (LootTableRegistry)
 import World.Types (WorldCommand, WorldManager, FloraCatalog
                    , WorldState, WorldPageId, wmWorlds, wmVisible)
 import World.Material (MaterialRegistry)
@@ -233,6 +234,11 @@ data EngineEnv = EngineEnv
     --   units / buildings. Read back by the `locations` Lua module
     --   (locations.listDefs / getDef / build). Pure data — content ids
     --   are resolved at spawn time by the world-gen overlay (#89/#90).
+  , lootTableRegistryRef ∷ IORef LootTableRegistry
+    -- ^ Registry of loot tables loaded from data/loot_tables/*.yaml at
+    --   boot. Rolled by `loot.roll` (Lua), which a `loot_table`
+    --   location content entry calls to resolve item ids at spawn
+    --   time (#90).
   , eventStoreRef      ∷ TVar (Seq PlayerEvent)
     -- ^ Ring buffer of player-facing events (~1000 entries; oldest
     --   dropped). Per-session only — not serialized to save files.

--- a/src/Engine/Scripting/Lua/API.hs
+++ b/src/Engine/Scripting/Lua/API.hs
@@ -62,6 +62,7 @@ import Engine.Scripting.Lua.API.Equipment
 import Engine.Scripting.Lua.API.Substance
 import Engine.Scripting.Lua.API.Infection
 import Engine.Scripting.Lua.API.Locations
+import Engine.Scripting.Lua.API.LootTables
 import Engine.Scripting.Lua.API.Flora
 import Engine.Scripting.Lua.API.UI
 import Engine.Core.State (EngineEnv)
@@ -174,6 +175,7 @@ registerLuaAPI lst env backendState = Lua.runWith lst $ do
   registerLuaFunction "loadInfectionYaml" (loadInfectionYamlFn env)
   registerLuaFunction "loadLocationYaml" (loadLocationYamlFn env)
   registerLuaFunction "listLocationDefs" (locationListDefsFn env)
+  registerLuaFunction "loadLootTableYaml" (loadLootTableYamlFn env)
   
   registerLuaFunction "isKeyDown"         (isKeyDownFn backendState)
   registerLuaFunction "isActionDown"      (isActionDownFn env backendState)
@@ -477,6 +479,13 @@ registerLuaAPI lst env backendState = Lua.runWith lst $ do
   registerLuaFunction "getNames" (infectionGetNamesFn env)
   Lua.setglobal (Lua.Name "infection")
 
+  -- Loot table global — weighted rolls against data/loot_tables/*.yaml
+  -- (loaded via engine.loadLootTableYaml). Consumed by a `loot_table`
+  -- location content entry (#90).
+  Lua.newtable
+  registerLuaFunction "roll" (lootRollFn env)
+  Lua.setglobal (Lua.Name "loot")
+
   Lua.newtable
   registerLuaFunction "listDefs"     (itemListDefsFn env)
   registerLuaFunction "spawnGround"  (itemSpawnGroundFn env)
@@ -572,6 +581,10 @@ registerLuaAPI lst env backendState = Lua.runWith lst $ do
   registerLuaFunction "getClimateAt" (worldGetClimateAtFn env)
   registerLuaFunction "getAmbientAt" (worldGetAmbientAtFn env)
   registerLuaFunction "listPlacedLocations" (worldListPlacedLocationsFn env)
+  registerLuaFunction "hasSpawnedLocationContents"
+    (worldHasSpawnedLocationContentsFn env)
+  registerLuaFunction "markLocationContentsSpawned"
+    (worldMarkLocationContentsSpawnedFn env)
 
   Lua.setglobal (Lua.Name "world")
 

--- a/src/Engine/Scripting/Lua/API/Buildings.hs
+++ b/src/Engine/Scripting/Lua/API/Buildings.hs
@@ -163,15 +163,21 @@ loadBuildingYamlFn env backendState = do
 
 -- * Spawn / destroy
 
--- | building.spawn(defName, gx, gy) — returns the new building id on
---   success, nil otherwise (unknown def, placement invalid). Placement
---   is validated server-side too so Lua scripts can't accidentally
---   place into water etc.
+-- | building.spawn(defName, gx, gy [, pageId]) — returns the new
+--   building id on success, nil otherwise (unknown def, placement
+--   invalid). Placement is validated server-side too so Lua scripts
+--   can't accidentally place into water etc. An explicit pageId (slot
+--   4) pins the spawn — AND the occupancy/terrain-Z check — to that
+--   live page (even hidden) instead of the active world: location
+--   content-spawning (#90) passes its own page so a building lands (and
+--   validates) on the page its location is on, not whichever happens to
+--   be visible. Omitted → the active world, as before (#76).
 buildingSpawnFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 buildingSpawnFn env = do
     nameArg ← Lua.tostring 1
     xArg    ← Lua.tointeger 2
     yArg    ← Lua.tointeger 3
+    pageArg ← Lua.tostring 4
     case (nameArg, xArg, yArg) of
         (Just nameBS, Just x, Just y) → do
             let defName = TE.decodeUtf8 nameBS
@@ -179,27 +185,29 @@ buildingSpawnFn env = do
                 gy      = fromIntegral y
             mBid ← Lua.liftIO $ do
                 bm ← readIORef (buildingManagerRef env)
-                mActive ← activeWorldPage env
-                case (HM.lookup defName (bmDefs bm), mActive) of
-                    (Just def, Just (pid, _)) → do
-                        mWtd ← snapshotVisibleWorldTiles env
-                        case mWtd of
-                            Nothing  → pure Nothing
-                            -- Occupancy scoped to the active world (#76).
-                            Just wtd → case canPlaceAt
-                                    (bm { bmInstances =
-                                            buildingsOnPage pid (bmInstances bm) })
-                                    wtd def gx gy of
-                                NotPlaceable _ → pure Nothing
-                                Placeable → do
-                                    let gz = floorZAt wtd gx gy
-                                    bid ← atomicModifyIORef'
-                                            (buildingManagerRef env) $ \bm' →
-                                                let (bid', bm'') = nextBuildingId bm'
-                                                in (bm'', bid')
-                                    Q.writeQueue (buildingQueue env) $
-                                        BuildingSpawn bid defName gx gy gz pid
-                                    pure (Just bid)
+                mTarget ← case pageArg of
+                    Just pidBS → do
+                        let pid = WorldPageId (TE.decodeUtf8 pidBS)
+                        wm ← readIORef (worldManagerRef env)
+                        pure $ (\ws → (pid, ws)) <$> lookup pid (wmWorlds wm)
+                    Nothing → activeWorldPage env
+                case (HM.lookup defName (bmDefs bm), mTarget) of
+                    (Just def, Just (pid, ws)) → do
+                        wtd ← readIORef (wsTilesRef ws)
+                        case canPlaceAt
+                                (bm { bmInstances =
+                                        buildingsOnPage pid (bmInstances bm) })
+                                wtd def gx gy of
+                            NotPlaceable _ → pure Nothing
+                            Placeable → do
+                                let gz = floorZAt wtd gx gy
+                                bid ← atomicModifyIORef'
+                                        (buildingManagerRef env) $ \bm' →
+                                            let (bid', bm'') = nextBuildingId bm'
+                                            in (bm'', bid')
+                                Q.writeQueue (buildingQueue env) $
+                                    BuildingSpawn bid defName gx gy gz pid
+                                pure (Just bid)
                     _ → pure Nothing
             case mBid of
                 Just (BuildingId n) → do

--- a/src/Engine/Scripting/Lua/API/Items.hs
+++ b/src/Engine/Scripting/Lua/API/Items.hs
@@ -41,7 +41,7 @@ import Engine.Graphics.Vulkan.Types.Vertex (Vertex(..), Vec2(..))
 import Engine.Scene.Types (SortableQuad(..))
 import World.Render.GroundItemQuads (hitTestGroundItemAt
                                     , renderGroundItemQuads)
-import World.Types (WorldManager(..), WorldState(..))
+import World.Types (WorldManager(..), WorldState(..), WorldPageId(..), wmWorlds)
 
 -- | If the preferred path doesn't exist on disk, swap in the equipment
 --   missing-texture placeholder so loadAndRegister has *something* to
@@ -197,6 +197,18 @@ loadItemYamlFn env backendState = do
 activeWorld ∷ EngineEnv → IO (Maybe WorldState)
 activeWorld = activeWorldState
 
+-- | Resolve which world page a ground-item op targets: a named page
+--   (any in wmWorlds, even hidden / non-active) when a page-id is
+--   given, else the active world. Location content-spawning (#90)
+--   passes the page id so an item spawned into a hidden secondary
+--   page's location lands on THAT page — mirrors
+--   'Engine.Scripting.Lua.API.Structure.resolveStructurePage'.
+resolveItemPage ∷ EngineEnv → Maybe Text → IO (Maybe WorldState)
+resolveItemPage env (Just pid) = do
+    mgr ← readIORef (worldManagerRef env)
+    pure $ lookup (WorldPageId pid) (wmWorlds mgr)
+resolveItemPage env Nothing = activeWorld env
+
 -- | item.listDefs() → array of {name, displayName, category, weight}
 --   Sorted by name for a stable debug-overlay listing.
 itemListDefsFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
@@ -217,18 +229,22 @@ itemListDefsFn env = do
         Lua.rawseti (Lua.nth 2) (fromIntegral i)
     return 1
 
--- | item.spawnGround(defName, x, y [, props]) → gid | nil
+-- | item.spawnGround(defName, x, y [, props] [, pageId]) → gid | nil
 --   Spawns an item into the world at float tile coords. Optional
 --   props table: fill, quality, condition (defaults 0/100/100).
 --   Resting height derives from terrain at render time, so items on
 --   slopes sit on the incline and items over dug tiles drop with
---   the terrain.
+--   the terrain. An explicit pageId (slot 5) pins the spawn to that
+--   live page (even hidden) instead of the active world — location
+--   content-spawning (#90) passes its own page so an item lands on
+--   the page its location is on.
 itemSpawnGroundFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 itemSpawnGroundFn env = do
     nameArg ← Lua.tostring 1
     xArg ← Lua.tonumber 2
     yArg ← Lua.tonumber 3
     propsTy ← Lua.ltype 4
+    pageArg ← Lua.tostring 5
     let getProp ∷ Lua.Name → Float → Lua.LuaE Lua.Exception Float
         getProp key def = case propsTy of
             Lua.TypeTable → do
@@ -246,7 +262,7 @@ itemSpawnGroundFn env = do
         (Just nameBS, Just x, Just y) → do
             let name = TE.decodeUtf8 nameBS
             im ← Lua.liftIO $ readIORef (itemManagerRef env)
-            mWs ← Lua.liftIO $ activeWorld env
+            mWs ← Lua.liftIO $ resolveItemPage env (TE.decodeUtf8 <$> pageArg)
             case (HM.lookup name (imDefs im), mWs) of
                 (Just iDef, Just ws) → do
                     wght ← Lua.liftIO $

--- a/src/Engine/Scripting/Lua/API/Locations.hs
+++ b/src/Engine/Scripting/Lua/API/Locations.hs
@@ -56,16 +56,23 @@ loadLocationYamlFn env = do
             return 1
   where
     toContent c = LocationContent
-        { lconKind  = lycKind c
-        , lconId    = lycId c
-        , lconCount = lycCount c
+        { lconKind     = lycKind c
+        , lconId       = lycId c
+        , lconCount    = lycCount c
+        , lconPosition = (\p → (lypX p, lypY p)) ⊚ lycPosition c
+        , lconFaction  = lycFaction c
+        , lconRolls    = lycRolls c
         }
 
 -- | engine.listLocationDefs() → array of location def tables, in
 --   registration order. Each entry:
 --     { id, label, type, builder,
 --       anchor   = { tag, … },
---       contents = { { kind, id, count }, … } }
+--       contents = { { kind, id, count, rolls,
+--                      position = {x,y} | nil,
+--                      faction  = string | nil }, … } }
+--   `position` / `faction` fields are OMITTED (not set to a Lua nil
+--   value) when absent, so `entry.position` reads as nil either way.
 --   The Lua `locations` module wraps this as locations.listDefs().
 locationListDefsFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 locationListDefsFn env = do
@@ -97,6 +104,22 @@ locationListDefsFn env = do
             Lua.setfield (-2) "id"
             Lua.pushinteger (fromIntegral (lconCount c))
             Lua.setfield (-2) "count"
+            Lua.pushinteger (fromIntegral (lconRolls c))
+            Lua.setfield (-2) "rolls"
+            case lconPosition c of
+                Just (px, py) → do
+                    Lua.newtable
+                    Lua.pushinteger (fromIntegral px)
+                    Lua.setfield (-2) "x"
+                    Lua.pushinteger (fromIntegral py)
+                    Lua.setfield (-2) "y"
+                    Lua.setfield (-2) "position"
+                Nothing → return ()
+            case lconFaction c of
+                Just fac → do
+                    Lua.pushstring (TE.encodeUtf8 fac)
+                    Lua.setfield (-2) "faction"
+                Nothing → return ()
             Lua.rawseti (-2) j
         Lua.setfield (-2) "contents"
         Lua.rawseti (-2) i

--- a/src/Engine/Scripting/Lua/API/LootTables.hs
+++ b/src/Engine/Scripting/Lua/API/LootTables.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE Strict, UnicodeSyntax, OverloadedStrings #-}
+module Engine.Scripting.Lua.API.LootTables
+    ( loadLootTableYamlFn
+    , lootRollFn
+    ) where
+
+import UPrelude
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified HsLua as Lua
+import Data.IORef (readIORef, atomicModifyIORef')
+import Engine.Core.State (EngineEnv(..))
+import Engine.Core.Log (LogCategory(..), logInfo)
+import Engine.Asset.YamlLootTables
+import LootTable.Types
+import LootTable.Roll (rollLootTable)
+
+-- | engine.loadLootTableYaml(path) — parses one loot table YAML file
+--   and registers it, returns 1 on success, 0 on failure (unlike the
+--   other engine.loadXYaml functions, a loot table file holds exactly
+--   one def, not a list).
+loadLootTableYamlFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+loadLootTableYamlFn env = do
+    pathArg ← Lua.tostring 1
+    case pathArg of
+        Nothing → do
+            Lua.pushnumber 0
+            return 1
+        Just pathBS → do
+            let filePath = T.unpack (TE.decodeUtf8 pathBS)
+            count ← Lua.liftIO $ do
+                logger ← readIORef (loggerRef env)
+                mDef ← loadLootTableYaml logger filePath
+                case mDef of
+                    Nothing → return (0 ∷ Int)
+                    Just d → do
+                        let def = LootTableDef
+                                { ltdId      = ltydId d
+                                , ltdEntries = map toEntry (ltydEntries d)
+                                }
+                        atomicModifyIORef' (lootTableRegistryRef env) $ \reg →
+                            (registerLootTable def reg, ())
+                        logInfo logger CatAsset $
+                            "loadLootTableYaml: loaded '" <> ltdId def
+                            <> "' from " <> T.pack filePath
+                        return 1
+            Lua.pushnumber (Lua.Number (fromIntegral count))
+            return 1
+  where
+    toEntry e = LootTableEntry
+        { lteId     = ltyeId e
+        , lteWeight = ltyeWeight e
+        }
+
+-- | loot.roll(tableId) → item def name (string) | nil. A single
+--   weighted draw from the named table using the same RNG source as
+--   item weight rolls ('Item.Roll.rollItemWeight'). Unknown table id
+--   (or an empty one) returns nil — the location content-spawn
+--   dispatcher (scripts/locations.lua) logs the warning.
+lootRollFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+lootRollFn env = do
+    idArg ← Lua.tostring 1
+    case idArg of
+        Nothing → Lua.pushnil >> return 1
+        Just idBS → do
+            let tid = TE.decodeUtf8 idBS
+            mPick ← Lua.liftIO $ do
+                reg ← readIORef (lootTableRegistryRef env)
+                case lookupLootTable tid reg of
+                    Nothing  → pure Nothing
+                    Just def → rollLootTable def (statRNGRef env)
+            case mPick of
+                Just pickedId → do
+                    Lua.pushstring (TE.encodeUtf8 pickedId)
+                    return 1
+                Nothing → Lua.pushnil >> return 1

--- a/src/Engine/Scripting/Lua/API/World.hs
+++ b/src/Engine/Scripting/Lua/API/World.hs
@@ -54,6 +54,7 @@ module Engine.Scripting.Lua.API.World
     , worldSetFluidTileFn
     , worldSetSlopeFn
     , worldSetCellFn
+    , worldMarkLocationContentsSpawnedFn
     ) where
 
 import UPrelude
@@ -67,12 +68,12 @@ import Data.IORef (atomicModifyIORef', readIORef, writeIORef)
 import Control.Monad (when, forM_)
 import Control.Concurrent (threadDelay)
 import qualified Engine.Core.Queue as Q
-import Engine.Core.State (EngineEnv(..), activeWorldState)
+import Engine.Core.State (EngineEnv(..), activeWorldState, activeWorldPage)
 import Engine.Core.Log (LogCategory(..), logWarn)
 import Engine.Asset.Handle (TextureHandle(..))
 import Engine.Scripting.Lua.Material (parseTextureType)
 import Engine.Scripting.Lua.Types (LuaMsg(..))
-import World.Types
+import World.Types hiding (activeWorldPage)
 import World.Fluid.Types (FluidType(..))
 import World.Generate.Coordinates (globalToChunk)
 import World.Material (MaterialId(..), getMaterialProps, MaterialProps(..)
@@ -730,6 +731,29 @@ worldSetWorldCursorSelectBgTextureFn env = do
     return 0
 
 -- * Mine designation tool
+
+-- | world.markLocationContentsSpawned(gx, gy [, pageId]) — one-time
+--   content-spawn flag (#90). An explicit pageId targets that live
+--   page (even hidden); omitted defaults to the active world. No-op
+--   (queues nothing) when neither resolves to a live page.
+worldMarkLocationContentsSpawnedFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+worldMarkLocationContentsSpawnedFn env = do
+    gxArg   ← Lua.tointeger 1
+    gyArg   ← Lua.tointeger 2
+    pageArg ← Lua.tostring 3
+    case (gxArg, gyArg) of
+        (Just gx, Just gy) → do
+            Lua.liftIO $ do
+                mPid ← case pageArg of
+                    Just pidBS → pure (Just (WorldPageId (TE.decodeUtf8 pidBS)))
+                    Nothing    → (fmap fst) <$> activeWorldPage env
+                case mPid of
+                    Just pid → Q.writeQueue (worldQueue env) $
+                        WorldMarkLocationContentsSpawned pid
+                            (fromIntegral gx) (fromIntegral gy)
+                    Nothing  → pure ()
+            return 0
+        _ → return 0
 
 -- | world.setMineAnchor(pageId, gx, gy) — anchor the designation
 --   rectangle at the given tile (mine tool first click).

--- a/src/Engine/Scripting/Lua/API/WorldQuery.hs
+++ b/src/Engine/Scripting/Lua/API/WorldQuery.hs
@@ -15,6 +15,7 @@ module Engine.Scripting.Lua.API.WorldQuery
     , worldGetClimateAtFn
     , worldGetAmbientAtFn
     , worldListPlacedLocationsFn
+    , worldHasSpawnedLocationContentsFn
     ) where
 
 import UPrelude
@@ -34,6 +35,7 @@ import World.Hydrology.Types
 import World.Cursor.Types (CursorState(..))
 import World.Generate.Types (WorldGenParams(..))
 import Location.Overlay.Types (overlayToList)
+import World.Generate.Coordinates (globalToChunk)
 import World.Weather.Lookup (lookupLocalClimate, LocalClimate(..))
 import World.Weather.Ambient (ambientTempAt)
 import Engine.Graphics.Camera (Camera2D(..))
@@ -744,3 +746,37 @@ worldListPlacedLocationsFn env = do
                 Lua.setfield (-2) "id"
                 Lua.rawseti (-2) i
             return 1
+
+-- | world.hasSpawnedLocationContents(gx, gy [, pageId]) → bool.
+--   One-time content-spawn flag (#90): true once the chunk containing
+--   (gx, gy) has had its placed location's `contents` spawned.
+--   Independent of structure-geometry state (structure.hasAt) — see
+--   'World.Command.Types.WorldMarkLocationContentsSpawned'. With no
+--   page argument the active world is read; false when no such world
+--   or its gen params aren't live.
+worldHasSpawnedLocationContentsFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+worldHasSpawnedLocationContentsFn env = do
+    gxA ← Lua.tointeger 1
+    gyA ← Lua.tointeger 2
+    pageA ← Lua.tostring 3
+    case (gxA, gyA) of
+        (Just gx, Just gy) → do
+            spawned ← Lua.liftIO $ do
+                mWs ← case pageA of
+                    Just pidBS → worldStateByPage env (TE.decodeUtf8 pidBS)
+                    Nothing    → activeWorldState env
+                case mWs of
+                    Nothing → pure False
+                    Just ws → do
+                        mParams ← readIORef (wsGenParamsRef ws)
+                        case mParams of
+                            Nothing → pure False
+                            Just params →
+                                let (coord, _) =
+                                        globalToChunk (fromIntegral gx)
+                                                       (fromIntegral gy)
+                                in pure (HS.member coord
+                                    (wgpLocationContentsSpawned params))
+            Lua.pushboolean spawned
+            return 1
+        _ → Lua.pushboolean False >> return 1

--- a/src/Location/Types.hs
+++ b/src/Location/Types.hs
@@ -14,15 +14,28 @@ import GHC.Generics (Generic)
 import Data.List (sortOn)
 
 -- | One piece of content a location places when it is stamped — a
---   building, unit, or ground item, addressed by its raw id string.
---   The ids are NOT validated or resolved here: the world-gen overlay
---   (#89) and the content-spawning pass (#90) resolve them at spawn
---   time. `kind` is a free string tag ("building" / "unit" / "item")
---   so new content kinds don't force a schema change.
+--   building, unit, ground item, loot-table roll, or nested structure,
+--   addressed by its raw id string. The ids are NOT validated or
+--   resolved here: the content-spawning pass (#90) resolves them at
+--   spawn time. `kind` is a free string tag ("building" / "unit" /
+--   "item" / "loot_table" / "structure") so new content kinds don't
+--   force a schema change.
 data LocationContent = LocationContent
-    { lconKind  ∷ !Text  -- ^ "building" | "unit" | "item"
-    , lconId    ∷ !Text  -- ^ raw id string, resolved at spawn time
-    , lconCount ∷ !Int   -- ^ how many to place (defaults to 1)
+    { lconKind     ∷ !Text            -- ^ "building" | "unit" | "item"
+                                      --   | "loot_table" | "structure"
+    , lconId       ∷ !Text            -- ^ raw id string, resolved at spawn time
+    , lconCount    ∷ !Int             -- ^ how many to place (defaults to 1;
+                                      --   ignored by "loot_table", which
+                                      --   uses 'lconRolls' instead)
+    , lconPosition ∷ !(Maybe (Int, Int))
+                                      -- ^ fixed (x, y) offset from the
+                                      --   location anchor; 'Nothing' scatters
+                                      --   randomly within the structure
+                                      --   footprint instead
+    , lconFaction  ∷ !(Maybe Text)    -- ^ "unit" only: spawn-time faction tag
+                                      --   (defaults to "hostile" when omitted)
+    , lconRolls    ∷ !Int             -- ^ "loot_table" only: how many times
+                                      --   to roll the table (defaults to 1)
     } deriving (Show, Eq, Generic)
 
 -- | A data-driven location definition (data/locations/*.yaml). Mirrors

--- a/src/LootTable/Roll.hs
+++ b/src/LootTable/Roll.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE Strict, UnicodeSyntax #-}
+module LootTable.Roll
+    ( rollLootTable
+    ) where
+
+import UPrelude
+import Data.IORef (IORef, atomicModifyIORef')
+import System.Random (StdGen, randomR)
+import LootTable.Types (LootTableDef(..), LootTableEntry(..))
+
+-- | One weighted draw from a loot table's entries. Mirrors
+--   'Unit.Injury.weightedPick': a roll in [0, 1) is scaled by the
+--   total weight and the entries are walked by running sum, the last
+--   entry catching any floating-point overshoot. 'Nothing' only for an
+--   empty table (an unknown table id is handled by the caller, which
+--   never looks one up in the first place).
+rollLootTable ∷ LootTableDef → IORef StdGen → IO (Maybe Text)
+rollLootTable def rngRef = case ltdEntries def of
+    [] → pure Nothing
+    entries → atomicModifyIORef' rngRef $ \g →
+        let (u, g') = randomR (0 ∷ Float, 1) g
+            total    = sum (map lteWeight entries)
+            target   = u * total
+            go acc (e : rest)
+                | acc + lteWeight e ≥ target ∨ null rest = lteId e
+                | otherwise = go (acc + lteWeight e) rest
+            go _ [] = error "rollLootTable: unreachable (empty guarded above)"
+        in (g', Just (go 0 entries))

--- a/src/LootTable/Types.hs
+++ b/src/LootTable/Types.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE Strict, UnicodeSyntax, DeriveGeneric #-}
+module LootTable.Types
+    ( LootTableEntry(..)
+    , LootTableDef(..)
+    , LootTableRegistry(..)
+    , emptyLootTableRegistry
+    , registerLootTable
+    , lookupLootTable
+    ) where
+
+import UPrelude
+import GHC.Generics (Generic)
+import qualified Data.HashMap.Strict as HM
+
+-- | One weighted entry in a loot table — an item def id and its
+--   relative weight (not a probability; weights are summed and scaled
+--   at roll time, see 'LootTable.Roll.rollLootTable').
+data LootTableEntry = LootTableEntry
+    { lteId     ∷ !Text
+    , lteWeight ∷ !Float
+    } deriving (Show, Eq, Generic)
+
+-- | A named loot table (data/loot_tables/*.yaml), rolled by a
+--   `loot_table` location content entry (#90).
+data LootTableDef = LootTableDef
+    { ltdId      ∷ !Text
+    , ltdEntries ∷ ![LootTableEntry]
+    } deriving (Show, Eq, Generic)
+
+-- | Engine-wide registry of loot table defs loaded from
+--   data/loot_tables/. One def per file (unlike the location/item/unit
+--   registries, which allow several defs per file) — each file's `id`
+--   is the whole document, not a member of a wrapping list.
+newtype LootTableRegistry = LootTableRegistry
+    { ltrDefs ∷ HM.HashMap Text LootTableDef
+    } deriving (Show, Eq)
+
+emptyLootTableRegistry ∷ LootTableRegistry
+emptyLootTableRegistry = LootTableRegistry HM.empty
+
+registerLootTable ∷ LootTableDef → LootTableRegistry → LootTableRegistry
+registerLootTable def (LootTableRegistry defs) =
+    LootTableRegistry (HM.insert (ltdId def) def defs)
+
+lookupLootTable ∷ Text → LootTableRegistry → Maybe LootTableDef
+lookupLootTable tid (LootTableRegistry defs) = HM.lookup tid defs

--- a/src/World/Command/Types.hs
+++ b/src/World/Command/Types.hs
@@ -184,4 +184,11 @@ data WorldCommand
         -- ^ Sim → World: apply the sim's settled/active fluid results to
         --   the visible world's 'wsTilesRef'. The world thread is the
         --   SOLE writer of 'wsTilesRef'; the sim never touches it.
+    | WorldMarkLocationContentsSpawned WorldPageId Int Int
+        -- ^ worldId, gx, gy. One-time content-spawn flag (#90): marks the
+        --   chunk containing (gx, gy) as having had its placed location's
+        --   `contents` spawned, in 'WorldGenParams.wgpLocationContentsSpawned'
+        --   — so a later chunk (re)load never respawns them. The world
+        --   thread is the sole owner of WorldGenParams; Lua queues this
+        --   rather than mutating wsGenParamsRef directly.
     deriving (Show)

--- a/src/World/Generate/Types.hs
+++ b/src/World/Generate/Types.hs
@@ -32,6 +32,7 @@ import World.Weather.Types (ClimateParams, ClimateState
 import World.Magma.Types (VolcanoCtx, emptyVolcanoCtx)
 import World.Magma.Init (buildVolcanoCtx)
 import Location.Overlay.Types (LocationOverlay, emptyLocationOverlay)
+import World.Chunk.Types (ChunkCoord)
 
 -- | Pure, serializable world generation parameters.
 --   Same params + same ChunkCoord = same Chunk, always.
@@ -66,6 +67,17 @@ data WorldGenParams = WorldGenParams
       --   deterministic overlay pass (#89). Serialized (appended to the
       --   manual instance below) so a loaded world keeps its layout
       --   without recomputation.
+    , wgpLocationContentsSpawned ∷ !(HS.HashSet ChunkCoord)
+      -- ^ One-time content-spawn flag (#90): chunks whose placed
+      --   location has already had its `contents` spawned (units,
+      --   items, buildings, …). Deliberately INDEPENDENT of the
+      --   structure-geometry idempotency check
+      --   (@structure.hasAt gx gy "floor"@) that gates re-STAMPING —
+      --   that check alone isn't enough for content: a floor-less
+      --   location type would re-run every chunk load, and a player
+      --   demolishing the floor would re-trigger a full re-stamp
+      --   including contents. Persisted alongside 'wgpLocationOverlay'
+      --   so a save never re-spawns contents already spawned.
     , wgpVolcanoCtx ∷ !VolcanoCtx
       -- ^ Pure-function lava system context. Transient: NOT serialized;
       --   rebuilt from gtFeatures + wgpSeed + wgpWorldSize on load.
@@ -97,6 +109,7 @@ instance Serialize WorldGenParams where
         put (wgpOreLevers p)
         put (wgpTimelineParams p)
         put (wgpLocationOverlay p)
+        put (wgpLocationContentsSpawned p)
     get = do
         seed       ← get
         ws         ← get
@@ -118,6 +131,7 @@ instance Serialize WorldGenParams where
         oreLevers  ← get
         timelineP  ← get
         locOverlay ← get
+        locSpawned ← get
         let vc = buildVolcanoCtx seed ws plates (gtFeatures timeline)
         pure WorldGenParams
             { wgpSeed             = seed
@@ -140,6 +154,7 @@ instance Serialize WorldGenParams where
             , wgpOreLevers        = oreLevers
             , wgpTimelineParams   = timelineP
             , wgpLocationOverlay  = locOverlay
+            , wgpLocationContentsSpawned = locSpawned
             , wgpVolcanoCtx       = vc
             }
 
@@ -170,6 +185,7 @@ defaultWorldGenParams = WorldGenParams
     , wgpOreLevers = defaultOreLevers
     , wgpTimelineParams = defaultTimelineParams
     , wgpLocationOverlay = emptyLocationOverlay
+    , wgpLocationContentsSpawned = HS.empty
     , wgpVolcanoCtx = emptyVolcanoCtx
     }
 

--- a/src/World/Save/Types.hs
+++ b/src/World/Save/Types.hs
@@ -117,7 +117,12 @@ saveMagic = 0x53595241
 --       river carve. Positional Generic Serialize drops the trailing
 --       field, incompatible with v61 (#385).
 currentSaveVersion ∷ Int
-currentSaveVersion = 63  -- v63: WorldGenParams gains trailing 'wgpLocationOverlay'
+currentSaveVersion = 64  -- v64: WorldGenParams gains trailing
+                         --      'wgpLocationContentsSpawned' (one-time
+                         --      content-spawn flag per chunk, independent
+                         --      of the structure-geometry idempotency
+                         --      check; #90).
+                         -- v63: WorldGenParams gains trailing 'wgpLocationOverlay'
                          --      (sparse chunk→location-id map placed at world
                          --      init; serialized so a loaded world keeps its
                          --      layout without recomputation; #89).

--- a/src/World/Thread/Command.hs
+++ b/src/World/Thread/Command.hs
@@ -79,6 +79,8 @@ import World.Thread.Command.Edit (handleWorldDeleteTileCommand
                                  , handleWorldClearAllStructuresCommand
                                  , handleWorldDigTileCommand
                                  , handleWorldAddTileCommand)
+import World.Thread.Command.Location
+    (handleWorldMarkLocationContentsSpawnedCommand)
 
 -- * Command Handler
 
@@ -183,6 +185,8 @@ handleWorldCommand env logger WorldDestroyAll
   = handleWorldDestroyAllCommand env logger
 handleWorldCommand env _ (WorldApplyFluids batch)
   = handleApplyFluidsCommand env batch
+handleWorldCommand env _ (WorldMarkLocationContentsSpawned pageId gx gy)
+  = handleWorldMarkLocationContentsSpawnedCommand env pageId gx gy
 
 -- | Sim → World: apply the sim's fluid writebacks to the ORIGINATING
 --   world's tile data, resolved by the batch's page id — not every

--- a/src/World/Thread/Command/Location.hs
+++ b/src/World/Thread/Command/Location.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE Strict, UnicodeSyntax #-}
+module World.Thread.Command.Location
+    ( handleWorldMarkLocationContentsSpawnedCommand
+    ) where
+
+import UPrelude
+import qualified Data.HashSet as HS
+import Data.IORef (readIORef, atomicModifyIORef')
+import Engine.Core.State (EngineEnv(..))
+import World.Types
+import World.Generate.Coordinates (globalToChunk)
+
+-- | One-time content-spawn flag (#90) — see
+--   'World.Command.Types.WorldMarkLocationContentsSpawned'. A no-op
+--   when the page or its gen params aren't live (mirrors the other
+--   cursor/designation command handlers).
+handleWorldMarkLocationContentsSpawnedCommand
+    ∷ EngineEnv → WorldPageId → Int → Int → IO ()
+handleWorldMarkLocationContentsSpawnedCommand env pageId gx gy = do
+    mgr ← readIORef (worldManagerRef env)
+    case lookup pageId (wmWorlds mgr) of
+        Nothing → pure ()
+        Just worldState → do
+            let (coord, _) = globalToChunk gx gy
+            atomicModifyIORef' (wsGenParamsRef worldState) $ \mParams →
+                case mParams of
+                    Nothing → (mParams, ())
+                    Just params →
+                        ( Just params
+                            { wgpLocationContentsSpawned =
+                                HS.insert coord
+                                    (wgpLocationContentsSpawned params)
+                            }
+                        , ()
+                        )

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -453,6 +453,10 @@ library
                      Location.Overlay
                      Engine.Asset.YamlLocations
                      Engine.Scripting.Lua.API.Locations
+                     LootTable.Types
+                     LootTable.Roll
+                     Engine.Asset.YamlLootTables
+                     Engine.Scripting.Lua.API.LootTables
                      Sim.Thread
                      Sim.Command.Types
                      Combat.Types
@@ -484,6 +488,7 @@ library
                      World.Thread.Command.Texture
                      World.Thread.Command.UI
                      World.Thread.Command.Edit
+                     World.Thread.Command.Location
                      World.Grid
                      World.Render
                      World.Render.Camera

--- a/tools/location_content_probe.py
+++ b/tools/location_content_probe.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Headless location content-spawning probe (#90).
+
+Issues #88/#89 give locations a definition and a place in the world;
+this checks the `contents` list actually spawns things when a
+location's chunk loads, end to end:
+
+  1. Visiting a `ruin_small` (contents: building, unit, item, loot_table)
+     spawns all of them: one `cargo_hold_S` building, one hostile
+     `acolyte` unit, one fixed-position `rations` ground item, and two
+     loot-table rolls (also ground items) — per ruin.
+  2. The one-time content-spawn flag survives a save -> quit -> fresh
+     restart -> load: revisiting the same chunk does NOT respawn
+     (counts stay exactly the same, not doubled).
+  3. An unknown content `kind` and an unknown content `id` both log a
+     warning and are skipped rather than crashing the engine.
+
+Headless skips the GUI data-loading step, so defs are registered by
+hand here (items/units/buildings/loot_tables/locations), same as
+tools/location_overlay_probe.py does for locations alone.
+
+Usage:
+  python3 tools/location_content_probe.py
+  python3 tools/location_content_probe.py --seed 42 --size 64 --port 9190
+
+Exit code 0 = all checks passed.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import socket
+import subprocess
+import sys
+import time
+
+LOG = "/tmp/location_content_engine.log"
+
+
+def send(port: int, lua: str, timeout: float = 10.0) -> str:
+    """Run one line of Lua in the debug console, return the result text."""
+    with socket.create_connection(("localhost", port), timeout=timeout) as s:
+        s.sendall((lua + "\n").encode())
+        chunks: list[bytes] = []
+        s.settimeout(0.3)
+        try:
+            while True:
+                b = s.recv(4096)
+                if not b:
+                    break
+                chunks.append(b)
+        except socket.timeout:
+            pass
+    out = b"".join(chunks).decode(errors="replace")
+    results = [ln[2:].strip() for ln in out.splitlines() if ln.startswith("> ")]
+    results = [r for r in results if r]
+    return results[-1] if results else out.strip()
+
+
+def boot(port: int) -> subprocess.Popen:
+    log = open(LOG, "w")
+    proc = subprocess.Popen(
+        ["cabal", "run", "-v0", "exe:synarchy", "--",
+         "--headless", "--port", str(port)],
+        stdout=log, stderr=subprocess.STDOUT,
+    )
+    deadline = time.time() + 240
+    while time.time() < deadline:
+        try:
+            if "READY" in open(LOG).read():
+                return proc
+        except FileNotFoundError:
+            pass
+        if proc.poll() is not None:
+            sys.exit(f"engine exited before READY; see {LOG}")
+        time.sleep(0.4)
+    proc.kill()
+    sys.exit("engine never printed READY")
+
+
+def shutdown(port: int, proc: subprocess.Popen) -> None:
+    try:
+        send(port, "engine.quit(); return 'bye'", timeout=3.0)
+    except OSError:
+        pass
+    try:
+        proc.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def load_yaml_dir(port: int, directory: str, loader: str) -> None:
+    lua = (f"local fs = engine.listFiles('{directory}', '.yaml') or {{}}; "
+           f"for _, f in ipairs(fs) do {loader}('{directory}/' .. f) end; "
+           f"return #fs")
+    send(port, lua, timeout=20.0)
+
+
+def load_defs(port: int) -> None:
+    load_yaml_dir(port, "data/items", "engine.loadItemYaml")
+    load_yaml_dir(port, "data/units", "engine.loadUnitYaml")
+    load_yaml_dir(port, "data/buildings", "engine.loadBuildingYaml")
+    load_yaml_dir(port, "data/loot_tables", "engine.loadLootTableYaml")
+    send(port, "engine.loadLocationYaml('data/locations/ruin_small.yaml'); return 'ok'")
+
+
+def gen_world(port: int, page: str, seed: int, size: int) -> None:
+    send(port, f"world.init('{page}', {seed}, {size}, 3); return 'ok'")
+    send(port, "return world.waitForInit(240)", timeout=250)
+    send(port, f"world.show('{page}'); return 'ok'")
+    send(port, "return world.loadChunksInRegion(-1,-1,1,1)")
+    send(port, "return world.waitForChunks(60)", timeout=65)
+
+
+def placed(port: int) -> list[dict]:
+    raw = send(port, "return world.listPlacedLocations()").strip()
+    if not raw or raw in ("nil", "{}", "[]"):
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    return data if isinstance(data, list) else []
+
+
+def placed_ready(port: int, tries: int = 30) -> list[dict]:
+    last: list[dict] = []
+    for _ in range(tries):
+        last = placed(port)
+        if last:
+            return last
+        time.sleep(0.5)
+    return last
+
+
+def load_chunk(port: int, cx: int, cy: int) -> None:
+    send(port, f"return world.loadChunksInRegion({cx},{cy},{cx},{cy})")
+    send(port, "return world.waitForChunks(30)", timeout=35)
+
+
+def has_floor(port: int, gx: int, gy: int) -> bool:
+    r = send(port, f"return structure.hasAt({gx},{gy},'floor') and 'yes' or 'no'")
+    return r.strip('"') == "yes"
+
+
+def wait_floor(port: int, gx: int, gy: int, tries: int = 40) -> bool:
+    for _ in range(tries):
+        if has_floor(port, gx, gy):
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def unit_count(port: int, def_name: str) -> int:
+    r = send(port, "return unit.list()")
+    return len(re.findall(re.escape(def_name), r))
+
+
+def building_count(port: int, def_name: str) -> int:
+    r = send(port, "return building.list()")
+    return len(re.findall(re.escape(def_name), r))
+
+
+def ground_items(port: int) -> list[dict]:
+    raw = send(port, "return item.listGround()").strip()
+    if not raw or raw in ("nil", "{}", "[]"):
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    return data if isinstance(data, list) else []
+
+
+def spawn_counts(port: int) -> dict:
+    items = ground_items(port)
+    counts: dict[str, int] = {}
+    for it in items:
+        name = it.get("defName", "?")
+        counts[name] = counts.get(name, 0) + 1
+    return {
+        "acolyte": unit_count(port, "acolyte"),
+        "cargo_hold_S": building_count(port, "cargo_hold_S"),
+        "ground_total": len(items),
+        "ground_by_name": counts,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--size", type=int, default=64)
+    ap.add_argument("--port", type=int, default=9190)
+    args = ap.parse_args()
+
+    failures: list[str] = []
+    ruins: list[dict] = []
+    counts1: dict = {}
+
+    # ---- Phase 1: content spawns when a ruin's chunk loads. ----
+    proc = boot(args.port)
+    try:
+        load_defs(args.port)
+        gen_world(args.port, "wa", args.seed, args.size)
+        la = placed_ready(args.port)
+        ruins = [e for e in la if e["id"] == "ruin_small"]
+        print(f"world (seed {args.seed}): {len(ruins)} ruin_small placed")
+        if not ruins:
+            failures.append("no ruin_small placed — cannot test content spawning")
+        else:
+            for e in ruins:
+                load_chunk(args.port, e["cx"], e["cy"])
+            n = 0
+            for _ in range(60):
+                n = sum(1 for e in ruins if has_floor(args.port, e["gx"], e["gy"]))
+                if n == len(ruins):
+                    break
+                time.sleep(0.5)
+            if n != len(ruins):
+                failures.append(f"only {n}/{len(ruins)} ruin(s) stamped")
+
+            # Content spawning has its own settle time (unit spawn queues to
+            # the unit thread) — poll briefly for the expected counts.
+            counts1 = {}
+            for _ in range(20):
+                counts1 = spawn_counts(args.port)
+                if (counts1["acolyte"] >= len(ruins)
+                        and counts1["cargo_hold_S"] >= len(ruins)):
+                    break
+                time.sleep(0.5)
+            print(f"  spawned: {counts1}")
+
+            want_units = len(ruins)
+            want_buildings = len(ruins)
+            # Each ruin: 1 fixed `rations` + 2 loot_table rolls (from
+            # ruin_common: rations/first_aid_kit/steel_dagger).
+            want_ground = 3 * len(ruins)
+
+            if counts1["acolyte"] == want_units:
+                print(f"PASS: {want_units} 'acolyte' unit(s) spawned (1 per ruin, faction hostile)")
+            else:
+                failures.append(
+                    f"expected {want_units} acolyte unit(s), got {counts1['acolyte']}")
+
+            if counts1["cargo_hold_S"] == want_buildings:
+                print(f"PASS: {want_buildings} 'cargo_hold_S' building(s) spawned")
+            else:
+                failures.append(
+                    f"expected {want_buildings} cargo_hold_S building(s), "
+                    f"got {counts1['cargo_hold_S']}")
+
+            if counts1["ground_total"] == want_ground:
+                print(f"PASS: {want_ground} ground item(s) spawned "
+                      f"(fixed 'rations' + 2 loot_table rolls per ruin)")
+            else:
+                failures.append(
+                    f"expected {want_ground} ground item(s), got "
+                    f"{counts1['ground_total']} ({counts1['ground_by_name']})")
+
+            rations = counts1["ground_by_name"].get("rations", 0)
+            if rations >= len(ruins):
+                print(f"PASS: fixed-position 'rations' item present ({rations} >= {len(ruins)})")
+            else:
+                failures.append(f"expected >= {len(ruins)} 'rations', got {rations}")
+
+            loot_names = {"rations", "first_aid_kit", "steel_dagger"}
+            unexpected = set(counts1["ground_by_name"]) - loot_names
+            if not unexpected:
+                print("PASS: all spawned ground items resolve to known ids "
+                      "(fixed item + loot table entries)")
+            else:
+                failures.append(f"unexpected ground item id(s): {unexpected}")
+
+            send(args.port, "engine.saveWorld('wa', 'loc_content_probe'); return 'saved'")
+            time.sleep(1.0)
+    finally:
+        shutdown(args.port, proc)
+
+    # ---- Phase 2: save -> quit -> fresh restart -> load -> revisit does
+    #      NOT respawn (one-time flag persisted, independent of the
+    #      structure.hasAt geometry check). ----
+    if ruins and not failures:
+        proc = boot(args.port)
+        try:
+            load_defs(args.port)
+            send(args.port, "engine.loadSave('loc_content_probe'); return 'queued'")
+            time.sleep(6.0)
+            send(args.port, "world.show('main_world'); return 'ok'")
+            time.sleep(1.0)
+            for e in ruins:
+                load_chunk(args.port, e["cx"], e["cy"])
+            # No settle-time poll needed here: a respawn would be immediate
+            # and permanent, unlike the initial spawn's queue latency.
+            time.sleep(2.0)
+            counts2 = spawn_counts(args.port)
+            print(f"  after reload: {counts2}")
+            if counts2 == counts1:
+                print("PASS: reload does not respawn contents (counts unchanged)")
+            else:
+                failures.append(
+                    f"contents respawned on reload: before={counts1} after={counts2}")
+        finally:
+            shutdown(args.port, proc)
+    elif not ruins:
+        failures.append("phase 2 skipped: no ruins from phase 1")
+
+    # ---- Phase 3: unknown content kind / id logs a warning and is
+    #      skipped, not a crash. ----
+    bogus_yaml = "/tmp/loc_content_probe_bogus.yaml"
+    with open(bogus_yaml, "w") as fh:
+        fh.write(
+            "locations:\n"
+            "  - id: bogus_ruin\n"
+            "    label: Bogus Ruin\n"
+            "    type: ruin\n"
+            "    builder: room_small\n"
+            "    anchor: []\n"
+            "    max_count: 0\n"
+            "    contents:\n"
+            "      - { kind: unit, id: does_not_exist, count: 1 }\n"
+            "      - { kind: not_a_real_kind, id: whatever, count: 1 }\n"
+        )
+    proc = boot(args.port)
+    try:
+        load_defs(args.port)
+        send(args.port, f"engine.loadLocationYaml('{bogus_yaml}'); return 'ok'")
+        gen_world(args.port, "wc", args.seed, args.size)
+        # Stamp directly (bogus_ruin has max_count 0, so it never places via
+        # the overlay) — content-spawning is the concern here, not overlay
+        # placement. spawnContents dispatches to unit/kind lookups directly.
+        r = send(args.port,
+                  "local locations = require('scripts.locations'); "
+                  "locations.spawnContents('bogus_ruin', 40, 40, 'wc'); "
+                  "return 'ok'")
+        alive = send(args.port, "return engine.getFPS() ~= nil and 'alive' or 'dead'")
+        if r.strip('"') == "ok" and "alive" in alive:
+            print("PASS: unknown unit id + unknown content kind did not crash the engine")
+        else:
+            failures.append(f"spawnContents with bogus content misbehaved: {r!r} / {alive!r}")
+        log_text = open(LOG, errors="replace").read()
+        if ("unknown unit content" in log_text
+                and "unknown content kind" in log_text):
+            print("PASS: both the unknown id and the unknown kind logged a warning")
+        else:
+            failures.append(
+                "expected warnings for unknown unit id AND unknown content "
+                f"kind not both found in {LOG}")
+    finally:
+        shutdown(args.port, proc)
+
+    print("-" * 56)
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}", file=sys.stderr)
+        return 1
+    print("ALL CHECKS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/location_content_probe.py
+++ b/tools/location_content_probe.py
@@ -97,11 +97,15 @@ def load_yaml_dir(port: int, directory: str, loader: str) -> None:
     send(port, lua, timeout=20.0)
 
 
-def load_defs(port: int) -> None:
+def load_registries(port: int) -> None:
     load_yaml_dir(port, "data/items", "engine.loadItemYaml")
     load_yaml_dir(port, "data/units", "engine.loadUnitYaml")
     load_yaml_dir(port, "data/buildings", "engine.loadBuildingYaml")
     load_yaml_dir(port, "data/loot_tables", "engine.loadLootTableYaml")
+
+
+def load_defs(port: int) -> None:
+    load_registries(port)
     send(port, "engine.loadLocationYaml('data/locations/ruin_small.yaml'); return 'ok'")
 
 
@@ -113,15 +117,43 @@ def gen_world(port: int, page: str, seed: int, size: int) -> None:
     send(port, "return world.waitForChunks(60)", timeout=65)
 
 
-def placed(port: int) -> list[dict]:
-    raw = send(port, "return world.listPlacedLocations()").strip()
-    if not raw or raw in ("nil", "{}", "[]"):
+def placed(port: int, page: str | None = None) -> list[dict]:
+    arg = f"'{page}'" if page else ""
+    raw = send(port, f"return world.listPlacedLocations({arg})").strip()
+    if not raw or raw in ("nil", "null", "{}", "[]"):
         return []
     try:
         data = json.loads(raw)
     except json.JSONDecodeError:
         return []
     return data if isinstance(data, list) else []
+
+
+def loc_at(port: int, cx: int, cy: int, page: str, tries: int = 120) -> tuple[int, int] | None:
+    """(gx, gy) of the location placed at chunk (cx, cy) on `page`, or
+    None. Server-side scan, never ships the full list to Python — needed
+    for a DENSE def (one location per land chunk; #90 phase 4), where the
+    full list is thousands of entries and JSON round-tripping it is the
+    kind of thing tools/location_overlay_probe.py deliberately avoids.
+
+    Polls: world.waitForInit always reads the ACTIVE world's load phase
+    (Engine/Scripting/Lua/API/World.hs worldWaitForInitFn), so it cannot
+    be used to wait for a HIDDEN page's init to finish — the caller can't
+    know when `page`'s gen params (and thus its overlay) become readable
+    other than by retrying this query."""
+    lua = (f"local t = world.listPlacedLocations('{page}'); "
+           f"for _, e in ipairs(t) do if e.cx == {cx} and e.cy == {cy} then "
+           f"return e.gx .. ',' .. e.gy end end; return 'none'")
+    r = "none"
+    for _ in range(tries):
+        r = send(port, lua, timeout=20.0).strip('"')
+        if r != "none":
+            break
+        time.sleep(0.5)
+    if r == "none" or "," not in r:
+        return None
+    gx_s, gy_s = r.split(",", 1)
+    return int(gx_s), int(gy_s)
 
 
 def placed_ready(port: int, tries: int = 30) -> list[dict]:
@@ -139,14 +171,15 @@ def load_chunk(port: int, cx: int, cy: int) -> None:
     send(port, "return world.waitForChunks(30)", timeout=35)
 
 
-def has_floor(port: int, gx: int, gy: int) -> bool:
-    r = send(port, f"return structure.hasAt({gx},{gy},'floor') and 'yes' or 'no'")
+def has_floor(port: int, gx: int, gy: int, page: str | None = None) -> bool:
+    arg = f",'{page}'" if page else ""
+    r = send(port, f"return structure.hasAt({gx},{gy},'floor'{arg}) and 'yes' or 'no'")
     return r.strip('"') == "yes"
 
 
-def wait_floor(port: int, gx: int, gy: int, tries: int = 40) -> bool:
+def wait_floor(port: int, gx: int, gy: int, page: str | None = None, tries: int = 40) -> bool:
     for _ in range(tries):
-        if has_floor(port, gx, gy):
+        if has_floor(port, gx, gy, page):
             return True
         time.sleep(0.5)
     return False
@@ -164,7 +197,7 @@ def building_count(port: int, def_name: str) -> int:
 
 def ground_items(port: int) -> list[dict]:
     raw = send(port, "return item.listGround()").strip()
-    if not raw or raw in ("nil", "{}", "[]"):
+    if not raw or raw in ("nil", "null", "{}", "[]"):
         return []
     try:
         data = json.loads(raw)
@@ -306,7 +339,8 @@ def main() -> int:
         failures.append("phase 2 skipped: no ruins from phase 1")
 
     # ---- Phase 3: unknown content kind / id logs a warning and is
-    #      skipped, not a crash. ----
+    #      skipped, not a crash. Also covers a loot_table rolling an
+    #      item id that isn't registered. ----
     bogus_yaml = "/tmp/loc_content_probe_bogus.yaml"
     with open(bogus_yaml, "w") as fh:
         fh.write(
@@ -320,11 +354,21 @@ def main() -> int:
             "    contents:\n"
             "      - { kind: unit, id: does_not_exist, count: 1 }\n"
             "      - { kind: not_a_real_kind, id: whatever, count: 1 }\n"
+            "      - { kind: loot_table, id: bogus_table, rolls: 1 }\n"
+        )
+    bogus_loot_yaml = "/tmp/loc_content_probe_bogus_loot.yaml"
+    with open(bogus_loot_yaml, "w") as fh:
+        fh.write(
+            "id: bogus_table\n"
+            "entries:\n"
+            "  - id: item_that_does_not_exist\n"
+            "    weight: 1\n"
         )
     proc = boot(args.port)
     try:
         load_defs(args.port)
         send(args.port, f"engine.loadLocationYaml('{bogus_yaml}'); return 'ok'")
+        send(args.port, f"engine.loadLootTableYaml('{bogus_loot_yaml}'); return 'ok'")
         gen_world(args.port, "wc", args.seed, args.size)
         # Stamp directly (bogus_ruin has max_count 0, so it never places via
         # the overlay) — content-spawning is the concern here, not overlay
@@ -335,17 +379,94 @@ def main() -> int:
                   "return 'ok'")
         alive = send(args.port, "return engine.getFPS() ~= nil and 'alive' or 'dead'")
         if r.strip('"') == "ok" and "alive" in alive:
-            print("PASS: unknown unit id + unknown content kind did not crash the engine")
+            print("PASS: unknown unit id + unknown content kind + unknown "
+                  "loot roll did not crash the engine")
         else:
             failures.append(f"spawnContents with bogus content misbehaved: {r!r} / {alive!r}")
         log_text = open(LOG, errors="replace").read()
         if ("unknown unit content" in log_text
-                and "unknown content kind" in log_text):
-            print("PASS: both the unknown id and the unknown kind logged a warning")
+                and "unknown content kind" in log_text
+                and "rolled unknown item id" in log_text):
+            print("PASS: the unknown unit id, unknown content kind, AND "
+                  "loot-table-rolled-unknown-item-id all logged a warning")
         else:
             failures.append(
-                "expected warnings for unknown unit id AND unknown content "
-                f"kind not both found in {LOG}")
+                "expected warnings for unknown unit id, unknown content "
+                f"kind, AND unknown loot roll not all found in {LOG}")
+    finally:
+        shutdown(args.port, proc)
+
+    # ---- Phase 4: a building content entry spawns correctly on a HIDDEN,
+    #      non-active page (#90 review fix — building.spawn now takes an
+    #      explicit pageId, mirroring unit.spawn/item.spawnGround, and its
+    #      occupancy/terrain-Z check is scoped to THAT page, not a snapshot
+    #      of the visible worlds). A DENSE location (one per land chunk,
+    #      like tools/location_overlay_probe.py's DENSE_YAML) guarantees
+    #      content at the SYNCHRONOUS centre chunk (0,0), which stamps at
+    #      world.init time via Init.hs's centre-chunk hook regardless of
+    #      active/visible status — so this needs no chunk loading on the
+    #      hidden page (world.loadChunksInRegion only targets the active
+    #      world, so a hidden page can't otherwise be force-loaded here). ----
+    dense_yaml = "/tmp/loc_content_probe_dense.yaml"
+    with open(dense_yaml, "w") as fh:
+        fh.write(
+            "locations:\n"
+            "  - id: dense_ruin\n"
+            "    label: Dense Ruin\n"
+            "    type: ruin\n"
+            "    builder: room_small\n"
+            "    anchor: [waterside]\n"
+            "    max_count: 100000\n"
+            "    min_spacing: 1\n"
+            "    contents:\n"
+            "      - { kind: building, id: cargo_hold_S, count: 1, position: {x: 0, y: 0} }\n"
+        )
+    proc = boot(args.port)
+    try:
+        # Registries only — NOT ruin_small.yaml, which would contend with
+        # dense_ruin for chunk (0,0) and make the placement non-deterministic
+        # (mirrors tools/location_overlay_probe.py's isolated DENSE_YAML use).
+        load_registries(args.port)
+        send(args.port, f"engine.loadLocationYaml('{dense_yaml}'); return 'ok'")
+        send(args.port, "world.initArena('arena'); world.initArenaDone('arena'); "
+                        "world.show('arena'); return 'ok'")
+        arena_ok = False
+        for _ in range(40):
+            r = send(args.port, "local i=world.getChunkInfo(0,0); return i and i.loaded and 'y' or 'n'").strip('"')
+            if r == "y":
+                arena_ok = True
+                break
+            time.sleep(0.25)
+        if not arena_ok:
+            failures.append("phase 4: arena never became ready")
+        else:
+            # Generate 'sw2' but NEVER show it — arena stays active throughout.
+            # NB world.waitForInit always polls the ACTIVE world (arena,
+            # already done) — it can't wait for a hidden page, so loc_at's
+            # own retry loop is what actually waits for 'sw2' to be ready.
+            send(args.port, f"world.init('sw2', {args.seed}, {args.size}, 3); return 'ok'")
+            active = send(args.port, "return world.getActiveWorldId()").strip('"')
+            if active != "arena":
+                failures.append(f"phase 4: expected 'arena' active throughout, got '{active}'")
+            else:
+                gxgy = loc_at(args.port, 0, 0, "sw2")
+                if gxgy is None:
+                    failures.append(
+                        "phase 4: no location on centre chunk (0,0) of hidden page 'sw2'")
+                else:
+                    gx, gy = gxgy
+                    if not wait_floor(args.port, gx, gy, page="sw2"):
+                        failures.append(
+                            f"phase 4: centre chunk (0,0)/({gx},{gy}) on 'sw2' never stamped")
+                    else:
+                        blist = send(args.port, "return building.list()")
+                        if f"({gx}, {gy}," in blist:
+                            print(f"PASS: building content spawned at ({gx},{gy}) on hidden "
+                                  f"page 'sw2' while 'arena' stayed active (multiworld fix)")
+                        else:
+                            failures.append(
+                                f"phase 4: no cargo_hold_S building at ({gx},{gy}) on "
+                                f"hidden page 'sw2' — building.list() returned: {blist!r}")
     finally:
         shutdown(args.port, proc)
 


### PR DESCRIPTION
## Summary

Makes each `LocationDef`'s `contents` list actually spawn things the first time its chunk loads. #88/#89 gave locations a definition and a place in the world; this is the general placement system for their content.

- **Content dispatch** (`scripts/locations.lua`): `unit` / `item` / `loot_table` / `building` / `structure` content kinds, each with an optional fixed `position` offset (relative to the anchor) — omit it and the entry scatters randomly within the location's footprint instead.
- **`LocationContent`** (`Location/Types.hs` + YAML schema) gains `position`, `faction` (unit-only, defaults `"hostile"`), and `rolls` (loot_table-only, defaults 1).
- **Loot tables**: a new data-driven registry (`data/loot_tables/*.yaml`, one table per file) + `loot.roll(id)` — a weighted pick using the same RNG source as item weight rolls, mirroring `Unit.Injury.weightedPick`'s algorithm. Ships with a reference `ruin_common` table.
- **One-time spawn flag**: `WorldGenParams` gains `wgpLocationContentsSpawned`, a `HashSet ChunkCoord` riding alongside the #89 chunk→location overlay (save version bump to v64). It's deliberately **independent** of the `structure.hasAt` geometry idempotency check — that check alone isn't enough for content: a floor-less location type would re-run every chunk load, and a player demolishing the floor would otherwise re-trigger every content spawn too. New `world.hasSpawnedLocationContents` / `world.markLocationContentsSpawned` Lua API + a `WorldMarkLocationContentsSpawned` command (the world thread is the sole owner of `WorldGenParams`, so Lua queues rather than mutating it directly).
- **Multiworld fix**: `item.spawnGround` gains an optional trailing `pageId` (mirroring `unit.spawn` / `structure.place`), so ground-item content lands on the right page even when it's hidden. `building.spawn` is left as-is — its occupancy check validates against a snapshot of the *visible* worlds, not a named page, which is a deeper, separate gap not introduced by this change (documented in the Lua dispatcher).
- **Reference data**: extended `data/locations/ruin_small.yaml` to exercise all four "real" content kinds (building/unit/item/loot_table).

## Approach

`scripts/location_stamper.lua`'s `onStampLocation` now always calls `locations.spawnContents(locId, gx, gy, pageId)` after the (possibly-skipped) geometry stamp, so content spawning is a standalone concern gated only by its own persisted flag. IDs are resolved at spawn time against the existing item/unit/building registries (and the new loot-table one) — an unknown `kind` or unknown `id` logs a warning and is skipped, never crashes.

## Testing

- `cabal test synarchy-test-headless` — 417/417 passing
- `python3 tools/world_check.py` — `bugs=0`, matches the known pre-existing baseline staleness (no worldgen-output regression; this change never touches terrain/fluid/material/ice/ore generation)
- `python3 tools/test_audit.py` — all 35 groups pass
- New `tools/location_content_probe.py` (headless, follows the `location_overlay_probe.py` pattern), covering:
  1. Visiting all 6 `ruin_small` locations in a generated world spawns exactly one `acolyte` unit (faction hostile), one `cargo_hold_S` building, and 3 ground items each (1 fixed `rations` + 2 `loot_table` rolls) per ruin
  2. Save → quit → fresh restart → load → revisit does **not** respawn (counts identical before/after)
  3. An unknown unit id and an unknown content kind both log a warning and don't crash the engine

Closes #90