### PR TITLE
Storable vectors for sprite-batch vertices (#445)

### DIFF
--- a/src/Engine/Graphics/Vulkan/Command/Sprite.hs
+++ b/src/Engine/Graphics/Vulkan/Command/Sprite.hs
@@ -6,6 +6,7 @@ module Engine.Graphics.Vulkan.Command.Sprite
 
 import UPrelude
 import qualified Data.Vector as V
+import qualified Data.Vector.Storable as VS
 import Data.IORef (IORef, readIORef, modifyIORef')
 import Engine.Core.Log (LogCategory(..))
 import Engine.Core.Log.Monad (logAndThrowM)
@@ -72,6 +73,6 @@ renderSpritesWith selectPipeline cmdBuf state viewport scissor uniformSet
 
     V.forM_ spriteBatches $ \batch → do
         offset ← liftIO $ readIORef vertexOffsetRef
-        let vertexCount = fromIntegral $ V.length $ rbVertices batch
+        let vertexCount = fromIntegral $ VS.length $ rbVertices batch
         cmdDraw cmdBuf vertexCount 1 offset 0
         liftIO $ modifyIORef' vertexOffsetRef (+ vertexCount)

--- a/src/Engine/Graphics/Vulkan/Types/Vertex.hs
+++ b/src/Engine/Graphics/Vulkan/Types/Vertex.hs
@@ -44,9 +44,13 @@ data Vec2 = Vec2
     , y ∷ !Float 
     } deriving (Show, Eq)
 
+-- NB: sizeOf/alignment take LAZY (~) patterns. This module is compiled
+-- with Strict, and Data.Vector.Storable calls @sizeOf undefined@ — a
+-- strict wildcard would force it and crash (same trap family as the
+-- Strict+derivingUnbox gotcha).
 instance Storable Vec2 where
-    sizeOf _ = 8
-    alignment _ = 4
+    sizeOf ~_ = 8
+    alignment ~_ = 4
     peek ptr = do
         x' ← Storable.peekElemOff (castPtr ptr ∷ Ptr Float) 0
         y' ← Storable.peekElemOff (castPtr ptr ∷ Ptr Float) 1
@@ -64,8 +68,8 @@ data Vec4 = Vec4
     } deriving (Show, Eq)
 
 instance Storable Vec4 where
-    sizeOf _ = 16
-    alignment _ = 4
+    sizeOf ~_ = 16
+    alignment ~_ = 4
     peek ptr = do
         r' ← Storable.peekElemOff (castPtr ptr ∷ Ptr Float) 0
         g' ← Storable.peekElemOff (castPtr ptr ∷ Ptr Float) 1
@@ -88,8 +92,8 @@ data Vertex = Vertex
     } deriving (Show, Eq)
 
 instance Storable Vertex where
-    sizeOf _ = vertexTotalSize
-    alignment _ = 4
+    sizeOf ~_ = vertexTotalSize
+    alignment ~_ = 4
     peek ptr = do
         p ← peek (ptr `plusPtr` vertexPositionOffset)
         t ← peek (ptr `plusPtr` vertexTexCoordOffset)

--- a/src/Engine/Loop/Frame.hs
+++ b/src/Engine/Loop/Frame.hs
@@ -10,6 +10,7 @@ import UPrelude
 import Control.Exception (displayException)
 import qualified Data.Text as T
 import qualified Data.Vector as V
+import qualified Data.Vector.Storable as VS
 import qualified Data.Map as Map
 import Data.IORef (readIORef, writeIORef)
 import Linear (identity)
@@ -148,7 +149,7 @@ drawFrame = do
             updateUniformBufferForFrame win frameIdx liveCamera
 
             -- Prepare dynamic vertex buffer
-            let totalVertices = V.sum $ V.map (fromIntegral . V.length . rbVertices) batches
+            let totalVertices = V.sum $ V.map (fromIntegral . VS.length . rbVertices) batches
 
             dynamicBuffer ← if totalVertices > 0
                 then do

--- a/src/Engine/Scene/Batch/Update.hs
+++ b/src/Engine/Scene/Batch/Update.hs
@@ -9,7 +9,8 @@ module Engine.Scene.Batch.Update
 
 import UPrelude
 import qualified Data.Vector as V
-import qualified Data.Vector.Mutable as VM
+import qualified Data.Vector.Storable as VS
+import qualified Data.Vector.Storable.Mutable as VSM
 import qualified Data.Map as Map
 import qualified Data.List as List
 import Engine.Asset.Handle (TextureHandle)
@@ -52,16 +53,16 @@ createBatch ((textureId, layerId), objects) =
         objectIds = V.map doId objects
         -- Compute average z-index while we have the objects
         !avgZ = V.sum (V.map doZIndex objects) / fromIntegral numObjs
-        allVertices = V.create $ do
-            mv ← VM.new totalVerts
+        allVertices = VS.create $ do
+            mv ← VSM.new totalVerts
             V.iforM_ objects $ \idx obj → do
                 let !i = idx * 6
-                VM.write mv  i      (doV0 obj)
-                VM.write mv (i+1)   (doV1 obj)
-                VM.write mv (i+2)   (doV2 obj)
-                VM.write mv (i+3)   (doV0 obj)
-                VM.write mv (i+4)   (doV2 obj)
-                VM.write mv (i+5)   (doV3 obj)
+                VSM.write mv  i      (doV0 obj)
+                VSM.write mv (i+1)   (doV1 obj)
+                VSM.write mv (i+2)   (doV2 obj)
+                VSM.write mv (i+3)   (doV0 obj)
+                VSM.write mv (i+4)   (doV2 obj)
+                VSM.write mv (i+5)   (doV3 obj)
             return mv
         batch = RenderBatch
             { rbTexture  = textureId

--- a/src/Engine/Scene/Render.hs
+++ b/src/Engine/Scene/Render.hs
@@ -3,6 +3,7 @@ module Engine.Scene.Render where
 
 import UPrelude
 import qualified Data.Vector as V
+import qualified Data.Vector.Storable as VS
 import qualified Data.Map as Map
 import qualified Data.Text as T
 import Data.IORef
@@ -61,7 +62,7 @@ updateSceneForRender = do
 
                 let updatedBatchMgr = updateTextBatches textRenderBatches (smBatchManager updatedSceneMgr)
                     spriteBatches = getCurrentBatches updatedSceneMgr
-                    spriteCount = V.sum $ V.map (V.length . rbVertices) spriteBatches
+                    spriteCount = V.sum $ V.map (VS.length . rbVertices) spriteBatches
                     drawCallCount = V.length spriteBatches + V.length textRenderBatches
 
                 logDebugSM CatScene "Batch generation complete"
@@ -163,7 +164,7 @@ uploadBatchesToBuffer frameIdx batches dynamicBuffer = do
                                            "No device"
         Just d → pure d
 
-    let totalVertices = V.sum $ V.map (fromIntegral . V.length . rbVertices) batches
+    let totalVertices = V.sum $ V.map (fromIntegral . VS.length . rbVertices) batches
 
     logDebugSM CatRender "Uploading batches to buffer"
         [("batches", T.pack $ show $ V.length batches)
@@ -187,12 +188,12 @@ uploadBatchesToBuffer frameIdx batches dynamicBuffer = do
     V.forM_ batches $ \batch → do
         offset ← liftIO $ readIORef currentOffset
         let !vertices = rbVertices batch
-            !batchSize = V.length vertices * fromIntegral vertexTotalSize
+            !batchSize = VS.length vertices * fromIntegral vertexTotalSize
 
         liftIO $ do
-            let ptr = castPtr dataPtr `plusPtr` offset
-            V.iforM_ vertices $ \i vertex →
-                pokeByteOff ptr (i * fromIntegral vertexTotalSize) vertex
+            let dst = castPtr dataPtr `plusPtr` offset ∷ Ptr Vertex
+            VS.unsafeWith vertices $ \src →
+                copyArray dst src (VS.length vertices)
             writeIORef currentOffset (offset + batchSize)
 
     unmapMemory device (sdbMemory finalBuffer)

--- a/src/Engine/Scene/Types/Batch.hs
+++ b/src/Engine/Scene/Types/Batch.hs
@@ -16,7 +16,8 @@ module Engine.Scene.Types.Batch
 
 import UPrelude
 import qualified Data.Vector as V
-import qualified Data.Vector.Mutable as VM
+import qualified Data.Vector.Storable as VS
+import qualified Data.Vector.Storable.Mutable as VSM
 import qualified Data.Vector.Algorithms.Intro as VA
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -78,16 +79,16 @@ mergeQuadsToBatch layer quads =
                     in if last' == first'
                        then last'
                        else (last' + first') / 2
-        !allVerts = V.create $ do
-            mv ← VM.new totalVerts
+        !allVerts = VS.create $ do
+            mv ← VSM.new totalVerts
             V.iforM_ sorted $ \idx q → do
                 let i = idx * 6
-                VM.write mv  i      (sqV0 q)
-                VM.write mv (i+1)   (sqV1 q)
-                VM.write mv (i+2)   (sqV2 q)
-                VM.write mv (i+3)   (sqV0 q)
-                VM.write mv (i+4)   (sqV2 q)
-                VM.write mv (i+5)   (sqV3 q)
+                VSM.write mv  i      (sqV0 q)
+                VSM.write mv (i+1)   (sqV1 q)
+                VSM.write mv (i+2)   (sqV2 q)
+                VSM.write mv (i+3)   (sqV0 q)
+                VSM.write mv (i+4)   (sqV2 q)
+                VSM.write mv (i+5)   (sqV3 q)
             return mv
         tex = if V.null sorted
               then TextureHandle 0
@@ -104,7 +105,9 @@ mergeQuadsToBatch layer quads =
 data RenderBatch = RenderBatch
     { rbTexture    ∷ TextureHandle
     , rbLayer      ∷ LayerId
-    , rbVertices   ∷ V.Vector Vertex
+      -- | Storable (unboxed, pinned) so upload is a straight memcpy and
+      --   per-frame batch builds allocate no boxed Vertex objects (#445).
+    , rbVertices   ∷ VS.Vector Vertex
     , rbObjects    ∷ V.Vector ObjectId
     , rbDirty      ∷ Bool
     , rbAvgZ       ∷ Float

--- a/src/UI/Render.hs
+++ b/src/UI/Render.hs
@@ -7,6 +7,7 @@ module UI.Render
 import UPrelude
 import qualified Data.Map.Strict as Map
 import qualified Data.Vector as V
+import qualified Data.Vector.Storable as VS
 import qualified Data.Text as T
 import Data.List (sortOn)
 import Data.IORef (readIORef)
@@ -303,7 +304,7 @@ makeBoxBatches bindless texSet x y w h tileSize color layerId =
 makeQuadVertices ∷ Float → Float → Float → Float 
                  → (Float, Float, Float, Float) 
                  → Float
-                 → V.Vector Vertex
+                 → VS.Vector Vertex
 makeQuadVertices x y w h (cr, cg, cb, ca) atlasId =
     let x0 = x
         y0 = y
@@ -319,4 +320,4 @@ makeQuadVertices x y w h (cr, cg, cb, ca) atlasId =
         v4' = mkVertex (Vec2 x1 y0) (Vec2 1 0) col atlasId fmId
         v5' = mkVertex (Vec2 x1 y1) (Vec2 1 1) col atlasId fmId
         v6' = mkVertex (Vec2 x0 y1) (Vec2 0 1) col atlasId fmId
-    in V.fromList [v1', v2', v3', v4', v5', v6']
+    in VS.fromList [v1', v2', v3', v4', v5', v6']

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -179,6 +179,7 @@ test-suite synarchy-test-headless
                    Test.Headless.World.Render.SlopeBit
                    Test.Headless.Render.ViewportGuard
                    Test.Headless.Camera.GotoClamp
+                   Test.Headless.Scene.BatchMerge
     default-extensions: DefaultSignatures
                      , DuplicateRecordFields
                      , MagicHash

--- a/test-headless/Spec.hs
+++ b/test-headless/Spec.hs
@@ -39,6 +39,7 @@ import qualified Test.Headless.World.Render.SideFace as RenderSideFace
 import qualified Test.Headless.World.Render.SlopeBit as RenderSlopeBit
 import qualified Test.Headless.Render.ViewportGuard as ViewportGuard
 import qualified Test.Headless.Camera.GotoClamp as GotoClamp
+import qualified Test.Headless.Scene.BatchMerge as BatchMerge
 
 main ∷ IO ()
 main = hspec $ do
@@ -84,3 +85,4 @@ main = hspec $ do
     describe "World.Slope.slopeBit" RenderSlopeBit.spec
     describe "Render.ViewportGuard" ViewportGuard.spec
     describe "Camera.GotoClamp" GotoClamp.spec
+    describe "Scene.BatchMerge" BatchMerge.spec

--- a/test-headless/Test/Headless/Scene/BatchMerge.hs
+++ b/test-headless/Test/Headless/Scene/BatchMerge.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE Strict, UnicodeSyntax #-}
+-- | Pure tests for the sprite-batch builders 'mergeQuadsToBatch' and
+--   'createBatch' — the vertex-expansion contract behind #445's
+--   boxed→storable 'rbVertices' switch. Guards that quads land in
+--   ascending sort-key order, each quad expands to the two-triangle
+--   pattern (v0,v1,v2, v0,v2,v3), and counts/metadata survive the
+--   representation change. No engine needed: both builders are pure.
+module Test.Headless.Scene.BatchMerge (spec) where
+
+import UPrelude
+import Test.Hspec
+import qualified Data.Vector as V
+import qualified Data.Vector.Storable as VS
+import Engine.Asset.Handle (TextureHandle(..))
+import Engine.Scene.Base (LayerId(..), ObjectId(..))
+import Engine.Scene.Types.Batch (SortableQuad(..), DrawableObject(..)
+                                , RenderBatch(..), mergeQuadsToBatch)
+import Engine.Scene.Batch.Update (createBatch)
+import Engine.Graphics.Vulkan.Types.Vertex (Vertex(..), Vec2(..), Vec4(..), mkVertex)
+
+-- | A vertex tagged by its position's x component, so expansion order
+--   is observable in the output vector.
+vAt ∷ Float → Vertex
+vAt k = mkVertex (Vec2 k 0) (Vec2 0 0) (Vec4 1 1 1 1) 0 0
+
+-- | Tag of a vertex (inverse of 'vAt').
+tagOf ∷ Vertex → Float
+tagOf v = x (pos v)
+
+-- | A quad whose four corners carry tags key·10+0..3.
+quadAt ∷ Float → SortableQuad
+quadAt key = SortableQuad
+    { sqSortKey  = key
+    , sqV0       = vAt (key * 10 + 0)
+    , sqV1       = vAt (key * 10 + 1)
+    , sqV2       = vAt (key * 10 + 2)
+    , sqV3       = vAt (key * 10 + 3)
+    , sqTexture  = TextureHandle 7
+    , sqLayer    = LayerId 1
+    }
+
+-- | The expected two-triangle expansion of one quad: v0,v1,v2, v0,v2,v3.
+expandedTags ∷ Float → [Float]
+expandedTags key = map (\i → key * 10 + i) [0, 1, 2, 0, 2, 3]
+
+spec ∷ Spec
+spec = do
+    describe "mergeQuadsToBatch" $ do
+        it "sorts quads by sort key and expands each as v0,v1,v2,v0,v2,v3" $ do
+            let batch = mergeQuadsToBatch (LayerId 1)
+                            (V.fromList [quadAt 3, quadAt 1, quadAt 2])
+            map tagOf (VS.toList (rbVertices batch))
+                `shouldBe` concatMap expandedTags [1, 2, 3]
+
+        it "emits 6 vertices per quad" $ do
+            let batch = mergeQuadsToBatch (LayerId 1)
+                            (V.fromList (map quadAt [1 .. 20]))
+            VS.length (rbVertices batch) `shouldBe` 120
+
+        it "produces an empty batch from no quads" $ do
+            let batch = mergeQuadsToBatch (LayerId 1) V.empty
+            VS.null (rbVertices batch) `shouldBe` True
+
+        it "averages the depth range into rbAvgZ" $ do
+            let batch = mergeQuadsToBatch (LayerId 1)
+                            (V.fromList [quadAt 4, quadAt 2])
+            rbAvgZ batch `shouldBe` 3
+
+    describe "createBatch" $ do
+        let dobj ∷ Word32 → Float → DrawableObject
+            dobj oid z = DrawableObject
+                { doId      = ObjectId oid
+                , doTexture = TextureHandle 9
+                , doV0      = vAt (z * 10 + 0)
+                , doV1      = vAt (z * 10 + 1)
+                , doV2      = vAt (z * 10 + 2)
+                , doV3      = vAt (z * 10 + 3)
+                , doZIndex  = z
+                , doLayer   = LayerId 2
+                }
+
+        it "expands objects in input order as v0,v1,v2,v0,v2,v3" $ do
+            let (_, batch) = createBatch ((TextureHandle 9, LayerId 2)
+                                         , V.fromList [dobj 1 1, dobj 2 2])
+            map tagOf (VS.toList (rbVertices batch))
+                `shouldBe` concatMap expandedTags [1, 2]
+
+        it "carries object ids and averages z" $ do
+            let (_, batch) = createBatch ((TextureHandle 9, LayerId 2)
+                                         , V.fromList [dobj 1 1, dobj 2 3])
+            V.toList (rbObjects batch) `shouldBe` [ObjectId 1, ObjectId 2]
+            rbAvgZ batch `shouldBe` 2


### PR DESCRIPTION
Closes #445.

## Approach

`RenderBatch.rbVertices` switches from boxed `Data.Vector.Vector Vertex` to `Data.Vector.Storable.Vector Vertex` (`Vertex` is a flat 44-byte `Storable`). Effects per frame:

- `mergeQuadsToBatch` / `createBatch` / `makeQuadVertices` build into unboxed pinned memory — no more 6 boxed `Vertex` heap objects per visible quad per frame.
- `uploadBatchesToBuffer` uploads with one `copyArray` (memcpy) per batch instead of a per-vertex `pokeByteOff` walk over a boxed vector.
- Remaining consumers (`Frame.hs`, `Command/Sprite.hs`, `Scene/Render.hs` counts) are 1:1 `V.length` → `VS.length` swaps.

**Enabling fix that the tests caught:** `Vertex.hs` is compiled with `Strict`, which silently made the `Storable` `sizeOf _`/`alignment _` wildcard patterns strict — and `Data.Vector.Storable` calls `sizeOf undefined`, so the very first storable vector of `Vertex` crashed with `Prelude.undefined`. The patterns are now explicitly lazy (`~_`) for `Vec2`/`Vec4`/`Vertex`, with a comment naming the trap (same family as the known Strict+derivingUnbox gotcha). Note for a possible follow-up: the `UBO` instance in `Engine/Graphics/Vulkan/Types.hs` has the same strict pattern under `Strict`; it's not currently reachable with `undefined`, so it's left untouched here.

Out of scope, per the issue: text glyph batches (already a cached instance buffer) and the per-frame re-sort/re-expansion (that's #446).

## Tested

- New pure spec `Test.Headless.Scene.BatchMerge` (6 examples) pins the builders' contract across the representation change: ascending sort-key order, `v0,v1,v2,v0,v2,v3` triangle expansion, 6-per-quad counts, empty input, `rbObjects` / `rbAvgZ` metadata. This spec fails with `Prelude.undefined` without the laziness fix.
- Full headless suite: 423 examples, 0 failures. `tools/test_audit.py`: all 35 groups pass.
- w64 seed-42 `--dump` byte-identical to master (worldgen untouched, as expected).
- **Needs eyes (can't be verified headless):** GUI visual check that world + UI render identically, and optionally a `+RTS -s` allocation-rate before/after at a matched scene — the sort order and vertex bytes are unchanged by construction, but pixels should be confirmed on a real window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)