### PR TITLE
#434: init.lua — kill location_stamper + item_info_panel on shutdown; declare all script-id locals

### DIFF
--- a/scripts/init.lua
+++ b/scripts/init.lua
@@ -4,16 +4,22 @@ local game = {}
 local shellScriptId = nil
 local uiScriptId = nil
 local debugScriptId = nil
+local debugAnimPanelScriptId = nil
 local unitManagerScriptId = nil
 local unitInfoPanelScriptId = nil
+local unitInfoV2ScriptId = nil
 local unitDragSelectScriptId = nil
 local unitResourcesScriptId = nil
 local unitAiScriptId = nil
 local buildToolScriptId = nil
 local buildingSpawnScriptId = nil
 local tileEditorScriptId = nil
+local locationStamperScriptId = nil
 local pauseScriptId = nil
 local buildingInfoPanelScriptId = nil
+local itemInfoPanelScriptId = nil
+local cargoInventoryPanelScriptId = nil
+local itemContentsPanelScriptId = nil
 local popupScriptId = nil
 local eventLogScriptId = nil
 local combatLogScriptId = nil
@@ -1078,11 +1084,17 @@ function game.shutdown()
     if tileEditorScriptId then
         engine.killScript(tileEditorScriptId)
     end
+    if locationStamperScriptId then
+        engine.killScript(locationStamperScriptId)
+    end
     if pauseScriptId then
         engine.killScript(pauseScriptId)
     end
     if buildingInfoPanelScriptId then
         engine.killScript(buildingInfoPanelScriptId)
+    end
+    if itemInfoPanelScriptId then
+        engine.killScript(itemInfoPanelScriptId)
     end
     if popupScriptId then
         engine.killScript(popupScriptId)


### PR DESCRIPTION
Closes #434

## Approach

Minimal, Lua-only, matching the file's existing patterns:

- **Shutdown symmetry:** added the two missing `engine.killScript` blocks to `game.shutdown` — `locationStamperScriptId` (after `tileEditorScriptId`) and `itemInfoPanelScriptId` (after `buildingInfoPanelScriptId`), same `if id then killScript(id) end` shape as the rest. Audited all 24 `engine.loadScript` calls in `game.init`: shutdown now kills all 24.
- **Missing `local`s:** declared the six script ids that were landing in the sandboxed `_G` (`debugAnimPanelScriptId`, `unitInfoV2ScriptId`, `locationStamperScriptId`, `itemInfoPanelScriptId`, `cargoInventoryPanelScriptId`, `itemContentsPanelScriptId`), inserted so the declaration block keeps tracking load order.

## Tested

- Cross-checked the three sets programmatically: loaded = killed = local-declared = 24, no orphans either direction.
- `luajit -bl` syntax check passes.
- **Runtime, headless:** booted the engine with the patched scripts (`--headless --port 9008`), used `loadScript`'s dedup-by-path to read live script ids, then `engine.killScript(1)` (the init script) to fire `game.shutdown`. Re-loading `location_stamper`, `item_info_panel`, `ui_manager`, and `unit_log` afterwards returned four fresh ids (26–29 vs. 14/17/25/24 before) — the two previously-leaked scripts are now killed, and `unit_log` (last kill in the chain) getting a new id shows the chain ran to completion without erroring. Engine log clean.
- `python3 tools/test_audit.py` — all 35 groups pass. No Haskell touched, so the build/hspec/worldgen gates are unaffected (CI runs them regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)