### PR TITLE
#392 Item buffs gain a percent axis (ibPercent → smPercent)

### DIFF
--- a/scripts/unit_info_v2.lua
+++ b/scripts/unit_info_v2.lua
@@ -2192,8 +2192,19 @@ local function buildItemHint(it, equippedSlot)
     end
     if it.buffs then
         for _, b in ipairs(it.buffs) do
-            local line = string.format("%s + %g",
-                capitalizeStat(b.stat), b.amount)
+            -- "Perception + 1", "Perception + 10%", or both:
+            -- "Perception + 1 + 10%". Percent arrives fractional
+            -- (0.1 = +10%), same convention as unit modifiers.
+            local parts = {}
+            if (b.amount or 0) ~= 0 then
+                parts[#parts + 1] = string.format("%g", b.amount)
+            end
+            if (b.percent or 0) ~= 0 then
+                parts[#parts + 1] = string.format("%g%%", b.percent * 100)
+            end
+            if #parts == 0 then parts[1] = "0" end
+            local line = capitalizeStat(b.stat)
+                .. " + " .. table.concat(parts, " + ")
             if b.scalesWithCondition and it.condition then
                 line = line .. string.format(" (x%.2f)", it.condition / 100)
             end

--- a/src/Engine/Asset/YamlItems.hs
+++ b/src/Engine/Asset/YamlItems.hs
@@ -82,16 +82,21 @@ instance FromJSON ItemYamlRollSpec where
 
 -- | One stat-modifier conferred by equipping an item.
 --   YAML shape: `{ stat: perception, amount: 1, scales_with_condition: true }`.
+--   `percent` is fractional and matches the unit-level modifiers block
+--   (0.1 = +10%); a buff can declare `amount`, `percent`, or both
+--   (#392). Both default to 0 so either can stand alone.
 data ItemYamlBuff = ItemYamlBuff
     { iybStat                ∷ !Text
     , iybAmount              ∷ !Float
+    , iybPercent             ∷ !Float
     , iybScalesWithCondition ∷ !Bool
     } deriving (Show, Eq, Generic)
 
 instance FromJSON ItemYamlBuff where
     parseJSON = withObject "ItemYamlBuff" $ \v → ItemYamlBuff
         ⊚ v .:  "stat"
-        ⊛ v .:  "amount"
+        ⊛ v .:? "amount"  .!= 0.0
+        ⊛ v .:? "percent" .!= 0.0
         ⊛ v .:? "scales_with_condition" .!= False
 
 -- | Optional weapon block on an item def. Geometric + material

--- a/src/Engine/Scripting/Lua/API/Equipment.hs
+++ b/src/Engine/Scripting/Lua/API/Equipment.hs
@@ -32,6 +32,7 @@ import Item.Types (ItemInstance(..), ItemDef(..), ItemWeapon(..),
                    itemContentsSig, itemTotalWeight)
 import Unit.Types (UnitInstance(..), UnitManager(..), UnitId(..),
                    UnitDef(..), StatModifier(..))
+import Unit.Stats (applyItemBuffs)
 
 -- | equipment.loadYaml(path) — parses a YAML file describing one or
 --   more equipment classes, loads each class's silhouette texture, and
@@ -171,34 +172,6 @@ removeFirstFromInventoryWhere p = go []
     go acc (x:xs)
         | p x       = (reverse acc ++ xs, Just x)
         | otherwise = go (x : acc) xs
-
--- | Effective buff delta after applying condition scaling.
-buffEffectiveDelta ∷ ItemBuff → Float → Float
-buffEffectiveDelta b cond
-    | ibScalesWithCondition b = ibAmount b * (cond / 100)
-    | otherwise               = ibAmount b
-
--- | Apply every buff on an item to the unit's `uiModifiers`. Source
---   string is the item's display_name; identical sources on the same
---   stat collapse via the existing dedup-by-source rule.
-applyItemBuffs ∷ ItemInstance → ItemDef
-               → HM.HashMap Text [StatModifier]
-               → HM.HashMap Text [StatModifier]
-applyItemBuffs inst iDef mods = foldl' applyOne mods (idBuffs iDef)
-  where
-    src   = idDisplayName iDef
-    cond  = iiCondition inst
-    applyOne acc b =
-        let delta = buffEffectiveDelta b cond
-            m     = StatModifier
-                      { smDelta  = delta
-                      , smSource = src
-                      , smExpiry = Nothing
-                      , smPercent = 0
-                      }
-            existing = HM.lookupDefault [] (ibStat b) acc
-            others   = filter (\x → smSource x ≢ src) existing
-        in HM.insert (ibStat b) (m : others) acc
 
 -- | Remove every modifier with @source@ across all stats. Mirrors
 --   `unit.removeModifier` exactly so equip/unequip stay symmetric.
@@ -532,7 +505,8 @@ pushItemInstance inst itemMgr = do
                     Lua.setfield (-2) "bluntEffectiveness"
                     Lua.setfield (-2) "weapon"
                 Nothing → pure ()
-            -- Buffs: pushed as an array of { stat, amount, scalesWithCondition }
+            -- Buffs: pushed as an array of
+            -- { stat, amount, percent, scalesWithCondition }
             unless (null (idBuffs iDef)) $ do
                 Lua.newtable
                 forM_ (zip [1 ∷ Int ..] (idBuffs iDef)) $ \(i, b) → do
@@ -541,6 +515,8 @@ pushItemInstance inst itemMgr = do
                     Lua.setfield (-2) "stat"
                     Lua.pushnumber (Lua.Number (realToFrac (ibAmount b)))
                     Lua.setfield (-2) "amount"
+                    Lua.pushnumber (Lua.Number (realToFrac (ibPercent b)))
+                    Lua.setfield (-2) "percent"
                     Lua.pushboolean (ibScalesWithCondition b)
                     Lua.setfield (-2) "scalesWithCondition"
                     Lua.rawseti (-2) (fromIntegral i)
@@ -592,7 +568,10 @@ equipmentEquipAccessoryFn env = do
                                         -- Apply the accessory's buffs to the
                                         -- unit's modifier list so combat /
                                         -- stat display sees them immediately.
-                                        let mods' = applyItemBuffs newI d
+                                        let mods' = applyItemBuffs
+                                                       (idDisplayName d)
+                                                       (iiCondition newI)
+                                                       (idBuffs d)
                                                        (uiModifiers inst)
                                             inst' = inst
                                               { uiInventory   = newInv

--- a/src/Engine/Scripting/Lua/API/Items.hs
+++ b/src/Engine/Scripting/Lua/API/Items.hs
@@ -176,6 +176,7 @@ loadItemYamlFn env backendState = do
                                 (\b → ItemBuff
                                     { ibStat = iybStat b
                                     , ibAmount = iybAmount b
+                                    , ibPercent = iybPercent b
                                     , ibScalesWithCondition =
                                         iybScalesWithCondition b
                                     })

--- a/src/Engine/Scripting/Lua/API/Units.hs
+++ b/src/Engine/Scripting/Lua/API/Units.hs
@@ -156,7 +156,7 @@ import Item.Ground (spawnGroundItem)
 import Combat.Wounds (bleedRateFor, kindBleedFactor)
 import Combat.Types (pushInjuryEvent)
 import Unit.LineOfSight (unitVisibleTiles)
-import Unit.Stats (rollStat, effectiveStat, applySkillXP)
+import Unit.Stats (rollStat, effectiveStat, applySkillXP, applyItemBuffs)
 import qualified Unit.Selection as Sel
 import qualified Unit.HitTest as HitTest
 import World.Types (WorldManager(..), WorldState(..), WorldGenParams(..)
@@ -1849,8 +1849,8 @@ refreshAccessoryBuffs ∷ ItemManager → [ItemInstance]
 refreshAccessoryBuffs itemMgr accs mods0 =
     foldl' (\mods inst → applyAccessoryBuffs itemMgr inst mods) mods0 accs
 
--- | Apply one accessory's buffs to a modifier map. Mirrors
---   `Equipment.applyItemBuffs`: the modifier source is the item's
+-- | Apply one accessory's buffs to a modifier map: def lookup + the
+--   shared Unit.Stats.applyItemBuffs. The modifier source is the item's
 --   display_name and same-source modifiers on a stat collapse, so this
 --   REPLACES that source's stale modifier rather than stacking. A no-op
 --   for items with no buffs (or no def in scope).
@@ -1860,19 +1860,9 @@ applyAccessoryBuffs ∷ ItemManager → ItemInstance
 applyAccessoryBuffs itemMgr inst mods =
     case lookupItemDef (iiDefName inst) itemMgr of
         Nothing   → mods
-        Just iDef →
-            let src  = idDisplayName iDef
-                cond = iiCondition inst
-                applyOne acc b =
-                    let delta = if ibScalesWithCondition b
-                                  then ibAmount b * (cond / 100)
-                                  else ibAmount b
-                        m = StatModifier { smDelta = delta, smSource = src
-                                         , smExpiry = Nothing, smPercent = 0 }
-                        existing = HM.lookupDefault [] (ibStat b) acc
-                        others   = filter (\x → smSource x ≢ src) existing
-                    in HM.insert (ibStat b) (m : others) acc
-            in foldl' applyOne mods (idBuffs iDef)
+        Just iDef → applyItemBuffs (idDisplayName iDef)
+                                   (iiCondition inst)
+                                   (idBuffs iDef) mods
 
 -- | unit.addItem(uid, defName, fill) → bool. Adds a new ItemInstance
 --   to the unit's inventory. Fill is clamped to the def's container
@@ -4578,6 +4568,9 @@ unitGetInventoryFn env = do
                                             Lua.pushnumber (Lua.Number
                                                 (realToFrac (ibAmount b)))
                                             Lua.setfield (-2) "amount"
+                                            Lua.pushnumber (Lua.Number
+                                                (realToFrac (ibPercent b)))
+                                            Lua.setfield (-2) "percent"
                                             Lua.pushboolean
                                                 (ibScalesWithCondition b)
                                             Lua.setfield (-2)

--- a/src/Item/Types.hs
+++ b/src/Item/Types.hs
@@ -57,10 +57,17 @@ data ItemBuff = ItemBuff
       -- ^ stat name, e.g. "perception", "strength".
     , ibAmount              ∷ !Float
       -- ^ base bonus amount. Positive for buff, negative for debuff.
+    , ibPercent             ∷ !Float
+      -- ^ percentage bonus, fractional like the unit-level modifiers
+      --   block (0.1 = +10%). Lands on the modifier's smPercent axis:
+      --   effectiveStat = (base + Σdeltas) × (1 + Σpercents). 0 for
+      --   purely additive buffs (#392).
     , ibScalesWithCondition ∷ !Bool
       -- ^ when True, the applied bonus = amount × (condition/100). A
       --   100%-condition technogoggles confers the full +1; a 50%
-      --   pair confers +0.5. When False the bonus is flat.
+      --   pair confers +0.5. When False the bonus is flat. The same
+      --   factor scales the percent component (a worn 50%-condition
+      --   "+10%" buff confers +5%).
     } deriving (Show, Eq)
 
 -- | Weapon-specific stats. Combined with the item's `idMaterial`

--- a/src/Unit/Stats.hs
+++ b/src/Unit/Stats.hs
@@ -14,12 +14,15 @@ module Unit.Stats
     , boxMuller
     , effectiveStat
     , applySkillXP
+    , applyItemBuffs
     , pickName
     ) where
 
 import UPrelude
+import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
 import System.Random (StdGen, randomR)
+import Item.Types (ItemBuff(..))
 import Unit.Types (StatModifier(..), NamePool(..))
 
 -- | One standard-normal sample via Box-Muller. Returns (z, newGen).
@@ -70,6 +73,33 @@ effectiveStat now base mods =
     isActive m = case smExpiry m of
         Nothing → True
         Just t  → now < t
+
+-- | Fold an item's buffs into a unit's modifier map — the single
+--   implementation behind spawn-time accessory buffs, equip-time buff
+--   application, and the condition-refresh path (#392). @src@ is the
+--   item's display name (the label the stat tooltip shows); same-source
+--   modifiers on a stat collapse (replace, not stack), so re-applying
+--   at a new condition updates the live modifier instead of duplicating
+--   it. A buff with scales_with_condition confers
+--   @amount × (condition/100)@ — the same factor scales the percent
+--   component, so a worn item's percentage bonus degrades with it.
+applyItemBuffs ∷ T.Text → Float → [ItemBuff]
+               → HM.HashMap T.Text [StatModifier]
+               → HM.HashMap T.Text [StatModifier]
+applyItemBuffs src cond buffs mods0 = foldl' applyOne mods0 buffs
+  where
+    scale b | ibScalesWithCondition b = cond / 100
+            | otherwise               = 1
+    applyOne acc b =
+        let m = StatModifier
+                  { smDelta   = ibAmount b * scale b
+                  , smSource  = src
+                  , smExpiry  = Nothing
+                  , smPercent = ibPercent b * scale b
+                  }
+            existing = HM.lookupDefault [] (ibStat b) acc
+            others   = filter (\x → smSource x ≢ src) existing
+        in HM.insert (ibStat b) (m : others) acc
 
 {-# NOINLINE rollStat #-}
 rollStat ∷ Float → Float → StdGen → (Float, StdGen)

--- a/src/Unit/Thread/Command.hs
+++ b/src/Unit/Thread/Command.hs
@@ -18,14 +18,14 @@ import Engine.Core.Log (logDebug, logInfo, logWarn, LogCategory(..))
 import qualified Engine.Core.Queue as Q
 import Unit.Types
 import Unit.Sim.Types
-import Unit.Stats (rollStat, pickName)
+import Unit.Stats (rollStat, pickName, applyItemBuffs)
 import Unit.Command.Types (UnitCommand(..))
 import Unit.Thread.Movement (startJump, jumpMaxTiles)
 import Equipment.Types (EquipmentClass(..), EquipmentSlot(..),
                         lookupEquipmentClass)
 import Item.Roll (rollItemSpec, rollItemWeight)
 import Item.Types (ItemDef(..), ItemContainer(..), ItemInstance(..)
-                  , ItemBuff(..), ItemManager(..), lookupItemDef
+                  , ItemManager(..), lookupItemDef
                   , itemTotalWeight)
 import Engine.Core.Log (LoggerState)
 import World.Types (WorldManager(..), WorldState(..), LoadedChunk(..), columnIndex, lookupChunk)
@@ -1088,32 +1088,20 @@ defModifierMap def = foldl' insertOne HM.empty (udModifiers def)
             others   = filter (\x → smSource x ≢ smSource m) existing
         in HM.insert stat (m : others) acc
 
--- | Fold an accessory's buffs into a modifier map. Mirrors
---   Engine.Scripting.Lua.API.Equipment.applyItemBuffs but kept here to
---   avoid the import cycle between Unit.Thread.Command and Equipment.
---   Source string = item display_name; same-source entries collapse.
+-- | Fold an accessory's buffs into a modifier map: def lookup + the
+--   shared Unit.Stats.applyItemBuffs (which handles condition scaling,
+--   the percent axis, and same-source collapse). Items without a def
+--   in scope contribute nothing.
 applyAccessoryBuffs ∷ ItemManager
                     → HM.HashMap Text [StatModifier]
                     → ItemInstance
                     → HM.HashMap Text [StatModifier]
 applyAccessoryBuffs itemMgr mods inst =
     case lookupItemDef (iiDefName inst) itemMgr of
-        Nothing → mods
-        Just iDef → foldl' (applyOne iDef) mods (idBuffs iDef)
-  where
-    applyOne iDef acc b =
-        let cond  = iiCondition inst
-            delta = if ibScalesWithCondition b
-                      then ibAmount b * (cond / 100)
-                      else ibAmount b
-            src   = idDisplayName iDef
-            m     = StatModifier { smDelta = delta
-                                 , smSource = src
-                                 , smExpiry = Nothing
-                                 , smPercent = 0 }
-            existing = HM.lookupDefault [] (ibStat b) acc
-            others   = filter (\x → smSource x ≢ src) existing
-        in HM.insert (ibStat b) (m : others) acc
+        Nothing   → mods
+        Just iDef → applyItemBuffs (idDisplayName iDef)
+                                   (iiCondition inst)
+                                   (idBuffs iDef) mods
 
 -- | Resolve a unit def's starting_accessories into ItemInstances.
 --   Unknown items log a warning and are dropped. Quality + condition

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -162,6 +162,7 @@ test-suite synarchy-test-headless
                    Test.Headless.Unit.Fall
                    Test.Headless.Unit.Stats
                    Test.Headless.Item.Temperature
+                   Test.Headless.Item.BuffYaml
                    Test.Headless.World.Save.Sanitize
                    Test.Headless.World.CursorInfo
                    Test.Headless.World.SelectTileZ

--- a/test-headless/Spec.hs
+++ b/test-headless/Spec.hs
@@ -22,6 +22,7 @@ import qualified Test.Headless.Unit.Injury as InjuryTest
 import qualified Test.Headless.Unit.Fall as FallTest
 import qualified Test.Headless.Unit.Stats as StatsTest
 import qualified Test.Headless.Item.Temperature as ItemTemp
+import qualified Test.Headless.Item.BuffYaml as ItemBuffYaml
 import qualified Test.Headless.World.Save.Sanitize as SaveSanitize
 import qualified Test.Headless.World.CursorInfo as CursorInfo
 import qualified Test.Headless.World.SelectTileZ as SelectTileZ
@@ -73,6 +74,7 @@ main = hspec $ do
     describe "Unit.Fall" FallTest.spec
     describe "Unit.Stats" StatsTest.spec
     describe "Item.Temperature" ItemTemp.spec
+    describe "Item.BuffYaml" ItemBuffYaml.spec
     describe "World.Save.Sanitize" SaveSanitize.spec
     describe "World.CursorInfo" CursorInfo.spec
     describe "World.Spoil" Spoil.spec

--- a/test-headless/Test/Headless/Item/BuffYaml.hs
+++ b/test-headless/Test/Headless/Item/BuffYaml.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE UnicodeSyntax, OverloadedStrings #-}
+-- | Pure tests for the item-buff YAML schema (#392): the `percent`
+--   field parses (fractional, matching the unit-level modifiers
+--   block), `amount` became optional so a buff can declare either or
+--   both, and existing amount-only YAML keeps parsing unchanged.
+module Test.Headless.Item.BuffYaml (spec) where
+
+import UPrelude
+import Test.Hspec
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.Yaml as Yaml
+import Engine.Asset.YamlItems (ItemYamlBuff(..))
+
+decode ∷ BS.ByteString → Either String ItemYamlBuff
+decode = either (Left . show) Right . Yaml.decodeEither'
+
+spec ∷ Spec
+spec = do
+    describe "ItemYamlBuff percent parsing (#392)" $ do
+        it "parses a buff declaring amount, percent and scaling" $
+            decode "{ stat: perception, amount: 1, percent: 0.1,\
+                    \ scales_with_condition: true }"
+              `shouldBe` Right ItemYamlBuff
+                  { iybStat = "perception", iybAmount = 1
+                  , iybPercent = 0.1, iybScalesWithCondition = True }
+        it "percent defaults to 0 (existing amount-only YAML unchanged)" $
+            -- The technogoggles shape.
+            decode "{ stat: perception, amount: 1,\
+                    \ scales_with_condition: true }"
+              `shouldBe` Right ItemYamlBuff
+                  { iybStat = "perception", iybAmount = 1
+                  , iybPercent = 0, iybScalesWithCondition = True }
+        it "amount is optional: a percent-only buff parses" $
+            decode "{ stat: strength, percent: 0.25 }"
+              `shouldBe` Right ItemYamlBuff
+                  { iybStat = "strength", iybAmount = 0
+                  , iybPercent = 0.25, iybScalesWithCondition = False }
+        it "stat stays required" $
+            decode "{ amount: 1, percent: 0.1 }"
+              `shouldSatisfy` either (const True) (const False)

--- a/test-headless/Test/Headless/Unit/Stats.hs
+++ b/test-headless/Test/Headless/Unit/Stats.hs
@@ -8,8 +8,11 @@ module Test.Headless.Unit.Stats (spec) where
 import UPrelude
 import Test.Hspec
 import System.Random (mkStdGen)
+import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
-import Unit.Stats (rollStat, effectiveStat, applySkillXP, pickName)
+import Item.Types (ItemBuff(..))
+import Unit.Stats (rollStat, effectiveStat, applySkillXP, applyItemBuffs,
+                   pickName)
 import Unit.Types (StatModifier(..), NamePool(..))
 
 -- | Roll one stat with the given seed and return just the value.
@@ -114,6 +117,76 @@ spec = do
         it "clamps at 0 when a negative percent overshoots" $
             effectiveStat 0 10.0 [mkPct (-1.5) "drain" Nothing]
               `shouldBe` 0.0
+
+    let mkBuff st amt pct scales = ItemBuff
+            { ibStat = st, ibAmount = amt, ibPercent = pct
+            , ibScalesWithCondition = scales }
+        modsFor stat m = HM.lookupDefault [] stat m
+    describe "applyItemBuffs (#392)" $ do
+        it "flat buff at full condition → delta only" $ do
+            let m = applyItemBuffs "Goggles" 100
+                        [mkBuff "perception" 1.0 0 True] HM.empty
+            case modsFor "perception" m of
+                [sm] → do
+                    smDelta sm   `shouldBe` 1.0
+                    smPercent sm `shouldBe` 0.0
+                    smSource sm  `shouldBe` "Goggles"
+                    smExpiry sm  `shouldBe` Nothing
+                other → expectationFailure ("expected 1 modifier, got "
+                                            ⧺ show (length other))
+        it "percent-only buff lands on the smPercent axis" $ do
+            let m = applyItemBuffs "Amulet" 100
+                        [mkBuff "perception" 0 0.1 False] HM.empty
+            case modsFor "perception" m of
+                [sm] → do
+                    smDelta sm   `shouldBe` 0.0
+                    smPercent sm `shouldBe` 0.1
+                other → expectationFailure ("expected 1 modifier, got "
+                                            ⧺ show (length other))
+        it "condition scales BOTH amount and percent (50% → half)" $ do
+            let m = applyItemBuffs "Amulet" 50
+                        [mkBuff "perception" 2.0 0.1 True] HM.empty
+            case modsFor "perception" m of
+                [sm] → do
+                    smDelta sm   `shouldBe` 1.0
+                    smPercent sm `shouldBe` 0.05
+                other → expectationFailure ("expected 1 modifier, got "
+                                            ⧺ show (length other))
+        it "non-scaling buff ignores condition" $ do
+            let m = applyItemBuffs "Amulet" 50
+                        [mkBuff "perception" 2.0 0.1 False] HM.empty
+            case modsFor "perception" m of
+                [sm] → do
+                    smDelta sm   `shouldBe` 2.0
+                    smPercent sm `shouldBe` 0.1
+                other → expectationFailure ("expected 1 modifier, got "
+                                            ⧺ show (length other))
+        it "re-applying the same source replaces, not stacks" $ do
+            let buffs = [mkBuff "perception" 1.0 0.1 True]
+                m0 = applyItemBuffs "Goggles" 100 buffs HM.empty
+                m1 = applyItemBuffs "Goggles" 50  buffs m0
+            case modsFor "perception" m1 of
+                [sm] → do
+                    smDelta sm   `shouldBe` 0.5
+                    smPercent sm `shouldBe` 0.05
+                other → expectationFailure ("expected 1 modifier, got "
+                                            ⧺ show (length other))
+        it "different sources on the same stat stack" $ do
+            let m = applyItemBuffs "Amulet" 100
+                        [mkBuff "perception" 0 0.1 False]
+                        (applyItemBuffs "Goggles" 100
+                            [mkBuff "perception" 1.0 0 False] HM.empty)
+            length (modsFor "perception" m) `shouldBe` 2
+        it "one item's buffs land on their respective stats" $ do
+            let m = applyItemBuffs "Exosuit" 100
+                        [ mkBuff "strength"   2.0 0    False
+                        , mkBuff "perception" 0   0.25 False ] HM.empty
+            (smDelta   <$> modsFor "strength"   m) `shouldBe` [2.0]
+            (smPercent <$> modsFor "perception" m) `shouldBe` [0.25]
+        it "end-to-end: effectiveStat sees (base+delta)×(1+percent)" $ do
+            let m = applyItemBuffs "Exoskeleton" 100
+                        [mkBuff "strength" 2.0 0.5 False] HM.empty
+            effectiveStat 0 10.0 (modsFor "strength" m) `shouldBe` 18.0
 
     describe "applySkillXP" $ do
         let approx target v = abs (v - target) < 1e-4


### PR DESCRIPTION
## Summary

Resolves the #392 discussion: item/accessory buffs should support percentage modifiers, not just flat deltas (decided with the user 2026-07-02).

Previously all three buff-application sites hardcoded `smPercent = 0` and the `buffs:` YAML schema had no percent field — even though `StatModifier` carries the axis, `effectiveStat` applies it, and unit-level `modifiers:` YAML already had a `percent:` convention (the technomule). This was an accidental gap, not a design choice.

## Decisions (from the interactive session)

- **Add percent support** to item buffs, matching the unit-modifier YAML convention: fractional `percent:` (0.1 = +10%).
- **`scales_with_condition: true` scales both axes** — a 50%-condition "+10%" item confers +5%, same rule as the flat amount.
- **Schema + tests only** — no new game items in this PR; content comes later when design calls for it.

## Changes

- `ItemBuff`/`ItemYamlBuff` gain `percent` (fractional, default 0); `amount` becomes optional so a buff can declare either or both. `stat` stays required.
- The three near-identical application copies (spawn-time accessories in `Unit.Thread.Command`, equip-time in `Lua.API.Equipment`, condition-refresh in `Lua.API.Units` — the third wasn't mentioned in the issue) collapse into one shared pure `Unit.Stats.applyItemBuffs`. The duplication predated this PR (import-cycle avoidance); `Unit.Stats` sits low enough in the module graph that all three can import it.
- Both Lua buff-table surfaces (`equipment.getLoadout`-style pushes, inventory rows) now include `percent`; the item tooltip renders percent buffs (`Perception + 10%`) with flat-buff display unchanged.
- No save bump: `ItemBuff` is def-side YAML data (not serialized) and `smPercent` has been in `SaveData` since v33.

## Tests

- 8 new hspec cases on `applyItemBuffs`: flat/percent/both, condition scaling of both axes, non-scaling buffs, same-source replace-vs-stack, cross-source stacking, `effectiveStat` end-to-end.
- 4 new hspec cases on the YAML schema (`Test.Headless.Item.BuffYaml`): percent parses, percent defaults to 0 (existing amount-only YAML like technogoggles parses byte-identically), percent-only buffs parse, missing `stat` rejects.
- Full headless suite: **508 examples, 0 failures** (1 pre-existing pending). `test_audit.py`: all 35 groups pass. Fresh full build, warning-clean.

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)