### PR TITLE
#156 shared view-transition teardown registry

### DIFF
--- a/scripts/hud.lua
+++ b/scripts/hud.lua
@@ -657,55 +657,17 @@ function hud.hide()
     if hud.zoom_page then
         UI.hidePage(hud.zoom_page)
     end
-    -- Suppress the info panel while the HUD is hidden. This both hides
-    -- the page and blocks background info watchers (which keep pushing
-    -- text for a still-selected object) from re-opening it over the menu.
-    -- hud.show() releases the suppression and restores from content (#134).
-    infoPanel.suppress("hud")
     if hud.global_page then
         UI.hidePage(hud.global_page)
     end
-    -- If any HUD-owned overlay happens to be open when the HUD hides
-    -- (e.g. world-view exits to main menu), hide it too so it doesn't
-    -- leak into the next screen. Each owns its own modal page / visible
-    -- flag, so hiding the HUD pages above does not cover them:
-    --   * event/combat/injury log panels (#84)
-    --   * notification popups (#85)
-    --   * right-click context menus (#86)
-    --   * item-contents popup (#100)
-    --   * per-unit log overlay (#104)
-    --   * cargo inventory popup (#99)
-    --   * main debug overlay (#147)
-    -- Ground-item selection (#175) is NOT cleared here: it lives in the
-    -- per-world cursor (wsCursorRef) and a Lua deselect resolves through
-    -- activeWorld, which head-falls-back to a different registered world
-    -- once this page leaves wmVisible — so it could clear the wrong
-    -- world. The world thread clears it deterministically in
-    -- handleWorldHideCommand, keyed on the exact page being hidden (which
-    -- worldView.hide()/testArena.hide() issue just before this runs).
-    --
-    -- Building selection (#176), by contrast, IS cleared here: it is a
-    -- single global id (bmSelected), not a per-world cursor, so deselect()
-    -- has no wrong-world hazard and is a no-op when nothing is selected.
-    -- Suppressing the panel alone is not enough — the building-info watcher
-    -- keeps polling building.getSelected() and re-pushing the selected
-    -- building into the panel's stored content, which hud.show() then
-    -- restores stale. Clearing the selection stops the repopulation.
-    building.deselect()
-    pcall(function() require("scripts.event_log").hide() end)
-    pcall(function() require("scripts.combat_log").hide() end)
-    pcall(function() require("scripts.injury_log_panel").hide() end)
-    pcall(function() require("scripts.popup").dismissAll() end)
-    pcall(function() require("scripts.ui.context_menu").hide() end)
-    pcall(function() require("scripts.item_contents_panel").closeIfOpen() end)
-    pcall(function() require("scripts.unit_log").hide() end)
-    pcall(function() require("scripts.cargo_inventory_panel").closeIfOpen() end)
-    pcall(function() require("scripts.debug").hide() end)
-    -- Active drag-select box (#146): its overlay page is independent of
-    -- the HUD pages hidden above, so a box in progress when the HUD
-    -- hides (e.g. world-view exits to a menu) would leak across the
-    -- transition. cancel() abandons it without committing a selection.
-    pcall(function() require("scripts.unit_drag_select").cancel() end)
+    -- Sweep every HUD-owned overlay / popup / selection that could leak
+    -- into the next screen (#156) — each owns its own modal page /
+    -- visible flag, so hiding the HUD pages above does not cover them.
+    -- One registry entry per widget; see scripts/ui/view_teardown.lua for
+    -- the per-widget rationale (including why the info panel is
+    -- SUPPRESSED rather than cleared — hud.show() releases it — and why
+    -- ground-item selection is deliberately NOT cleared on this path).
+    require("scripts.ui.view_teardown").run("hudHide")
 
     engine.logDebug("HUD hidden")
 end
@@ -832,30 +794,9 @@ end
 -- zoom closes that gap (#175). It also keeps hud.currentView authoritative
 -- so the HUD page never lags the camera.
 --
--- Teardown on each real transition:
---   * infoPanel.clear() — the shared HUD info panel.
---   * item-contents popup (#142): mounted on hud.world_page, so hiding
---     the page only takes it off-view; its logical state stays open and
---     could reappear stale. closeIfOpen() tears it down.
---   * cargo-inventory popup (#141): same story as the item-contents
---     popup — mounted on hud.world_page, so a band change only hides the
---     page while state.open stays true and the popup reappears stale on
---     return. closeIfOpen() (idempotent) tears it down on every band change.
---   * right-click context menu (#139): own modal page, anchored to the
---     click target; hide() it so it can't survive over the wrong view.
---   * ground-item selection (#175): per-world cursor state the item
---     watcher (item_info_panel.update) keeps polling and would use to
---     repopulate the panel. item.deselect() clears the active world's
---     selection — and here the world is still the visible/active one, so
---     activeWorld resolves correctly (unlike the menu-hide path, which is
---     handled engine-side in handleWorldHideCommand).
---   * chunk/tile cursor selection (#132): zoomSelectedPos (zoom-map chunk)
---     and worldSelectedTile (zoomed-in tile) also live in the per-world
---     cursor. infoPanel.clear() blanks the panel, but the selection itself
---     survives the band change, and pollCursorInfo only republishes on a
---     selection *change* — so without clearing it the highlight stays set
---     while the panel stays empty. clearZoom/WorldCursorSelect tear both
---     down with the panel.
+-- Per-widget logical-state teardown on each real transition is swept via
+-- the shared registry (scripts/ui/view_teardown.lua, #156) — one entry per
+-- overlay / popup / armed tool / selection, with the per-widget rationale.
 function hud.reconcileView()
     local zoom = camera.getZoom()
     local zoomFadeStart = camera.getZoomFadeStart()
@@ -891,89 +832,11 @@ function hud.reconcileView()
     end
     hud.currentView = newView
 
-    infoPanel.clear()
-    require("scripts.item_contents_panel").closeIfOpen()
-    require("scripts.cargo_inventory_panel").closeIfOpen()
-    -- Right-click context menu (#139): it lives on its own modal page and
-    -- is anchored to the tile/unit/item under the click in the zoomed-in
-    -- view. Hiding the world/zoom pages above only takes it off-view; its
-    -- logical state stays open and it can reappear over the wrong view.
-    -- hide() is idempotent (no-op when no menu is open), so dismiss it on
-    -- every band change.
-    require("scripts.ui.context_menu").hide()
-    -- Active drag-select box (#146): the rect lives on its own
-    -- "drag_select_overlay" page, so the world/zoom page swap above
-    -- never touches it. An armed/dragging box would otherwise survive
-    -- the band change and resume or commit against the wrong view.
-    -- cancel() is idempotent (no-op when idle), so abandon any in-flight
-    -- box on every band change.
-    require("scripts.unit_drag_select").cancel()
-    -- Mine-designation anchor (#144): a pending first-corner anchor lives in
-    -- mine_tool's Lua state + the world cursor (mineAnchor) and renders a
-    -- preview grid. The tool only acts in zoomed_in, but nothing cleared the
-    -- anchor on a band change, so it survived off-view and could not be
-    -- canceled there (Escape/right-click are gated on the zoomed_in view).
-    -- cancel() is idempotent (clears Lua state + WorldClearMineAnchor is a
-    -- no-op when nothing is pending), so tear it down on every transition.
-    require("scripts.mine_tool").cancel()
-    -- Construction designation anchor (#95): same idempotent teardown as
-    -- the mine anchor above, so a pending rectangle can't survive off-view.
-    require("scripts.construct_tool").cancel()
-    -- Chop designation anchor (#97): same idempotent teardown.
-    require("scripts.chop_tool").cancel()
-    -- Build picker (#143): the picker panel lives on hud.world_page and
-    -- its "picker" mode persists across band changes. The world/zoom page
-    -- swap above only takes it off-view, so a picker opened in zoomed_in
-    -- stays logically alive and reappears stale when the world page is
-    -- next shown. hidePicker() is idempotent (destroyPicker no-ops with
-    -- no panel; mode only resets from "picker"), so tear it down on every
-    -- transition. It deliberately does NOT touch "placement" mode.
-    require("scripts.build_tool").hidePicker()
-    -- Build placement (#140): once the build tool enters "placement" mode,
-    -- its ghost preview and click handling keep running off the world
-    -- cursor regardless of the HUD view. The page swap above only takes
-    -- the world-page tool UI off-view, so placement stays live in
-    -- zoomed-out / fade-zone and keeps consuming clicks. exitPlacement()
-    -- is idempotent (clearGhost no-ops with no ghost; mode resets to
-    -- "off"), so cancel any in-progress placement on every band change.
-    require("scripts.build_tool").exitPlacement()
-    -- Arena tile-editor popup (#138): the test-arena tile editor lives on
-    -- hud.world_page and was only torn down on empty tile-info broadcasts,
-    -- tool changes, or arena exit. The page swap above only takes it
-    -- off-view, and zoom-map chunk selection produces non-empty HUD info
-    -- text, so neither the band change nor the empty-text clear path
-    -- closed it — it survived off-view and reappeared stale when the world
-    -- page returned. clear() is idempotent (destroyPopup no-ops with no
-    -- popup, and is a no-op outside arena mode), so tear it down on every
-    -- transition.
-    require("scripts.tile_editor").clear()
-    if newView ~= "zoomed_in" then
-        require("scripts.debug").hide()
-    end
-    item.deselect()
-    -- Building selection (#176): unlike the per-world cursor selections
-    -- below, building selection is a single global id (bmSelected), so the
-    -- page swap above never touches it and the building-info watcher keeps
-    -- polling building.getSelected() and re-pushing the same building into
-    -- the shared info panel — repopulating it stale after the band change.
-    -- deselect() clears the global selection and is a no-op when nothing is
-    -- selected, matching item.deselect() above; no wrong-world hazard since
-    -- there is no per-world building cursor to resolve through activeWorld.
-    building.deselect()
-    -- Chunk/tile cursor selection (#132): the zoom-map chunk selection
-    -- (zoomSelectedPos) and zoomed-in tile selection (worldSelectedTile)
-    -- both live in the per-world cursor (wsCursorRef), independent of the
-    -- HUD pages swapped above. The info panel is cleared on this transition
-    -- (infoPanel.clear() above), but pollCursorInfo only republishes when
-    -- the selection *changes* — so a selection that survives the band change
-    -- unchanged leaves the highlight logically set while the panel stays
-    -- blank until the user re-selects. Clear both selections here, exactly
-    -- like item.deselect() does for the ground-item selection, so the
-    -- highlight and panel tear down together. The clears are keyed on
-    -- hud.worldId (the visible/active world that owns this view, the same id
-    -- onMouseDown uses), and are no-ops when nothing is selected.
-    world.clearZoomCursorSelect(hud.worldId)
-    world.clearWorldCursorSelect(hud.worldId)
+    -- Sweep every overlay / popup / armed tool / selection that could
+    -- survive the page swap above (#156). One registry entry per widget;
+    -- see scripts/ui/view_teardown.lua for the per-widget rationale.
+    require("scripts.ui.view_teardown").run("zoomBand",
+        { worldId = hud.worldId, newView = newView })
 end
 
 -- Wheel hook (no UI element under cursor, no shift). Reconcile immediately

--- a/scripts/ui/view_teardown.lua
+++ b/scripts/ui/view_teardown.lua
@@ -1,0 +1,219 @@
+-- Shared view-transition teardown registry (#156).
+--
+-- Root cause of a whole bug family (#99/#100/#104/#137–#148): overlays,
+-- popups, and armed tool modes live on their own pages or module state,
+-- so the page swaps done by view transitions never touch their LOGICAL
+-- state — they survive off-view, leak into the wrong view or the next
+-- world, reappear stale, or keep consuming clicks. Each widget used to
+-- be fixed with one-off cleanup calls sprinkled across the transition
+-- sites; this registry is the shared mechanism: one ordered table of
+-- per-widget hooks, swept by every transition site.
+--
+-- Transitions (the key passed to run()):
+--   * "zoomBand" — hud.reconcileView(): the camera crossed a zoom band
+--     (zoomed_in / none / zoomed_out) and the HUD swapped view pages.
+--     ctx = { worldId = hud.worldId, newView = <the band just entered> }.
+--   * "hudHide"  — hud.hide(): the gameplay HUD is leaving the screen
+--     (world view exits to a menu, or a menu opens over it).
+--   * "menu"     — uiManager.showMenu(): every menu transition,
+--     INCLUDING the keepWorld Settings path that deliberately skips
+--     hud.hide() — so only widgets that must die even while the world
+--     stays visible behind Settings hook this one (#146/#147). The
+--     non-keepWorld paths also run hud.hide(), i.e. the full "hudHide"
+--     sweep.
+--
+-- Rules for entries:
+--   * Hooks MUST be idempotent — they run on every transition of their
+--     kind, almost always with nothing to tear down.
+--   * Hooks are pcall-wrapped: a failing hook logs and never blocks the
+--     rest of the sweep (the page swap has already happened).
+--   * require() the widget module inside the hook, not at file scope,
+--     so widget modules keep loading lazily.
+--   * A new overlay / popup / armed tool mode gets an entry HERE, not a
+--     one-off call at a transition site. If your widget owns its own
+--     page or module-level "open"/"armed" state, it belongs in this
+--     table — decide per transition what should happen to it.
+
+local viewTeardown = {}
+
+local registry = {
+    -- Shared HUD info panel. On a band change the content is stale for
+    -- the new view — clear it. On hud.hide the panel is only SUPPRESSED:
+    -- this hides the page and blocks background info watchers (which
+    -- keep pushing text for a still-selected object) from re-opening it
+    -- over the menu, while the stored tab text survives for re-show —
+    -- hud.show() releases the suppression and restores from content
+    -- (#134).
+    { name = "info_panel",
+      zoomBand = function() require("scripts.hud.info_panel").clear() end,
+      hudHide  = function() require("scripts.hud.info_panel").suppress("hud") end },
+
+    -- Item-contents popup (#142/#100): mounted on hud.world_page, so
+    -- hiding the page only takes it off-view; its logical state stays
+    -- open and it would reappear stale. closeIfOpen() is idempotent.
+    { name = "item_contents_panel",
+      zoomBand = function() require("scripts.item_contents_panel").closeIfOpen() end,
+      hudHide  = function() require("scripts.item_contents_panel").closeIfOpen() end },
+
+    -- Cargo-inventory popup (#141/#99): same story as the item-contents
+    -- popup — mounted on hud.world_page, so a page hide leaves
+    -- state.open true and the popup reappears stale. closeIfOpen() is
+    -- idempotent.
+    { name = "cargo_inventory_panel",
+      zoomBand = function() require("scripts.cargo_inventory_panel").closeIfOpen() end,
+      hudHide  = function() require("scripts.cargo_inventory_panel").closeIfOpen() end },
+
+    -- Right-click context menu (#139/#86): lives on its own modal page,
+    -- anchored to the tile/unit/item under the click. Page swaps never
+    -- touch it, so it could survive over the wrong view or leak into the
+    -- next screen. hide() is idempotent (no-op when no menu is open).
+    { name = "context_menu",
+      zoomBand = function() require("scripts.ui.context_menu").hide() end,
+      hudHide  = function() require("scripts.ui.context_menu").hide() end },
+
+    -- Active drag-select box (#146): the rect lives on its own
+    -- "drag_select_overlay" page, independent of every page the
+    -- transitions swap. An armed/dragging box would survive and resume
+    -- or commit against the wrong view — including on the keepWorld
+    -- Settings path, hence the "menu" hook. cancel() abandons it
+    -- without committing a selection (idempotent, no-op when idle).
+    { name = "unit_drag_select",
+      zoomBand = function() require("scripts.unit_drag_select").cancel() end,
+      hudHide  = function() require("scripts.unit_drag_select").cancel() end,
+      menu     = function() require("scripts.unit_drag_select").cancel() end },
+
+    -- Mine-designation anchor (#144): a pending first-corner anchor
+    -- lives in mine_tool's Lua state + the world cursor (mineAnchor)
+    -- and renders a preview grid. The tool only acts in zoomed_in, and
+    -- Escape/right-click cancel is gated on that view — so an anchor
+    -- surviving a band change could not be canceled off-view. cancel()
+    -- is idempotent (WorldClearMineAnchor no-ops when nothing pending).
+    { name = "mine_tool",
+      zoomBand = function() require("scripts.mine_tool").cancel() end },
+
+    -- Construction designation anchor (#95): same idempotent teardown
+    -- as the mine anchor, so a pending rectangle can't survive off-view.
+    { name = "construct_tool",
+      zoomBand = function() require("scripts.construct_tool").cancel() end },
+
+    -- Chop designation anchor (#97): same idempotent teardown.
+    { name = "chop_tool",
+      zoomBand = function() require("scripts.chop_tool").cancel() end },
+
+    -- Build picker (#143): the picker panel lives on hud.world_page and
+    -- its "picker" mode persists across band changes, so a picker opened
+    -- in zoomed_in stays logically alive and reappears stale when the
+    -- world page is next shown. hidePicker() is idempotent (destroyPicker
+    -- no-ops with no panel; mode only resets from "picker") and
+    -- deliberately does NOT touch "placement" mode.
+    { name = "build_tool_picker",
+      zoomBand = function() require("scripts.build_tool").hidePicker() end },
+
+    -- Build placement (#140): once the build tool enters "placement"
+    -- mode, its ghost preview and click handling keep running off the
+    -- world cursor regardless of the HUD view, consuming clicks in
+    -- zoomed-out / fade-zone. exitPlacement() is idempotent (clearGhost
+    -- no-ops with no ghost; mode resets to "off").
+    { name = "build_tool_placement",
+      zoomBand = function() require("scripts.build_tool").exitPlacement() end },
+
+    -- Arena tile-editor popup (#138): lives on hud.world_page and was
+    -- only torn down on empty tile-info broadcasts, tool changes, or
+    -- arena exit — zoom-map chunk selection produces non-empty HUD info
+    -- text, so a band change left it alive off-view to reappear stale.
+    -- clear() is idempotent (destroyPopup no-ops with no popup, and is
+    -- a no-op outside arena mode).
+    { name = "tile_editor",
+      zoomBand = function() require("scripts.tile_editor").clear() end },
+
+    -- Main debug overlay (#147, and the armed spawn/edit modes it owns,
+    -- #148 — debug.hide() clears them all): only meaningful in the
+    -- zoomed-in gameplay view and never torn down by any page it sits
+    -- over. Without the "menu" hook, Settings opened from a game view
+    -- (keepWorld skips hud.hide()) left the F8 overlay visible AND
+    -- clickable (uiManager.onMouseDown gives it first crack via
+    -- tryClaimClick) on the Settings screen. hide() is idempotent.
+    { name = "debug_overlay",
+      zoomBand = function(ctx)
+          if ctx.newView ~= "zoomed_in" then
+              require("scripts.debug").hide()
+          end
+      end,
+      hudHide  = function() require("scripts.debug").hide() end,
+      menu     = function() require("scripts.debug").hide() end },
+
+    -- HUD-owned log panels (#84) and notification popups (#85): each
+    -- owns its own modal page / visible flag, so hiding the HUD pages
+    -- does not cover them — hide on hudHide so they don't leak into the
+    -- next screen.
+    { name = "event_log",
+      hudHide = function() require("scripts.event_log").hide() end },
+    { name = "combat_log",
+      hudHide = function() require("scripts.combat_log").hide() end },
+    { name = "injury_log_panel",
+      hudHide = function() require("scripts.injury_log_panel").hide() end },
+    { name = "notification_popups",
+      hudHide = function() require("scripts.popup").dismissAll() end },
+
+    -- Per-unit log overlay (#104): same own-page story as the log
+    -- panels above.
+    { name = "unit_log",
+      hudHide = function() require("scripts.unit_log").hide() end },
+
+    -- Ground-item selection (#175): per-world cursor state the item
+    -- watcher (item_info_panel.update) keeps polling and would use to
+    -- repopulate the panel. On a band change the world is still the
+    -- visible/active one, so item.deselect() resolves activeWorld
+    -- correctly. Deliberately NO hudHide hook: on the hide path the
+    -- page is leaving wmVisible and activeWorld head-falls-back to a
+    -- DIFFERENT registered world, so a Lua deselect could clear the
+    -- wrong world — the world thread clears it deterministically in
+    -- handleWorldHideCommand, keyed on the exact page being hidden
+    -- (which worldView.hide()/testArena.hide() issue just before
+    -- hud.hide() runs).
+    { name = "item_selection",
+      zoomBand = function() item.deselect() end },
+
+    -- Building selection (#176): a single global id (bmSelected), not a
+    -- per-world cursor — so no wrong-world hazard, and the
+    -- building-info watcher keeps polling building.getSelected() and
+    -- re-pushing the same building into the shared info panel,
+    -- repopulating it stale after either transition. deselect() is a
+    -- no-op when nothing is selected.
+    { name = "building_selection",
+      zoomBand = function() building.deselect() end,
+      hudHide  = function() building.deselect() end },
+
+    -- Chunk/tile cursor selection (#132): the zoom-map chunk selection
+    -- (zoomSelectedPos) and zoomed-in tile selection (worldSelectedTile)
+    -- both live in the per-world cursor (wsCursorRef), independent of
+    -- the HUD pages. The info panel is cleared on the band change, but
+    -- pollCursorInfo only republishes on a selection *change* — so a
+    -- surviving selection leaves the highlight set while the panel
+    -- stays blank. Clear both, keyed on ctx.worldId (the visible/active
+    -- world that owns the view, the same id hud.onMouseDown uses);
+    -- no-ops when nothing is selected.
+    { name = "cursor_selection",
+      zoomBand = function(ctx)
+          world.clearZoomCursorSelect(ctx.worldId)
+          world.clearWorldCursorSelect(ctx.worldId)
+      end },
+}
+
+-- Sweep every registered hook for one transition, in registry order.
+-- ctx is forwarded to each hook (zoomBand passes worldId/newView).
+function viewTeardown.run(transition, ctx)
+    ctx = ctx or {}
+    for _, entry in ipairs(registry) do
+        local hook = entry[transition]
+        if hook then
+            local ok, err = pcall(hook, ctx)
+            if not ok then
+                engine.logError("view_teardown: " .. entry.name
+                    .. " failed on " .. transition .. ": " .. tostring(err))
+            end
+        end
+    end
+end
+
+return viewTeardown

--- a/scripts/ui_manager.lua
+++ b/scripts/ui_manager.lua
@@ -400,20 +400,14 @@ function uiManager.showMenu(menuName, params)
         if uiManager.moduleReady.worldView then worldView.hide() end
         if uiManager.moduleReady.hud then hud.hide() end
     end
-    -- The main debug overlay is only meaningful in the gameplay world
-    -- view and is never torn down by the menu's own pages. hud.hide()
-    -- handles it, but Settings opened from a game view keeps the HUD
-    -- alive (keepWorld) and so skips that path — leaving the F8 overlay
-    -- visible AND clickable (uiManager.onMouseDown still gives it first
-    -- crack via tryClaimClick) on the Settings screen. Hide it on every
-    -- menu transition regardless of keepWorld (#147).
-    pcall(function() require("scripts.debug").hide() end)
-    -- Same leak for an in-flight drag-select box (#146): the keepWorld
-    -- Settings path skips hud.hide(), so an armed/dragging box would
-    -- survive onto the Settings screen and could commit afterward. cancel()
-    -- abandons it (idempotent) on every menu transition regardless of
-    -- keepWorld.
-    pcall(function() require("scripts.unit_drag_select").cancel() end)
+    -- Sweep the widgets that must die on EVERY menu transition regardless
+    -- of keepWorld (#156) — the keepWorld Settings path skips hud.hide()
+    -- above, which would otherwise leave the F8 debug overlay visible AND
+    -- clickable (uiManager.onMouseDown still gives it first crack via
+    -- tryClaimClick, #147) and an in-flight drag-select box committable
+    -- (#146) on the Settings screen. One registry entry per widget; see
+    -- scripts/ui/view_teardown.lua for the per-widget rationale.
+    require("scripts.ui.view_teardown").run("menu")
     if uiManager.moduleReady.saveBrowser then saveBrowser.hide() end
     if uiManager.moduleReady.loadingScreen then loadingScreen.hide() end
     if uiManager.moduleReady.testArena and not keepWorld then testArena.hide() end


### PR DESCRIPTION
Closes #156

## Approach

All 15 member issues of the ui-lifecycle epic (#99/#100/#104/#137–#148) were already fixed individually, leaving ~25 one-off cleanup calls sprinkled across the three transition sites. This PR lands the shared mechanism the epic called for:

- **`scripts/ui/view_teardown.lua`** — an ordered registry with one entry per overlay / popup / armed tool / selection. Each entry declares what happens to that widget per transition (`zoomBand` / `hudHide` / `menu`) and keeps the per-widget issue-history rationale that previously lived inline at the call sites. Hooks lazy-`require` their widget module, are pcall-wrapped, and log through `engine.logError` so one failing widget can't block the rest of a sweep.
- **`hud.reconcileView()`**, **`hud.hide()`**, and **`uiManager.showMenu()`** now sweep the registry instead of hand-listing widgets. A new overlay gets one registry entry instead of remembering to patch three sites.

Semantics preserved exactly, including the deliberate asymmetries:
- info panel is **cleared** on a band change but **suppressed** on hud.hide (hud.show releases it, #134)
- ground-item deselect is deliberately **absent** from the hudHide sweep (wrong-world hazard; handled engine-side in `handleWorldHideCommand`, #175)
- debug overlay stays gated on `newView ~= "zoomed_in"` in the band sweep, and the keepWorld Settings menu path still tears down only the debug overlay (#147) and drag-select (#146)

## Tested

- `luajit -bl` syntax check on all three touched files
- Live headless exercise (worktree binary, TCP console): direct `run()` of all three transitions, real `hud.hide()`, and a real forced `zoomed_in → zoomed_out` band transition through `hud.reconcileView()` — every hook (all widget module loads + engine-API calls) ran with **zero** `view_teardown` errors in the engine log; unknown transition is a clean no-op
- `cabal test synarchy-test-headless` — 492 examples, 0 failures
- `python3 tools/test_audit.py` — all 35 groups pass
- `python3 tools/world_check.py --quick` — 6/6 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)