### PR TITLE
#365: Arena pages survive save/load — rebuild via the flat builder instead of the generator

### DIFF
--- a/src/World/Generate/Arena.hs
+++ b/src/World/Generate/Arena.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE Strict, UnicodeSyntax #-}
 module World.Generate.Arena
     ( generateFlatChunk
+    , generateArenaChunks
+    , arenaRadius
     ) where
 
 import UPrelude
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU
+import System.Random (StdGen, randomR)
 import World.Types
 import World.Material
 import World.Vegetation
@@ -38,3 +41,75 @@ generateFlatChunk coord =
         , lcMagma             = Nothing
         , lcStructures        = emptyChunkStructures
         }
+
+-- | Arena footprint: (2r+1)² chunks centred on the origin (5×5).
+arenaRadius ∷ Int
+arenaRadius = 2
+
+-- | Build the full eager arena chunk set — the 5×5 flat loam-over-granite
+--   region 'handleWorldInitArenaCommand' stamps at init. Moved here (#365)
+--   so the save-load path can rebuild an arena page identically instead of
+--   running the real generator on the arena's synthetic gen params (which
+--   wedges the world thread). The StdGen only varies the surface grass
+--   sprites; every chunk shares one column layout.
+generateArenaChunks ∷ StdGen → [LoadedChunk]
+generateArenaChunks gen =
+    let MaterialId loamId    = matLoam
+        MaterialId graniteId = matGranite
+        -- Surface veg base id: + rand 0..3 spreads across the grass/moss
+        -- variants (ids 5..8), matching the original arena look.
+        grassId    = vegMediumGrass
+        arenaZ     = seaLevel    -- z = 0 (surface)
+        loamLayers    = 4        -- top 4 tiles
+        graniteLayers = 12       -- 12 tiles below
+        arenaDepth    = loamLayers + graniteLayers
+        columnStartZ  = arenaZ - arenaDepth + 1   -- bottom of the column
+        chunkArea     = chunkSize * chunkSize     -- 256
+
+        -- Column material stack (shared across all columns): index 0 is
+        -- the bottom of the column, index (arenaDepth - 1) is the top.
+        -- Loam fills the top loamLayers; granite fills below.
+        columnMats   = VU.generate arenaDepth (\i →
+                         if i ≥ graniteLayers then loamId else graniteId)
+        columnSlopes = VU.replicate arenaDepth 0
+
+        buildColumns ∷ Int → V.Vector ColumnTiles → StdGen → V.Vector ColumnTiles
+        buildColumns 0    acc _g = acc
+        buildColumns area acc g = buildColumns (area - 1)
+                                      (V.cons newelem acc) newg
+            where (rand, newg) = randomR (0, 3) g
+                  actualId = grassId + rand
+                  -- Vegetation only on the top tile (the visible surface);
+                  -- granite + lower loam tiles get 0 so the renderer
+                  -- doesn't sprout grass underground after a dig.
+                  columnVeg = VU.generate arenaDepth (\i →
+                                if i ≡ arenaDepth - 1 then actualId else 0)
+                  newelem = (ColumnTiles
+                             { ctStartZ = columnStartZ
+                             , ctMats   = columnMats
+                             , ctSlopes = columnSlopes
+                             , ctVeg    = columnVeg
+                             })
+        flatSurfaceMap = VU.replicate chunkArea arenaZ
+        flatFluidMap   = V.replicate chunkArea Nothing
+        flatFlora      = emptyFloraChunkData
+        flatChunk      = buildColumns chunkArea V.empty gen
+
+        mkChunk cx cy = LoadedChunk
+            { lcCoord             = ChunkCoord cx cy
+            , lcTiles             = flatChunk
+            , lcSurfaceMap        = flatSurfaceMap
+            , lcTerrainSurfaceMap = flatSurfaceMap
+            , lcFluidMap          = flatFluidMap
+            , lcIceMap            = emptyIceMap
+            , lcFlora             = flatFlora
+            , lcSideDeco          = VU.replicate (chunkSize * chunkSize) 0
+            , lcWaterTableMap    = VU.replicate (chunkSize * chunkSize) (arenaZ - 2)
+            , lcMagma             = Nothing
+            , lcStructures        = emptyChunkStructures
+            }
+
+    in [ mkChunk cx cy
+       | cx ← [-arenaRadius .. arenaRadius]
+       , cy ← [-arenaRadius .. arenaRadius]
+       ]

--- a/src/World/Thread/Command/Init.hs
+++ b/src/World/Thread/Command/Init.hs
@@ -25,6 +25,7 @@ import World.Material (MaterialProps(..), registerMaterial
 import World.Types
 import Structure.Types (emptyChunkStructures)
 import World.Generate (generateChunk)
+import World.Generate.Arena (generateArenaChunks)
 import World.Generate.Constants (chunkLoadRadius)
 import World.Geology (buildTimeline)
 import World.Geology.Log (formatPlatesSummary)
@@ -321,67 +322,11 @@ handleWorldInitArenaCommand env logger pageId = do
     atomicModifyIORef' (loadProvenanceRef env) $ \m →
         (HM.map (HS.delete pageId) m, ())
 
-    -- Arena parameters
-    let arenaRadius = 2           -- 5×5 chunks
-        loamId     = 56 ∷ Word8  -- matLoam    = MaterialId 56
-        graniteId  = 1  ∷ Word8  -- matGranite = MaterialId 1
-        grassId    = 5  ∷ Word8  -- matGrass   = MaterialId 5
-        arenaZ     = seaLevel    -- z = 0 (surface)
-        loamLayers    = 4        -- top 4 tiles
-        graniteLayers = 12       -- 12 tiles below
-        arenaDepth    = loamLayers + graniteLayers
-        columnStartZ  = arenaZ - arenaDepth + 1   -- bottom of the column
-        chunkArea     = chunkSize * chunkSize     -- 256
-
-        -- Column material stack (shared across all columns): index 0 is
-        -- the bottom of the column, index (arenaDepth - 1) is the top.
-        -- Loam fills the top loamLayers; granite fills below.
-        columnMats   = VU.generate arenaDepth (\i →
-                         if i ≥ graniteLayers then loamId else graniteId)
-        columnSlopes = VU.replicate arenaDepth 0
-
-        generateChunk ∷ Int → V.Vector ColumnTiles → StdGen → V.Vector ColumnTiles
-        generateChunk 0    init _g = init
-        generateChunk area init g = generateChunk (area - 1)
-                                      (V.cons newelem init) newg
-            where (rand, newg) = randomR (0, 3) g
-                  actualId = grassId + rand
-                  -- Vegetation only on the top tile (the visible surface);
-                  -- granite + lower loam tiles get 0 so the renderer
-                  -- doesn't sprout grass underground after a dig.
-                  columnVeg = VU.generate arenaDepth (\i →
-                                if i ≡ arenaDepth - 1 then actualId else 0)
-                  newelem = (ColumnTiles
-                             { ctStartZ = columnStartZ
-                             , ctMats   = columnMats
-                             , ctSlopes = columnSlopes
-                             , ctVeg    = columnVeg
-                             })
-        flatSurfaceMap = VU.replicate chunkArea arenaZ
-        flatFluidMap   = V.replicate chunkArea Nothing
-        flatFlora      = emptyFloraChunkData
-        flatChunk      = generateChunk chunkArea V.empty gen
-
-        mkChunk cx cy = LoadedChunk
-            { lcCoord             = ChunkCoord cx cy
-            , lcTiles             = flatChunk
-            , lcSurfaceMap        = flatSurfaceMap
-            , lcTerrainSurfaceMap = flatSurfaceMap
-            , lcFluidMap          = flatFluidMap
-            , lcIceMap            = emptyIceMap
-            , lcFlora             = flatFlora
-            , lcSideDeco          = VU.replicate (chunkSize * chunkSize) 0
-            , lcWaterTableMap    = VU.replicate (chunkSize * chunkSize) (arenaZ - 2)
-            , lcMagma             = Nothing
-            , lcStructures        = emptyChunkStructures
-            }
-
-        allChunks = [ mkChunk cx cy
-                    | cx ← [-arenaRadius .. arenaRadius]
-                    , cy ← [-arenaRadius .. arenaRadius]
-                    ]
-
-        chunkMap = HM.fromList [ (lcCoord c, c) | c ← allChunks ]
+    -- Arena chunk set: shared with the save-load restore path (#365) so a
+    -- loaded arena page is rebuilt exactly like a fresh one.
+    let arenaZ    = seaLevel    -- z = 0 (surface)
+        allChunks = generateArenaChunks gen
+        chunkMap  = HM.fromList [ (lcCoord c, c) | c ← allChunks ]
 
     -- Write tile data
     atomicModifyIORef' (wsTilesRef worldState) $ \_ →

--- a/src/World/Thread/Command/Save.hs
+++ b/src/World/Thread/Command/Save.hs
@@ -22,8 +22,10 @@ import World.Types
 import World.Thread.Command.UI (handleWorldShowCommand, handleWorldHideCommand)
 import Structure.Types (emptyChunkStructures)
 import World.Generate (generateChunk, cameraChunkCoord)
+import World.Generate.Arena (generateArenaChunks)
 import World.Grid (worldToGrid)
 import World.Generate.Constants (chunkLoadRadius)
+import System.Random (mkStdGen)
 import World.Plate (elevationAtGlobal)
 import World.Preview (buildPreviewFromPixels, PreviewImage(..))
 import World.Render (surfaceHeadroom)
@@ -429,132 +431,184 @@ handleWorldLoadSaveCommand env logger pageId saveData
         writeIORef (wsGroundItemsRef worldState) (wpsGroundItems wps)
         writeIORef (wsSpoilRef worldState) (wpsSpoilPiles wps)
 
-        -- 1b. Rebuild this page's zoom cache with per-chunk textures.
-        --     'buildTimeline' didn't run on this code path, so we don't have
-        --     the init-time bordered cache; pass Nothing and let
-        --     generateZoomTerrain recompute the per-chunk pipeline.
-        when isActive $ writeIORef phaseRef (LoadPhase1 2 totalSteps)
-        let (zoomCache, chunkPixels) =
-                buildZoomCacheWithPixels params registry palette Nothing
-        _ ← evaluate (force zoomCache)
-        writeIORef (wsZoomCacheRef worldState) zoomCache
-        writeIORef (wsZoomAtlasRef worldState) Nothing
-        -- The zoom atlas + preview stage through GLOBAL env refs, and the GPU
-        -- upload writes one shared atlas to every world's wsZoomAtlasRef
-        -- (handleZoomAtlasUpload). So only the ACTIVE/visible page stages its
-        -- atlas; background pages keep their per-page zoom cache and adopt the
-        -- shared atlas if later shown (the existing single-atlas limitation —
-        -- background worlds are latent today).
-        when isActive $ do
-            _ ← evaluate (force chunkPixels)
-            sendGenLog env "Assembling zoom texture atlas..."
-            let atlas = buildZoomAtlas (V.length zoomCache) chunkPixels
-            _ ← evaluate (force atlas)
-            writeIORef (zoomAtlasDataRef env) $
-                Just (zadWidth atlas, zadHeight atlas, zadPixelData atlas)
-            sendGenLog env "Rendering world preview..."
-            let preview = buildPreviewFromPixels params zoomCache chunkPixels
-            _ ← evaluate (force preview)
-            writeIORef (worldPreviewRef env) $
-                Just (piWidth preview, piHeight preview, piData preview)
+        -- #365: an arena page (world.initArena) carries SYNTHETIC gen params
+        -- (wgpSeed 0, empty timeline, no plates, worldSize 100000) that the
+        -- real pipeline cannot run: buildZoomCacheWithPixels / generateChunk
+        -- make no progress on them (world thread wedges, stranding every
+        -- later page of the restore), and 1e's elevationAtGlobal errors on
+        -- the empty plate list. Rebuild the flat arena exactly like
+        -- handleWorldInitArenaCommand instead, then replay this page's
+        -- saved edits onto it.
+        if isArenaParams params
+          then do
+            when isActive $ writeIORef phaseRef (LoadPhase1 2 totalSteps)
+            when isActive $ sendGenLog env "Rebuilding arena page..."
+            edits  ← readIORef (wsEditsRef worldState)
+            desigs ← readIORef (wsMineDesignationsRef worldState)
+            -- Fixed StdGen: the gen only varies cosmetic surface grass, and
+            -- a fixed seed keeps repeated loads of the same save identical.
+            let arenaChunks = map (applyDigSlopes desigs . replayEdits edits)
+                                  (generateArenaChunks (mkStdGen 0))
+                chunkMap = HM.fromList [ (lcCoord c, c) | c ← arenaChunks ]
+            _ ← evaluate (force arenaChunks)
+            atomicModifyIORef' (wsTilesRef worldState) $ \_ →
+                (WorldTileData { wtdChunks = chunkMap, wtdMaxChunks = 100 }, ())
+            -- Seed the sim thread with every eager chunk: they bypass the
+            -- init queue, so drainInitQueues never emits SimChunkLoaded for
+            -- them, and replayed fluid edits (movement_arena water/lava)
+            -- must reach the fluid sim.
+            forM_ arenaChunks $ \c →
+                Q.writeQueue (simQueue env) $
+                    SimChunkLoaded rid (lcCoord c)
+                        (lcFluidMap c) (lcTerrainSurfaceMap c)
+            writeIORef (wsInitQueueRef worldState) []
+            writeIORef phaseRef LoadDone
+            -- Arena analogue of 1e: flat ground at seaLevel; no
+            -- elevationAtGlobal (it errors on the arena's empty plates).
+            when isActive $ do
+                atomicModifyIORef' (cameraRef env) $ \_ →
+                    (Camera2D
+                        { camPosition     = (wpsCameraX wps, wpsCameraY wps)
+                        , camVelocity     = (0, 0)
+                        , camZoom         = wpsCameraZoom wps
+                        , camZoomVelocity = 0
+                        , camRotation     = 0
+                        , camFacing       = wpsCameraFacing wps
+                        , camDragging     = False
+                        , camDragOrigin   = (0, 0)
+                        , camZSlice       = seaLevel + surfaceHeadroom
+                        , camZTracking    = True
+                        }, ())
+                sendGenLog env "Save loaded: arena page rebuilt"
+                logInfo logger CatWorld $
+                    "Save loaded: arena page rebuilt: " <> unWorldPageId rid
+          else do
+            -- 1b. Rebuild this page's zoom cache with per-chunk textures.
+            --     'buildTimeline' didn't run on this code path, so we don't have
+            --     the init-time bordered cache; pass Nothing and let
+            --     generateZoomTerrain recompute the per-chunk pipeline.
+            when isActive $ writeIORef phaseRef (LoadPhase1 2 totalSteps)
+            let (zoomCache, chunkPixels) =
+                    buildZoomCacheWithPixels params registry palette Nothing
+            _ ← evaluate (force zoomCache)
+            writeIORef (wsZoomCacheRef worldState) zoomCache
+            writeIORef (wsZoomAtlasRef worldState) Nothing
+            -- The zoom atlas + preview stage through GLOBAL env refs, and the GPU
+            -- upload writes one shared atlas to every world's wsZoomAtlasRef
+            -- (handleZoomAtlasUpload). So only the ACTIVE/visible page stages its
+            -- atlas; background pages keep their per-page zoom cache and adopt the
+            -- shared atlas if later shown (the existing single-atlas limitation —
+            -- background worlds are latent today).
+            when isActive $ do
+                _ ← evaluate (force chunkPixels)
+                sendGenLog env "Assembling zoom texture atlas..."
+                let atlas = buildZoomAtlas (V.length zoomCache) chunkPixels
+                _ ← evaluate (force atlas)
+                writeIORef (zoomAtlasDataRef env) $
+                    Just (zadWidth atlas, zadHeight atlas, zadPixelData atlas)
+                sendGenLog env "Rendering world preview..."
+                let preview = buildPreviewFromPixels params zoomCache chunkPixels
+                _ ← evaluate (force preview)
+                writeIORef (worldPreviewRef env) $
+                    Just (piWidth preview, piHeight preview, piData preview)
 
-        -- 1c. Generate the center chunk synchronously for immediate display.
-        --     Use the canonical screen→grid→chunk conversion so the saved
-        --     camera facing targets the right chunk for synchronous regen.
-        when isActive $ writeIORef phaseRef (LoadPhase1 3 totalSteps)
-        when isActive $ sendGenLog env "Generating initial chunks..."
-        let centerCoord@(ChunkCoord camCX camCY) =
-                cameraChunkCoord (wpsCameraFacing wps)
-                                 (wpsCameraX wps)
-                                 (wpsCameraY wps)
-            (ct, cs, cterrain, cf, cice, cflora, cwt, cmagma) =
-                generateChunk registry catalog params centerCoord
-            seededSurf = VU.imap (\idx surfZ →
-                case cf V.! idx of
-                    Just fc → max surfZ (fcSurface fc)
-                    Nothing → surfZ
-                ) cs
-            centerChunkRaw = LoadedChunk
-                { lcCoord             = centerCoord
-                , lcTiles             = ct
-                , lcSurfaceMap        = seededSurf
-                , lcTerrainSurfaceMap = cterrain
-                , lcFluidMap          = cf
-                , lcIceMap            = cice
-                , lcFlora             = cflora
-                , lcSideDeco          = VU.replicate (chunkSize * chunkSize) 0
-                , lcWaterTableMap    = cwt
-                , lcMagma            = cmagma
-                , lcStructures       = emptyChunkStructures
-                }
-        edits ← readIORef (wsEditsRef worldState)
-        desigs ← readIORef (wsMineDesignationsRef worldState)
-        let centerChunk = applyDigSlopes desigs (replayEdits edits centerChunkRaw)
-        atomicModifyIORef' (wsTilesRef worldState) $ \_ →
-            (WorldTileData { wtdChunks    = HM.singleton centerCoord centerChunk
-                           , wtdMaxChunks = 200 }, ())
-        -- Seed sim with the synchronously-loaded center chunk. drainInitQueues
-        -- emits SimChunkLoaded only for the QUEUED remainder (below), so the
-        -- center — written straight to wsTilesRef, not queued — would otherwise
-        -- never reach the sim thread (after the SimDropWorld above cleared any
-        -- stale copy). Matches the per-chunk message the queue loader sends.
-        Q.writeQueue (simQueue env) $
-            SimChunkLoaded rid centerCoord
-                (lcFluidMap centerChunk) (lcTerrainSurfaceMap centerChunk)
+            -- 1c. Generate the center chunk synchronously for immediate display.
+            --     Use the canonical screen→grid→chunk conversion so the saved
+            --     camera facing targets the right chunk for synchronous regen.
+            when isActive $ writeIORef phaseRef (LoadPhase1 3 totalSteps)
+            when isActive $ sendGenLog env "Generating initial chunks..."
+            let centerCoord@(ChunkCoord camCX camCY) =
+                    cameraChunkCoord (wpsCameraFacing wps)
+                                     (wpsCameraX wps)
+                                     (wpsCameraY wps)
+                (ct, cs, cterrain, cf, cice, cflora, cwt, cmagma) =
+                    generateChunk registry catalog params centerCoord
+                seededSurf = VU.imap (\idx surfZ →
+                    case cf V.! idx of
+                        Just fc → max surfZ (fcSurface fc)
+                        Nothing → surfZ
+                    ) cs
+                centerChunkRaw = LoadedChunk
+                    { lcCoord             = centerCoord
+                    , lcTiles             = ct
+                    , lcSurfaceMap        = seededSurf
+                    , lcTerrainSurfaceMap = cterrain
+                    , lcFluidMap          = cf
+                    , lcIceMap            = cice
+                    , lcFlora             = cflora
+                    , lcSideDeco          = VU.replicate (chunkSize * chunkSize) 0
+                    , lcWaterTableMap    = cwt
+                    , lcMagma            = cmagma
+                    , lcStructures       = emptyChunkStructures
+                    }
+            edits ← readIORef (wsEditsRef worldState)
+            desigs ← readIORef (wsMineDesignationsRef worldState)
+            let centerChunk = applyDigSlopes desigs (replayEdits edits centerChunkRaw)
+            atomicModifyIORef' (wsTilesRef worldState) $ \_ →
+                (WorldTileData { wtdChunks    = HM.singleton centerCoord centerChunk
+                               , wtdMaxChunks = 200 }, ())
+            -- Seed sim with the synchronously-loaded center chunk. drainInitQueues
+            -- emits SimChunkLoaded only for the QUEUED remainder (below), so the
+            -- center — written straight to wsTilesRef, not queued — would otherwise
+            -- never reach the sim thread (after the SimDropWorld above cleared any
+            -- stale copy). Matches the per-chunk message the queue loader sends.
+            Q.writeQueue (simQueue env) $
+                SimChunkLoaded rid centerCoord
+                    (lcFluidMap centerChunk) (lcTerrainSurfaceMap centerChunk)
 
-        -- Stamp any placed location on the synchronously-regenerated centre
-        -- chunk (#89). Like Init's centre chunk it is written straight to
-        -- wsTilesRef and excluded from the init queue, so the chunk-loading
-        -- dispatch never sees it. A location saved un-stamped on the camera
-        -- chunk thus still materializes on load.
-        dispatchLocationStamps env params rid [centerChunk]
+            -- Stamp any placed location on the synchronously-regenerated centre
+            -- chunk (#89). Like Init's centre chunk it is written straight to
+            -- wsTilesRef and excluded from the init queue, so the chunk-loading
+            -- dispatch never sees it. A location saved un-stamped on the camera
+            -- chunk thus still materializes on load.
+            dispatchLocationStamps env params rid [centerChunk]
 
-        -- 1d. Queue the remaining initial chunks for progressive loading.
-        when isActive $ writeIORef phaseRef (LoadPhase1 4 totalSteps)
-        let remainingCoords =
-                [ ChunkCoord cx cy
-                | cx ← [camCX - chunkLoadRadius .. camCX + chunkLoadRadius]
-                , cy ← [camCY - chunkLoadRadius .. camCY + chunkLoadRadius]
-                , not (cx ≡ camCX ∧ cy ≡ camCY)
-                ]
-            totalInitialChunks =
-                (2 * chunkLoadRadius + 1) * (2 * chunkLoadRadius + 1)
-        writeIORef (wsInitQueueRef worldState) remainingCoords
-        writeIORef phaseRef (LoadPhase2 (length remainingCoords) totalInitialChunks)
+            -- 1d. Queue the remaining initial chunks for progressive loading.
+            when isActive $ writeIORef phaseRef (LoadPhase1 4 totalSteps)
+            let remainingCoords =
+                    [ ChunkCoord cx cy
+                    | cx ← [camCX - chunkLoadRadius .. camCX + chunkLoadRadius]
+                    , cy ← [camCY - chunkLoadRadius .. camCY + chunkLoadRadius]
+                    , not (cx ≡ camCX ∧ cy ≡ camCY)
+                    ]
+                totalInitialChunks =
+                    (2 * chunkLoadRadius + 1) * (2 * chunkLoadRadius + 1)
+            writeIORef (wsInitQueueRef worldState) remainingCoords
+            writeIORef phaseRef (LoadPhase2 (length remainingCoords) totalInitialChunks)
 
-        -- 1e. Active page only: set the global camera (position/zoom/facing)
-        --     and its z-slice. elevationAtGlobal takes grid coords (gx, gy),
-        --     not world coords — go through worldToGrid (Render.hs:136 etc.).
-        when isActive $ do
-            let (camGX, camGY) = worldToGrid (wpsCameraFacing wps)
-                                             (wpsCameraX wps)
-                                             (wpsCameraY wps)
-                (surfaceElev, _mat) =
-                    elevationAtGlobal seed (wgpPlates params) worldSize camGX camGY
-                startZSlice = surfaceElev + surfaceHeadroom
-            -- Record-construction (not update) so every Camera2D field is set
-            -- explicitly: an update would preserve the prior camera's
-            -- transient state (pan/zoom velocity, mid-drag flag), and the
-            -- compiler now forces a decision if Camera2D gains a field.
-            atomicModifyIORef' (cameraRef env) $ \_ →
-                (Camera2D
-                    { camPosition     = (wpsCameraX wps, wpsCameraY wps)
-                    , camVelocity     = (0, 0)
-                    , camZoom         = wpsCameraZoom wps
-                    , camZoomVelocity = 0
-                    , camRotation     = 0
-                    , camFacing       = wpsCameraFacing wps
-                    , camDragging     = False
-                    , camDragOrigin   = (0, 0)
-                    , camZSlice       = startZSlice
-                    , camZTracking    = True
-                    }, ())
-            sendGenLog env $ "Save loaded: "
-                <> T.pack (show totalInitialChunks) <> " chunks queued"
-            logInfo logger CatWorld $ "Save loaded: "
-                <> T.pack (show totalInitialChunks) <> " chunks, "
-                <> "surface at z=" <> T.pack (show surfaceElev)
-                <> ": " <> unWorldPageId rid
+            -- 1e. Active page only: set the global camera (position/zoom/facing)
+            --     and its z-slice. elevationAtGlobal takes grid coords (gx, gy),
+            --     not world coords — go through worldToGrid (Render.hs:136 etc.).
+            when isActive $ do
+                let (camGX, camGY) = worldToGrid (wpsCameraFacing wps)
+                                                 (wpsCameraX wps)
+                                                 (wpsCameraY wps)
+                    (surfaceElev, _mat) =
+                        elevationAtGlobal seed (wgpPlates params) worldSize camGX camGY
+                    startZSlice = surfaceElev + surfaceHeadroom
+                -- Record-construction (not update) so every Camera2D field is set
+                -- explicitly: an update would preserve the prior camera's
+                -- transient state (pan/zoom velocity, mid-drag flag), and the
+                -- compiler now forces a decision if Camera2D gains a field.
+                atomicModifyIORef' (cameraRef env) $ \_ →
+                    (Camera2D
+                        { camPosition     = (wpsCameraX wps, wpsCameraY wps)
+                        , camVelocity     = (0, 0)
+                        , camZoom         = wpsCameraZoom wps
+                        , camZoomVelocity = 0
+                        , camRotation     = 0
+                        , camFacing       = wpsCameraFacing wps
+                        , camDragging     = False
+                        , camDragOrigin   = (0, 0)
+                        , camZSlice       = startZSlice
+                        , camZTracking    = True
+                        }, ())
+                sendGenLog env $ "Save loaded: "
+                    <> T.pack (show totalInitialChunks) <> " chunks queued"
+                logInfo logger CatWorld $ "Save loaded: "
+                    <> T.pack (show totalInitialChunks) <> " chunks, "
+                    <> "surface at z=" <> T.pack (show surfaceElev)
+                    <> ": " <> unWorldPageId rid
 
         -- 1f. Resolve this page's building/unit slices, stamped with its
         --     restore id, for the manager merge below. Buildings/units carry

--- a/tools/multiworld_save_probe.py
+++ b/tools/multiworld_save_probe.py
@@ -31,12 +31,13 @@ What it does:
      membership; the cross-page negative checks (main_world's unit is NOT
      on second_world, and vice-versa) prove the pages didn't get merged.
 
-Why two real worlds and not world.initArena: the issue text suggested an
-arena as the secondary page, but loading a save that contains an arena
-page hangs the world thread (the arena's degenerate gen params break the
-regenerate-from-params load path) — tracked as #365. The feature this
-guards is multi-PAGE persistence of real generated worlds, so the test
-uses two of those.
+Arena pages (#365): loading a save containing a world.initArena page used
+to hang the world thread (the arena's synthetic gen params wedge the
+regenerate-from-params load path). Fixed by rebuilding arena pages through
+the shared flat builder on load; pass --arena to run this probe with an
+arena as the secondary page — it additionally asserts a pre-save
+world.addTile edit is replayed onto the rebuilt arena. The default run
+keeps two real generated worlds (the #219 gate) unchanged.
 
 Note on visibility ordering: world.show does not promote an
 ALREADY-visible page to the head of the visible stack (a documented
@@ -260,6 +261,49 @@ def populate_world(port: int, page: str, seed: int, size: int, plates: int
     return uid, bid
 
 
+ARENA_EDIT_TILE = (6, 6)  # tile raised pre-save; must survive the reload
+
+
+def populate_arena(port: int, page: str) -> tuple[int, int, int]:
+    """world.initArena `page`, show it, spawn a unit + cargo-hold building
+    on the flat ground, and raise one tile so the load path's edit replay
+    is exercised. Returns (unitId, buildingId, editedTileZ)."""
+    send(port, f"world.initArena('{page}'); return 'ok'")
+    send(port, f"world.show('{page}'); return 'ok'")
+    if not wait_active(port, page):
+        sys.exit(f"FAIL: {page} never became active")
+
+    gx, gy = 2, 2
+    # No explicit z: unit.spawn resolves the surface of the page it lands
+    # on, which is the arena's flat top.
+    uid = as_int(send(port,
+        f"return unit.spawn('acolyte', {gx}, {gy}, 'player')"))
+    bid = as_int(send(port,
+        f"return building.spawn('cargo_hold_S', {gx + 2}, {gy})"))
+    print(f"{page}: arena  unit=#{uid}  building=#{bid}")
+    if uid is None or uid < 0:
+        sys.exit(f"FAIL: unit.spawn rejected on arena {page}")
+    if bid is None or bid < 0:
+        sys.exit(f"FAIL: building.spawn rejected on arena {page}")
+
+    # Raise one tile (granite, material id 1). addTile runs on the world
+    # thread — poll until the surface reflects it.
+    ex, ey = ARENA_EDIT_TILE
+    base = as_int(send(port, f"local s = world.getTerrainAt({ex}, {ey}); return s"))
+    if base is None:
+        sys.exit(f"FAIL: could not read arena terrain at ({ex},{ey})")
+    send(port, f"return world.addTile('{page}', {ex}, {ey}, 1)")
+    for _ in range(50):
+        cur = as_int(send(port, f"local s = world.getTerrainAt({ex}, {ey}); return s"))
+        if cur == base + 1:
+            break
+        time.sleep(0.1)
+    else:
+        sys.exit(f"FAIL: arena addTile at ({ex},{ey}) never landed")
+    print(f"{page}: raised tile ({ex},{ey}) to z={base + 1}")
+    return uid, bid, base + 1
+
+
 class Checks:
     def __init__(self) -> None:
         self.failed = 0
@@ -277,6 +321,10 @@ def main() -> int:
     ap.add_argument("--seed2", type=int, default=7, help="second_world seed")
     ap.add_argument("--size", type=int, default=64)
     ap.add_argument("--plates", type=int, default=3)
+    ap.add_argument("--arena", action="store_true",
+                    help="second_world is a world.initArena page "
+                         "(#365 regression: arena pages must survive "
+                         "the save -> restart -> load round-trip)")
     args = ap.parse_args()
 
     # Unique per run (random, NOT pid-derived): a reused pid could collide
@@ -301,8 +349,12 @@ def main() -> int:
 
         u_mw, b_mw = populate_world(args.port, "main_world",
                                     args.seed, args.size, args.plates)
-        u_sw, b_sw = populate_world(args.port, "second_world",
-                                    args.seed2, args.size, args.plates)
+        arena_z = None
+        if args.arena:
+            u_sw, b_sw, arena_z = populate_arena(args.port, "second_world")
+        else:
+            u_sw, b_sw = populate_world(args.port, "second_world",
+                                        args.seed2, args.size, args.plates)
 
         # Leave only main_world visible so the post-load show toggles are
         # clean (see module docstring). Then save with main_world primary.
@@ -381,6 +433,16 @@ def main() -> int:
                f"main_world unit #{u_mw} is NOT on second_world ({sw_units})")
         chk.ok(b_sw in sw_bldgs,
                f"second_world building #{b_sw} is on second_world ({sw_bldgs})")
+
+        if args.arena and arena_z is not None:
+            # The pre-save addTile edit must have been replayed onto the
+            # rebuilt arena chunks (#365).
+            ex, ey = ARENA_EDIT_TILE
+            got = as_int(send(args.port,
+                f"local s = world.getTerrainAt({ex}, {ey}); return s"))
+            chk.ok(got == arena_z,
+                   f"arena edit at ({ex},{ey}) replayed on load "
+                   f"(z={got}, expected {arena_z})")
 
         print(f"\n{'PASS' if chk.failed == 0 else 'FAIL'}: "
               f"{chk.failed} check(s) failed")


### PR DESCRIPTION
Closes #365

## Approach

The per-page restore in `World/Thread/Command/Save.hs` ran the real pipeline on every page's saved gen params. For an arena page those params are synthetic (`wgpSeed 0`, empty timeline, no plates, `worldSize 100000` — stamped by `handleWorldInitArenaCommand` purely to keep the renderer happy), and two steps can never survive them: `buildZoomCacheWithPixels`/`generateChunk` make no progress (the world-thread wedge from the issue — and since non-active pages restore first, it stranded **every** page's entities), and step 1e's `elevationAtGlobal` calls `error` on the empty plate list for an active arena page.

Fix, per the issue's first suggested option — **reconstruct arena pages via the flat builder on load**:

- The arena chunk builder moves verbatim from `Init.hs` into `World.Generate.Arena` (`generateArenaChunks`), next to the existing `generateFlatChunk` the on-demand loader already uses for arenas. Init and load now build arenas from one function.
- The restore path branches on the **existing** `isArenaParams` predicate (already the arena discriminator in `Cursor.hs` / `ChunkLoading.hs`): arena pages skip the zoom/generator pipeline entirely; the 5×5 flat region is rebuilt eagerly, the page's saved edits + dig slopes are replayed onto it, every chunk is seeded to the sim thread (replayed fluid edits must reach the fluid sim), the load phase goes straight to `LoadDone`, and an active arena gets its camera z-slice at `seaLevel + surfaceHeadroom` like arena init — no `elevationAtGlobal`.
- **No save-format change and no version bump**: arena pages are detectable from params already in every existing save.

## Tested

- `multiworld_save_probe.py --arena` (new mode added for exactly this): main_world + arena secondary, unit + building on each, a pre-save `world.addTile` edit on the arena, then the gold-standard save → quit → fresh restart → load. **11/11 checks pass** — no hang, both pages' entities on the correct pages, and the tile edit replayed onto the rebuilt arena (z verified).
- `multiworld_save_probe.py` (default two-real-worlds mode — the #219 gate): PASS, unchanged.
- `cabal test synarchy-test-headless`: pass; `tools/test_audit.py`: 35/35; `tools/world_check.py --quick`: 6/6 (no worldgen-output change — bare `--dump` never touches arena code).
- Build warning-free (CI enforces `-Werror`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)