### PR TITLE
#433: legacy fullscreen fallback uses .:? — missing key no longer resets the video config

### DIFF
--- a/src/Engine/Graphics/Config.hs
+++ b/src/Engine/Graphics/Config.hs
@@ -179,7 +179,7 @@ instance FromJSON VideoConfigFile where
       windowMode ← case mWindowMode of
           Just wm → pure wm
           Nothing → do
-              fs ← videoObj .: "fullscreen" .!= False
+              fs ← videoObj .:? "fullscreen" .!= False
               pure $ if fs then Fullscreen else Windowed
       -- '.:? key .!= def' is the correct idiom for *optional* fields
       -- with a fallback: '.:' would fail the entire parse when a key

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -172,6 +172,7 @@ test-suite synarchy-test-headless
                    Test.Headless.Sim.Seam
                    Test.Headless.Input.KeyNames
                    Test.Headless.Input.Bindings
+                   Test.Headless.Graphics.VideoConfig
                    Test.Headless.UI.Tooltip
                    Test.Headless.World.Calendar
                    Test.Headless.River.Graph

--- a/test-headless/Spec.hs
+++ b/test-headless/Spec.hs
@@ -32,6 +32,7 @@ import qualified Test.Headless.Magma.Shape as MagmaShape
 import qualified Test.Headless.Sim.Seam as SimSeam
 import qualified Test.Headless.Input.KeyNames as InputKeyNames
 import qualified Test.Headless.Input.Bindings as InputBindings
+import qualified Test.Headless.Graphics.VideoConfig as VideoConfig
 import qualified Test.Headless.UI.Tooltip as UITooltip
 import qualified Test.Headless.World.Calendar as Calendar
 import qualified Test.Headless.River.Graph as RiverGraph
@@ -79,6 +80,7 @@ main = hspec $ do
     describe "Sim.Fluid.Seam" SimSeam.spec
     describe "Input.KeyNames" InputKeyNames.spec
     describe "Input.Bindings" InputBindings.spec
+    describe "Graphics.VideoConfig" VideoConfig.spec
     describe "UI.Tooltip" UITooltip.spec
     describe "World.Calendar" Calendar.spec
     describe "River.Graph" RiverGraph.spec

--- a/test-headless/Test/Headless/Graphics/VideoConfig.hs
+++ b/test-headless/Test/Headless/Graphics/VideoConfig.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE UnicodeSyntax, OverloadedStrings #-}
+-- | Video-config YAML parsing tests (issue #433). The contract under
+--   test: the legacy-@fullscreen@ fallback (taken whenever @window_mode@
+--   is absent) must treat @fullscreen@ itself as *optional* — a @video:@
+--   section with neither key parses to windowed defaults instead of
+--   failing the whole parse and silently resetting every video setting
+--   back to 'defaultVideoConfig'.
+module Test.Headless.Graphics.VideoConfig (spec) where
+
+import UPrelude
+import Test.Hspec
+import Data.ByteString (ByteString)
+import qualified Data.Yaml as Yaml
+import Engine.Graphics.Config
+
+-- | Parse a video-config YAML document or fail the test loudly.
+parseConfig ∷ ByteString → VideoConfigFile
+parseConfig bs = case Yaml.decodeEither' bs of
+    Left err  → error ("decode failed: " ⧺ show err)
+    Right cfg → cfg
+
+minimalVideo ∷ ByteString
+minimalVideo = "video:\n  resolution:\n    width: 1280\n    height: 720\n"
+
+spec ∷ Spec
+spec = do
+    describe "legacy fullscreen fallback" $ do
+        it "parses when neither window_mode nor fullscreen is present" $ do
+            let cfg = parseConfig minimalVideo
+            vfWindowMode cfg `shouldBe` Windowed
+            -- The point of #433: the rest of the section survives too.
+            vfResolution cfg `shouldBe` Resolution 1280 720
+
+        it "maps legacy fullscreen: true to Fullscreen" $ do
+            let cfg = parseConfig (minimalVideo <> "  fullscreen: true\n")
+            vfWindowMode cfg `shouldBe` Fullscreen
+
+        it "maps legacy fullscreen: false to Windowed" $ do
+            let cfg = parseConfig (minimalVideo <> "  fullscreen: false\n")
+            vfWindowMode cfg `shouldBe` Windowed
+
+        it "prefers window_mode over the legacy key when both appear" $ do
+            let cfg = parseConfig
+                    (minimalVideo <> "  window_mode: borderless\n  fullscreen: true\n")
+            vfWindowMode cfg `shouldBe` BorderlessWindowed


### PR DESCRIPTION
Closes #433

## Approach

One-character fix in `src/Engine/Graphics/Config.hs`: the legacy-`fullscreen` fallback inside `FromJSON VideoConfigFile` (taken whenever `window_mode` is absent) used `.: "fullscreen" .!= False`. Since `.:` fails the entire parse when the key is missing (the `.!=` never runs), a `video:` section with neither `window_mode` nor `fullscreen` failed to parse and `loadVideoConfig` silently fell back to `defaultVideoConfig`, resetting resolution, ui_scale, vsync, and every other video setting. Now `.:? "fullscreen" .!= False`, consistent with every other optional field in the instance (and with the comment block right below it that documents exactly this anti-pattern).

Adds `Test.Headless.Graphics.VideoConfig` (registered in `Spec.hs` + cabal): the regression case (neither key present → parses, windowed, resolution preserved), the legacy `fullscreen: true/false` mapping, and `window_mode` precedence over the legacy key when both appear.

No save-version bump — video config YAML, not world save.

## Tested

- `cabal test synarchy-test-headless --test-options='--match "Graphics.VideoConfig"'` — 4 examples, 0 failures
- Full `cabal test synarchy-test-headless` — 439 examples, 0 failures, 1 pending (the `SYNARCHY_FULL_TESTS`-gated case)
- `python3 tools/test_audit.py` — all 35 groups passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)