### PR TITLE
Add ntfy.sh push notifications for PR lifecycle

### DIFF
--- a/.github/workflows/ntfy-notify.yml
+++ b/.github/workflows/ntfy-notify.yml
@@ -1,0 +1,38 @@
+name: ntfy-notify
+on:
+  pull_request:
+    types: [opened, labeled, closed]
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR opened
+        if: ${{ github.event.action == 'opened' }}
+        env:
+          NTFY_URL: ${{ secrets.NTFY_URL }}
+          NUM: ${{ github.event.pull_request.number }}
+          TITLE: ${{ github.event.pull_request.title }}
+          URL: ${{ github.event.pull_request.html_url }}
+        run: curl -sS -H "Title: PR #$NUM opened" -H "Tags: rocket" -H "Click: $URL" -d "$TITLE — ready for review" "$NTFY_URL"
+      - name: PR reviewed approve
+        if: ${{ github.event.action == 'labeled' && github.event.label.name == 'reviewed:approve' }}
+        env:
+          NTFY_URL: ${{ secrets.NTFY_URL }}
+          NUM: ${{ github.event.pull_request.number }}
+          URL: ${{ github.event.pull_request.html_url }}
+        run: curl -sS -H "Title: PR #$NUM reviewed: APPROVE" -H "Tags: white_check_mark" -H "Click: $URL" -d "Review approved — ready to finalize" "$NTFY_URL"
+      - name: PR reviewed changes
+        if: ${{ github.event.action == 'labeled' && github.event.label.name == 'reviewed:changes' }}
+        env:
+          NTFY_URL: ${{ secrets.NTFY_URL }}
+          NUM: ${{ github.event.pull_request.number }}
+          URL: ${{ github.event.pull_request.html_url }}
+        run: curl -sS -H "Title: PR #$NUM reviewed: CHANGES REQUESTED" -H "Tags: warning" -H "Click: $URL" -d "Changes requested — needs fixes" "$NTFY_URL"
+      - name: PR merged
+        if: ${{ github.event.action == 'closed' && github.event.pull_request.merged == true }}
+        env:
+          NTFY_URL: ${{ secrets.NTFY_URL }}
+          NUM: ${{ github.event.pull_request.number }}
+          URL: ${{ github.event.pull_request.html_url }}
+          BASE: ${{ github.event.pull_request.base.ref }}
+        run: curl -sS -H "Title: PR #$NUM merged" -H "Tags: tada" -H "Click: $URL" -d "Merged to $BASE" "$NTFY_URL"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ntfy-notify.yml`: notifies https://ntfy.sh/coghex on PR opened, review-label applied (`reviewed:approve` / `reviewed:changes`), and PR merged — each with a tap-to-open link to the PR.
- GitHub context values are passed through `env:` and referenced as quoted shell variables in `run:` to avoid script injection.
- Companion setup (secret `NTFY_URL`, the two review-verdict labels, and reviewer definitions that apply them) is done alongside this PR, outside the diff.

## Test plan
- [x] YAML is valid (workflow file structurally matches the reviewed spec)
- [ ] First real PR open/label/merge event confirms a notification arrives at ntfy.sh/coghex