### PR TITLE
Parallelize module compilation + unlock RTS tuning (#443)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,11 @@ Conventions that keep this fast — don't undo them:
   the suite, and don't grow the baseline seed list without tagging the
   quick tier accordingly.
 
-**Do NOT use `-f dev` for routine work.** The project is 360+ modules; switching between the `dev` and production flag profiles forces a full rebuild that takes about five minutes. The default (prod) profile is what the test suite, dump tool, and binaries are expected to run under, and what every code change should be validated against.
+**Do NOT use `-f dev` for routine work.** The project is 360+ modules; a full prod rebuild takes ~1.5 minutes (parallelized via the `semaphore:` setting in `cabal.project`), and flag-profile switches force one. The default (prod) profile is what the test suite, dump tool, and binaries are expected to run under, and what every code change should be validated against.
 
-The `dev` flag enables Vulkan validation layers, address sanitizer on macOS, and `ENGINE_DEBUG` plumbing. Reach for it only when actively chasing a graphics or memory bug, and tell the user before switching — they may want to flip back afterward to avoid the rebuild cost on the next change. Production builds use `-O2 -optc-O3`.
+The `dev` flag enables Vulkan validation layers, address sanitizer on macOS, and `ENGINE_DEBUG` plumbing. Reach for it only when actively chasing a graphics or memory bug. When you do, give it its own build dir so the two profiles' artifacts coexist and flipping back is free: `cabal build -f dev --builddir=dist-dev` (every `cabal run`/`test` in that profile needs the same `-f dev --builddir=dist-dev` pair; plain commands keep using the prod `dist-newstyle`). Production builds use `-O2 -optc-O3`.
+
+The executable is built with `-rtsopts`, so RTS behavior can be inspected and tuned at run time without a rebuild — e.g. append `+RTS -s` to a `--dump` run for a GC/allocation summary on stderr, or experiment with `-N<n>` / `-A<size>`. The baked-in default remains `-N -A128M`.
 
 ## Language & Conventions
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,8 @@
+packages: .
+
+-- Parallel builds (#443). The library is one 360+-module package, so
+-- package-level `jobs` alone can't help; `semaphore: True` makes cabal
+-- create a jobserver semaphore and pass -jsem to GHC (9.8+), letting the
+-- single --make session compile modules in parallel up to $ncpus.
+jobs: $ncpus
+semaphore: True

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -822,6 +822,7 @@ executable synarchy
                        -Wincomplete-patterns
                        -Wno-ambiguous-fields
                        -threaded
+                       -rtsopts
                        "-with-rtsopts=-N -A128M"
                        -haddock
     else
@@ -832,6 +833,7 @@ executable synarchy
                        -optc-O3
                        -fexcess-precision
                        -threaded
+                       -rtsopts
                        "-with-rtsopts=-N -A128M"
                        -feager-blackholing
       else
@@ -839,6 +841,7 @@ executable synarchy
                        -optc-O3
                        -fexcess-precision
                        -threaded
+                       -rtsopts
                        "-with-rtsopts=-N -A128M"
                        -feager-blackholing
 


### PR DESCRIPTION
Closes #443.

## What

Three build-infrastructure changes, no module-level flag or behavior changes:

1. **`cabal.project` with `jobs: $ncpus` + `semaphore: True`** — the library is one 360+-module package, so cabal previously ran a single serial `ghc --make` session. The semaphore hands that session jobserver tokens (`-jsem`, GHC 9.8+), letting it compile modules in parallel.
2. **`-rtsopts` on the executable in all flag profiles** (only dev/darwin had it). Without it the RTS silently ignores `+RTS` args, so nothing could be measured or tuned without a rebuild. Link-time only; baked-in defaults (`-N -A128M`) unchanged.
3. **CLAUDE.md**: document the `--builddir=dist-dev` trick (dev↔prod flag flips no longer force full rebuilds of each other's artifacts), update the full-rebuild figure, note `+RTS -s` availability.

## Validation

- From-scratch `cabal build all` in a fresh worktree (16-core M-series): **~5 min → 93 s** (254 s user, ~2.7× average parallelism — bounded by the module graph's serial spine).
- Behavior: w64 seed-42 `--dump` output is **byte-identical** to master after each cabal change (flags reaching modules are unchanged, so no worldgen/save impact).
- `+RTS -s` verified working; first measurement shows worldgen at 98.4% productivity (GC 0.08 s of a ~5 s w64 gen, max residency 164 MB) — i.e. gen time is pure mutator work, and the multi-GB RSS people see is the by-design `-A128M` × `-N` nursery, not live data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)