### PR TITLE
Pan margin + parallel chunk build for quad-cache rebuilds (#447)

### DIFF
--- a/src/Engine/Graphics/Vulkan/Types/Vertex.hs
+++ b/src/Engine/Graphics/Vulkan/Types/Vertex.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE Strict, UnicodeSyntax #-}
 module Engine.Graphics.Vulkan.Types.Vertex where
 import UPrelude
+import Control.DeepSeq (NFData(..), rwhnf)
 import qualified Foreign.Storable as Storable
 
 -- Constants for vertex layout
@@ -39,10 +40,15 @@ mkVertex ∷ Vec2 → Vec2 → Vec4 → Float → Float → Vertex
 mkVertex p t c a f = Vertex p t c a f 0
 
 -- | 2D vector for positions and texture coordinates
-data Vec2 = Vec2 
+data Vec2 = Vec2
     { x ∷ !Float
-    , y ∷ !Float 
+    , y ∷ !Float
     } deriving (Show, Eq)
+
+-- | All fields strict and primitive, so WHNF = NF for these three
+--   (needed by the parallel quad build's rdeepseq, #447).
+instance NFData Vec2 where
+    rnf = rwhnf
 
 -- NB: sizeOf/alignment take LAZY (~) patterns. This module is compiled
 -- with Strict, and Data.Vector.Storable calls @sizeOf undefined@ — a
@@ -60,12 +66,15 @@ instance Storable Vec2 where
         Storable.pokeElemOff (castPtr ptr ∷ Ptr Float) 1 y'
 
 -- | 4D vector for colors
-data Vec4 = Vec4 
+data Vec4 = Vec4
     { r ∷ !Float
     , g ∷ !Float
     , b ∷ !Float
-    , a ∷ !Float 
+    , a ∷ !Float
     } deriving (Show, Eq)
+
+instance NFData Vec4 where
+    rnf = rwhnf
 
 instance Storable Vec4 where
     sizeOf ~_ = 16
@@ -90,6 +99,9 @@ data Vertex = Vertex
     , faceMapId   ∷ !Float  -- ^ Face map texture slot (layout = 4)
     , renderFlags ∷ !Word32 -- ^ Render-flag bitset, see renderFlag* (layout = 5)
     } deriving (Show, Eq)
+
+instance NFData Vertex where
+    rnf = rwhnf
 
 instance Storable Vertex where
     sizeOf ~_ = vertexTotalSize

--- a/src/Engine/Scene/Types/Batch.hs
+++ b/src/Engine/Scene/Types/Batch.hs
@@ -20,6 +20,7 @@ module Engine.Scene.Types.Batch
   ) where
 
 import UPrelude
+import Control.DeepSeq (NFData(..), rwhnf)
 import qualified Data.Vector as V
 import qualified Data.Vector.Mutable as VM
 import qualified Data.Vector.Storable as VS
@@ -47,6 +48,11 @@ data SortableQuad = SortableQuad
     , sqTexture  ∷ !TextureHandle  -- ^ Needed for potential future per-texture batching
     , sqLayer    ∷ !LayerId
     } deriving (Show)
+
+-- | Every field is strict (Vertex transitively so), so WHNF = NF —
+--   what the parallel per-chunk quad build's rdeepseq forces (#447).
+instance NFData SortableQuad where
+    rnf = rwhnf
 
 -- | Drawable object ready for rendering
 data DrawableObject = DrawableObject

--- a/src/World/Render/Camera.hs
+++ b/src/World/Render/Camera.hs
@@ -1,10 +1,13 @@
 {-# LANGUAGE Strict, UnicodeSyntax #-}
 module World.Render.Camera
     ( camEpsilon
+    , quadCacheMarginFrac
+    , quadCacheMargins
     , cameraChanged
     ) where
 
 import UPrelude
+import Engine.Graphics.Viewport (safeAspect)
 import World.Types
 import World.Grid (tileHalfWidth)
 
@@ -13,12 +16,39 @@ import World.Grid (tileHalfWidth)
 camEpsilon ∷ Float
 camEpsilon = tileHalfWidth
 
+-- | Fraction of the viewport half-extent baked into the cached tile
+--   pass as extra view-bounds margin, and — paired — the extra camera
+--   travel allowed before the quad cache invalidates (#447). One
+--   constant feeds both consumers of 'quadCacheMargins' (bounds
+--   expansion in renderWorldQuads, invalidation below) so coverage and
+--   invalidation can't diverge. 0.25 trades ~1.5× more cached quads
+--   for ~5× fewer full rebuilds while panning.
+quadCacheMarginFrac ∷ Float
+quadCacheMarginFrac = 0.25
+
+-- | Per-axis world-unit margins for a snapshot's viewport. camZoom is
+--   the viewport HALF-HEIGHT in world units; width scales by the
+--   framebuffer aspect (zero-size-safe), so the relative overhead is
+--   constant across zoom levels.
+quadCacheMargins ∷ WorldCameraSnapshot → (Float, Float)
+quadCacheMargins snap =
+    let (fbW, fbH) = wcsFbSize snap
+        aspect     = safeAspect fbW fbH
+        z          = wcsZoom snap
+    in (quadCacheMarginFrac * z * aspect, quadCacheMarginFrac * z)
+
+-- | The position threshold pairs exactly with the coverage built at
+--   'old': quads were culled to viewport(old) + camEpsilon pad
+--   (computeViewBounds) + quadCacheMargins(old) (renderWorldQuads), so
+--   the true viewport stays inside the built coverage for any pan up
+--   to camEpsilon + margin per axis.
 cameraChanged ∷ WorldCameraSnapshot → WorldCameraSnapshot → Bool
 cameraChanged old new =
     let (ox, oy) = wcsPosition old
         (nx, ny) = wcsPosition new
-    in abs (ox - nx) > camEpsilon
-     ∨ abs (oy - ny) > camEpsilon
+        (mX, mY) = quadCacheMargins old
+    in abs (ox - nx) > camEpsilon + mX
+     ∨ abs (oy - ny) > camEpsilon + mY
      ∨ abs (wcsZoom old - wcsZoom new) > camEpsilon
      ∨ wcsZSlice old ≢ wcsZSlice new
      ∨ wcsFbSize old ≢ wcsFbSize new

--- a/src/World/Render/Quads.hs
+++ b/src/World/Render/Quads.hs
@@ -9,6 +9,7 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.Vector.Unboxed as VU
 import qualified Data.Vector as V
 import Data.IORef (readIORef, atomicModifyIORef')
+import Control.Parallel.Strategies (parListChunk, rdeepseq, using)
 import Engine.Core.State (EngineEnv(..))
 import Engine.Asset.Handle (TextureHandle(..), toInt)
 import Engine.Scene.Types (SortableQuad(..))
@@ -21,7 +22,8 @@ import World.Grid (gridToScreen, tileSideHeight, applyFacing)
 import Structure.Types (StructureSlot(..), spdGridZ)
 import World.Mine.Types (MineDesignation(..))
 import World.Construct.Types (ConstructDesignation(..), ConstructTarget(..))
-import World.Render.ViewBounds (computeViewBounds, isTileVisible)
+import World.Render.ViewBounds (computeViewBounds, expandViewBounds, isTileVisible)
+import World.Render.Camera (quadCacheMargins)
 import World.Render.ChunkCulling (isChunkRelevantForSlice, isChunkVisibleWrapped)
 import World.Render.HitTest (pickWorldTile)
 import World.Render.FloraQuads (floraToQuad)
@@ -182,7 +184,12 @@ renderWorldQuads env worldState zoomAlpha snap = do
                  [] → Nothing
                  ks → Just (maximum ks)
 
-        vb = computeViewBounds camera fbW fbH effectiveDepth
+        -- Cached pass: widen the bounds by the pan margin so the camera
+        -- can travel that far before cameraChanged forces a rebuild
+        -- (#447). The margins come from the SAME snapshot the cache is
+        -- stamped with, pairing coverage with invalidation.
+        vb = expandViewBounds (quadCacheMargins snap) $
+                 computeViewBounds camera fbW fbH effectiveDepth
 
         visibleChunksWithOffset =
             [ (lc, offset)
@@ -398,6 +405,12 @@ renderWorldQuads env worldState zoomAlpha snap = do
                                      <> blankQuads <> iceQuads <> oceanQuads
                                      <> lavaQuads <> freshwaterQuads)
             ) visibleChunksWithOffset
+            -- Chunks build independently, so rebuilds (already off the
+            -- render thread — this runs on the world thread) spread
+            -- across cores, same pattern as ChunkLoading /
+            -- ZoomMap.Cache (#447). Chunk-of-4 keeps spark overhead
+            -- low at typical visible-chunk counts (~20–100).
+            `using` parListChunk 4 rdeepseq
     return $! V.concat chunkVectors
 
 -- * World Cursor Quads (generated every frame, not cached)

--- a/src/World/Render/ViewBounds.hs
+++ b/src/World/Render/ViewBounds.hs
@@ -2,6 +2,7 @@
 module World.Render.ViewBounds
     ( ViewBounds(..)
     , computeViewBounds
+    , expandViewBounds
     , isTileVisible
     ) where
 
@@ -38,6 +39,19 @@ computeViewBounds camera fbW fbH effDepth =
         , vbTop    = cy - halfH - padY
         , vbBottom = cy + halfH + padY
         }
+
+-- | Widen bounds by per-axis margins. The cached tile pass uses this
+--   with 'World.Render.Camera.quadCacheMargins' so a pan can travel
+--   the margin before the quad cache must rebuild (#447). Per-frame
+--   (dynamic) passes keep the tight bounds — margin would only make
+--   them build more offscreen quads every tick.
+expandViewBounds ∷ (Float, Float) → ViewBounds → ViewBounds
+expandViewBounds (mX, mY) vb = ViewBounds
+    { vbLeft   = vbLeft vb - mX
+    , vbRight  = vbRight vb + mX
+    , vbTop    = vbTop vb - mY
+    , vbBottom = vbBottom vb + mY
+    }
 
 isTileVisible ∷ ViewBounds → Float → Float → Bool
 isTileVisible vb drawX drawY =

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -180,6 +180,7 @@ test-suite synarchy-test-headless
                    Test.Headless.Render.ViewportGuard
                    Test.Headless.Camera.GotoClamp
                    Test.Headless.Scene.BatchMerge
+                   Test.Headless.Render.PanMargin
     default-extensions: DefaultSignatures
                      , DuplicateRecordFields
                      , MagicHash

--- a/test-headless/Spec.hs
+++ b/test-headless/Spec.hs
@@ -40,6 +40,7 @@ import qualified Test.Headless.World.Render.SlopeBit as RenderSlopeBit
 import qualified Test.Headless.Render.ViewportGuard as ViewportGuard
 import qualified Test.Headless.Camera.GotoClamp as GotoClamp
 import qualified Test.Headless.Scene.BatchMerge as BatchMerge
+import qualified Test.Headless.Render.PanMargin as PanMargin
 
 main ∷ IO ()
 main = hspec $ do
@@ -86,3 +87,4 @@ main = hspec $ do
     describe "Render.ViewportGuard" ViewportGuard.spec
     describe "Camera.GotoClamp" GotoClamp.spec
     describe "Scene.BatchMerge" BatchMerge.spec
+    describe "Render.PanMargin" PanMargin.spec

--- a/test-headless/Test/Headless/Render/PanMargin.hs
+++ b/test-headless/Test/Headless/Render/PanMargin.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE Strict, UnicodeSyntax #-}
+-- | Pure tests for the pan-margin quad-cache invalidation (#447).
+--   The contract under test: 'cameraChanged' allows exactly the camera
+--   travel whose coverage 'expandViewBounds' + 'quadCacheMargins'
+--   baked into the cached tile pass — pans inside the margin reuse the
+--   cache AND still have every visible tile inside the built bounds;
+--   pans beyond it invalidate.
+module Test.Headless.Render.PanMargin (spec) where
+
+import UPrelude
+import Test.Hspec
+import Engine.Graphics.Camera (Camera2D(..), CameraFacing(..), defaultCamera)
+import Engine.Graphics.Viewport (safeAspect)
+import World.Types (WorldCameraSnapshot(..))
+import World.Grid (tileWidth)
+import World.Render.Camera (camEpsilon, quadCacheMargins, cameraChanged)
+import World.Render.ViewBounds (ViewBounds(..), computeViewBounds, expandViewBounds)
+
+testZoom ∷ Float
+testZoom = 1.2
+
+testFb ∷ (Int, Int)
+testFb = (1920, 1080)
+
+snapAt ∷ (Float, Float) → WorldCameraSnapshot
+snapAt p = WorldCameraSnapshot
+    { wcsPosition = p
+    , wcsZoom     = testZoom
+    , wcsZSlice   = 30
+    , wcsFbSize   = testFb
+    , wcsFacing   = FaceSouth
+    }
+
+-- | A hair inside float-comparison noise, well under any margin.
+nudge ∷ Float
+nudge = 0.001
+
+spec ∷ Spec
+spec = do
+    let s0       = snapAt (0, 0)
+        (mX, mY) = quadCacheMargins s0
+
+    describe "quadCacheMargins" $ do
+        it "scales with zoom and framebuffer aspect" $ do
+            let aspect = safeAspect (fst testFb) (snd testFb)
+            mY `shouldBe` 0.25 * testZoom
+            mX `shouldBe` 0.25 * testZoom * aspect
+
+    describe "cameraChanged" $ do
+        it "tolerates a pan up to margin + epsilon per axis" $ do
+            cameraChanged s0 (snapAt (mX + camEpsilon - nudge, 0)) `shouldBe` False
+            cameraChanged s0 (snapAt (0, mY + camEpsilon - nudge)) `shouldBe` False
+
+        it "invalidates on a pan beyond margin + epsilon" $ do
+            cameraChanged s0 (snapAt (mX + camEpsilon + nudge, 0)) `shouldBe` True
+            cameraChanged s0 (snapAt (0, -(mY + camEpsilon + nudge))) `shouldBe` True
+
+        it "still invalidates on zoom / zSlice / fbSize / facing changes" $ do
+            cameraChanged s0 (s0 { wcsZoom = testZoom + camEpsilon + nudge }) `shouldBe` True
+            cameraChanged s0 (s0 { wcsZSlice = 31 }) `shouldBe` True
+            cameraChanged s0 (s0 { wcsFbSize = (800, 600) }) `shouldBe` True
+            cameraChanged s0 (s0 { wcsFacing = FaceEast }) `shouldBe` True
+
+    describe "expandViewBounds" $ do
+        it "widens each side by the per-axis margin" $ do
+            let vb  = ViewBounds { vbLeft = -1, vbRight = 1, vbTop = -2, vbBottom = 2 }
+                vb' = expandViewBounds (0.5, 0.25) vb
+            vbLeft vb'   `shouldBe` (-1.5)
+            vbRight vb'  `shouldBe` 1.5
+            vbTop vb'    `shouldBe` (-2.25)
+            vbBottom vb' `shouldBe` 2.25
+
+    describe "coverage/invalidation pairing" $ do
+        -- The cached pass builds bounds at s0 expanded by the margins;
+        -- the LARGEST pan cameraChanged tolerates must still keep every
+        -- tile overlapping the true viewport inside those bounds. A
+        -- tile overlaps the viewport when its drawX is within tileWidth
+        -- left of the viewport edge, hence the tileWidth term.
+        it "largest tolerated pan keeps the true viewport inside built bounds" $ do
+            let cam0 = defaultCamera { camPosition = (0, 0)
+                                     , camZoom = testZoom
+                                     , camZSlice = 30 }
+                built = expandViewBounds (quadCacheMargins s0) $
+                            computeViewBounds cam0 (fst testFb) (snd testFb) 25
+                aspect = safeAspect (fst testFb) (snd testFb)
+                halfW  = testZoom * aspect
+                dx     = mX + camEpsilon - nudge   -- tolerated per cameraChanged
+                dy     = mY + camEpsilon - nudge
+            -- each edge checked against the pan direction that stresses
+            -- it: left/top against a negative pan, right/bottom positive
+            vbLeft built  `shouldSatisfy` (≤ -dx - halfW - tileWidth)
+            vbRight built `shouldSatisfy` (≥ dx + halfW)
+            -- vertical (padY also carries tile height + depth padding,
+            -- so this holds with slack)
+            vbTop built    `shouldSatisfy` (≤ -dy - testZoom - tileWidth)
+            vbBottom built `shouldSatisfy` (≥ dy + testZoom)


### PR DESCRIPTION
Closes #447.

## Approach

Both levers from the issue, independent as specified:

**1. View margin.** `renderWorldQuads` (the cached static pass only) widens its culling bounds by `quadCacheMargins`: `quadCacheMarginFrac = 0.25` of the viewport half-extent **per axis** — proportional to `camZoom` and framebuffer aspect, so the relative quad overhead is constant across zoom levels (a fixed world-unit margin would triple the viewport at close zoom). `cameraChanged`'s position threshold becomes `camEpsilon + margin` per axis, from the **same** `quadCacheMargins` on the **same** snapshot the cache is stamped with — one constant feeds both, so coverage and invalidation can't diverge. Net: ~1.5× more cached quads for ~5× fewer full rebuilds while panning; at zero margin it degenerates to exactly the old behavior. Dynamic per-tick passes (cursor, spoil, ground items) keep the tight bounds — margin would just make them build offscreen quads every tick.

**2. Parallel rebuild.** The per-chunk `map` in `renderWorldQuads` now runs under `parListChunk 4 rdeepseq` — the same pattern as `World.Thread.ChunkLoading` and `World.ZoomMap.Cache`. Rebuilds already run on the world thread (not the render thread); now they also spread across cores. Enabling piece: `NFData` for `SortableQuad`/`Vertex`/`Vec2`/`Vec4` — all-strict records, so `rnf = rwhnf` (WHNF = NF), with a comment explaining why.

**Zoom-epsilon ride-along from the issue:** not touched — the margin now absorbs zoom-out growth up to the existing epsilon, strictly safer than before.

## Tested

- New pure spec `Test.Headless.Render.PanMargin` (6 examples) pins the coverage/invalidation pairing: pans within margin+epsilon don't invalidate AND the largest tolerated pan keeps every viewport-overlapping tile inside the built bounds (the tight case passes with exactly the test's float-nudge of slack, i.e. the pairing is exact); pans beyond invalidate; zoom/zSlice/fbSize/facing triggers unchanged.
- Full headless suite: 435 examples, 0 failures. `tools/test_audit.py`: 35/35.
- `world_check.py --quick`: FAIL=5/bugs=0 — **identical failure summary on master with the same baselines** (pre-existing staleness, being fixed by open #449), so not introduced here. w64 seed-42 `--dump` byte-identical to master.
- **Needs eyes (GUI):** pan across a large loaded view (vsync off) and confirm reduced frame spikes and no pop-in at screen edges; rotation and z-slice changes still rebuild correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)