### PR TITLE
#223 River/lake bed depth: canyon rivers + graben rift lakes

### DIFF
--- a/src/World/Fluid/Lake/Graben.hs
+++ b/src/World/Fluid/Lake/Graben.hs
@@ -1,0 +1,243 @@
+{-# OPTIONS_GHC -fprof-auto #-}
+{-# LANGUAGE Strict, UnicodeSyntax #-}
+-- | Graben (rift-lake) bed carving — issue #223.
+--
+--   Lakes are natural-basin fills with no bed model of their own:
+--   the floor is whatever terrain the priority flood happened to
+--   cover, so tectonically-rifted basins read identically to any
+--   shallow pan. This pass gives lakes that sit on a divergent
+--   plate boundary (per 'World.Plate.riftFieldMemo') a graben
+--   cross-section: an untouched shore shelf, steep walls dropping
+--   ~3 z per tile from two tiles off the shore, and a deep floor at
+--   @lkSurface − riftDepth@ with mild value-noise relief so it reads
+--   as a rift floor rather than a flat box.
+--
+--   The carve is expressed through the same per-chunk delta plumbing
+--   the coastal clamp used ('wlCarveDelta', applied at chunk gen via
+--   @max@ with the river deltas), and is strictly lower-only: where
+--   the natural basin is already deeper than the graben target, the
+--   natural floor wins. Lake SURFACES are untouched — the fill level
+--   comes from the pre-carve priority flood, so deepening a bed only
+--   deepens the water column.
+--
+--   Scope guards:
+--     * only inland lakes ('lkSurface' > 'seaLevel') — sub-sea and
+--       coastal-clamped basins belong to the seabed pass, which
+--       supersedes lake carve deltas there;
+--     * only lakes of at least 'grabenMinArea' tiles — a graben
+--       needs room for shelf + wall + floor;
+--     * only where the footprint-mean rift intensity reaches
+--       'grabenRiftThreshold'.
+module World.Fluid.Lake.Graben
+    ( grabenCarveIndex
+    , grabenRiftThreshold
+    , grabenMinArea
+    , grabenWallSlope
+    ) where
+
+import UPrelude
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as VU
+import qualified Data.Vector.Unboxed.Mutable as VUM
+import Control.Monad.ST (runST)
+import Data.STRef (newSTRef, readSTRef, writeSTRef)
+import World.Chunk.Types (ChunkCoord(..), chunkSize)
+import World.Constants (seaLevel)
+import World.Fluid.Lake.Types
+    ( Lake(..), WorldLakes(..), LakeChunkEntry(..) )
+import World.Plate (wrappedValueNoise2D)
+
+-- | Footprint-mean rift intensity a lake needs before it grabens.
+grabenRiftThreshold ∷ Float
+grabenRiftThreshold = 0.35
+
+-- | Minimum lake area (tiles). Below this the ring profile barely
+--   reaches its wall, let alone a floor.
+grabenMinArea ∷ Int
+grabenMinArea = 24
+
+-- | Wall steepness: z dropped per ring step once past the shore
+--   shelf (rings 0/1 untouched, the drop starts at ring 2).
+grabenWallSlope ∷ Int
+grabenWallSlope = 3
+
+-- | Depth of the graben floor below the lake surface, scaled by the
+--   footprint-mean rift intensity.
+grabenDepthFor ∷ Float → Int
+grabenDepthFor riftMean =
+    max 8 (min 24 (round (8.0 + 20.0 * riftMean ∷ Float)))
+
+-- | Wavelength (tiles) of the floor relief noise.
+grabenFloorNoiseScale ∷ Int
+grabenFloorNoiseScale = 6
+
+-- | Build the per-chunk graben carve deltas for a final lake table.
+--   Returns the map Timeline attaches as 'wlCarveDelta' (the clamp
+--   deltas the identifier itself produced are superseded by the
+--   seabed pass and dropped before this runs).
+grabenCarveIndex
+    ∷ Word64               -- ^ world seed (floor relief noise)
+    → Int                  -- ^ worldSize (chunks per side)
+    → VU.Vector Int        -- ^ world terrain (pre-carve, worldTiles²)
+    → (Int → Int → Float)  -- ^ rift-intensity field
+    → WorldLakes           -- ^ final lake table
+    → HM.HashMap ChunkCoord (VU.Vector Int)
+grabenCarveIndex seed worldSize terrain riftAt lakes =
+    let worldTiles = worldSize * chunkSize
+        nTiles     = worldTiles * worldTiles
+        half       = worldTiles `div` 2
+        chunkArea  = chunkSize * chunkSize
+        nLakes     = V.length (wlLakes lakes)
+
+        -- Per-tile lake id (−1 = not a lake tile), rebuilt from the
+        -- per-chunk bitmasks so this pass needs no access to the
+        -- identifier's internal label grid.
+        lakeIdAt ∷ VU.Vector Int
+        lakeIdAt = VU.create $ do
+            v ← VUM.replicate nTiles (-1)
+            forM_ (HM.toList (wlByChunk lakes)) $ \(ChunkCoord cx cy, entries) →
+                V.forM_ entries $ \entry → do
+                    let bm = lceBitmask entry
+                    forM_ [0 .. chunkArea - 1] $ \li →
+                        when (bm VU.! li) $ do
+                            let lx = li `mod` chunkSize
+                                ly = li `div` chunkSize
+                                gxOff = cx * chunkSize + lx + half
+                                gyOff = cy * chunkSize + ly + half
+                            when (gxOff ≥ 0 ∧ gxOff < worldTiles
+                                  ∧ gyOff ≥ 0 ∧ gyOff < worldTiles) $
+                                VUM.write v (gyOff * worldTiles + gxOff)
+                                            (lceLakeId entry)
+            pure v
+
+        -- Footprint-mean rift intensity per lake.
+        riftMeanOf ∷ V.Vector Float
+        riftMeanOf = runST $ do
+            sums ← VUM.replicate nLakes (0.0 ∷ Float)
+            cnts ← VUM.replicate nLakes (0 ∷ Int)
+            forM_ [0 .. nTiles - 1] $ \i → do
+                let lid = lakeIdAt VU.! i
+                when (lid ≥ 0) $ do
+                    let gx = (i `mod` worldTiles) - half
+                        gy = (i `div` worldTiles) - half
+                    s ← VUM.read sums lid
+                    VUM.write sums lid (s + riftAt gx gy)
+                    c ← VUM.read cnts lid
+                    VUM.write cnts lid (c + 1)
+            V.generateM nLakes $ \lid → do
+                s ← VUM.read sums lid
+                c ← VUM.read cnts lid
+                pure (if c ≡ 0 then 0.0 else s / fromIntegral c)
+
+        -- Which lakes graben, and how deep.
+        depthOf ∷ V.Vector Int      -- ^ 0 = not a graben lake
+        depthOf = V.generate nLakes $ \lid →
+            let lake = wlLakes lakes V.! lid
+                rm   = riftMeanOf V.! lid
+            in if lkSurface lake > seaLevel
+                  ∧ lkArea lake ≥ grabenMinArea
+                  ∧ rm ≥ grabenRiftThreshold
+               then grabenDepthFor rm
+               else 0
+
+        anyGraben = V.any (> 0) depthOf
+
+        -- Ring distance from shore for every lake tile: tiles whose
+        -- 4-neighbourhood leaves their own lake are ring 1; BFS
+        -- inward from there. Grid edges count as shore (the lake
+        -- identifier treats them as walls the same way).
+        ringOf ∷ VU.Vector Int
+        ringOf = VU.create $ do
+            ring ← VUM.replicate nTiles (0 ∷ Int)
+            let neighbours i =
+                    let bx = i `mod` worldTiles
+                        by = i `div` worldTiles
+                    in [ i - 1          | bx > 0 ]
+                     ⧺ [ i + 1          | bx < worldTiles - 1 ]
+                     ⧺ [ i - worldTiles | by > 0 ]
+                     ⧺ [ i + worldTiles | by < worldTiles - 1 ]
+                isShoreEdge i =
+                    let bx = i `mod` worldTiles
+                        by = i `div` worldTiles
+                        lid = lakeIdAt VU.! i
+                    in bx ≡ 0 ∨ bx ≡ worldTiles - 1
+                     ∨ by ≡ 0 ∨ by ≡ worldTiles - 1
+                     ∨ any (\j → lakeIdAt VU.! j ≠ lid) (neighbours i)
+            frontier0Ref ← newSTRef []
+            forM_ [0 .. nTiles - 1] $ \i →
+                when (lakeIdAt VU.! i ≥ 0 ∧ isShoreEdge i) $ do
+                    VUM.write ring i 1
+                    fs ← readSTRef frontier0Ref
+                    writeSTRef frontier0Ref (i : fs)
+            let expand [] _ = pure ()
+                expand frontier d = do
+                    nextRef ← newSTRef []
+                    forM_ frontier $ \i → do
+                        let lid = lakeIdAt VU.! i
+                        forM_ (neighbours i) $ \j →
+                            when (lakeIdAt VU.! j ≡ lid) $ do
+                                rj ← VUM.read ring j
+                                when (rj ≡ 0) $ do
+                                    VUM.write ring j d
+                                    ns ← readSTRef nextRef
+                                    writeSTRef nextRef (j : ns)
+                    next ← readSTRef nextRef
+                    expand next (d + 1)
+            frontier0 ← readSTRef frontier0Ref
+            expand frontier0 2
+            pure ring
+
+        -- Per-tile carve delta.
+        deltaAt i =
+            let lid = lakeIdAt VU.! i
+            in if lid < 0 then 0
+               else
+                 let gDepth = depthOf V.! lid
+                     ring   = ringOf VU.! i
+                 in if gDepth ≡ 0 ∨ ring < 2
+                    then 0
+                    else
+                      let prof0 = min gDepth (grabenWallSlope * (ring - 1))
+                          gx = (i `mod` worldTiles) - half
+                          gy = (i `div` worldTiles) - half
+                          -- Floor relief: only the flat floor gets
+                          -- the ±2 z noise, walls stay monotone.
+                          var | prof0 < gDepth = 0
+                              | otherwise =
+                                  round (wrappedValueNoise2D
+                                            (seed + 20623) worldSize
+                                            gx gy grabenFloorNoiseScale
+                                         * 4.0 ∷ Float) - 2
+                          prof = max grabenWallSlope (prof0 + var)
+                          surf = lkSurface (wlLakes lakes V.! lid)
+                          target = surf - prof
+                      in max 0 (terrain VU.! i - target)
+
+        -- Bucket non-zero deltas per chunk (same output shape as the
+        -- identifier's clamp-carve index).
+        step acc i =
+            let d = deltaAt i
+            in if d ≤ 0 then acc
+               else
+                 let gx = (i `mod` worldTiles) - half
+                     gy = (i `div` worldTiles) - half
+                     cx = gx `div` chunkSize
+                     cy = gy `div` chunkSize
+                     lx = ((gx `mod` chunkSize) + chunkSize) `mod` chunkSize
+                     ly = ((gy `mod` chunkSize) + chunkSize) `mod` chunkSize
+                     li = ly * chunkSize + lx
+                 in HM.insertWith (⧺) (ChunkCoord cx cy) [(li, d)] acc
+
+        buckets = foldl' step HM.empty [0 .. nTiles - 1]
+
+        toVec assocs = VU.create $ do
+            v ← VUM.replicate chunkArea 0
+            forM_ assocs $ \(li, d) → do
+                cur ← VUM.read v li
+                when (d > cur) (VUM.write v li d)
+            pure v
+
+    in if not anyGraben
+       then HM.empty
+       else HM.map toVec buckets

--- a/src/World/Fluid/River/Identify.hs
+++ b/src/World/Fluid/River/Identify.hs
@@ -45,6 +45,10 @@ module World.Fluid.River.Identify
     , riverThreshold
       -- * Exported for tests (Test.Headless.WorldGen.WrapSeam)
     , labelRiverComponents
+      -- * Exported for tests (Test.Headless.WorldGen.BedDepth)
+    , computeBedDepth
+    , depthFromRadius
+    , maxBedDepth
     ) where
 
 import UPrelude
@@ -63,6 +67,7 @@ import World.Fluid.Lake.Types
     ( WorldLakes(..), LakeChunkEntry(..), Lake(..) )
 import World.Fluid.River.Types
     ( River(..), WorldRivers(..), RiverChunkEntry(..), emptyWorldRivers )
+import World.Plate (wrappedValueNoise2D)
 import World.Weather.Lookup (LocalClimate(..), lookupLocalClimate)
 import World.Weather.Types (ClimateState)
 
@@ -169,13 +174,16 @@ stepDir worldTiles idx d
 
 -- | Run the full river identification pipeline.
 identifyWorldRivers
-    ∷ Int                  -- ^ worldSize (chunks per side)
+    ∷ Word64               -- ^ world seed (pool/riffle bed noise, #223)
+    → Int                  -- ^ worldSize (chunks per side)
     → WorldLakes
     → VU.Vector Int        -- ^ world terrain (worldTiles²)
     → ClimateState
     → Int                  -- ^ waterfall quantum (max surface drop / step)
+    → (Int → Int → Float)  -- ^ rift-intensity field (#223)
     → WorldRivers
-identifyWorldRivers worldSize lakes terrain climate waterfallQuantum0 =
+identifyWorldRivers seed worldSize lakes terrain climate waterfallQuantum0
+                    riftAt =
     let -- Guard: a non-positive quantum would flatten / break the
         -- stepped-gorge clamp, so floor it at 1 regardless of config source.
         waterfallQuantum = max 1 waterfallQuantum0
@@ -206,8 +214,8 @@ identifyWorldRivers worldSize lakes terrain climate waterfallQuantum0 =
             worldTiles terrain lakeIdAt dir spillwayOf
             precipUnits evapUnits ascOrder
 
-    in traceRivers worldSize terrain lakeIdAt isSpillwayOf spillwayOf
-                   dir flow ascOrder waterfallQuantum
+    in traceRivers seed worldSize terrain lakeIdAt isSpillwayOf spillwayOf
+                   dir flow ascOrder waterfallQuantum riftAt
 
 -- * Climate → flow units
 --
@@ -568,7 +576,8 @@ sortDescOn key = foldr insertDesc []
 --   them into connected components, compute quantised surface z, and
 --   build per-chunk bitmasks.
 traceRivers
-    ∷ Int                  -- ^ worldSize
+    ∷ Word64               -- ^ world seed (pool/riffle bed noise)
+    → Int                  -- ^ worldSize
     → VU.Vector Int        -- ^ terrain
     → VU.Vector Int        -- ^ lakeIdAt
     → VU.Vector Int        -- ^ isSpillwayOf
@@ -577,9 +586,10 @@ traceRivers
     → VU.Vector Int        -- ^ flow
     → VU.Vector Int        -- ^ ascending z order
     → Int                  -- ^ waterfall quantum (max surface drop / step)
+    → (Int → Int → Float)  -- ^ rift-intensity field
     → WorldRivers
-traceRivers worldSize terrain lakeIdAt isSpillwayOf spillwayOf dir flow
-            ascOrder waterfallQuantum =
+traceRivers seed worldSize terrain lakeIdAt isSpillwayOf spillwayOf dir flow
+            ascOrder waterfallQuantum riftAt =
     let worldTiles = worldSize * chunkSize
         nTiles     = worldTiles * worldTiles
         half       = worldTiles `div` 2
@@ -612,7 +622,7 @@ traceRivers worldSize terrain lakeIdAt isSpillwayOf spillwayOf dir flow
         -- 'clampCentreSurfaces'; widened tiles inherit the lowest
         -- centre's surface so the water plane stays flat across the
         -- river's cross-section).
-        (isRiverTile, widthRadius, surfZ) =
+        (isRiverTile, widthRadius, surfZ, perpDist) =
             expandWidth worldTiles terrain dir flow isRiverCentre centreSurf
 
         -- Step 2: label connected components — plain 4-adjacency over
@@ -635,9 +645,9 @@ traceRivers worldSize terrain lakeIdAt isSpillwayOf spillwayOf dir flow
         -- added to the bitmask with width 0; surface descends to
         -- @seaLevel + 1@ at the path's end.
         worldOcean = computeWorldEdgeOcean terrain worldTiles
-        (isRiverTileB, compIdB, widthRadiusB, surfZB) =
+        (isRiverTileB, compIdB, widthRadiusB, surfZB, perpDistB) =
             addBreakthroughs worldTiles isRiverTileF compIdF dir terrain
-                             worldOcean widthRadius surfZ
+                             worldOcean widthRadius surfZ perpDist
 
         -- Step 3.5: lateral waterfall clamp. The chain clamp (1c-pre)
         -- bounds steps along flow edges only; meander necks and
@@ -658,11 +668,18 @@ traceRivers worldSize terrain lakeIdAt isSpillwayOf spillwayOf dir flow
         byChunk = buildRiverChunkIndex worldSize half isRiverTileB compIdB
                                        surfZL widthRadiusB
 
+        -- Step 5.5 (#223): per-tile bed depth. Ordinary reaches keep
+        -- the flat 'depthFromRadius' fit; confined (canyon-walled)
+        -- and tectonically-rifted reaches deepen, with a thalweg
+        -- cross-section and pool/riffle variation along the channel.
+        bedDepth = computeBedDepth seed worldSize terrain isRiverTileB
+                                   widthRadiusB perpDistB surfZL riftAt
+
         -- Step 6: per-tile carve delta. Includes breakthrough path
         -- tiles, which can have large delta where they cut through
         -- coastal mountains.
         carveDelta = computeCarveDelta worldTiles terrain
-                                       isRiverTileB widthRadiusB surfZL
+                                       isRiverTileB bedDepth surfZL
         carveByChunk = buildCarveDeltaIndex worldSize half isRiverTileB
                                             carveDelta
 
@@ -824,7 +841,7 @@ expandWidth
     → VU.Vector Int        -- ^ flow
     → VU.Vector Bool       -- ^ isRiverCentre (after extension)
     → VU.Vector Int        -- ^ waterfall-clamped per-centre surface z
-    → (VU.Vector Bool, VU.Vector Int, VU.Vector Int)
+    → (VU.Vector Bool, VU.Vector Int, VU.Vector Int, VU.Vector Int)
 expandWidth worldTiles terrain dir flow isRiverCentre centreSurf =
     let nTiles = worldTiles * worldTiles
         -- Don't widen into terrain that rises too far above the river's
@@ -839,12 +856,19 @@ expandWidth worldTiles terrain dir flow isRiverCentre centreSurf =
         isR    ← VUM.replicate nTiles False
         width  ← VUM.replicate nTiles (-1   ∷ Int)
         surfZ  ← VUM.replicate nTiles minBound
-        let updateTile tIdx r s = do
+        -- Perpendicular distance from the channel centreline (0 =
+        -- centre tile, k = k-th wing tile out). Drives the thalweg
+        -- cross-section in 'computeBedDepth'; min wins when a tile
+        -- is claimed by several centres.
+        perp   ← VUM.replicate nTiles (maxBound ∷ Int)
+        let updateTile tIdx r s p = do
                 VUM.write isR tIdx True
                 curR ← VUM.read width tIdx
                 when (r > curR) (VUM.write width tIdx r)
                 curS ← VUM.read surfZ tIdx
                 when (curS ≡ minBound ∨ s < curS) (VUM.write surfZ tIdx s)
+                curP ← VUM.read perp tIdx
+                when (p < curP) (VUM.write perp tIdx p)
             walkWing centreIdx r perpD = do
                 centreS ← VUM.read surfZ centreIdx
                 let maxBank = centreS + depthFromRadius r + bankSlack
@@ -865,19 +889,20 @@ expandWidth worldTiles terrain dir flow isRiverCentre centreSurf =
                                     when (nT ≠ minBound
                                           ∧ nT ≤ maxBank
                                           ∧ nT ≥ minBank) $ do
-                                        updateTile nxt r centreS
+                                        updateTile nxt r centreS k
                                         loop (k + 1) nxt
                 loop 1 centreIdx
         forM_ [0 .. nTiles - 1] $ \i → when (isRiverCentre VU.! i) $ do
             let surf = centreSurf VU.! i
                 r    = widthRadiusFromFlow (flow VU.! i)
-            updateTile i r surf
+            updateTile i r surf 0
             when (r > 0) $
                 forM_ (perpDirs (dir VU.! i)) (walkWing i r)
         isRf   ← VU.unsafeFreeze isR
         widthF ← VU.unsafeFreeze width
         surfZf ← VU.unsafeFreeze surfZ
-        pure (isRf, widthF, surfZf)
+        perpF  ← VU.unsafeFreeze perp
+        pure (isRf, widthF, surfZf, perpF)
 
 -- | Carve depth in z for a given width radius. v2 user-approved:
 --   narrow rivers (radius 0/1) carve 1 z; wider rivers carve deeper
@@ -1213,9 +1238,11 @@ addBreakthroughs
     → VU.Vector Bool       -- ^ worldOcean
     → VU.Vector Int        -- ^ widthRadius
     → VU.Vector Int        -- ^ surfZ
-    → (VU.Vector Bool, VU.Vector Int, VU.Vector Int, VU.Vector Int)
+    → VU.Vector Int        -- ^ perpDist
+    → ( VU.Vector Bool, VU.Vector Int, VU.Vector Int, VU.Vector Int
+      , VU.Vector Int )
 addBreakthroughs worldTiles isRiverTile compId dir terrain worldOcean
-                 widthRadius surfZ =
+                 widthRadius surfZ perpDist =
     let nTiles = worldTiles * worldTiles
         mouths = findStrandedMouths nTiles isRiverTile dir terrain
     in runST $ do
@@ -1223,6 +1250,7 @@ addBreakthroughs worldTiles isRiverTile compId dir terrain worldOcean
         compM  ← VU.thaw compId
         widthM ← VU.thaw widthRadius
         surfM  ← VU.thaw surfZ
+        perpM  ← VU.thaw perpDist
         forM_ mouths $ \m → do
             let mSurf = surfZ VU.! m
                 mCid  = compId VU.! m
@@ -1247,6 +1275,9 @@ addBreakthroughs worldTiles isRiverTile compId dir terrain worldOcean
                                 VUM.write isRM   p True
                                 curW ← VUM.read widthM p
                                 when (curW < 0) (VUM.write widthM p 0)
+                                -- Path tiles are their own centreline.
+                                curP ← VUM.read perpM p
+                                when (curP > 0) (VUM.write perpM p 0)
                                 VUM.write compM  p mCid
                                 VUM.write surfM  p target
                                 walk target rest
@@ -1255,7 +1286,8 @@ addBreakthroughs worldTiles isRiverTile compId dir terrain worldOcean
         compF  ← VU.unsafeFreeze compM
         widthF ← VU.unsafeFreeze widthM
         surfF  ← VU.unsafeFreeze surfM
-        pure (isRf, compF, widthF, surfF)
+        perpF  ← VU.unsafeFreeze perpM
+        pure (isRf, compF, widthF, surfF, perpF)
 
 -- | Per-tile carve delta in z — the FINAL channel-bed fit, the second
 --   of the two-stage hydrology (see the note at the 'identifyWorldRivers'
@@ -1278,10 +1310,10 @@ computeCarveDelta
     ∷ Int                  -- ^ worldTiles
     → VU.Vector Int        -- ^ terrain
     → VU.Vector Bool       -- ^ isRiverTile
-    → VU.Vector Int        -- ^ widthRadius
+    → VU.Vector Int        -- ^ per-tile bed depth ('computeBedDepth')
     → VU.Vector Int        -- ^ surfaceZ
     → VU.Vector Int
-computeCarveDelta worldTiles terrain isRiverTile widthRadius surfZ =
+computeCarveDelta worldTiles terrain isRiverTile bedDepth surfZ =
     let nTiles = worldTiles * worldTiles
     in VU.generate nTiles $ \i →
         if not (isRiverTile VU.! i)
@@ -1289,9 +1321,171 @@ computeCarveDelta worldTiles terrain isRiverTile widthRadius surfZ =
         else
           let preCarve = terrain VU.! i
               surf     = surfZ   VU.! i
-              r        = max 0 (widthRadius VU.! i)
-              depth    = depthFromRadius r
+              depth    = bedDepth VU.! i
           in max 0 (preCarve - surf + depth)
+
+-- * Bed depth model (#223)
+
+-- | Valley-wall height (above the water surface) at which a reach
+--   starts counting as confined; each 'canyonConfSlope' z above that
+--   adds one z of bed depth, up to 'canyonConfCap'. Calibrated on the
+--   seed-42 w128 wall-height census: at 12/4 the first boost lands at
+--   walls 16 z above the water surface (~15% of river mileage), the
+--   cap at 32+ z — ordinary hilly valleys stay on the flat shallow
+--   fit and only genuine gorges deepen.
+canyonConfMin, canyonConfSlope, canyonConfCap ∷ Int
+canyonConfMin   = 12
+canyonConfSlope = 4
+canyonConfCap   = 5
+
+-- | Chebyshev radius of the wall-height scan around each river tile.
+--   Deliberately tight: a wall 2 tiles from the water IS the channel
+--   wall; wider scans read nearby hills as confinement and boost
+--   every mountain-adjacent reach.
+canyonScanRadius ∷ Int
+canyonScanRadius = 2
+
+-- | Rift-intensity floor below which the tectonic bed bonus is zero,
+--   and the maximum bonus (z) a fully-rifted reach adds.
+riftBedThreshold ∷ Float
+riftBedThreshold = 0.25
+
+riftBedCap ∷ Int
+riftBedCap = 3
+
+-- | Hard cap on the water column a canyon/rift reach can carve.
+maxBedDepth ∷ Int
+maxBedDepth = 9
+
+-- | Wavelength (tiles) of the pool/riffle bed noise on deep reaches.
+poolRiffleScale ∷ Int
+poolRiffleScale = 12
+
+-- | Per-tile channel bed depth (z of water column the carve fits).
+--
+--   Ordinary reaches keep the historical behaviour EXACTLY: depth =
+--   'depthFromRadius' width, flat across the cross-section — the
+--   issue #223 requirement is that lowland rivers stay shallow and
+--   flat. A reach only deepens when it has a canyon/rift *boost*:
+--
+--     * confinement — the highest terrain within 'canyonScanRadius'
+--       tiles stands ≥ 'canyonConfMin' z above the water surface
+--       (gorges through plateaus, breakthrough cuts, rift shoulders);
+--     * rift intensity — the tile sits on a divergent plate boundary
+--       ('riftTectonicIntensity' ≥ 'riftBedThreshold').
+--
+--   The boost is smoothed along the channel (two Jacobi passes over
+--   river-tile 4-neighbours) so depth never pops tile-to-tile, then
+--   shaped by a thalweg profile (deepest at the centreline, one z
+--   shallower per wing tile out) and pool/riffle value noise (±1–2 z
+--   at 'poolRiffleScale' wavelength) so deep beds read as carved
+--   channels rather than flat boxes. Result clamped to
+--   [1, 'maxBedDepth']. The carve stays lower-only downstream —
+--   deeper targets only ever LOWER the bed further below the fixed
+--   water surface.
+computeBedDepth
+    ∷ Word64               -- ^ world seed
+    → Int                  -- ^ worldSize (chunks per side)
+    → VU.Vector Int        -- ^ terrain (pre-carve)
+    → VU.Vector Bool       -- ^ isRiverTile
+    → VU.Vector Int        -- ^ widthRadius
+    → VU.Vector Int        -- ^ perpDist (0 = centreline)
+    → VU.Vector Int        -- ^ surfaceZ
+    → (Int → Int → Float)  -- ^ rift-intensity field
+    → VU.Vector Int
+computeBedDepth seed worldSize terrain isRiverTile widthRadius perpDist
+                surfZ riftAt =
+    let worldTiles = worldSize * chunkSize
+        nTiles     = worldTiles * worldTiles
+        half       = worldTiles `div` 2
+
+        -- Highest terrain within the scan window, minus the water
+        -- surface. Grid edges clamp; near-seam correctness comes from
+        -- the stitched grid's double coverage (same convention as the
+        -- rest of this module).
+        wallAbove i =
+            let bx = i `mod` worldTiles
+                by = i `div` worldTiles
+                x0 = max 0 (bx - canyonScanRadius)
+                x1 = min (worldTiles - 1) (bx + canyonScanRadius)
+                y0 = max 0 (by - canyonScanRadius)
+                y1 = min (worldTiles - 1) (by + canyonScanRadius)
+                goY y !acc
+                    | y > y1 = acc
+                    | otherwise = goY (y + 1) (goX y x0 acc)
+                goX y x !acc
+                    | x > x1 = acc
+                    | otherwise =
+                        let t = terrain VU.! (y * worldTiles + x)
+                            acc' = if t ≡ minBound then acc else max acc t
+                        in goX y (x + 1) acc'
+            in goY y0 minBound - surfZ VU.! i
+
+        rawBoost = VU.generate nTiles $ \i →
+            if not (isRiverTile VU.! i)
+            then 0
+            else
+              let confB = min canyonConfCap
+                              (max 0 ((wallAbove i - canyonConfMin)
+                                      `div` canyonConfSlope))
+                  gx = (i `mod` worldTiles) - half
+                  gy = (i `div` worldTiles) - half
+                  rift = riftAt gx gy
+                  riftB = if rift < riftBedThreshold
+                          then 0
+                          else min riftBedCap
+                                   (round (fromIntegral riftBedCap * rift))
+              in confB + riftB
+
+        -- Two smoothing passes over river 4-neighbours: kills
+        -- tile-to-tile depth pops where the wall scan enters/leaves
+        -- a cliff's window.
+        smoothPass bv = VU.generate nTiles $ \i →
+            if not (isRiverTile VU.! i)
+            then 0
+            else
+              let bx = i `mod` worldTiles
+                  by = i `div` worldTiles
+                  neigh = [ j
+                          | (dx, dy) ← [(1,0),(-1,0),(0,1),(0,-1)]
+                          , let nx = bx + dx
+                                ny = by + dy
+                          , nx ≥ 0, nx < worldTiles
+                          , ny ≥ 0, ny < worldTiles
+                          , let j = ny * worldTiles + nx
+                          , isRiverTile VU.! j
+                          ]
+                  s = sum (map (bv VU.!) neigh)
+                  n = length neigh
+              in (2 * (bv VU.! i) + s) `div` (2 + n)
+
+        boost = smoothPass (smoothPass rawBoost)
+
+    in VU.generate nTiles $ \i →
+        if not (isRiverTile VU.! i)
+        then 0
+        else
+          let base = depthFromRadius (max 0 (widthRadius VU.! i))
+              b    = boost VU.! i
+          in if b ≤ 0
+             then base
+             else
+               let gx = (i `mod` worldTiles) - half
+                   gy = (i `div` worldTiles) - half
+                   -- [0,1] noise → {−1, 0, +1, +2}
+                   pool = round (wrappedValueNoise2D seed worldSize gx gy
+                                                     poolRiffleScale
+                                 * 3.0 ∷ Float) - 1
+                   perp = min 8 (perpDist VU.! i)
+                   raw  = max 1 (min maxBedDepth (base + b + pool - perp))
+                   -- The boost may only deepen while the bed stays
+                   -- ABOVE sea level — a boosted bed at seaLevel or
+                   -- below reclassifies the channel as ocean in an
+                   -- oceanic chunk. Where the water surface is too
+                   -- low to afford any extra depth, fall back to the
+                   -- exact unboosted fit (master-identical mouths).
+                   aboveSea = surfZ VU.! i - (seaLevel + 1)
+               in max base (min raw aboveSea)
 
 -- | Bucket the per-tile carve delta into per-chunk vectors so chunk
 --   gen can look up its slice in O(1). Only chunks that touch a river

--- a/src/World/Geology/Timeline.hs
+++ b/src/World/Geology/Timeline.hs
@@ -10,7 +10,8 @@ import qualified Data.Vector.Unboxed as VU
 import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
 import World.Types
-import World.Plate (generatePlates, wrapGlobalU, elevationAtGlobal)
+import World.Plate (generatePlates, wrapGlobalU, elevationAtGlobal
+                   , riftFieldMemo)
 import World.Material (MaterialRegistry, MaterialId, matGlacier)
 import World.Generate.Constants (chunkBorder)
 import World.Fluid.River (fixupSegmentContinuity)
@@ -18,6 +19,7 @@ import World.Generate.Timeline.Fast (applyTimelineFastFrom)
 import World.Geology.Hash
 import World.Geology.Crater (generateCraters)
 import World.Fluid.IceLevel (computeIceLevelGrid)
+import World.Fluid.Lake.Graben (grabenCarveIndex)
 import World.Fluid.Lake.Identify (identifyWorldLakes, computeRenderedOcean)
 import World.Fluid.Seabed (identifySeabed)
 import World.Fluid.Seabed.Types (emptySeabedTable)
@@ -234,16 +236,27 @@ buildTimeline registry seed worldSize plateCount erosionIntensity volcanicActivi
 
         -- The seabed pass (below) supersedes the flat seaLevel−1
         -- floor carve for sub-sea basins, so drop the lake table's
-        -- carve deltas — seabed covers every clamped-lake tile and
-        -- carves it to the ramp instead (which is still ≤ seaLevel−1,
-        -- so the surface fills). Keeps the two mechanisms from
-        -- double-carving.
-        finalLakes = finalLakes0 { wlCarveDelta = HM.empty }
+        -- clamp carve deltas — seabed covers every clamped-lake tile
+        -- and carves it to the ramp instead (which is still ≤
+        -- seaLevel−1, so the surface fills). Keeps the two mechanisms
+        -- from double-carving. In their place ride the graben deltas
+        -- (#223): rift-lake bed carves for INLAND lakes only
+        -- (lkSurface > seaLevel), which the seabed pass never touches.
+        finalLakes = finalLakes0
+            { wlCarveDelta = grabenCarveIndex seed worldSize worldTerrain
+                                              riftAt finalLakes0 }
 
-        finalRivers = identifyWorldRivers worldSize finalLakes
+        -- Inland rift-intensity field (#223): shared by the river
+        -- bed-depth model and the graben lake carve so both agree on
+        -- where the world is rifting. Memoized once — cell samples
+        -- are reused across every per-tile query below.
+        riftAt = riftFieldMemo seed worldSize plates
+
+        finalRivers = identifyWorldRivers seed worldSize finalLakes
                                           worldTerrain
                                           (tbsClimateState s2)
                                           waterfallQuantum
+                                          riftAt
 
         -- Global seabed pass (save v26): continental-margin relief
         -- (shelf + slope profile blended with the natural floor),

--- a/src/World/Plate.hs
+++ b/src/World/Plate.hs
@@ -19,6 +19,10 @@ module World.Plate
     , coastCellSteepness
     , coastSteepAt
     , coastTectonicSteepness
+      -- * Inland rift intensity (#223)
+    , riftCellIntensity
+    , riftTectonicIntensity
+    , riftFieldMemo
       -- * wrapping
     , wrapGlobalX
     , wrapGlobalU
@@ -28,6 +32,7 @@ module World.Plate
     ) where
 
 import UPrelude
+import qualified Data.Vector.Unboxed as VU
 import World.Material (MaterialId(..), matGranite, matDiorite, matGabbro, matGlacier)
 import World.Scale (WorldScale(..), computeWorldScale, scaleElev, scaleDist, scaleElevI)
 import World.Constants (seaLevel)
@@ -238,14 +243,14 @@ boundarySteepness (Convergent s) = 0.8 + 0.2 * min 1.0 s
 boundarySteepness (Transform  _) = 0.5
 boundarySteepness (Divergent  _) = 0.1
 
--- | Steepness sample at one coarse cell center. @ju@ is the u-cell
---   index (any integer — the physical position wraps), @jv@ the
---   v-cell index. Fades toward gentle away from the plate boundary so
---   coasts deep inside a plate ignore its far-off margin type.
-coastCellSteepness ∷ Word64 → Int → [TectonicPlate] → Int → Int → Float
-coastCellSteepness seed worldSize plates ju jv =
-    let wsc = computeWorldScale worldSize
-        w = worldWidthTiles worldSize
+-- | Boundary classification + distance-to-boundary at one coarse
+--   cell center, shared by the coastal-steepness and rift-intensity
+--   cell samplers. @ju@ is the u-cell index (any integer — the
+--   physical position wraps), @jv@ the v-cell index.
+cellBoundarySample ∷ Word64 → Int → [TectonicPlate] → Int → Int
+                   → (BoundaryType, Float)
+cellBoundarySample seed worldSize plates ju jv =
+    let w = worldWidthTiles worldSize
         effCell = fromIntegral w / fromIntegral (coastCellsInU worldSize) ∷ Float
         uC = (fromIntegral ju + 0.5) * effCell
         vC = (fromIntegral jv + 0.5) * fromIntegral coastCellSize ∷ Float
@@ -255,7 +260,17 @@ coastCellSteepness seed worldSize plates ju jv =
         ((plateA, distA), (plateB, distB)) =
             twoNearestPlates seed worldSize plates gx' gy'
         boundaryDist = abs (distB - distA) / 2.0
-        base = boundarySteepness (classifyBoundary worldSize plateA plateB)
+    in (classifyBoundary worldSize plateA plateB, boundaryDist)
+
+-- | Steepness sample at one coarse cell center. Fades toward gentle
+--   away from the plate boundary so coasts deep inside a plate ignore
+--   their far-off margin type.
+coastCellSteepness ∷ Word64 → Int → [TectonicPlate] → Int → Int → Float
+coastCellSteepness seed worldSize plates ju jv =
+    let wsc = computeWorldScale worldSize
+        (boundary, boundaryDist) =
+            cellBoundarySample seed worldSize plates ju jv
+        base = boundarySteepness boundary
         nearR = scaleDist wsc 40.0
         fadeR = max 1.0 (scaleDist wsc 200.0)
         fade = 1.0 - smoothstep (clamp01 ((boundaryDist - nearR) / fadeR))
@@ -288,6 +303,61 @@ coastSteepAt sample worldSize gx gy =
 coastTectonicSteepness ∷ Word64 → Int → [TectonicPlate] → Int → Int → Float
 coastTectonicSteepness seed worldSize plates =
     coastSteepAt (coastCellSteepness seed worldSize plates) worldSize
+
+-- * Inland Rift Intensity (#223)
+
+-- | How strongly a rifting/extensional margin expresses at a cell.
+--   Only divergent boundaries rift; convergent and transform margins
+--   contribute nothing.
+riftBoundaryIntensity ∷ BoundaryType → Float
+riftBoundaryIntensity (Divergent s) = 0.6 + 0.4 * min 1.0 s
+riftBoundaryIntensity _             = 0.0
+
+-- | Rift-intensity sample at one coarse cell center. Same cell grid
+--   as the coastal steepness field but with a much tighter boundary
+--   fade — rift valleys and graben lakes hug the spreading boundary
+--   instead of colouring the whole margin the way coastal steepness
+--   does.
+riftCellIntensity ∷ Word64 → Int → [TectonicPlate] → Int → Int → Float
+riftCellIntensity seed worldSize plates ju jv =
+    let wsc = computeWorldScale worldSize
+        (boundary, boundaryDist) =
+            cellBoundarySample seed worldSize plates ju jv
+        base = riftBoundaryIntensity boundary
+        nearR = scaleDist wsc 16.0
+        fadeR = max 1.0 (scaleDist wsc 64.0)
+        fade = 1.0 - smoothstep (clamp01 ((boundaryDist - nearR) / fadeR))
+    in base * fade
+
+-- | Smooth, coherent "how tectonically rifted is this area" field in
+--   [0,1]. Pure function of seed + plates, interpolated on the same
+--   wrap-exact cell grid as 'coastTectonicSteepness' so a tile and
+--   its u-alias read identical values.
+riftTectonicIntensity ∷ Word64 → Int → [TectonicPlate] → Int → Int → Float
+riftTectonicIntensity seed worldSize plates =
+    coastSteepAt (riftCellIntensity seed worldSize plates) worldSize
+
+-- | Memoized rift field: every cell of the coarse grid is sampled
+--   once up front (a few thousand cells even at large world sizes),
+--   and the returned closure interpolates per tile. Use this when
+--   querying many tiles (river tracing, lake footprints) — the
+--   direct 'riftTectonicIntensity' re-runs 'twoNearestPlates' for
+--   every cell corner of every query.
+riftFieldMemo ∷ Word64 → Int → [TectonicPlate] → (Int → Int → Float)
+riftFieldMemo seed worldSize plates =
+    let worldTiles = worldWidthTiles worldSize
+        cellsU = coastCellsInU worldSize
+        -- v = gx + gy spans [−worldTiles, worldTiles]; pad two cells
+        -- each side so interpolation corners never read out of range.
+        vCells = 2 * (worldTiles `div` coastCellSize) + 4
+        jvOff  = worldTiles `div` coastCellSize + 2
+        wrapJu ju = ((ju `mod` cellsU) + cellsU) `mod` cellsU
+        clampJv jv = max (negate jvOff) (min (vCells - jvOff - 1) jv)
+        cellIdx ju jv = (clampJv jv + jvOff) * cellsU + wrapJu ju
+        cells = VU.generate (cellsU * vCells) $ \i →
+            let (jvI, juI) = i `divMod` cellsU
+            in riftCellIntensity seed worldSize plates juI (jvI - jvOff)
+    in coastSteepAt (\ju jv → cells VU.! cellIdx ju jv) worldSize
 
 -- * Glacier Border
 

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -154,6 +154,7 @@ test-suite synarchy-test-headless
                    Test.Headless.WorldGen.BorderProbe
                    Test.Headless.WorldGen.WrapSeam
                    Test.Headless.WorldGen.CoastBreach
+                   Test.Headless.WorldGen.BedDepth
                    Test.Headless.Unit.Pathing.Cost
                    Test.Headless.Unit.Pathing.AStar
                    Test.Headless.Unit.Pathing.Config
@@ -629,6 +630,7 @@ library
                      World.Fluid.IceLevel
                      World.Fluid.Lake.Types
                      World.Fluid.Lake.Identify
+                     World.Fluid.Lake.Graben
                      World.Fluid.River.Types
                      World.Fluid.River.Identify
                      World.Fluid.Lava

--- a/test-headless/Spec.hs
+++ b/test-headless/Spec.hs
@@ -14,6 +14,7 @@ import qualified Test.Headless.WorldGen.ZoomParity as ZoomParity
 import qualified Test.Headless.WorldGen.BorderProbe as BorderProbe
 import qualified Test.Headless.WorldGen.WrapSeam as WrapSeam
 import qualified Test.Headless.WorldGen.CoastBreach as CoastBreach
+import qualified Test.Headless.WorldGen.BedDepth as BedDepth
 import qualified Test.Headless.Unit.Pathing.Cost as PathingCost
 import qualified Test.Headless.Unit.Pathing.AStar as PathingAStar
 import qualified Test.Headless.Unit.Pathing.Config as PathingConfig
@@ -67,6 +68,7 @@ main = hspec $ do
         describe "Border Probe" BorderProbe.spec
     describe "Wrap Seam" WrapSeam.spec
     describe "WorldGen.CoastBreach" CoastBreach.spec
+    describe "WorldGen.BedDepth" BedDepth.spec
     describe "Unit.Pathing.Cost" PathingCost.spec
     describe "Unit.Pathing.AStar" PathingAStar.spec
     describe "Unit.Pathing.Config" PathingConfig.spec

--- a/test-headless/Test/Headless/WorldGen/BedDepth.hs
+++ b/test-headless/Test/Headless/WorldGen/BedDepth.hs
@@ -1,0 +1,205 @@
+{-# LANGUAGE Strict, UnicodeSyntax #-}
+-- | Unit contracts for the #223 bed-depth work: the inland rift
+--   field ('World.Plate.riftFieldMemo'), the river channel bed model
+--   ('World.Fluid.River.Identify.computeBedDepth'), and the graben
+--   lake carve ('World.Fluid.Lake.Graben.grabenCarveIndex').
+--
+--   Synthetic grids only — no worldgen.
+module Test.Headless.WorldGen.BedDepth (spec) where
+
+import UPrelude
+import Test.Hspec
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as VU
+import World.Chunk.Types (ChunkCoord(..), chunkSize)
+import World.Constants (seaLevel)
+import World.Fluid.Lake.Graben
+    ( grabenCarveIndex, grabenRiftThreshold, grabenMinArea )
+import World.Fluid.Lake.Types
+    ( Lake(..), LakeChunkEntry(..), WorldLakes(..) )
+import World.Fluid.River.Identify
+    ( computeBedDepth, depthFromRadius, maxBedDepth )
+import World.Plate
+    ( generatePlates, riftFieldMemo, riftTectonicIntensity, wrapGlobalU )
+
+worldSizeT ∷ Int
+worldSizeT = 2
+
+worldTilesT ∷ Int
+worldTilesT = worldSizeT * chunkSize
+
+nTilesT ∷ Int
+nTilesT = worldTilesT * worldTilesT
+
+halfT ∷ Int
+halfT = worldTilesT `div` 2
+
+idxOf ∷ Int → Int → Int
+idxOf gx gy = (gy + halfT) * worldTilesT + (gx + halfT)
+
+mkGrid ∷ (Int → Int → Int) → VU.Vector Int
+mkGrid f = VU.generate nTilesT $ \i →
+    let gx = i `mod` worldTilesT - halfT
+        gy = i `div` worldTilesT - halfT
+    in f gx gy
+
+-- | A straight west-east river along gy ≡ 0: centre tiles with
+--   width radius 0, perp 0, surface at the given z.
+riverRow ∷ Int → (VU.Vector Bool, VU.Vector Int, VU.Vector Int, VU.Vector Int)
+riverRow surf =
+    let isR  = VU.generate nTilesT $ \i →
+            i `div` worldTilesT ≡ halfT     -- gy ≡ 0 row
+        wr   = VU.map (\r → if r then 0 else (-1)) isR
+        perp = VU.replicate nTilesT 0
+        sz   = VU.map (\r → if r then surf else minBound) isR
+    in (isR, wr, perp, sz)
+
+noRift ∷ Int → Int → Float
+noRift _ _ = 0.0
+
+fullRift ∷ Int → Int → Float
+fullRift _ _ = 1.0
+
+spec ∷ Spec
+spec = describe "bed depth (#223)" $ do
+    describe "riftFieldMemo" $ do
+        let plates = generatePlates 42 worldSizeT 4
+            direct = riftTectonicIntensity 42 worldSizeT plates
+            memo   = riftFieldMemo 42 worldSizeT plates
+            coords = [ (gx, gy)
+                     | gx ← [-halfT, -halfT + 5 .. halfT - 1]
+                     , gy ← [-halfT, -halfT + 5 .. halfT - 1] ]
+
+        it "stays in [0,1]" $
+            forM_ coords $ \(gx, gy) → do
+                let v = memo gx gy
+                v `shouldSatisfy` (≥ 0.0)
+                v `shouldSatisfy` (≤ 1.0)
+
+        it "memoized field equals the direct query" $
+            forM_ coords $ \(gx, gy) →
+                memo gx gy `shouldBe` direct gx gy
+
+        it "is wrap-exact (tile ≡ its u-alias)" $ do
+            let canonical = [ (gx, gy) | (gx, gy) ← coords
+                            , gx - gy ≥ negate halfT, gx - gy < halfT ]
+            forM_ canonical $ \(gx, gy) → do
+                let u = gx - gy
+                    v = gx + gy
+                    -- shift one full wrap in u
+                    gx' = (u + worldTilesT + v) `div` 2
+                    gy' = (v - u - worldTilesT) `div` 2
+                    (cgx, cgy) = wrapGlobalU worldSizeT gx' gy'
+                -- the alias projects back onto the canonical tile...
+                (cgx, cgy) `shouldBe` (gx, gy)
+                -- ...and the field agrees at the alias coordinates
+                memo gx' gy' `shouldBe` memo gx gy
+
+    describe "computeBedDepth" $ do
+        it "keeps ordinary flat reaches at exactly depthFromRadius" $ do
+            let terrain = mkGrid (\_ _ → 5)
+                (isR, wr, perp, sz) = riverRow 5
+                bd = computeBedDepth 42 worldSizeT terrain isR wr perp
+                                     sz noRift
+            forM_ [-halfT .. halfT - 1] $ \gx →
+                bd VU.! idxOf gx 0 `shouldBe` depthFromRadius 0
+
+        it "deepens confined reaches but never past maxBedDepth" $ do
+            -- sheer 40-z walls one tile to each side of the channel
+            let terrain = mkGrid $ \_ gy →
+                    if abs gy ≤ 1 then 20 else 60
+                (isR, wr, perp, sz) = riverRow 20
+                bd = computeBedDepth 42 worldSizeT terrain isR wr perp
+                                     sz noRift
+                depths = [ bd VU.! idxOf gx 0
+                         | gx ← [-halfT .. halfT - 1] ]
+            maximum depths `shouldSatisfy` (> depthFromRadius 0)
+            forM_ depths $ \d → do
+                d `shouldSatisfy` (≥ 1)
+                d `shouldSatisfy` (≤ maxBedDepth)
+
+        it "rift intensity alone deepens the bed" $ do
+            let terrain = mkGrid (\_ _ → 5)
+                (isR, wr, perp, sz) = riverRow 5
+                bd = computeBedDepth 42 worldSizeT terrain isR wr perp
+                                     sz fullRift
+                depths = [ bd VU.! idxOf gx 0
+                         | gx ← [-halfT .. halfT - 1] ]
+            maximum depths `shouldSatisfy` (> depthFromRadius 0)
+
+        it "never deepens a near-sea reach below the unboosted fit" $ do
+            -- max confinement AND max rift at a surface of seaLevel+1:
+            -- the boost cannot afford any depth, base fit wins.
+            let terrain = mkGrid $ \_ gy →
+                    if abs gy ≤ 1 then seaLevel + 1 else 60
+                (isR, wr, perp, sz) = riverRow (seaLevel + 1)
+                bd = computeBedDepth 42 worldSizeT terrain isR wr perp
+                                     sz fullRift
+            forM_ [-halfT .. halfT - 1] $ \gx →
+                bd VU.! idxOf gx 0 `shouldBe` depthFromRadius 0
+
+    describe "grabenCarveIndex" $ do
+        -- one square inland lake, surface 10, natural floor 9
+        -- (1-deep pan), big enough to qualify
+        let side = 12   -- 144 tiles ≥ grabenMinArea
+            inLake gx gy = gx ≥ 0 ∧ gx < side ∧ gy ≥ 0 ∧ gy < side
+            terrain = mkGrid $ \gx gy → if inLake gx gy then 9 else 14
+            lake = Lake { lkSurface = 10, lkFloor = 9
+                        , lkArea = side * side
+                        , lkBBoxMinX = 0, lkBBoxMinY = 0
+                        , lkBBoxMaxX = side - 1, lkBBoxMaxY = side - 1 }
+            entryFor cx cy = LakeChunkEntry
+                { lceLakeId = 0
+                , lceBitmask = VU.generate (chunkSize * chunkSize) $ \li →
+                    let lx = li `mod` chunkSize
+                        ly = li `div` chunkSize
+                    in inLake (cx * chunkSize + lx) (cy * chunkSize + ly)
+                }
+            byChunk = HM.fromList
+                [ (ChunkCoord cx cy, V.singleton (entryFor cx cy))
+                | cx ← [0 .. (side - 1) `div` chunkSize]
+                , cy ← [0 .. (side - 1) `div` chunkSize] ]
+            lakes = WorldLakes { wlLakes = V.singleton lake
+                               , wlByChunk = byChunk
+                               , wlCarveDelta = HM.empty }
+
+        it "grabens a shallow rifted lake, shore shelf untouched" $ do
+            let out = grabenCarveIndex 42 worldSizeT terrain fullRift lakes
+            HM.null out `shouldBe` False
+            let deltaAt gx gy =
+                    case HM.lookup (ChunkCoord (gx `div` chunkSize)
+                                               (gy `div` chunkSize)) out of
+                        Nothing → 0
+                        Just dv →
+                            let lx = ((gx `mod` chunkSize) + chunkSize)
+                                     `mod` chunkSize
+                                ly = ((gy `mod` chunkSize) + chunkSize)
+                                     `mod` chunkSize
+                            in dv VU.! (ly * chunkSize + lx)
+            -- interior deepens
+            deltaAt (side `div` 2) (side `div` 2) `shouldSatisfy` (> 0)
+            -- ring-1 shore shelf untouched
+            forM_ [0 .. side - 1] $ \gx →
+                deltaAt gx 0 `shouldBe` 0
+            -- deltas are bounded by the graben depth cap (24) plus
+            -- the shallow pan's existing 1 z of depth
+            forM_ [ (gx, gy) | gx ← [0 .. side - 1], gy ← [0 .. side - 1] ] $
+                \(gx, gy) → deltaAt gx gy `shouldSatisfy` (≤ 24)
+
+        it "ignores lakes below the rift threshold" $ do
+            let weak _ _ = grabenRiftThreshold - 0.05
+                out = grabenCarveIndex 42 worldSizeT terrain weak lakes
+            out `shouldBe` HM.empty
+
+        it "ignores small lakes regardless of rift" $ do
+            let tiny = lakes { wlLakes = V.singleton
+                                 lake { lkArea = grabenMinArea - 1 } }
+                out = grabenCarveIndex 42 worldSizeT terrain fullRift tiny
+            out `shouldBe` HM.empty
+
+        it "ignores sea-level (coastal-clamped) lakes" $ do
+            let clamped = lakes { wlLakes = V.singleton
+                                    lake { lkSurface = seaLevel } }
+                out = grabenCarveIndex 42 worldSizeT terrain fullRift clamped
+            out `shouldBe` HM.empty

--- a/tools/baselines/seed12321_size32_region_-4_-4_4_4.json
+++ b/tools/baselines/seed12321_size32_region_-4_-4_4_4.json
@@ -14,9 +14,9 @@
     "deterministic": true,
     "distinctHashes": 1,
     "hashes": [
-      "a7858ac66f7d7b317fabe6130e6b16332be656ffc51b7ff1449fbc7f50d59a02",
-      "a7858ac66f7d7b317fabe6130e6b16332be656ffc51b7ff1449fbc7f50d59a02",
-      "a7858ac66f7d7b317fabe6130e6b16332be656ffc51b7ff1449fbc7f50d59a02"
+      "d9295d6aac9f0790712d5e2c0ae9683a15e07e54333ff26308694fdc6aee5b61",
+      "d9295d6aac9f0790712d5e2c0ae9683a15e07e54333ff26308694fdc6aee5b61",
+      "d9295d6aac9f0790712d5e2c0ae9683a15e07e54333ff26308694fdc6aee5b61"
     ]
   },
   "tileCount": 20736,
@@ -87,13 +87,13 @@
   },
   "auditEnvelope": {
     "FLAT_ISOLATED_WATER": {
-      "min": 7,
-      "max": 7,
-      "median": 7,
+      "min": 6,
+      "max": 6,
+      "median": 6,
       "all": [
-        7,
-        7,
-        7
+        6,
+        6,
+        6
       ]
     },
     "FLOATING_LAKE": {
@@ -117,13 +117,13 @@
       ]
     },
     "FLOATING_WATER": {
-      "min": 319,
-      "max": 319,
-      "median": 319,
+      "min": 226,
+      "max": 226,
+      "median": 226,
       "all": [
-        319,
-        319,
-        319
+        226,
+        226,
+        226
       ]
     },
     "ISOLATED_FLUID": {
@@ -137,13 +137,13 @@
       ]
     },
     "MID_RIVER_CLIFF": {
-      "min": 25,
-      "max": 25,
-      "median": 25,
+      "min": 81,
+      "max": 81,
+      "median": 81,
       "all": [
-        25,
-        25,
-        25
+        81,
+        81,
+        81
       ]
     },
     "MULTI_ISLAND": {
@@ -167,23 +167,23 @@
       ]
     },
     "WATER_ABOVE_LAND": {
-      "min": 323,
-      "max": 323,
-      "median": 323,
+      "min": 331,
+      "max": 331,
+      "median": 331,
       "all": [
-        323,
-        323,
-        323
+        331,
+        331,
+        331
       ]
     },
     "WATER_CLIFF": {
-      "min": 323,
-      "max": 323,
-      "median": 323,
+      "min": 331,
+      "max": 331,
+      "median": 331,
       "all": [
-        323,
-        323,
-        323
+        331,
+        331,
+        331
       ]
     },
     "WATER_WATER_CLIFF": {
@@ -199,25 +199,20 @@
   },
   "representativeAudit": {
     "summary": {
-      "FLAT_ISOLATED_WATER": 7,
+      "FLAT_ISOLATED_WATER": 6,
       "FLOATING_LAKE": 2024,
       "FLOATING_LAVA": 11,
-      "FLOATING_WATER": 319,
+      "FLOATING_WATER": 226,
       "ISOLATED_FLUID": 12,
-      "MID_RIVER_CLIFF": 25,
+      "MID_RIVER_CLIFF": 81,
       "MULTI_ISLAND": 7,
       "RIVER_CHUNK_GAP": 11,
-      "WATER_ABOVE_LAND": 323,
-      "WATER_CLIFF": 323,
+      "WATER_ABOVE_LAND": 331,
+      "WATER_CLIFF": 331,
       "WATER_WATER_CLIFF": 3229
     },
     "issues": {
       "FLAT_ISOLATED_WATER": [
-        {
-          "x": 45,
-          "y": -37,
-          "details": "lake surf=208 terr=206 water_nbrs=1 terr_range=2"
-        },
         {
           "x": 46,
           "y": -36,
@@ -10263,7 +10258,7 @@
         {
           "x": 63,
           "y": -61,
-          "details": "lake fluidSurf=183 terrainZ=121 depth=62"
+          "details": "lake fluidSurf=183 terrainZ=116 depth=67"
         },
         {
           "x": 63,
@@ -10283,7 +10278,7 @@
         {
           "x": 64,
           "y": -61,
-          "details": "lake fluidSurf=183 terrainZ=149 depth=34"
+          "details": "lake fluidSurf=183 terrainZ=144 depth=39"
         },
         {
           "x": 64,
@@ -10477,7 +10472,7 @@
         {
           "x": 3,
           "y": -49,
-          "details": "river terr=20 -> dry(2,-49) terr=17 gap=3"
+          "details": "river terr=18 -> dry(2,-49) terr=17 gap=1"
         },
         {
           "x": 3,
@@ -10501,16 +10496,6 @@
         },
         {
           "x": 5,
-          "y": -53,
-          "details": "river terr=44 -> dry(5,-54) terr=42 gap=2"
-        },
-        {
-          "x": 5,
-          "y": -52,
-          "details": "river terr=45 -> dry(5,-51) terr=44 gap=1"
-        },
-        {
-          "x": 5,
           "y": -37,
           "details": "river terr=10 -> dry(5,-36) terr=9 gap=1"
         },
@@ -10520,39 +10505,14 @@
           "details": "river terr=9 -> dry(5,-26) terr=8 gap=1"
         },
         {
-          "x": 6,
-          "y": -53,
-          "details": "river terr=49 -> dry(6,-54) terr=46 gap=3"
-        },
-        {
-          "x": 6,
-          "y": -47,
-          "details": "river terr=44 -> dry(6,-46) terr=43 gap=1"
-        },
-        {
-          "x": 6,
-          "y": -37,
-          "details": "river terr=15 -> dry(6,-36) terr=14 gap=1"
-        },
-        {
-          "x": 7,
-          "y": -54,
-          "details": "river terr=50 -> dry(6,-54) terr=46 gap=4"
-        },
-        {
           "x": 7,
           "y": -46,
-          "details": "river terr=54 -> dry(6,-46) terr=43 gap=11"
-        },
-        {
-          "x": 7,
-          "y": -37,
-          "details": "river terr=23 -> dry(7,-36) terr=20 gap=3"
+          "details": "river terr=49 -> dry(6,-46) terr=43 gap=6"
         },
         {
           "x": 8,
           "y": -36,
-          "details": "river terr=25 -> dry(7,-36) terr=20 gap=5"
+          "details": "river terr=21 -> dry(7,-36) terr=20 gap=1"
         },
         {
           "x": 9,
@@ -10560,29 +10520,14 @@
           "details": "river terr=11 -> dry(8,-24) terr=10 gap=1"
         },
         {
-          "x": 10,
-          "y": -53,
-          "details": "river terr=83 -> dry(10,-54) terr=81 gap=2"
-        },
-        {
           "x": 11,
           "y": -36,
-          "details": "river terr=53 -> dry(11,-35) terr=47 gap=6"
-        },
-        {
-          "x": 12,
-          "y": -63,
-          "details": "river terr=65 -> dry(12,-64) terr=61 gap=4"
+          "details": "river terr=48 -> dry(11,-35) terr=47 gap=1"
         },
         {
           "x": 12,
           "y": -39,
-          "details": "river terr=86 -> dry(12,-38) terr=81 gap=5"
-        },
-        {
-          "x": 13,
-          "y": -62,
-          "details": "river terr=83 -> dry(13,-63) terr=81 gap=2"
+          "details": "river terr=82 -> dry(12,-38) terr=81 gap=1"
         },
         {
           "x": 13,
@@ -10592,12 +10537,12 @@
         {
           "x": 13,
           "y": -52,
-          "details": "river terr=131 -> dry(12,-52) terr=125 gap=6"
+          "details": "river terr=129 -> dry(12,-52) terr=120 gap=9"
         },
         {
           "x": 13,
           "y": -51,
-          "details": "river terr=142 -> dry(12,-51) terr=137 gap=5"
+          "details": "river terr=140 -> dry(12,-51) terr=137 gap=3"
         },
         {
           "x": 13,
@@ -10617,32 +10562,32 @@
         {
           "x": 14,
           "y": -32,
-          "details": "river terr=50 -> dry(13,-32) terr=45 gap=5"
+          "details": "river terr=46 -> dry(13,-32) terr=45 gap=1"
         },
         {
           "x": 15,
           "y": -50,
-          "details": "river terr=147 -> dry(16,-50) terr=141 gap=6"
+          "details": "river terr=144 -> dry(16,-50) terr=141 gap=3"
         },
         {
           "x": 15,
           "y": -49,
-          "details": "river terr=157 -> dry(16,-49) terr=150 gap=7"
+          "details": "river terr=156 -> dry(16,-49) terr=150 gap=6"
         },
         {
           "x": 15,
           "y": -35,
-          "details": "river terr=83 -> dry(14,-35) terr=76 gap=7"
+          "details": "river terr=78 -> dry(14,-35) terr=76 gap=2"
         },
         {
           "x": 15,
           "y": -34,
-          "details": "river terr=74 -> dry(14,-34) terr=67 gap=7"
+          "details": "river terr=69 -> dry(14,-34) terr=67 gap=2"
         },
         {
           "x": 15,
           "y": -33,
-          "details": "river terr=65 -> dry(14,-33) terr=58 gap=7"
+          "details": "river terr=60 -> dry(14,-33) terr=58 gap=2"
         },
         {
           "x": 16,
@@ -10652,22 +10597,22 @@
         {
           "x": 16,
           "y": -39,
-          "details": "river terr=134 -> dry(15,-39) terr=126 gap=8"
+          "details": "river terr=131 -> dry(15,-39) terr=126 gap=5"
         },
         {
           "x": 16,
           "y": -38,
-          "details": "river terr=123 -> dry(15,-38) terr=116 gap=7"
+          "details": "river terr=119 -> dry(15,-38) terr=116 gap=3"
         },
         {
           "x": 16,
           "y": -37,
-          "details": "river terr=113 -> dry(15,-37) terr=105 gap=8"
+          "details": "river terr=109 -> dry(15,-37) terr=105 gap=4"
         },
         {
           "x": 16,
           "y": -36,
-          "details": "river terr=102 -> dry(15,-36) terr=95 gap=7"
+          "details": "river terr=97 -> dry(15,-36) terr=95 gap=2"
         },
         {
           "x": 17,
@@ -10677,37 +10622,37 @@
         {
           "x": 17,
           "y": -61,
-          "details": "river terr=127 -> dry(16,-61) terr=121 gap=6"
+          "details": "river terr=125 -> dry(16,-61) terr=121 gap=4"
         },
         {
           "x": 17,
           "y": -59,
-          "details": "river terr=124 -> dry(16,-59) terr=120 gap=4"
+          "details": "river terr=121 -> dry(16,-59) terr=120 gap=1"
         },
         {
           "x": 17,
           "y": -30,
-          "details": "river terr=56 -> dry(17,-29) terr=49 gap=7"
+          "details": "river terr=51 -> dry(17,-29) terr=49 gap=2"
         },
         {
           "x": 18,
           "y": -64,
-          "details": "river terr=126 -> dry(17,-64) terr=120 gap=6"
+          "details": "river terr=122 -> dry(17,-64) terr=120 gap=2"
         },
         {
           "x": 18,
           "y": -63,
-          "details": "river terr=135 -> dry(17,-63) terr=129 gap=6"
+          "details": "river terr=132 -> dry(17,-63) terr=129 gap=3"
         },
         {
           "x": 18,
           "y": -45,
-          "details": "river terr=159 -> dry(18,-46) terr=155 gap=4"
+          "details": "river terr=158 -> dry(18,-46) terr=155 gap=3"
         },
         {
           "x": 18,
           "y": -32,
-          "details": "river terr=84 -> dry(18,-31) terr=77 gap=7"
+          "details": "river terr=80 -> dry(18,-31) terr=77 gap=3"
         },
         {
           "x": 19,
@@ -10722,212 +10667,37 @@
         {
           "x": 19,
           "y": -44,
-          "details": "river terr=158 -> dry(20,-44) terr=152 gap=6"
+          "details": "river terr=157 -> dry(20,-44) terr=152 gap=5"
         },
         {
           "x": 19,
           "y": -40,
-          "details": "river terr=162 -> dry(18,-40) terr=157 gap=5"
+          "details": "river terr=160 -> dry(18,-40) terr=157 gap=3"
         },
         {
           "x": 19,
           "y": -32,
-          "details": "river terr=95 -> dry(19,-31) terr=88 gap=7"
-        },
-        {
-          "x": 19,
-          "y": -25,
-          "details": "river terr=35 -> dry(18,-25) terr=32 gap=3"
-        },
-        {
-          "x": 20,
-          "y": -61,
-          "details": "river terr=155 -> dry(20,-62) terr=153 gap=2"
-        },
-        {
-          "x": 20,
-          "y": -55,
-          "details": "river terr=155 -> dry(20,-54) terr=154 gap=1"
+          "details": "river terr=91 -> dry(19,-31) terr=88 gap=3"
         },
         {
           "x": 20,
           "y": -34,
-          "details": "river terr=118 -> dry(20,-33) terr=113 gap=5"
-        },
-        {
-          "x": 20,
-          "y": -26,
-          "details": "river terr=49 -> dry(19,-26) terr=44 gap=5"
-        },
-        {
-          "x": 21,
-          "y": -55,
-          "details": "river terr=167 -> dry(21,-54) terr=163 gap=4"
-        },
-        {
-          "x": 21,
-          "y": -37,
-          "details": "river terr=147 -> dry(20,-37) terr=141 gap=6"
+          "details": "river terr=114 -> dry(20,-33) terr=113 gap=1"
         },
         {
           "x": 21,
           "y": -34,
-          "details": "river terr=126 -> dry(21,-33) terr=121 gap=5"
+          "details": "river terr=122 -> dry(21,-33) terr=121 gap=1"
         },
         {
           "x": 21,
           "y": -28,
-          "details": "river terr=77 -> dry(20,-28) terr=70 gap=7"
-        },
-        {
-          "x": 21,
-          "y": -27,
-          "details": "river terr=66 -> dry(20,-27) terr=60 gap=6"
-        },
-        {
-          "x": 22,
-          "y": -55,
-          "details": "river terr=175 -> dry(22,-54) terr=172 gap=3"
-        },
-        {
-          "x": 22,
-          "y": -34,
-          "details": "river terr=133 -> dry(22,-33) terr=129 gap=4"
-        },
-        {
-          "x": 22,
-          "y": -20,
-          "details": "river terr=22 -> dry(22,-19) terr=21 gap=1"
-        },
-        {
-          "x": 23,
-          "y": -54,
-          "details": "river terr=177 -> dry(22,-54) terr=172 gap=5"
-        },
-        {
-          "x": 23,
-          "y": -53,
-          "details": "river terr=165 -> dry(22,-53) terr=164 gap=1"
+          "details": "river terr=71 -> dry(20,-28) terr=70 gap=1"
         },
         {
           "x": 23,
           "y": -47,
-          "details": "river terr=149 -> dry(22,-47) terr=147 gap=2"
-        },
-        {
-          "x": 23,
-          "y": -34,
-          "details": "river terr=139 -> dry(23,-33) terr=135 gap=4"
-        },
-        {
-          "x": 23,
-          "y": -30,
-          "details": "river terr=111 -> dry(22,-30) terr=107 gap=4"
-        },
-        {
-          "x": 23,
-          "y": -29,
-          "details": "river terr=99 -> dry(22,-29) terr=96 gap=3"
-        },
-        {
-          "x": 23,
-          "y": -20,
-          "details": "river terr=29 -> dry(23,-19) terr=26 gap=3"
-        },
-        {
-          "x": 24,
-          "y": -51,
-          "details": "river terr=162 -> dry(23,-51) terr=160 gap=2"
-        },
-        {
-          "x": 24,
-          "y": -33,
-          "details": "river terr=139 -> dry(23,-33) terr=135 gap=4"
-        },
-        {
-          "x": 24,
-          "y": -32,
-          "details": "river terr=133 -> dry(23,-32) terr=129 gap=4"
-        },
-        {
-          "x": 24,
-          "y": -31,
-          "details": "river terr=126 -> dry(23,-31) terr=122 gap=4"
-        },
-        {
-          "x": 24,
-          "y": -22,
-          "details": "river terr=45 -> dry(24,-21) terr=41 gap=4"
-        },
-        {
-          "x": 24,
-          "y": -19,
-          "details": "river terr=30 -> dry(23,-19) terr=26 gap=4"
-        },
-        {
-          "x": 24,
-          "y": -18,
-          "details": "river terr=25 -> dry(23,-18) terr=22 gap=3"
-        },
-        {
-          "x": 24,
-          "y": -17,
-          "details": "river terr=21 -> dry(23,-17) terr=18 gap=3"
-        },
-        {
-          "x": 24,
-          "y": -16,
-          "details": "river terr=16 -> dry(23,-16) terr=13 gap=3"
-        },
-        {
-          "x": 24,
-          "y": -15,
-          "details": "river terr=11 -> dry(23,-15) terr=9 gap=2"
-        },
-        {
-          "x": 25,
-          "y": -48,
-          "details": "river terr=160 -> dry(24,-48) terr=157 gap=3"
-        },
-        {
-          "x": 25,
-          "y": -23,
-          "details": "river terr=62 -> dry(25,-22) terr=58 gap=4"
-        },
-        {
-          "x": 25,
-          "y": -19,
-          "details": "river terr=36 -> dry(25,-18) terr=32 gap=4"
-        },
-        {
-          "x": 26,
-          "y": -25,
-          "details": "river terr=93 -> dry(26,-24) terr=86 gap=7"
-        },
-        {
-          "x": 26,
-          "y": -19,
-          "details": "river terr=43 -> dry(26,-18) terr=38 gap=5"
-        },
-        {
-          "x": 27,
-          "y": -41,
-          "details": "river terr=173 -> dry(26,-41) terr=172 gap=1"
-        },
-        {
-          "x": 27,
-          "y": -28,
-          "details": "river terr=124 -> dry(27,-27) terr=119 gap=5"
-        },
-        {
-          "x": 27,
-          "y": -19,
-          "details": "river terr=49 -> dry(27,-18) terr=45 gap=4"
-        },
-        {
-          "x": 27,
-          "y": -15,
-          "details": "river terr=22 -> dry(26,-15) terr=19 gap=3"
+          "details": "river terr=148 -> dry(22,-47) terr=147 gap=1"
         },
         {
           "x": 28,
@@ -10935,99 +10705,79 @@
           "details": "river terr=179 -> dry(27,-35) terr=174 gap=5"
         },
         {
-          "x": 28,
-          "y": -31,
-          "details": "river terr=149 -> dry(28,-30) terr=148 gap=1"
-        },
-        {
-          "x": 28,
-          "y": -19,
-          "details": "river terr=56 -> dry(28,-18) terr=52 gap=4"
-        },
-        {
           "x": 29,
           "y": -57,
-          "details": "river terr=210 -> dry(29,-58) terr=206 gap=4"
+          "details": "river terr=207 -> dry(29,-58) terr=206 gap=1"
         },
         {
           "x": 29,
           "y": -21,
-          "details": "river terr=87 -> dry(28,-21) terr=79 gap=8"
+          "details": "river terr=82 -> dry(28,-21) terr=79 gap=3"
         },
         {
           "x": 29,
           "y": -20,
-          "details": "river terr=77 -> dry(28,-20) terr=68 gap=9"
+          "details": "river terr=72 -> dry(28,-20) terr=68 gap=4"
         },
         {
           "x": 29,
           "y": -19,
-          "details": "river terr=67 -> dry(29,-18) terr=60 gap=7"
+          "details": "river terr=61 -> dry(29,-18) terr=60 gap=1"
         },
         {
           "x": 30,
           "y": -54,
-          "details": "river terr=218 -> dry(31,-54) terr=212 gap=6"
+          "details": "river terr=216 -> dry(31,-54) terr=212 gap=4"
         },
         {
           "x": 30,
           "y": -41,
-          "details": "river terr=187 -> dry(29,-41) terr=181 gap=6"
-        },
-        {
-          "x": 30,
-          "y": -40,
-          "details": "river terr=179 -> dry(30,-39) terr=176 gap=3"
+          "details": "river terr=184 -> dry(29,-41) terr=181 gap=3"
         },
         {
           "x": 30,
           "y": -34,
-          "details": "river terr=182 -> dry(29,-34) terr=177 gap=5"
+          "details": "river terr=180 -> dry(29,-34) terr=177 gap=3"
         },
         {
           "x": 30,
           "y": -33,
-          "details": "river terr=172 -> dry(29,-33) terr=166 gap=6"
+          "details": "river terr=169 -> dry(29,-33) terr=166 gap=3"
         },
         {
           "x": 30,
           "y": -25,
-          "details": "river terr=127 -> dry(29,-25) terr=121 gap=6"
+          "details": "river terr=123 -> dry(29,-25) terr=121 gap=2"
         },
         {
           "x": 30,
           "y": -24,
-          "details": "river terr=119 -> dry(29,-24) terr=114 gap=5"
+          "details": "river terr=115 -> dry(29,-24) terr=114 gap=1"
         },
         {
           "x": 30,
           "y": -23,
-          "details": "river terr=111 -> dry(29,-23) terr=106 gap=5"
+          "details": "river terr=107 -> dry(29,-23) terr=106 gap=1"
         },
         {
           "x": 30,
           "y": -22,
-          "details": "river terr=103 -> dry(29,-22) terr=98 gap=5"
+          "details": "river terr=99 -> dry(29,-22) terr=98 gap=1"
         },
         {
           "x": 30,
           "y": -18,
-          "details": "river terr=65 -> dry(29,-18) terr=60 gap=5"
-        },
-        {
-          "x": 30,
-          "y": -17,
-          "details": "river terr=53 -> dry(29,-17) terr=51 gap=2"
+          "details": "river terr=61 -> dry(29,-18) terr=60 gap=1"
         },
         {
           "x": 31,
           "y": -53,
-          "details": "river terr=218 -> dry(31,-54) terr=212 gap=6"
+          "details": "river terr=217 -> dry(31,-54) terr=212 gap=5"
         },
         {
           "x": 31,
           "y": -42,
-          "details": "river terr=203 -> dry(30,-42) terr=198 gap=5"
+          "details": "river terr=201 -> dry(30,-42) terr=198 gap=3"
         },
         {
           "x": 32,
@@ -11036,38 +10786,18 @@
         },
         {
           "x": 32,
-          "y": -43,
-          "details": "river terr=213 -> dry(31,-43) terr=212 gap=1"
-        },
-        {
-          "x": 32,
           "y": -26,
-          "details": "river terr=148 -> dry(31,-26) terr=142 gap=6"
-        },
-        {
-          "x": 33,
-          "y": -44,
-          "details": "river terr=225 -> dry(32,-44) terr=223 gap=2"
-        },
-        {
-          "x": 33,
-          "y": -31,
-          "details": "river terr=170 -> dry(32,-31) terr=168 gap=2"
-        },
-        {
-          "x": 33,
-          "y": -30,
-          "details": "river terr=161 -> dry(33,-29) terr=159 gap=2"
+          "details": "river terr=146 -> dry(31,-26) terr=142 gap=4"
         },
         {
           "x": 34,
           "y": -63,
-          "details": "river terr=182 -> dry(33,-63) terr=175 gap=7"
+          "details": "river terr=181 -> dry(33,-63) terr=175 gap=6"
         },
         {
           "x": 34,
           "y": -62,
-          "details": "river terr=189 -> dry(33,-62) terr=183 gap=6"
+          "details": "river terr=188 -> dry(33,-62) terr=183 gap=5"
         },
         {
           "x": 34,
@@ -11082,27 +10812,22 @@
         {
           "x": 34,
           "y": -54,
-          "details": "river terr=208 -> dry(34,-55) terr=203 gap=5"
+          "details": "river terr=206 -> dry(34,-55) terr=203 gap=3"
         },
         {
           "x": 34,
           "y": -11,
-          "details": "river terr=29 -> dry(34,-10) terr=23 gap=6"
+          "details": "river terr=24 -> dry(34,-10) terr=23 gap=1"
         },
         {
           "x": 35,
           "y": -40,
-          "details": "river terr=205 -> dry(35,-39) terr=202 gap=3"
+          "details": "river terr=204 -> dry(35,-39) terr=202 gap=2"
         },
         {
           "x": 35,
           "y": -26,
-          "details": "river terr=133 -> dry(35,-25) terr=129 gap=4"
-        },
-        {
-          "x": 35,
-          "y": -12,
-          "details": "river terr=45 -> dry(35,-11) terr=43 gap=2"
+          "details": "river terr=130 -> dry(35,-25) terr=129 gap=1"
         },
         {
           "x": 36,
@@ -11116,18 +10841,8 @@
         },
         {
           "x": 36,
-          "y": -40,
-          "details": "river terr=211 -> dry(36,-39) terr=210 gap=1"
-        },
-        {
-          "x": 36,
           "y": -22,
           "details": "river terr=120 -> dry(35,-22) terr=119 gap=1"
-        },
-        {
-          "x": 36,
-          "y": -12,
-          "details": "river terr=57 -> dry(36,-11) terr=55 gap=2"
         },
         {
           "x": 37,
@@ -11141,48 +10856,23 @@
         },
         {
           "x": 37,
-          "y": -12,
-          "details": "river terr=69 -> dry(37,-11) terr=66 gap=3"
-        },
-        {
-          "x": 37,
           "y": -7,
-          "details": "river terr=21 -> dry(36,-7) terr=14 gap=7"
-        },
-        {
-          "x": 38,
-          "y": -42,
-          "details": "river terr=231 -> dry(38,-41) terr=229 gap=2"
-        },
-        {
-          "x": 38,
-          "y": -38,
-          "details": "river terr=212 -> dry(37,-38) terr=210 gap=2"
+          "details": "river terr=16 -> dry(36,-7) terr=14 gap=2"
         },
         {
           "x": 38,
           "y": -37,
-          "details": "river terr=206 -> dry(37,-37) terr=203 gap=3"
+          "details": "river terr=204 -> dry(37,-37) terr=203 gap=1"
         },
         {
           "x": 38,
           "y": -12,
-          "details": "river terr=81 -> dry(38,-11) terr=76 gap=5"
-        },
-        {
-          "x": 38,
-          "y": -8,
-          "details": "river terr=36 -> dry(37,-8) terr=35 gap=1"
+          "details": "river terr=78 -> dry(38,-11) terr=76 gap=2"
         },
         {
           "x": 39,
           "y": -60,
-          "details": "river terr=225 -> dry(39,-59) terr=223 gap=2"
-        },
-        {
-          "x": 39,
-          "y": -49,
-          "details": "river terr=248 -> dry(38,-49) terr=244 gap=4"
+          "details": "river terr=224 -> dry(39,-59) terr=223 gap=1"
         },
         {
           "x": 39,
@@ -11212,22 +10902,17 @@
         {
           "x": 39,
           "y": -12,
-          "details": "river terr=91 -> dry(39,-11) terr=85 gap=6"
+          "details": "river terr=89 -> dry(39,-11) terr=85 gap=4"
         },
         {
           "x": 40,
           "y": -59,
-          "details": "river terr=231 -> dry(39,-59) terr=223 gap=8"
-        },
-        {
-          "x": 40,
-          "y": -49,
-          "details": "river terr=254 -> dry(40,-50) terr=250 gap=4"
+          "details": "river terr=229 -> dry(39,-59) terr=223 gap=6"
         },
         {
           "x": 40,
           "y": -27,
-          "details": "river terr=158 -> dry(40,-26) terr=148 gap=10"
+          "details": "river terr=155 -> dry(40,-26) terr=148 gap=7"
         },
         {
           "x": 40,
@@ -11241,33 +10926,23 @@
         },
         {
           "x": 41,
-          "y": -37,
-          "details": "river terr=215 -> dry(40,-37) terr=213 gap=2"
-        },
-        {
-          "x": 41,
           "y": -35,
           "details": "river terr=201 -> dry(41,-34) terr=199 gap=2"
         },
         {
           "x": 41,
           "y": -28,
-          "details": "river terr=179 -> dry(40,-28) terr=172 gap=7"
+          "details": "river terr=177 -> dry(40,-28) terr=172 gap=5"
         },
         {
           "x": 41,
           "y": -27,
-          "details": "river terr=170 -> dry(41,-26) terr=162 gap=8"
+          "details": "river terr=168 -> dry(41,-26) terr=162 gap=6"
         },
         {
           "x": 41,
           "y": -13,
           "details": "river terr=109 -> dry(41,-12) terr=106 gap=3"
-        },
-        {
-          "x": 42,
-          "y": -50,
-          "details": "river terr=259 -> dry(41,-50) terr=256 gap=3"
         },
         {
           "x": 42,
@@ -11281,48 +10956,33 @@
         },
         {
           "x": 43,
-          "y": -49,
-          "details": "river terr=267 -> dry(42,-49) terr=265 gap=2"
-        },
-        {
-          "x": 43,
-          "y": -42,
-          "details": "river terr=240 -> dry(43,-41) terr=239 gap=1"
-        },
-        {
-          "x": 43,
           "y": -24,
-          "details": "river terr=160 -> dry(42,-24) terr=154 gap=6"
+          "details": "river terr=158 -> dry(42,-24) terr=154 gap=4"
         },
         {
           "x": 43,
           "y": -23,
-          "details": "river terr=152 -> dry(42,-23) terr=148 gap=4"
-        },
-        {
-          "x": 43,
-          "y": -22,
-          "details": "river terr=143 -> dry(42,-22) terr=141 gap=2"
+          "details": "river terr=150 -> dry(42,-23) terr=148 gap=2"
         },
         {
           "x": 44,
           "y": -45,
-          "details": "river terr=281 -> dry(43,-45) terr=271 gap=10"
+          "details": "river terr=274 -> dry(43,-45) terr=271 gap=3"
         },
         {
           "x": 44,
           "y": -44,
-          "details": "river terr=269 -> dry(43,-44) terr=259 gap=10"
+          "details": "river terr=262 -> dry(43,-44) terr=259 gap=3"
         },
         {
           "x": 44,
           "y": -40,
-          "details": "river terr=229 -> dry(45,-40) terr=223 gap=6"
+          "details": "river terr=225 -> dry(45,-40) terr=223 gap=2"
         },
         {
           "x": 44,
           "y": -39,
-          "details": "river terr=221 -> dry(44,-38) terr=215 gap=6"
+          "details": "river terr=218 -> dry(44,-38) terr=215 gap=3"
         },
         {
           "x": 44,
@@ -11357,7 +11017,7 @@
         {
           "x": 47,
           "y": -25,
-          "details": "river terr=163 -> dry(47,-24) terr=159 gap=4"
+          "details": "river terr=161 -> dry(47,-24) terr=159 gap=2"
         },
         {
           "x": 47,
@@ -11372,7 +11032,7 @@
         {
           "x": 48,
           "y": -25,
-          "details": "river terr=158 -> dry(48,-24) terr=152 gap=6"
+          "details": "river terr=156 -> dry(48,-24) terr=152 gap=4"
         },
         {
           "x": 49,
@@ -11382,17 +11042,17 @@
         {
           "x": 49,
           "y": -27,
-          "details": "river terr=163 -> dry(49,-26) terr=160 gap=3"
+          "details": "river terr=162 -> dry(49,-26) terr=160 gap=2"
         },
         {
           "x": 49,
           "y": -25,
-          "details": "river terr=150 -> dry(49,-24) terr=146 gap=4"
+          "details": "river terr=147 -> dry(49,-24) terr=146 gap=1"
         },
         {
           "x": 49,
           "y": -21,
-          "details": "river terr=131 -> dry(50,-21) terr=129 gap=2"
+          "details": "river terr=130 -> dry(50,-21) terr=129 gap=1"
         },
         {
           "x": 49,
@@ -11402,12 +11062,12 @@
         {
           "x": 50,
           "y": -29,
-          "details": "river terr=176 -> dry(51,-29) terr=168 gap=8"
+          "details": "river terr=174 -> dry(51,-29) terr=168 gap=6"
         },
         {
           "x": 50,
           "y": -27,
-          "details": "river terr=153 -> dry(50,-26) terr=147 gap=6"
+          "details": "river terr=152 -> dry(50,-26) terr=147 gap=5"
         },
         {
           "x": 50,
@@ -11417,7 +11077,7 @@
         {
           "x": 50,
           "y": -1,
-          "details": "river terr=32 -> dry(50,0) terr=28 gap=4"
+          "details": "river terr=30 -> dry(50,0) terr=28 gap=2"
         },
         {
           "x": 50,
@@ -11427,7 +11087,7 @@
         {
           "x": 51,
           "y": -27,
-          "details": "river terr=143 -> dry(51,-26) terr=136 gap=7"
+          "details": "river terr=140 -> dry(51,-26) terr=136 gap=4"
         },
         {
           "x": 51,
@@ -11441,13 +11101,8 @@
         },
         {
           "x": 51,
-          "y": -11,
-          "details": "river terr=92 -> dry(51,-10) terr=91 gap=1"
-        },
-        {
-          "x": 51,
           "y": 0,
-          "details": "river terr=33 -> dry(50,0) terr=28 gap=5"
+          "details": "river terr=32 -> dry(50,0) terr=28 gap=4"
         },
         {
           "x": 51,
@@ -11462,17 +11117,12 @@
         {
           "x": 52,
           "y": -28,
-          "details": "river terr=145 -> dry(53,-28) terr=137 gap=8"
+          "details": "river terr=142 -> dry(53,-28) terr=137 gap=5"
         },
         {
           "x": 52,
           "y": -19,
           "details": "river terr=113 -> dry(52,-18) terr=112 gap=1"
-        },
-        {
-          "x": 52,
-          "y": -10,
-          "details": "river terr=83 -> dry(52,-9) terr=82 gap=1"
         },
         {
           "x": 52,
@@ -11491,13 +11141,8 @@
         },
         {
           "x": 53,
-          "y": -40,
-          "details": "river terr=184 -> dry(54,-40) terr=183 gap=1"
-        },
-        {
-          "x": 53,
           "y": -12,
-          "details": "river terr=84 -> dry(54,-12) terr=82 gap=2"
+          "details": "river terr=83 -> dry(54,-12) terr=82 gap=1"
         },
         {
           "x": 53,
@@ -11532,17 +11177,12 @@
         {
           "x": 54,
           "y": 7,
-          "details": "river terr=36 -> dry(53,7) terr=32 gap=4"
-        },
-        {
-          "x": 54,
-          "y": 8,
-          "details": "river terr=31 -> dry(53,8) terr=29 gap=2"
+          "details": "river terr=35 -> dry(53,7) terr=32 gap=3"
         },
         {
           "x": 54,
           "y": 10,
-          "details": "river terr=30 -> dry(53,10) terr=28 gap=2"
+          "details": "river terr=29 -> dry(53,10) terr=28 gap=1"
         },
         {
           "x": 54,
@@ -11558,11 +11198,6 @@
           "x": 54,
           "y": 25,
           "details": "river terr=54 -> dry(54,26) terr=51 gap=3"
-        },
-        {
-          "x": 55,
-          "y": -32,
-          "details": "river terr=147 -> dry(55,-31) terr=145 gap=2"
         },
         {
           "x": 55,
@@ -11592,7 +11227,7 @@
         {
           "x": 55,
           "y": 23,
-          "details": "river terr=59 -> dry(54,23) terr=54 gap=5"
+          "details": "river terr=57 -> dry(54,23) terr=54 gap=3"
         },
         {
           "x": 55,
@@ -11601,43 +11236,13 @@
         },
         {
           "x": 56,
-          "y": -30,
-          "details": "river terr=120 -> dry(56,-29) terr=116 gap=4"
-        },
-        {
-          "x": 56,
           "y": -8,
           "details": "river terr=56 -> dry(56,-7) terr=54 gap=2"
         },
         {
           "x": 56,
-          "y": 2,
-          "details": "river terr=64 -> dry(56,3) terr=63 gap=1"
-        },
-        {
-          "x": 56,
-          "y": 18,
-          "details": "river terr=60 -> dry(56,17) terr=58 gap=2"
-        },
-        {
-          "x": 56,
           "y": 25,
-          "details": "river terr=69 -> dry(56,26) terr=66 gap=3"
-        },
-        {
-          "x": 57,
-          "y": -43,
-          "details": "river terr=181 -> dry(56,-43) terr=179 gap=2"
-        },
-        {
-          "x": 57,
-          "y": -41,
-          "details": "river terr=175 -> dry(58,-41) terr=171 gap=4"
-        },
-        {
-          "x": 57,
-          "y": -40,
-          "details": "river terr=163 -> dry(58,-40) terr=159 gap=4"
+          "details": "river terr=67 -> dry(56,26) terr=66 gap=1"
         },
         {
           "x": 57,
@@ -11647,47 +11252,32 @@
         {
           "x": 57,
           "y": 11,
-          "details": "river terr=45 -> dry(57,12) terr=43 gap=2"
+          "details": "river terr=44 -> dry(57,12) terr=43 gap=1"
         },
         {
           "x": 57,
           "y": 18,
-          "details": "river terr=67 -> dry(57,17) terr=64 gap=3"
+          "details": "river terr=65 -> dry(57,17) terr=64 gap=1"
         },
         {
           "x": 57,
           "y": 25,
-          "details": "river terr=77 -> dry(57,26) terr=73 gap=4"
+          "details": "river terr=75 -> dry(57,26) terr=73 gap=2"
         },
         {
           "x": 58,
           "y": 12,
-          "details": "river terr=48 -> dry(57,12) terr=43 gap=5"
-        },
-        {
-          "x": 58,
-          "y": 15,
-          "details": "river terr=54 -> dry(57,15) terr=51 gap=3"
-        },
-        {
-          "x": 58,
-          "y": 16,
-          "details": "river terr=63 -> dry(57,16) terr=59 gap=4"
+          "details": "river terr=46 -> dry(57,12) terr=43 gap=3"
         },
         {
           "x": 58,
           "y": 17,
-          "details": "river terr=70 -> dry(57,17) terr=64 gap=6"
+          "details": "river terr=67 -> dry(57,17) terr=64 gap=3"
         },
         {
           "x": 58,
           "y": 25,
-          "details": "river terr=85 -> dry(58,26) terr=80 gap=5"
-        },
-        {
-          "x": 62,
-          "y": -22,
-          "details": "river terr=79 -> dry(62,-21) terr=76 gap=3"
+          "details": "river terr=83 -> dry(58,26) terr=80 gap=3"
         },
         {
           "x": 62,
@@ -11700,19 +11290,9 @@
           "details": "river terr=69 -> dry(63,3) terr=68 gap=1"
         },
         {
-          "x": 62,
-          "y": 13,
-          "details": "river terr=85 -> dry(62,12) terr=83 gap=2"
-        },
-        {
           "x": 63,
           "y": -61,
-          "details": "lake terr=121 -> dry(63,-62) terr=109 gap=12"
-        },
-        {
-          "x": 63,
-          "y": -24,
-          "details": "river terr=99 -> dry(63,-23) terr=97 gap=2"
+          "details": "lake terr=116 -> dry(63,-62) terr=104 gap=12"
         },
         {
           "x": 63,
@@ -11720,34 +11300,19 @@
           "details": "river terr=62 -> dry(63,-10) terr=61 gap=1"
         },
         {
-          "x": 63,
-          "y": 13,
-          "details": "river terr=92 -> dry(63,12) terr=91 gap=1"
-        },
-        {
           "x": 64,
           "y": -61,
-          "details": "lake terr=149 -> dry(64,-62) terr=137 gap=12"
-        },
-        {
-          "x": 64,
-          "y": -26,
-          "details": "river terr=119 -> dry(64,-25) terr=117 gap=2"
+          "details": "lake terr=144 -> dry(64,-62) terr=132 gap=12"
         },
         {
           "x": 64,
           "y": 15,
-          "details": "river terr=107 -> dry(64,14) terr=104 gap=3"
+          "details": "river terr=105 -> dry(64,14) terr=104 gap=1"
         },
         {
           "x": 65,
           "y": -60,
-          "details": "lake terr=182 -> dry(64,-60) terr=177 gap=5"
-        },
-        {
-          "x": 65,
-          "y": -36,
-          "details": "river terr=129 -> dry(64,-36) terr=128 gap=1"
+          "details": "lake terr=182 -> dry(64,-60) terr=172 gap=10"
         },
         {
           "x": 65,
@@ -11782,7 +11347,7 @@
         {
           "x": 65,
           "y": 15,
-          "details": "river terr=114 -> dry(65,14) terr=111 gap=3"
+          "details": "river terr=112 -> dry(65,14) terr=111 gap=1"
         },
         {
           "x": 66,
@@ -11797,7 +11362,7 @@
         {
           "x": 67,
           "y": -31,
-          "details": "river terr=120 -> dry(68,-31) terr=97 gap=23"
+          "details": "river terr=119 -> dry(68,-31) terr=91 gap=28"
         },
         {
           "x": 67,
@@ -11852,12 +11417,12 @@
         {
           "x": 68,
           "y": -38,
-          "details": "river terr=143 -> dry(68,-37) terr=140 gap=3"
+          "details": "river terr=141 -> dry(68,-37) terr=140 gap=1"
         },
         {
           "x": 68,
           "y": -30,
-          "details": "river terr=125 -> dry(69,-30) terr=97 gap=28"
+          "details": "river terr=119 -> dry(69,-30) terr=91 gap=28"
         },
         {
           "x": 68,
@@ -11867,27 +11432,22 @@
         {
           "x": 68,
           "y": -18,
-          "details": "river terr=85 -> dry(68,-17) terr=79 gap=6"
+          "details": "river terr=84 -> dry(68,-17) terr=79 gap=5"
         },
         {
           "x": 68,
           "y": -14,
-          "details": "river terr=57 -> dry(68,-13) terr=53 gap=4"
+          "details": "river terr=55 -> dry(68,-13) terr=53 gap=2"
         },
         {
           "x": 69,
           "y": -20,
-          "details": "river terr=94 -> dry(69,-19) terr=87 gap=7"
+          "details": "river terr=92 -> dry(69,-19) terr=87 gap=5"
         },
         {
           "x": 69,
           "y": -18,
-          "details": "river terr=73 -> dry(69,-17) terr=70 gap=3"
-        },
-        {
-          "x": 69,
-          "y": 9,
-          "details": "river terr=99 -> dry(70,9) terr=98 gap=1"
+          "details": "river terr=71 -> dry(69,-17) terr=70 gap=1"
         },
         {
           "x": 69,
@@ -11907,32 +11467,22 @@
         {
           "x": 70,
           "y": -20,
-          "details": "river terr=85 -> dry(70,-19) terr=78 gap=7"
-        },
-        {
-          "x": 70,
-          "y": -18,
-          "details": "river terr=61 -> dry(70,-17) terr=59 gap=2"
+          "details": "river terr=83 -> dry(70,-19) terr=78 gap=5"
         },
         {
           "x": 70,
           "y": 5,
-          "details": "river terr=71 -> dry(70,4) terr=66 gap=5"
+          "details": "river terr=70 -> dry(70,4) terr=66 gap=4"
         },
         {
           "x": 71,
           "y": -31,
-          "details": "river terr=45 -> dry(72,-31) terr=26 gap=19"
+          "details": "river terr=39 -> dry(72,-31) terr=26 gap=13"
         },
         {
           "x": 71,
           "y": -20,
-          "details": "river terr=73 -> dry(72,-20) terr=68 gap=5"
-        },
-        {
-          "x": 71,
-          "y": -18,
-          "details": "river terr=49 -> dry(71,-17) terr=46 gap=3"
+          "details": "river terr=70 -> dry(72,-20) terr=68 gap=2"
         },
         {
           "x": 71,
@@ -11943,11 +11493,6 @@
           "x": 72,
           "y": 7,
           "details": "river terr=93 -> dry(72,6) terr=92 gap=1"
-        },
-        {
-          "x": 73,
-          "y": -23,
-          "details": "river terr=85 -> dry(74,-23) terr=82 gap=3"
         },
         {
           "x": 73,
@@ -11976,11 +11521,6 @@
         },
         {
           "x": 75,
-          "y": -20,
-          "details": "river terr=38 -> dry(76,-20) terr=35 gap=3"
-        },
-        {
-          "x": 75,
           "y": 5,
           "details": "river terr=84 -> dry(75,4) terr=80 gap=4"
         },
@@ -11992,32 +11532,22 @@
         {
           "x": 76,
           "y": 4,
-          "details": "river terr=70 -> dry(76,3) terr=67 gap=3"
-        },
-        {
-          "x": 77,
-          "y": 7,
-          "details": "river terr=86 -> dry(78,7) terr=84 gap=2"
+          "details": "river terr=69 -> dry(76,3) terr=67 gap=2"
         },
         {
           "x": 77,
           "y": 8,
-          "details": "river terr=90 -> dry(78,8) terr=88 gap=2"
+          "details": "river terr=89 -> dry(78,8) terr=88 gap=1"
         },
         {
           "x": 77,
           "y": 9,
-          "details": "river terr=94 -> dry(78,9) terr=92 gap=2"
-        },
-        {
-          "x": 77,
-          "y": 10,
-          "details": "river terr=97 -> dry(78,10) terr=95 gap=2"
+          "details": "river terr=93 -> dry(78,9) terr=92 gap=1"
         },
         {
           "x": 77,
           "y": 11,
-          "details": "river terr=101 -> dry(78,11) terr=98 gap=3"
+          "details": "river terr=99 -> dry(78,11) terr=98 gap=1"
         },
         {
           "x": 79,
@@ -12099,14 +11629,79 @@
           "details": "lake surf=10 (terr=-3) -> water nbr surf=0 (terr=-3) surf_diff=10 terr_diff=0"
         },
         {
-          "x": 13,
-          "y": -30,
-          "details": "river surf=40 (terr=36) -> water nbr surf=38 (terr=36) surf_diff=2 terr_diff=0"
+          "x": 3,
+          "y": -48,
+          "details": "river surf=17 (terr=14) -> water nbr surf=13 (terr=12) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 4,
+          "y": -58,
+          "details": "river surf=15 (terr=9) -> water nbr surf=11 (terr=11) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 4,
+          "y": -47,
+          "details": "river surf=21 (terr=17) -> water nbr surf=17 (terr=15) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 5,
+          "y": -57,
+          "details": "river surf=27 (terr=23) -> water nbr surf=25 (terr=23) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 5,
+          "y": -53,
+          "details": "river surf=45 (terr=42) -> water nbr surf=41 (terr=40) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 5,
+          "y": -44,
+          "details": "river surf=28 (terr=24) -> water nbr surf=26 (terr=24) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 6,
+          "y": -57,
+          "details": "river surf=34 (terr=29) -> water nbr surf=31 (terr=30) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 6,
+          "y": -50,
+          "details": "river surf=46 (terr=41) -> water nbr surf=40 (terr=39) surf_diff=6 terr_diff=2"
+        },
+        {
+          "x": 6,
+          "y": -44,
+          "details": "river surf=36 (terr=31) -> water nbr surf=32 (terr=29) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 6,
+          "y": -42,
+          "details": "river surf=28 (terr=25) -> water nbr surf=24 (terr=23) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 7,
+          "y": -58,
+          "details": "river surf=38 (terr=34) -> water nbr surf=35 (terr=34) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 8,
+          "y": -58,
+          "details": "river surf=43 (terr=38) -> water nbr surf=41 (terr=38) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 8,
+          "y": -56,
+          "details": "river surf=46 (terr=39) -> water nbr surf=42 (terr=37) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 10,
+          "y": -34,
+          "details": "river surf=32 (terr=27) -> water nbr surf=28 (terr=25) surf_diff=4 terr_diff=2"
         },
         {
           "x": 13,
-          "y": -29,
-          "details": "river surf=37 (terr=33) -> water nbr surf=35 (terr=33) surf_diff=2 terr_diff=0"
+          "y": -54,
+          "details": "river surf=122 (terr=117) -> water nbr surf=120 (terr=117) surf_diff=2 terr_diff=0"
         },
         {
           "x": 13,
@@ -12117,6 +11712,31 @@
           "x": 13,
           "y": -22,
           "details": "river surf=10 (terr=-2) -> water nbr surf=0 (terr=-3) surf_diff=10 terr_diff=1"
+        },
+        {
+          "x": 15,
+          "y": -52,
+          "details": "river surf=131 (terr=128) -> water nbr surf=129 (terr=128) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 15,
+          "y": -29,
+          "details": "river surf=37 (terr=32) -> water nbr surf=35 (terr=32) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 15,
+          "y": -26,
+          "details": "river surf=23 (terr=19) -> water nbr surf=21 (terr=19) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 16,
+          "y": -51,
+          "details": "river surf=137 (terr=133) -> water nbr surf=134 (terr=134) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 16,
+          "y": -23,
+          "details": "river surf=14 (terr=10) -> water nbr surf=10 (terr=8) surf_diff=4 terr_diff=2"
         },
         {
           "x": 17,
@@ -12136,7 +11756,12 @@
         {
           "x": 18,
           "y": -21,
-          "details": "river surf=14 (terr=11) -> water nbr surf=11 (terr=10) surf_diff=3 terr_diff=1"
+          "details": "river surf=14 (terr=9) -> water nbr surf=11 (terr=10) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 18,
+          "y": -21,
+          "details": "river surf=14 (terr=9) -> water nbr surf=10 (terr=7) surf_diff=4 terr_diff=2"
         },
         {
           "x": 18,
@@ -12150,8 +11775,53 @@
         },
         {
           "x": 19,
+          "y": -54,
+          "details": "river surf=145 (terr=141) -> water nbr surf=141 (terr=140) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": 19,
+          "y": -20,
+          "details": "river surf=12 (terr=7) -> water nbr surf=10 (terr=7) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 19,
+          "y": -20,
+          "details": "river surf=12 (terr=7) -> water nbr surf=9 (terr=6) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 19,
           "y": -18,
           "details": "river surf=9 (terr=-3) -> water nbr surf=0 (terr=-4) surf_diff=9 terr_diff=1"
+        },
+        {
+          "x": 20,
+          "y": -19,
+          "details": "river surf=12 (terr=7) -> water nbr surf=9 (terr=6) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 24,
+          "y": -47,
+          "details": "river surf=153 (terr=149) -> water nbr surf=150 (terr=148) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 24,
+          "y": -46,
+          "details": "river surf=151 (terr=148) -> water nbr surf=147 (terr=146) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 30,
+          "y": -40,
+          "details": "lake surf=180 (terr=176) -> water nbr surf=175 (terr=174) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": 30,
+          "y": -13,
+          "details": "river surf=14 (terr=8) -> water nbr surf=11 (terr=7) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 31,
+          "y": -12,
+          "details": "river surf=14 (terr=9) -> water nbr surf=11 (terr=8) surf_diff=3 terr_diff=1"
         },
         {
           "x": 31,
@@ -12175,8 +11845,73 @@
         },
         {
           "x": 32,
+          "y": -40,
+          "details": "river surf=189 (terr=185) -> water nbr surf=186 (terr=184) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 32,
+          "y": -11,
+          "details": "river surf=14 (terr=8) -> water nbr surf=11 (terr=8) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 32,
+          "y": -11,
+          "details": "river surf=14 (terr=8) -> water nbr surf=11 (terr=7) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 32,
           "y": -8,
           "details": "river surf=8 (terr=-4) -> water nbr surf=0 (terr=-5) surf_diff=8 terr_diff=1"
+        },
+        {
+          "x": 33,
+          "y": -10,
+          "details": "river surf=14 (terr=8) -> water nbr surf=11 (terr=7) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 38,
+          "y": -36,
+          "details": "river surf=200 (terr=197) -> water nbr surf=198 (terr=197) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 38,
+          "y": -23,
+          "details": "lake surf=124 (terr=121) -> water nbr surf=122 (terr=121) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 39,
+          "y": -43,
+          "details": "river surf=237 (terr=233) -> water nbr surf=235 (terr=233) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 39,
+          "y": -35,
+          "details": "river surf=197 (terr=194) -> water nbr surf=195 (terr=194) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 39,
+          "y": -35,
+          "details": "river surf=197 (terr=194) -> water nbr surf=195 (terr=194) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 43,
+          "y": -2,
+          "details": "river surf=11 (terr=5) -> water nbr surf=9 (terr=5) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 44,
+          "y": -19,
+          "details": "river surf=120 (terr=117) -> water nbr surf=117 (terr=116) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 44,
+          "y": -1,
+          "details": "river surf=11 (terr=8) -> water nbr surf=9 (terr=8) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 45,
+          "y": -31,
+          "details": "river surf=184 (terr=181) -> water nbr surf=181 (terr=180) surf_diff=3 terr_diff=1"
         },
         {
           "x": 45,
@@ -12189,9 +11924,84 @@
           "details": "river surf=9 (terr=-3) -> water nbr surf=0 (terr=-3) surf_diff=9 terr_diff=0"
         },
         {
-          "x": 68,
-          "y": -30,
-          "details": "river surf=129 (terr=125) -> water nbr surf=125 (terr=124) surf_diff=4 terr_diff=1"
+          "x": 53,
+          "y": -18,
+          "details": "river surf=105 (terr=102) -> water nbr surf=102 (terr=101) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 54,
+          "y": -16,
+          "details": "river surf=92 (terr=89) -> water nbr surf=90 (terr=89) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 57,
+          "y": -18,
+          "details": "river surf=70 (terr=66) -> water nbr surf=68 (terr=66) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 58,
+          "y": -31,
+          "details": "river surf=102 (terr=95) -> water nbr surf=100 (terr=95) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 58,
+          "y": -23,
+          "details": "river surf=70 (terr=67) -> water nbr surf=68 (terr=67) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 58,
+          "y": 13,
+          "details": "lake surf=43 (terr=39) -> water nbr surf=40 (terr=39) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 59,
+          "y": -33,
+          "details": "river surf=111 (terr=105) -> water nbr surf=109 (terr=105) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 59,
+          "y": -24,
+          "details": "river surf=70 (terr=66) -> water nbr surf=68 (terr=66) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 64,
+          "y": -35,
+          "details": "river surf=123 (terr=120) -> water nbr surf=119 (terr=118) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 66,
+          "y": 6,
+          "details": "river surf=80 (terr=77) -> water nbr surf=78 (terr=77) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 72,
+          "y": -14,
+          "details": "river surf=18 (terr=12) -> water nbr surf=15 (terr=11) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 72,
+          "y": -13,
+          "details": "river surf=17 (terr=12) -> water nbr surf=14 (terr=12) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 72,
+          "y": -12,
+          "details": "river surf=19 (terr=15) -> water nbr surf=16 (terr=14) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 73,
+          "y": -14,
+          "details": "river surf=15 (terr=11) -> water nbr surf=12 (terr=10) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 75,
+          "y": -16,
+          "details": "river surf=13 (terr=10) -> water nbr surf=10 (terr=9) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 77,
+          "y": -17,
+          "details": "river surf=10 (terr=7) -> water nbr surf=8 (terr=7) surf_diff=2 terr_diff=0"
         },
         {
           "x": 77,
@@ -12367,7 +12177,7 @@
         {
           "x": 3,
           "y": -49,
-          "details": "river surf=21 terr=20 -> land(2,-49) terr=17 cliff=4"
+          "details": "river surf=21 terr=18 -> land(2,-49) terr=17 cliff=4"
         },
         {
           "x": 3,
@@ -12392,12 +12202,12 @@
         {
           "x": 5,
           "y": -53,
-          "details": "river surf=45 terr=44 -> land(5,-54) terr=42 cliff=3"
+          "details": "river surf=45 terr=42 -> land(5,-54) terr=42 cliff=3"
         },
         {
           "x": 5,
           "y": -52,
-          "details": "river surf=46 terr=45 -> land(5,-51) terr=44 cliff=2"
+          "details": "river surf=46 terr=43 -> land(5,-51) terr=44 cliff=2"
         },
         {
           "x": 5,
@@ -12412,37 +12222,37 @@
         {
           "x": 6,
           "y": -53,
-          "details": "river surf=50 terr=49 -> land(6,-54) terr=46 cliff=4"
+          "details": "river surf=50 terr=46 -> land(6,-54) terr=46 cliff=4"
         },
         {
           "x": 6,
           "y": -47,
-          "details": "river surf=45 terr=44 -> land(6,-46) terr=43 cliff=2"
+          "details": "river surf=45 terr=40 -> land(6,-46) terr=43 cliff=2"
         },
         {
           "x": 6,
           "y": -37,
-          "details": "river surf=16 terr=15 -> land(6,-36) terr=14 cliff=2"
+          "details": "river surf=16 terr=13 -> land(6,-36) terr=14 cliff=2"
         },
         {
           "x": 7,
           "y": -54,
-          "details": "river surf=51 terr=50 -> land(6,-54) terr=46 cliff=5"
+          "details": "river surf=51 terr=46 -> land(6,-54) terr=46 cliff=5"
         },
         {
           "x": 7,
           "y": -46,
-          "details": "river surf=55 terr=54 -> land(6,-46) terr=43 cliff=12"
+          "details": "river surf=55 terr=49 -> land(6,-46) terr=43 cliff=12"
         },
         {
           "x": 7,
           "y": -37,
-          "details": "river surf=24 terr=23 -> land(7,-36) terr=20 cliff=4"
+          "details": "river surf=24 terr=20 -> land(7,-36) terr=20 cliff=4"
         },
         {
           "x": 8,
           "y": -36,
-          "details": "river surf=26 terr=25 -> land(7,-36) terr=20 cliff=6"
+          "details": "river surf=26 terr=21 -> land(7,-36) terr=20 cliff=6"
         },
         {
           "x": 9,
@@ -12452,27 +12262,27 @@
         {
           "x": 10,
           "y": -53,
-          "details": "river surf=84 terr=83 -> land(10,-54) terr=81 cliff=3"
+          "details": "river surf=84 terr=77 -> land(10,-54) terr=81 cliff=3"
         },
         {
           "x": 11,
           "y": -36,
-          "details": "river surf=54 terr=53 -> land(11,-35) terr=47 cliff=7"
+          "details": "river surf=54 terr=48 -> land(11,-35) terr=47 cliff=7"
         },
         {
           "x": 12,
           "y": -63,
-          "details": "river surf=66 terr=65 -> land(12,-64) terr=61 cliff=5"
+          "details": "river surf=66 terr=60 -> land(12,-64) terr=61 cliff=5"
         },
         {
           "x": 12,
           "y": -39,
-          "details": "river surf=87 terr=86 -> land(12,-38) terr=81 cliff=6"
+          "details": "river surf=87 terr=82 -> land(12,-38) terr=81 cliff=6"
         },
         {
           "x": 13,
           "y": -62,
-          "details": "river surf=84 terr=83 -> land(13,-63) terr=81 cliff=3"
+          "details": "river surf=84 terr=78 -> land(13,-63) terr=81 cliff=3"
         },
         {
           "x": 13,
@@ -12482,12 +12292,12 @@
         {
           "x": 13,
           "y": -52,
-          "details": "river surf=132 terr=131 -> land(12,-52) terr=125 cliff=7"
+          "details": "river surf=132 terr=129 -> land(12,-52) terr=120 cliff=12"
         },
         {
           "x": 13,
           "y": -51,
-          "details": "river surf=143 terr=142 -> land(12,-51) terr=137 cliff=6"
+          "details": "river surf=143 terr=140 -> land(12,-51) terr=137 cliff=6"
         },
         {
           "x": 13,
@@ -12511,33 +12321,38 @@
         },
         {
           "x": 14,
+          "y": -42,
+          "details": "river surf=122 terr=116 -> land(13,-42) terr=120 cliff=2"
+        },
+        {
+          "x": 14,
           "y": -32,
-          "details": "river surf=51 terr=50 -> land(13,-32) terr=45 cliff=6"
+          "details": "river surf=51 terr=46 -> land(13,-32) terr=45 cliff=6"
         },
         {
           "x": 15,
           "y": -50,
-          "details": "river surf=148 terr=147 -> land(16,-50) terr=141 cliff=7"
+          "details": "river surf=148 terr=144 -> land(16,-50) terr=141 cliff=7"
         },
         {
           "x": 15,
           "y": -49,
-          "details": "river surf=158 terr=157 -> land(16,-49) terr=150 cliff=8"
+          "details": "river surf=158 terr=156 -> land(16,-49) terr=150 cliff=8"
         },
         {
           "x": 15,
           "y": -35,
-          "details": "river surf=84 terr=83 -> land(14,-35) terr=76 cliff=8"
+          "details": "river surf=84 terr=78 -> land(14,-35) terr=76 cliff=8"
         },
         {
           "x": 15,
           "y": -34,
-          "details": "river surf=75 terr=74 -> land(14,-34) terr=67 cliff=8"
+          "details": "river surf=75 terr=69 -> land(14,-34) terr=67 cliff=8"
         },
         {
           "x": 15,
           "y": -33,
-          "details": "river surf=66 terr=65 -> land(14,-33) terr=58 cliff=8"
+          "details": "river surf=66 terr=60 -> land(14,-33) terr=58 cliff=8"
         },
         {
           "x": 16,
@@ -12547,22 +12362,22 @@
         {
           "x": 16,
           "y": -39,
-          "details": "river surf=135 terr=134 -> land(15,-39) terr=126 cliff=9"
+          "details": "river surf=135 terr=131 -> land(15,-39) terr=126 cliff=9"
         },
         {
           "x": 16,
           "y": -38,
-          "details": "river surf=124 terr=123 -> land(15,-38) terr=116 cliff=8"
+          "details": "river surf=124 terr=119 -> land(15,-38) terr=116 cliff=8"
         },
         {
           "x": 16,
           "y": -37,
-          "details": "river surf=114 terr=113 -> land(15,-37) terr=105 cliff=9"
+          "details": "river surf=114 terr=109 -> land(15,-37) terr=105 cliff=9"
         },
         {
           "x": 16,
           "y": -36,
-          "details": "river surf=103 terr=102 -> land(15,-36) terr=95 cliff=8"
+          "details": "river surf=103 terr=97 -> land(15,-36) terr=95 cliff=8"
         },
         {
           "x": 17,
@@ -12572,37 +12387,37 @@
         {
           "x": 17,
           "y": -61,
-          "details": "river surf=128 terr=127 -> land(16,-61) terr=121 cliff=7"
+          "details": "river surf=128 terr=125 -> land(16,-61) terr=121 cliff=7"
         },
         {
           "x": 17,
           "y": -59,
-          "details": "river surf=125 terr=124 -> land(16,-59) terr=120 cliff=5"
+          "details": "river surf=125 terr=121 -> land(16,-59) terr=120 cliff=5"
         },
         {
           "x": 17,
           "y": -30,
-          "details": "river surf=57 terr=56 -> land(17,-29) terr=49 cliff=8"
+          "details": "river surf=57 terr=51 -> land(17,-29) terr=49 cliff=8"
         },
         {
           "x": 18,
           "y": -64,
-          "details": "river surf=127 terr=126 -> land(17,-64) terr=120 cliff=7"
+          "details": "river surf=127 terr=122 -> land(17,-64) terr=120 cliff=7"
         },
         {
           "x": 18,
           "y": -63,
-          "details": "river surf=136 terr=135 -> land(17,-63) terr=129 cliff=7"
+          "details": "river surf=136 terr=132 -> land(17,-63) terr=129 cliff=7"
         },
         {
           "x": 18,
           "y": -45,
-          "details": "river surf=160 terr=159 -> land(18,-46) terr=155 cliff=5"
+          "details": "river surf=160 terr=158 -> land(18,-46) terr=155 cliff=5"
         },
         {
           "x": 18,
           "y": -32,
-          "details": "river surf=85 terr=84 -> land(18,-31) terr=77 cliff=8"
+          "details": "river surf=85 terr=80 -> land(18,-31) terr=77 cliff=8"
         },
         {
           "x": 19,
@@ -12617,212 +12432,212 @@
         {
           "x": 19,
           "y": -44,
-          "details": "river surf=159 terr=158 -> land(20,-44) terr=152 cliff=7"
+          "details": "river surf=159 terr=157 -> land(20,-44) terr=152 cliff=7"
         },
         {
           "x": 19,
           "y": -40,
-          "details": "river surf=163 terr=162 -> land(18,-40) terr=157 cliff=6"
+          "details": "river surf=163 terr=160 -> land(18,-40) terr=157 cliff=6"
         },
         {
           "x": 19,
           "y": -32,
-          "details": "river surf=96 terr=95 -> land(19,-31) terr=88 cliff=8"
+          "details": "river surf=96 terr=91 -> land(19,-31) terr=88 cliff=8"
         },
         {
           "x": 19,
           "y": -25,
-          "details": "river surf=36 terr=35 -> land(18,-25) terr=32 cliff=4"
+          "details": "river surf=36 terr=30 -> land(18,-25) terr=32 cliff=4"
         },
         {
           "x": 20,
           "y": -61,
-          "details": "river surf=156 terr=155 -> land(20,-62) terr=153 cliff=3"
+          "details": "river surf=156 terr=152 -> land(20,-62) terr=153 cliff=3"
         },
         {
           "x": 20,
           "y": -55,
-          "details": "river surf=156 terr=155 -> land(20,-54) terr=154 cliff=2"
+          "details": "river surf=156 terr=151 -> land(20,-54) terr=154 cliff=2"
         },
         {
           "x": 20,
           "y": -34,
-          "details": "river surf=119 terr=118 -> land(20,-33) terr=113 cliff=6"
+          "details": "river surf=119 terr=114 -> land(20,-33) terr=113 cliff=6"
         },
         {
           "x": 20,
           "y": -26,
-          "details": "river surf=50 terr=49 -> land(19,-26) terr=44 cliff=6"
+          "details": "river surf=50 terr=44 -> land(19,-26) terr=44 cliff=6"
         },
         {
           "x": 21,
           "y": -55,
-          "details": "river surf=168 terr=167 -> land(21,-54) terr=163 cliff=5"
+          "details": "river surf=168 terr=162 -> land(21,-54) terr=163 cliff=5"
         },
         {
           "x": 21,
           "y": -37,
-          "details": "river surf=148 terr=147 -> land(20,-37) terr=141 cliff=7"
+          "details": "river surf=148 terr=141 -> land(20,-37) terr=141 cliff=7"
         },
         {
           "x": 21,
           "y": -34,
-          "details": "river surf=127 terr=126 -> land(21,-33) terr=121 cliff=6"
+          "details": "river surf=127 terr=122 -> land(21,-33) terr=121 cliff=6"
         },
         {
           "x": 21,
           "y": -28,
-          "details": "river surf=78 terr=77 -> land(20,-28) terr=70 cliff=8"
+          "details": "river surf=78 terr=71 -> land(20,-28) terr=70 cliff=8"
         },
         {
           "x": 21,
           "y": -27,
-          "details": "river surf=67 terr=66 -> land(20,-27) terr=60 cliff=7"
+          "details": "river surf=67 terr=60 -> land(20,-27) terr=60 cliff=7"
         },
         {
           "x": 22,
           "y": -55,
-          "details": "river surf=176 terr=175 -> land(22,-54) terr=172 cliff=4"
+          "details": "river surf=176 terr=170 -> land(22,-54) terr=172 cliff=4"
         },
         {
           "x": 22,
           "y": -34,
-          "details": "river surf=134 terr=133 -> land(22,-33) terr=129 cliff=5"
+          "details": "river surf=134 terr=128 -> land(22,-33) terr=129 cliff=5"
         },
         {
           "x": 22,
           "y": -20,
-          "details": "river surf=24 terr=22 -> land(22,-19) terr=21 cliff=3"
+          "details": "river surf=24 terr=18 -> land(22,-19) terr=21 cliff=3"
         },
         {
           "x": 23,
           "y": -54,
-          "details": "river surf=178 terr=177 -> land(22,-54) terr=172 cliff=6"
+          "details": "river surf=178 terr=172 -> land(22,-54) terr=172 cliff=6"
         },
         {
           "x": 23,
           "y": -53,
-          "details": "river surf=166 terr=165 -> land(22,-53) terr=164 cliff=2"
+          "details": "river surf=166 terr=160 -> land(22,-53) terr=164 cliff=2"
         },
         {
           "x": 23,
           "y": -47,
-          "details": "river surf=150 terr=149 -> land(22,-47) terr=147 cliff=3"
+          "details": "river surf=150 terr=148 -> land(22,-47) terr=147 cliff=3"
         },
         {
           "x": 23,
           "y": -34,
-          "details": "river surf=140 terr=139 -> land(23,-33) terr=135 cliff=5"
+          "details": "river surf=140 terr=134 -> land(23,-33) terr=135 cliff=5"
         },
         {
           "x": 23,
           "y": -30,
-          "details": "river surf=112 terr=111 -> land(22,-30) terr=107 cliff=5"
+          "details": "river surf=112 terr=106 -> land(22,-30) terr=107 cliff=5"
         },
         {
           "x": 23,
           "y": -29,
-          "details": "river surf=100 terr=99 -> land(22,-29) terr=96 cliff=4"
+          "details": "river surf=100 terr=93 -> land(22,-29) terr=96 cliff=4"
         },
         {
           "x": 23,
           "y": -20,
-          "details": "river surf=30 terr=29 -> land(23,-19) terr=26 cliff=4"
+          "details": "river surf=30 terr=25 -> land(23,-19) terr=26 cliff=4"
         },
         {
           "x": 24,
           "y": -51,
-          "details": "river surf=163 terr=162 -> land(23,-51) terr=160 cliff=3"
+          "details": "river surf=163 terr=157 -> land(23,-51) terr=160 cliff=3"
         },
         {
           "x": 24,
           "y": -33,
-          "details": "river surf=140 terr=139 -> land(23,-33) terr=135 cliff=5"
+          "details": "river surf=140 terr=135 -> land(23,-33) terr=135 cliff=5"
         },
         {
           "x": 24,
           "y": -32,
-          "details": "river surf=134 terr=133 -> land(23,-32) terr=129 cliff=5"
+          "details": "river surf=134 terr=129 -> land(23,-32) terr=129 cliff=5"
         },
         {
           "x": 24,
           "y": -31,
-          "details": "river surf=127 terr=126 -> land(23,-31) terr=122 cliff=5"
+          "details": "river surf=127 terr=122 -> land(23,-31) terr=122 cliff=5"
         },
         {
           "x": 24,
           "y": -22,
-          "details": "river surf=46 terr=45 -> land(24,-21) terr=41 cliff=5"
+          "details": "river surf=46 terr=39 -> land(24,-21) terr=41 cliff=5"
         },
         {
           "x": 24,
           "y": -19,
-          "details": "river surf=31 terr=30 -> land(23,-19) terr=26 cliff=5"
+          "details": "river surf=31 terr=25 -> land(23,-19) terr=26 cliff=5"
         },
         {
           "x": 24,
           "y": -18,
-          "details": "river surf=26 terr=25 -> land(23,-18) terr=22 cliff=4"
+          "details": "river surf=26 terr=20 -> land(23,-18) terr=22 cliff=4"
         },
         {
           "x": 24,
           "y": -17,
-          "details": "river surf=22 terr=21 -> land(23,-17) terr=18 cliff=4"
+          "details": "river surf=22 terr=17 -> land(23,-17) terr=18 cliff=4"
         },
         {
           "x": 24,
           "y": -16,
-          "details": "river surf=17 terr=16 -> land(23,-16) terr=13 cliff=4"
+          "details": "river surf=17 terr=13 -> land(23,-16) terr=13 cliff=4"
         },
         {
           "x": 24,
           "y": -15,
-          "details": "river surf=12 terr=11 -> land(23,-15) terr=9 cliff=3"
+          "details": "river surf=12 terr=9 -> land(23,-15) terr=9 cliff=3"
         },
         {
           "x": 25,
           "y": -48,
-          "details": "river surf=161 terr=160 -> land(24,-48) terr=157 cliff=4"
+          "details": "river surf=161 terr=155 -> land(24,-48) terr=157 cliff=4"
         },
         {
           "x": 25,
           "y": -23,
-          "details": "river surf=63 terr=62 -> land(25,-22) terr=58 cliff=5"
+          "details": "river surf=63 terr=55 -> land(25,-22) terr=58 cliff=5"
         },
         {
           "x": 25,
           "y": -19,
-          "details": "river surf=37 terr=36 -> land(25,-18) terr=32 cliff=5"
+          "details": "river surf=37 terr=30 -> land(25,-18) terr=32 cliff=5"
         },
         {
           "x": 26,
           "y": -25,
-          "details": "river surf=94 terr=93 -> land(26,-24) terr=86 cliff=8"
+          "details": "river surf=94 terr=86 -> land(26,-24) terr=86 cliff=8"
         },
         {
           "x": 26,
           "y": -19,
-          "details": "river surf=44 terr=43 -> land(26,-18) terr=38 cliff=6"
+          "details": "river surf=44 terr=37 -> land(26,-18) terr=38 cliff=6"
         },
         {
           "x": 27,
           "y": -41,
-          "details": "river surf=174 terr=173 -> land(26,-41) terr=172 cliff=2"
+          "details": "river surf=174 terr=169 -> land(26,-41) terr=172 cliff=2"
         },
         {
           "x": 27,
           "y": -28,
-          "details": "river surf=125 terr=124 -> land(27,-27) terr=119 cliff=6"
+          "details": "river surf=125 terr=119 -> land(27,-27) terr=119 cliff=6"
         },
         {
           "x": 27,
           "y": -19,
-          "details": "river surf=50 terr=49 -> land(27,-18) terr=45 cliff=5"
+          "details": "river surf=50 terr=42 -> land(27,-18) terr=45 cliff=5"
         },
         {
           "x": 27,
           "y": -15,
-          "details": "river surf=23 terr=22 -> land(26,-15) terr=19 cliff=4"
+          "details": "river surf=23 terr=18 -> land(26,-15) terr=19 cliff=4"
         },
         {
           "x": 28,
@@ -12832,97 +12647,97 @@
         {
           "x": 28,
           "y": -31,
-          "details": "river surf=150 terr=149 -> land(28,-30) terr=148 cliff=2"
+          "details": "river surf=150 terr=145 -> land(28,-30) terr=148 cliff=2"
         },
         {
           "x": 28,
           "y": -19,
-          "details": "river surf=57 terr=56 -> land(28,-18) terr=52 cliff=5"
+          "details": "river surf=57 terr=50 -> land(28,-18) terr=52 cliff=5"
         },
         {
           "x": 29,
           "y": -57,
-          "details": "river surf=211 terr=210 -> land(29,-58) terr=206 cliff=5"
+          "details": "river surf=211 terr=207 -> land(29,-58) terr=206 cliff=5"
         },
         {
           "x": 29,
           "y": -21,
-          "details": "river surf=88 terr=87 -> land(28,-21) terr=79 cliff=9"
+          "details": "river surf=88 terr=82 -> land(28,-21) terr=79 cliff=9"
         },
         {
           "x": 29,
           "y": -20,
-          "details": "river surf=78 terr=77 -> land(28,-20) terr=68 cliff=10"
+          "details": "river surf=78 terr=72 -> land(28,-20) terr=68 cliff=10"
         },
         {
           "x": 29,
           "y": -19,
-          "details": "river surf=68 terr=67 -> land(29,-18) terr=60 cliff=8"
+          "details": "river surf=68 terr=61 -> land(29,-18) terr=60 cliff=8"
         },
         {
           "x": 30,
           "y": -54,
-          "details": "river surf=219 terr=218 -> land(31,-54) terr=212 cliff=7"
+          "details": "river surf=219 terr=216 -> land(31,-54) terr=212 cliff=7"
         },
         {
           "x": 30,
           "y": -41,
-          "details": "river surf=188 terr=187 -> land(29,-41) terr=181 cliff=7"
+          "details": "river surf=188 terr=184 -> land(29,-41) terr=181 cliff=7"
         },
         {
           "x": 30,
           "y": -40,
-          "details": "river surf=180 terr=179 -> land(30,-39) terr=176 cliff=4"
+          "details": "river surf=180 terr=176 -> land(30,-39) terr=176 cliff=4"
         },
         {
           "x": 30,
           "y": -34,
-          "details": "river surf=183 terr=182 -> land(29,-34) terr=177 cliff=6"
+          "details": "river surf=183 terr=180 -> land(29,-34) terr=177 cliff=6"
         },
         {
           "x": 30,
           "y": -33,
-          "details": "river surf=173 terr=172 -> land(29,-33) terr=166 cliff=7"
+          "details": "river surf=173 terr=169 -> land(29,-33) terr=166 cliff=7"
         },
         {
           "x": 30,
           "y": -25,
-          "details": "river surf=128 terr=127 -> land(29,-25) terr=121 cliff=7"
+          "details": "river surf=128 terr=123 -> land(29,-25) terr=121 cliff=7"
         },
         {
           "x": 30,
           "y": -24,
-          "details": "river surf=120 terr=119 -> land(29,-24) terr=114 cliff=6"
+          "details": "river surf=120 terr=115 -> land(29,-24) terr=114 cliff=6"
         },
         {
           "x": 30,
           "y": -23,
-          "details": "river surf=112 terr=111 -> land(29,-23) terr=106 cliff=6"
+          "details": "river surf=112 terr=107 -> land(29,-23) terr=106 cliff=6"
         },
         {
           "x": 30,
           "y": -22,
-          "details": "river surf=104 terr=103 -> land(29,-22) terr=98 cliff=6"
+          "details": "river surf=104 terr=99 -> land(29,-22) terr=98 cliff=6"
         },
         {
           "x": 30,
           "y": -18,
-          "details": "river surf=66 terr=65 -> land(29,-18) terr=60 cliff=6"
+          "details": "river surf=66 terr=61 -> land(29,-18) terr=60 cliff=6"
         },
         {
           "x": 30,
           "y": -17,
-          "details": "river surf=54 terr=53 -> land(29,-17) terr=51 cliff=3"
+          "details": "river surf=54 terr=48 -> land(29,-17) terr=51 cliff=3"
         },
         {
           "x": 31,
           "y": -53,
-          "details": "river surf=219 terr=218 -> land(31,-54) terr=212 cliff=7"
+          "details": "river surf=219 terr=217 -> land(31,-54) terr=212 cliff=7"
         },
         {
           "x": 31,
           "y": -42,
-          "details": "river surf=204 terr=203 -> land(30,-42) terr=198 cliff=6"
+          "details": "river surf=204 terr=201 -> land(30,-42) terr=198 cliff=6"
         },
         {
           "x": 32,
@@ -12932,37 +12747,37 @@
         {
           "x": 32,
           "y": -43,
-          "details": "river surf=214 terr=213 -> land(31,-43) terr=212 cliff=2"
+          "details": "river surf=214 terr=210 -> land(31,-43) terr=212 cliff=2"
         },
         {
           "x": 32,
           "y": -26,
-          "details": "river surf=149 terr=148 -> land(31,-26) terr=142 cliff=7"
+          "details": "river surf=149 terr=146 -> land(31,-26) terr=142 cliff=7"
         },
         {
           "x": 33,
           "y": -44,
-          "details": "river surf=226 terr=225 -> land(32,-44) terr=223 cliff=3"
+          "details": "river surf=226 terr=221 -> land(32,-44) terr=223 cliff=3"
         },
         {
           "x": 33,
           "y": -31,
-          "details": "river surf=171 terr=170 -> land(32,-31) terr=168 cliff=3"
+          "details": "river surf=171 terr=164 -> land(32,-31) terr=168 cliff=3"
         },
         {
           "x": 33,
           "y": -30,
-          "details": "river surf=162 terr=161 -> land(33,-29) terr=159 cliff=3"
+          "details": "river surf=162 terr=156 -> land(33,-29) terr=159 cliff=3"
         },
         {
           "x": 34,
           "y": -63,
-          "details": "river surf=183 terr=182 -> land(33,-63) terr=175 cliff=8"
+          "details": "river surf=183 terr=181 -> land(33,-63) terr=175 cliff=8"
         },
         {
           "x": 34,
           "y": -62,
-          "details": "river surf=190 terr=189 -> land(33,-62) terr=183 cliff=7"
+          "details": "river surf=190 terr=188 -> land(33,-62) terr=183 cliff=7"
         },
         {
           "x": 34,
@@ -12977,27 +12792,27 @@
         {
           "x": 34,
           "y": -54,
-          "details": "river surf=209 terr=208 -> land(34,-55) terr=203 cliff=6"
+          "details": "river surf=209 terr=206 -> land(34,-55) terr=203 cliff=6"
         },
         {
           "x": 34,
           "y": -11,
-          "details": "river surf=30 terr=29 -> land(34,-10) terr=23 cliff=7"
+          "details": "river surf=30 terr=24 -> land(34,-10) terr=23 cliff=7"
         },
         {
           "x": 35,
           "y": -40,
-          "details": "river surf=206 terr=205 -> land(35,-39) terr=202 cliff=4"
+          "details": "river surf=206 terr=204 -> land(35,-39) terr=202 cliff=4"
         },
         {
           "x": 35,
           "y": -26,
-          "details": "river surf=134 terr=133 -> land(35,-25) terr=129 cliff=5"
+          "details": "river surf=134 terr=130 -> land(35,-25) terr=129 cliff=5"
         },
         {
           "x": 35,
           "y": -12,
-          "details": "river surf=46 terr=45 -> land(35,-11) terr=43 cliff=3"
+          "details": "river surf=46 terr=41 -> land(35,-11) terr=43 cliff=3"
         },
         {
           "x": 36,
@@ -13012,7 +12827,7 @@
         {
           "x": 36,
           "y": -40,
-          "details": "river surf=212 terr=211 -> land(36,-39) terr=210 cliff=2"
+          "details": "river surf=212 terr=209 -> land(36,-39) terr=210 cliff=2"
         },
         {
           "x": 36,
@@ -13022,7 +12837,7 @@
         {
           "x": 36,
           "y": -12,
-          "details": "river surf=58 terr=57 -> land(36,-11) terr=55 cliff=3"
+          "details": "river surf=58 terr=52 -> land(36,-11) terr=55 cliff=3"
         },
         {
           "x": 37,
@@ -13037,47 +12852,47 @@
         {
           "x": 37,
           "y": -12,
-          "details": "river surf=70 terr=69 -> land(37,-11) terr=66 cliff=4"
+          "details": "river surf=70 terr=65 -> land(37,-11) terr=66 cliff=4"
         },
         {
           "x": 37,
           "y": -7,
-          "details": "river surf=22 terr=21 -> land(36,-7) terr=14 cliff=8"
+          "details": "river surf=22 terr=16 -> land(36,-7) terr=14 cliff=8"
         },
         {
           "x": 38,
           "y": -42,
-          "details": "river surf=232 terr=231 -> land(38,-41) terr=229 cliff=3"
+          "details": "river surf=232 terr=229 -> land(38,-41) terr=229 cliff=3"
         },
         {
           "x": 38,
           "y": -38,
-          "details": "river surf=213 terr=212 -> land(37,-38) terr=210 cliff=3"
+          "details": "river surf=213 terr=210 -> land(37,-38) terr=210 cliff=3"
         },
         {
           "x": 38,
           "y": -37,
-          "details": "river surf=207 terr=206 -> land(37,-37) terr=203 cliff=4"
+          "details": "river surf=207 terr=204 -> land(37,-37) terr=203 cliff=4"
         },
         {
           "x": 38,
           "y": -12,
-          "details": "river surf=82 terr=81 -> land(38,-11) terr=76 cliff=6"
+          "details": "river surf=82 terr=78 -> land(38,-11) terr=76 cliff=6"
         },
         {
           "x": 38,
           "y": -8,
-          "details": "river surf=37 terr=36 -> land(37,-8) terr=35 cliff=2"
+          "details": "river surf=37 terr=30 -> land(37,-8) terr=35 cliff=2"
         },
         {
           "x": 39,
           "y": -60,
-          "details": "river surf=226 terr=225 -> land(39,-59) terr=223 cliff=3"
+          "details": "river surf=226 terr=224 -> land(39,-59) terr=223 cliff=3"
         },
         {
           "x": 39,
           "y": -49,
-          "details": "river surf=249 terr=248 -> land(38,-49) terr=244 cliff=5"
+          "details": "river surf=249 terr=243 -> land(38,-49) terr=244 cliff=5"
         },
         {
           "x": 39,
@@ -13107,22 +12922,22 @@
         {
           "x": 39,
           "y": -12,
-          "details": "river surf=92 terr=91 -> land(39,-11) terr=85 cliff=7"
+          "details": "river surf=92 terr=89 -> land(39,-11) terr=85 cliff=7"
         },
         {
           "x": 40,
           "y": -59,
-          "details": "river surf=232 terr=231 -> land(39,-59) terr=223 cliff=9"
+          "details": "river surf=232 terr=229 -> land(39,-59) terr=223 cliff=9"
         },
         {
           "x": 40,
           "y": -49,
-          "details": "river surf=255 terr=254 -> land(40,-50) terr=250 cliff=5"
+          "details": "river surf=255 terr=248 -> land(40,-50) terr=250 cliff=5"
         },
         {
           "x": 40,
           "y": -27,
-          "details": "river surf=159 terr=158 -> land(40,-26) terr=148 cliff=11"
+          "details": "river surf=159 terr=155 -> land(40,-26) terr=148 cliff=11"
         },
         {
           "x": 40,
@@ -13137,7 +12952,7 @@
         {
           "x": 41,
           "y": -37,
-          "details": "river surf=216 terr=215 -> land(40,-37) terr=213 cliff=3"
+          "details": "river surf=216 terr=213 -> land(40,-37) terr=213 cliff=3"
         },
         {
           "x": 41,
@@ -13147,12 +12962,12 @@
         {
           "x": 41,
           "y": -28,
-          "details": "river surf=180 terr=179 -> land(40,-28) terr=172 cliff=8"
+          "details": "river surf=180 terr=177 -> land(40,-28) terr=172 cliff=8"
         },
         {
           "x": 41,
           "y": -27,
-          "details": "river surf=171 terr=170 -> land(41,-26) terr=162 cliff=9"
+          "details": "river surf=171 terr=168 -> land(41,-26) terr=162 cliff=9"
         },
         {
           "x": 41,
@@ -13162,7 +12977,7 @@
         {
           "x": 42,
           "y": -50,
-          "details": "river surf=260 terr=259 -> land(41,-50) terr=256 cliff=4"
+          "details": "river surf=260 terr=251 -> land(41,-50) terr=256 cliff=4"
         },
         {
           "x": 42,
@@ -13177,47 +12992,47 @@
         {
           "x": 43,
           "y": -49,
-          "details": "river surf=268 terr=267 -> land(42,-49) terr=265 cliff=3"
+          "details": "river surf=268 terr=259 -> land(42,-49) terr=265 cliff=3"
         },
         {
           "x": 43,
           "y": -42,
-          "details": "river surf=241 terr=240 -> land(43,-41) terr=239 cliff=2"
+          "details": "river surf=241 terr=233 -> land(43,-41) terr=239 cliff=2"
         },
         {
           "x": 43,
           "y": -24,
-          "details": "river surf=161 terr=160 -> land(42,-24) terr=154 cliff=7"
+          "details": "river surf=161 terr=158 -> land(42,-24) terr=154 cliff=7"
         },
         {
           "x": 43,
           "y": -23,
-          "details": "river surf=153 terr=152 -> land(42,-23) terr=148 cliff=5"
+          "details": "river surf=153 terr=150 -> land(42,-23) terr=148 cliff=5"
         },
         {
           "x": 43,
           "y": -22,
-          "details": "river surf=144 terr=143 -> land(42,-22) terr=141 cliff=3"
+          "details": "river surf=144 terr=141 -> land(42,-22) terr=141 cliff=3"
         },
         {
           "x": 44,
           "y": -45,
-          "details": "river surf=282 terr=281 -> land(43,-45) terr=271 cliff=11"
+          "details": "river surf=282 terr=274 -> land(43,-45) terr=271 cliff=11"
         },
         {
           "x": 44,
           "y": -44,
-          "details": "river surf=270 terr=269 -> land(43,-44) terr=259 cliff=11"
+          "details": "river surf=270 terr=262 -> land(43,-44) terr=259 cliff=11"
         },
         {
           "x": 44,
           "y": -40,
-          "details": "river surf=230 terr=229 -> land(45,-40) terr=223 cliff=7"
+          "details": "river surf=230 terr=225 -> land(45,-40) terr=223 cliff=7"
         },
         {
           "x": 44,
           "y": -39,
-          "details": "river surf=222 terr=221 -> land(44,-38) terr=215 cliff=7"
+          "details": "river surf=222 terr=218 -> land(44,-38) terr=215 cliff=7"
         },
         {
           "x": 44,
@@ -13252,7 +13067,7 @@
         {
           "x": 47,
           "y": -25,
-          "details": "river surf=164 terr=163 -> land(47,-24) terr=159 cliff=5"
+          "details": "river surf=164 terr=161 -> land(47,-24) terr=159 cliff=5"
         },
         {
           "x": 47,
@@ -13267,7 +13082,7 @@
         {
           "x": 48,
           "y": -25,
-          "details": "river surf=159 terr=158 -> land(48,-24) terr=152 cliff=7"
+          "details": "river surf=159 terr=156 -> land(48,-24) terr=152 cliff=7"
         },
         {
           "x": 49,
@@ -13277,17 +13092,17 @@
         {
           "x": 49,
           "y": -27,
-          "details": "river surf=164 terr=163 -> land(49,-26) terr=160 cliff=4"
+          "details": "river surf=164 terr=162 -> land(49,-26) terr=160 cliff=4"
         },
         {
           "x": 49,
           "y": -25,
-          "details": "river surf=151 terr=150 -> land(49,-24) terr=146 cliff=5"
+          "details": "river surf=151 terr=147 -> land(49,-24) terr=146 cliff=5"
         },
         {
           "x": 49,
           "y": -21,
-          "details": "river surf=132 terr=131 -> land(50,-21) terr=129 cliff=3"
+          "details": "river surf=132 terr=130 -> land(50,-21) terr=129 cliff=3"
         },
         {
           "x": 49,
@@ -13297,12 +13112,12 @@
         {
           "x": 50,
           "y": -29,
-          "details": "river surf=177 terr=176 -> land(51,-29) terr=168 cliff=9"
+          "details": "river surf=177 terr=174 -> land(51,-29) terr=168 cliff=9"
         },
         {
           "x": 50,
           "y": -27,
-          "details": "river surf=154 terr=153 -> land(50,-26) terr=147 cliff=7"
+          "details": "river surf=154 terr=152 -> land(50,-26) terr=147 cliff=7"
         },
         {
           "x": 50,
@@ -13312,7 +13127,7 @@
         {
           "x": 50,
           "y": -1,
-          "details": "river surf=33 terr=32 -> land(50,0) terr=28 cliff=5"
+          "details": "river surf=33 terr=30 -> land(50,0) terr=28 cliff=5"
         },
         {
           "x": 50,
@@ -13322,7 +13137,7 @@
         {
           "x": 51,
           "y": -27,
-          "details": "river surf=144 terr=143 -> land(51,-26) terr=136 cliff=8"
+          "details": "river surf=144 terr=140 -> land(51,-26) terr=136 cliff=8"
         },
         {
           "x": 51,
@@ -13337,12 +13152,12 @@
         {
           "x": 51,
           "y": -11,
-          "details": "river surf=93 terr=92 -> land(51,-10) terr=91 cliff=2"
+          "details": "river surf=93 terr=90 -> land(51,-10) terr=91 cliff=2"
         },
         {
           "x": 51,
           "y": 0,
-          "details": "river surf=34 terr=33 -> land(50,0) terr=28 cliff=6"
+          "details": "river surf=34 terr=32 -> land(50,0) terr=28 cliff=6"
         },
         {
           "x": 51,
@@ -13356,8 +13171,13 @@
         },
         {
           "x": 52,
+          "y": -63,
+          "details": "river surf=130 terr=123 -> land(52,-64) terr=127 cliff=3"
+        },
+        {
+          "x": 52,
           "y": -28,
-          "details": "river surf=146 terr=145 -> land(53,-28) terr=137 cliff=9"
+          "details": "river surf=146 terr=142 -> land(53,-28) terr=137 cliff=9"
         },
         {
           "x": 52,
@@ -13367,7 +13187,7 @@
         {
           "x": 52,
           "y": -10,
-          "details": "river surf=84 terr=83 -> land(52,-9) terr=82 cliff=2"
+          "details": "river surf=84 terr=82 -> land(52,-9) terr=82 cliff=2"
         },
         {
           "x": 52,
@@ -13387,12 +13207,12 @@
         {
           "x": 53,
           "y": -40,
-          "details": "river surf=185 terr=184 -> land(54,-40) terr=183 cliff=2"
+          "details": "river surf=185 terr=183 -> land(54,-40) terr=183 cliff=2"
         },
         {
           "x": 53,
           "y": -12,
-          "details": "river surf=85 terr=84 -> land(54,-12) terr=82 cliff=3"
+          "details": "river surf=85 terr=83 -> land(54,-12) terr=82 cliff=3"
         },
         {
           "x": 53,
@@ -13427,17 +13247,17 @@
         {
           "x": 54,
           "y": 7,
-          "details": "river surf=37 terr=36 -> land(53,7) terr=32 cliff=5"
+          "details": "river surf=37 terr=35 -> land(53,7) terr=32 cliff=5"
         },
         {
           "x": 54,
           "y": 8,
-          "details": "river surf=32 terr=31 -> land(53,8) terr=29 cliff=3"
+          "details": "river surf=32 terr=29 -> land(53,8) terr=29 cliff=3"
         },
         {
           "x": 54,
           "y": 10,
-          "details": "river surf=31 terr=30 -> land(53,10) terr=28 cliff=3"
+          "details": "river surf=31 terr=29 -> land(53,10) terr=28 cliff=3"
         },
         {
           "x": 54,
@@ -13457,7 +13277,7 @@
         {
           "x": 55,
           "y": -32,
-          "details": "river surf=148 terr=147 -> land(55,-31) terr=145 cliff=3"
+          "details": "river surf=148 terr=142 -> land(55,-31) terr=145 cliff=3"
         },
         {
           "x": 55,
@@ -13487,7 +13307,7 @@
         {
           "x": 55,
           "y": 23,
-          "details": "river surf=60 terr=59 -> land(54,23) terr=54 cliff=6"
+          "details": "river surf=60 terr=57 -> land(54,23) terr=54 cliff=6"
         },
         {
           "x": 55,
@@ -13497,7 +13317,7 @@
         {
           "x": 56,
           "y": -30,
-          "details": "river surf=121 terr=120 -> land(56,-29) terr=116 cliff=5"
+          "details": "river surf=121 terr=116 -> land(56,-29) terr=116 cliff=5"
         },
         {
           "x": 56,
@@ -13507,32 +13327,32 @@
         {
           "x": 56,
           "y": 2,
-          "details": "river surf=65 terr=64 -> land(56,3) terr=63 cliff=2"
+          "details": "river surf=65 terr=63 -> land(56,3) terr=63 cliff=2"
         },
         {
           "x": 56,
           "y": 18,
-          "details": "river surf=61 terr=60 -> land(56,17) terr=58 cliff=3"
+          "details": "river surf=61 terr=58 -> land(56,17) terr=58 cliff=3"
         },
         {
           "x": 56,
           "y": 25,
-          "details": "river surf=70 terr=69 -> land(56,26) terr=66 cliff=4"
+          "details": "river surf=70 terr=67 -> land(56,26) terr=66 cliff=4"
         },
         {
           "x": 57,
           "y": -43,
-          "details": "river surf=182 terr=181 -> land(56,-43) terr=179 cliff=3"
+          "details": "river surf=182 terr=176 -> land(56,-43) terr=179 cliff=3"
         },
         {
           "x": 57,
           "y": -41,
-          "details": "river surf=176 terr=175 -> land(58,-41) terr=171 cliff=5"
+          "details": "river surf=176 terr=171 -> land(58,-41) terr=171 cliff=5"
         },
         {
           "x": 57,
           "y": -40,
-          "details": "river surf=164 terr=163 -> land(58,-40) terr=159 cliff=5"
+          "details": "river surf=164 terr=159 -> land(58,-40) terr=159 cliff=5"
         },
         {
           "x": 57,
@@ -13542,47 +13362,62 @@
         {
           "x": 57,
           "y": 11,
-          "details": "river surf=46 terr=45 -> land(57,12) terr=43 cliff=3"
+          "details": "river surf=46 terr=44 -> land(57,12) terr=43 cliff=3"
         },
         {
           "x": 57,
           "y": 18,
-          "details": "river surf=68 terr=67 -> land(57,17) terr=64 cliff=4"
+          "details": "river surf=68 terr=65 -> land(57,17) terr=64 cliff=4"
         },
         {
           "x": 57,
           "y": 25,
-          "details": "river surf=78 terr=77 -> land(57,26) terr=73 cliff=5"
+          "details": "river surf=78 terr=75 -> land(57,26) terr=73 cliff=5"
+        },
+        {
+          "x": 58,
+          "y": -61,
+          "details": "river surf=106 terr=100 -> land(58,-62) terr=104 cliff=2"
         },
         {
           "x": 58,
           "y": 12,
-          "details": "river surf=49 terr=48 -> land(57,12) terr=43 cliff=6"
+          "details": "river surf=49 terr=46 -> land(57,12) terr=43 cliff=6"
         },
         {
           "x": 58,
           "y": 15,
-          "details": "river surf=55 terr=54 -> land(57,15) terr=51 cliff=4"
+          "details": "river surf=55 terr=50 -> land(57,15) terr=51 cliff=4"
         },
         {
           "x": 58,
           "y": 16,
-          "details": "river surf=64 terr=63 -> land(57,16) terr=59 cliff=5"
+          "details": "river surf=64 terr=59 -> land(57,16) terr=59 cliff=5"
         },
         {
           "x": 58,
           "y": 17,
-          "details": "river surf=71 terr=70 -> land(57,17) terr=64 cliff=7"
+          "details": "river surf=71 terr=67 -> land(57,17) terr=64 cliff=7"
         },
         {
           "x": 58,
           "y": 25,
-          "details": "river surf=86 terr=85 -> land(58,26) terr=80 cliff=6"
+          "details": "river surf=86 terr=83 -> land(58,26) terr=80 cliff=6"
+        },
+        {
+          "x": 60,
+          "y": -61,
+          "details": "river surf=106 terr=100 -> land(60,-62) terr=104 cliff=2"
+        },
+        {
+          "x": 61,
+          "y": -61,
+          "details": "river surf=106 terr=100 -> land(61,-62) terr=104 cliff=2"
         },
         {
           "x": 62,
           "y": -22,
-          "details": "river surf=80 terr=79 -> land(62,-21) terr=76 cliff=4"
+          "details": "river surf=80 terr=75 -> land(62,-21) terr=76 cliff=4"
         },
         {
           "x": 62,
@@ -13597,17 +13432,17 @@
         {
           "x": 62,
           "y": 13,
-          "details": "river surf=86 terr=85 -> land(62,12) terr=83 cliff=3"
+          "details": "river surf=86 terr=83 -> land(62,12) terr=83 cliff=3"
         },
         {
           "x": 63,
           "y": -61,
-          "details": "lake surf=183 terr=121 -> land(63,-62) terr=109 cliff=74"
+          "details": "lake surf=183 terr=116 -> land(63,-62) terr=104 cliff=79"
         },
         {
           "x": 63,
           "y": -24,
-          "details": "river surf=100 terr=99 -> land(63,-23) terr=97 cliff=3"
+          "details": "river surf=100 terr=95 -> land(63,-23) terr=97 cliff=3"
         },
         {
           "x": 63,
@@ -13617,32 +13452,32 @@
         {
           "x": 63,
           "y": 13,
-          "details": "river surf=93 terr=92 -> land(63,12) terr=91 cliff=2"
+          "details": "river surf=93 terr=90 -> land(63,12) terr=91 cliff=2"
         },
         {
           "x": 64,
           "y": -61,
-          "details": "lake surf=183 terr=149 -> land(65,-61) terr=177 cliff=6"
+          "details": "lake surf=183 terr=144 -> land(65,-61) terr=172 cliff=11"
         },
         {
           "x": 64,
           "y": -26,
-          "details": "river surf=120 terr=119 -> land(64,-25) terr=117 cliff=3"
+          "details": "river surf=120 terr=117 -> land(64,-25) terr=117 cliff=3"
         },
         {
           "x": 64,
           "y": 15,
-          "details": "river surf=108 terr=107 -> land(64,14) terr=104 cliff=4"
+          "details": "river surf=108 terr=105 -> land(64,14) terr=104 cliff=4"
         },
         {
           "x": 65,
           "y": -60,
-          "details": "lake surf=183 terr=182 -> land(64,-60) terr=177 cliff=6"
+          "details": "lake surf=183 terr=182 -> land(64,-60) terr=172 cliff=11"
         },
         {
           "x": 65,
           "y": -36,
-          "details": "river surf=130 terr=129 -> land(64,-36) terr=128 cliff=2"
+          "details": "river surf=130 terr=127 -> land(64,-36) terr=128 cliff=2"
         },
         {
           "x": 65,
@@ -13677,7 +13512,12 @@
         {
           "x": 65,
           "y": 15,
-          "details": "river surf=115 terr=114 -> land(65,14) terr=111 cliff=4"
+          "details": "river surf=115 terr=112 -> land(65,14) terr=111 cliff=4"
+        },
+        {
+          "x": 66,
+          "y": -32,
+          "details": "river surf=106 terr=102 -> land(67,-32) terr=104 cliff=2"
         },
         {
           "x": 66,
@@ -13691,8 +13531,13 @@
         },
         {
           "x": 67,
+          "y": -34,
+          "details": "river surf=94 terr=88 -> land(68,-34) terr=91 cliff=3"
+        },
+        {
+          "x": 67,
           "y": -31,
-          "details": "river surf=121 terr=120 -> land(68,-31) terr=97 cliff=24"
+          "details": "river surf=121 terr=119 -> land(68,-31) terr=91 cliff=30"
         },
         {
           "x": 67,
@@ -13747,12 +13592,12 @@
         {
           "x": 68,
           "y": -38,
-          "details": "river surf=144 terr=143 -> land(68,-37) terr=140 cliff=4"
+          "details": "river surf=144 terr=141 -> land(68,-37) terr=140 cliff=4"
         },
         {
           "x": 68,
           "y": -30,
-          "details": "river surf=129 terr=125 -> land(69,-30) terr=97 cliff=32"
+          "details": "river surf=129 terr=119 -> land(69,-30) terr=91 cliff=38"
         },
         {
           "x": 68,
@@ -13762,27 +13607,32 @@
         {
           "x": 68,
           "y": -18,
-          "details": "river surf=86 terr=85 -> land(68,-17) terr=79 cliff=7"
+          "details": "river surf=86 terr=84 -> land(68,-17) terr=79 cliff=7"
         },
         {
           "x": 68,
           "y": -14,
-          "details": "river surf=58 terr=57 -> land(68,-13) terr=53 cliff=5"
+          "details": "river surf=58 terr=55 -> land(68,-13) terr=53 cliff=5"
+        },
+        {
+          "x": 69,
+          "y": -31,
+          "details": "river surf=70 terr=63 -> land(70,-31) terr=67 cliff=3"
         },
         {
           "x": 69,
           "y": -20,
-          "details": "river surf=95 terr=94 -> land(69,-19) terr=87 cliff=8"
+          "details": "river surf=95 terr=92 -> land(69,-19) terr=87 cliff=8"
         },
         {
           "x": 69,
           "y": -18,
-          "details": "river surf=74 terr=73 -> land(69,-17) terr=70 cliff=4"
+          "details": "river surf=74 terr=71 -> land(69,-17) terr=70 cliff=4"
         },
         {
           "x": 69,
           "y": 9,
-          "details": "river surf=100 terr=99 -> land(70,9) terr=98 cliff=2"
+          "details": "river surf=100 terr=98 -> land(70,9) terr=98 cliff=2"
         },
         {
           "x": 69,
@@ -13802,32 +13652,32 @@
         {
           "x": 70,
           "y": -20,
-          "details": "river surf=86 terr=85 -> land(70,-19) terr=78 cliff=8"
+          "details": "river surf=86 terr=83 -> land(70,-19) terr=78 cliff=8"
         },
         {
           "x": 70,
           "y": -18,
-          "details": "river surf=62 terr=61 -> land(70,-17) terr=59 cliff=3"
+          "details": "river surf=62 terr=57 -> land(70,-17) terr=59 cliff=3"
         },
         {
           "x": 70,
           "y": 5,
-          "details": "river surf=72 terr=71 -> land(70,4) terr=66 cliff=6"
+          "details": "river surf=72 terr=70 -> land(70,4) terr=66 cliff=6"
         },
         {
           "x": 71,
           "y": -31,
-          "details": "river surf=46 terr=45 -> land(72,-31) terr=26 cliff=20"
+          "details": "river surf=46 terr=39 -> land(72,-31) terr=26 cliff=20"
         },
         {
           "x": 71,
           "y": -20,
-          "details": "river surf=74 terr=73 -> land(72,-20) terr=68 cliff=6"
+          "details": "river surf=74 terr=70 -> land(72,-20) terr=68 cliff=6"
         },
         {
           "x": 71,
           "y": -18,
-          "details": "river surf=50 terr=49 -> land(71,-17) terr=46 cliff=4"
+          "details": "river surf=50 terr=45 -> land(71,-17) terr=46 cliff=4"
         },
         {
           "x": 71,
@@ -13842,7 +13692,7 @@
         {
           "x": 73,
           "y": -23,
-          "details": "river surf=86 terr=85 -> land(74,-23) terr=82 cliff=4"
+          "details": "river surf=86 terr=81 -> land(74,-23) terr=82 cliff=4"
         },
         {
           "x": 73,
@@ -13877,7 +13727,7 @@
         {
           "x": 75,
           "y": -20,
-          "details": "river surf=39 terr=38 -> land(76,-20) terr=35 cliff=4"
+          "details": "river surf=39 terr=33 -> land(76,-20) terr=35 cliff=4"
         },
         {
           "x": 75,
@@ -13892,32 +13742,32 @@
         {
           "x": 76,
           "y": 4,
-          "details": "river surf=71 terr=70 -> land(76,3) terr=67 cliff=4"
+          "details": "river surf=71 terr=69 -> land(76,3) terr=67 cliff=4"
         },
         {
           "x": 77,
           "y": 7,
-          "details": "river surf=87 terr=86 -> land(78,7) terr=84 cliff=3"
+          "details": "river surf=87 terr=84 -> land(78,7) terr=84 cliff=3"
         },
         {
           "x": 77,
           "y": 8,
-          "details": "river surf=91 terr=90 -> land(78,8) terr=88 cliff=3"
+          "details": "river surf=91 terr=89 -> land(78,8) terr=88 cliff=3"
         },
         {
           "x": 77,
           "y": 9,
-          "details": "river surf=95 terr=94 -> land(78,9) terr=92 cliff=3"
+          "details": "river surf=95 terr=93 -> land(78,9) terr=92 cliff=3"
         },
         {
           "x": 77,
           "y": 10,
-          "details": "river surf=98 terr=97 -> land(78,10) terr=95 cliff=3"
+          "details": "river surf=98 terr=95 -> land(78,10) terr=95 cliff=3"
         },
         {
           "x": 77,
           "y": 11,
-          "details": "river surf=102 terr=101 -> land(78,11) terr=98 cliff=4"
+          "details": "river surf=102 terr=99 -> land(78,11) terr=98 cliff=4"
         },
         {
           "x": 79,
@@ -14099,7 +13949,7 @@
         {
           "x": 13,
           "y": -52,
-          "details": "river surf=132 -> dry(12,-52) terr=125 cliff=7"
+          "details": "river surf=132 -> dry(12,-52) terr=120 cliff=12"
         },
         {
           "x": 13,
@@ -14125,6 +13975,11 @@
           "x": 13,
           "y": -28,
           "details": "river surf=32 -> dry(12,-28) terr=30 cliff=2"
+        },
+        {
+          "x": 14,
+          "y": -42,
+          "details": "river surf=122 -> dry(13,-42) terr=120 cliff=2"
         },
         {
           "x": 14,
@@ -14973,6 +14828,11 @@
         },
         {
           "x": 52,
+          "y": -63,
+          "details": "river surf=130 -> dry(52,-64) terr=127 cliff=3"
+        },
+        {
+          "x": 52,
           "y": -28,
           "details": "river surf=146 -> dry(53,-28) terr=137 cliff=9"
         },
@@ -15173,6 +15033,11 @@
         },
         {
           "x": 58,
+          "y": -61,
+          "details": "river surf=106 -> dry(58,-62) terr=104 cliff=2"
+        },
+        {
+          "x": 58,
           "y": 12,
           "details": "river surf=49 -> dry(57,12) terr=43 cliff=6"
         },
@@ -15197,6 +15062,16 @@
           "details": "river surf=86 -> dry(58,26) terr=80 cliff=6"
         },
         {
+          "x": 60,
+          "y": -61,
+          "details": "river surf=106 -> dry(60,-62) terr=104 cliff=2"
+        },
+        {
+          "x": 61,
+          "y": -61,
+          "details": "river surf=106 -> dry(61,-62) terr=104 cliff=2"
+        },
+        {
           "x": 62,
           "y": -22,
           "details": "river surf=80 -> dry(62,-21) terr=76 cliff=4"
@@ -15219,7 +15094,7 @@
         {
           "x": 63,
           "y": -61,
-          "details": "lake surf=183 -> dry(63,-62) terr=109 cliff=74"
+          "details": "lake surf=183 -> dry(63,-62) terr=104 cliff=79"
         },
         {
           "x": 63,
@@ -15239,7 +15114,7 @@
         {
           "x": 64,
           "y": -61,
-          "details": "lake surf=183 -> dry(65,-61) terr=177 cliff=6"
+          "details": "lake surf=183 -> dry(65,-61) terr=172 cliff=11"
         },
         {
           "x": 64,
@@ -15254,7 +15129,7 @@
         {
           "x": 65,
           "y": -60,
-          "details": "lake surf=183 -> dry(64,-60) terr=177 cliff=6"
+          "details": "lake surf=183 -> dry(64,-60) terr=172 cliff=11"
         },
         {
           "x": 65,
@@ -15298,6 +15173,11 @@
         },
         {
           "x": 66,
+          "y": -32,
+          "details": "river surf=106 -> dry(67,-32) terr=104 cliff=2"
+        },
+        {
+          "x": 66,
           "y": -14,
           "details": "river surf=68 -> dry(66,-13) terr=64 cliff=4"
         },
@@ -15308,8 +15188,13 @@
         },
         {
           "x": 67,
+          "y": -34,
+          "details": "river surf=94 -> dry(68,-34) terr=91 cliff=3"
+        },
+        {
+          "x": 67,
           "y": -31,
-          "details": "river surf=121 -> dry(68,-31) terr=97 cliff=24"
+          "details": "river surf=121 -> dry(68,-31) terr=91 cliff=30"
         },
         {
           "x": 67,
@@ -15369,7 +15254,7 @@
         {
           "x": 68,
           "y": -30,
-          "details": "river surf=129 -> dry(69,-30) terr=97 cliff=32"
+          "details": "river surf=129 -> dry(69,-30) terr=91 cliff=38"
         },
         {
           "x": 68,
@@ -15385,6 +15270,11 @@
           "x": 68,
           "y": -14,
           "details": "river surf=58 -> dry(68,-13) terr=53 cliff=5"
+        },
+        {
+          "x": 69,
+          "y": -31,
+          "details": "river surf=70 -> dry(70,-31) terr=67 cliff=3"
         },
         {
           "x": 69,

--- a/tools/baselines/seed1337_size32_region_-4_-4_4_4.json
+++ b/tools/baselines/seed1337_size32_region_-4_-4_4_4.json
@@ -14,16 +14,16 @@
     "deterministic": true,
     "distinctHashes": 1,
     "hashes": [
-      "618b131f6132ab91d8e7683d1111af5868a59c63682185acc75bc4ec4fc54f4d",
-      "618b131f6132ab91d8e7683d1111af5868a59c63682185acc75bc4ec4fc54f4d",
-      "618b131f6132ab91d8e7683d1111af5868a59c63682185acc75bc4ec4fc54f4d"
+      "8ac36e520b108db0f851f0c8dad55c375d0eae924cc553161559599d4506770b",
+      "8ac36e520b108db0f851f0c8dad55c375d0eae924cc553161559599d4506770b",
+      "8ac36e520b108db0f851f0c8dad55c375d0eae924cc553161559599d4506770b"
     ]
   },
   "tileCount": 20736,
   "elevationStats": {
     "min": -17,
     "max": 460,
-    "median": 33,
+    "median": 32,
     "count": 20736
   },
   "fluidStats": {
@@ -106,13 +106,13 @@
       ]
     },
     "FLOATING_WATER": {
-      "min": 195,
-      "max": 195,
-      "median": 195,
+      "min": 139,
+      "max": 139,
+      "median": 139,
       "all": [
-        195,
-        195,
-        195
+        139,
+        139,
+        139
       ]
     },
     "ISOLATED_FLUID": {
@@ -126,13 +126,13 @@
       ]
     },
     "MID_RIVER_CLIFF": {
-      "min": 1,
-      "max": 1,
-      "median": 1,
+      "min": 60,
+      "max": 60,
+      "median": 60,
       "all": [
-        1,
-        1,
-        1
+        60,
+        60,
+        60
       ]
     },
     "MULTI_ISLAND": {
@@ -156,23 +156,23 @@
       ]
     },
     "WATER_ABOVE_LAND": {
-      "min": 196,
-      "max": 196,
-      "median": 196,
+      "min": 208,
+      "max": 208,
+      "median": 208,
       "all": [
-        196,
-        196,
-        196
+        208,
+        208,
+        208
       ]
     },
     "WATER_CLIFF": {
-      "min": 196,
-      "max": 196,
-      "median": 196,
+      "min": 208,
+      "max": 208,
+      "median": 208,
       "all": [
-        196,
-        196,
-        196
+        208,
+        208,
+        208
       ]
     },
     "WATER_WATER_CLIFF": {
@@ -191,13 +191,13 @@
       "DESERT_SOIL_ON_SLOPE": 35,
       "FLAT_ISOLATED_WATER": 26,
       "FLOATING_LAKE": 153,
-      "FLOATING_WATER": 195,
+      "FLOATING_WATER": 139,
       "ISOLATED_FLUID": 28,
-      "MID_RIVER_CLIFF": 1,
+      "MID_RIVER_CLIFF": 60,
       "MULTI_ISLAND": 11,
       "RIVER_CHUNK_GAP": 19,
-      "WATER_ABOVE_LAND": 196,
-      "WATER_CLIFF": 196,
+      "WATER_ABOVE_LAND": 208,
+      "WATER_CLIFF": 208,
       "WATER_WATER_CLIFF": 2294
     },
     "issues": {
@@ -210,7 +210,7 @@
         {
           "x": -60,
           "y": 45,
-          "details": "sand maxNbrDelta=4"
+          "details": "sand maxNbrDelta=3"
         },
         {
           "x": -51,
@@ -1291,7 +1291,7 @@
         {
           "x": -62,
           "y": 60,
-          "details": "river terr=80 -> dry(-63,60) terr=74 gap=6"
+          "details": "river terr=78 -> dry(-63,60) terr=74 gap=4"
         },
         {
           "x": -62,
@@ -1305,48 +1305,13 @@
         },
         {
           "x": -58,
-          "y": 46,
-          "details": "river terr=16 -> dry(-59,46) terr=12 gap=4"
-        },
-        {
-          "x": -58,
-          "y": 47,
-          "details": "river terr=24 -> dry(-59,47) terr=20 gap=4"
-        },
-        {
-          "x": -58,
-          "y": 48,
-          "details": "river terr=34 -> dry(-59,48) terr=29 gap=5"
-        },
-        {
-          "x": -58,
           "y": 49,
-          "details": "river terr=44 -> dry(-59,49) terr=38 gap=6"
-        },
-        {
-          "x": -58,
-          "y": 50,
-          "details": "river terr=51 -> dry(-59,50) terr=46 gap=5"
-        },
-        {
-          "x": -58,
-          "y": 51,
-          "details": "river terr=63 -> dry(-59,51) terr=61 gap=2"
-        },
-        {
-          "x": -58,
-          "y": 53,
-          "details": "river terr=87 -> dry(-59,53) terr=85 gap=2"
-        },
-        {
-          "x": -58,
-          "y": 54,
-          "details": "river terr=93 -> dry(-59,54) terr=90 gap=3"
+          "details": "river terr=39 -> dry(-59,49) terr=38 gap=1"
         },
         {
           "x": -58,
           "y": 55,
-          "details": "river terr=97 -> dry(-59,55) terr=94 gap=3"
+          "details": "river terr=95 -> dry(-59,55) terr=94 gap=1"
         },
         {
           "x": -58,
@@ -1356,7 +1321,7 @@
         {
           "x": -58,
           "y": 64,
-          "details": "river terr=105 -> dry(-59,64) terr=101 gap=4"
+          "details": "river terr=104 -> dry(-59,64) terr=101 gap=3"
         },
         {
           "x": -57,
@@ -1366,22 +1331,22 @@
         {
           "x": -56,
           "y": 46,
-          "details": "river terr=27 -> dry(-57,46) terr=22 gap=5"
+          "details": "river terr=23 -> dry(-57,46) terr=22 gap=1"
         },
         {
           "x": -56,
           "y": 47,
-          "details": "river terr=38 -> dry(-57,47) terr=32 gap=6"
+          "details": "river terr=34 -> dry(-57,47) terr=32 gap=2"
         },
         {
           "x": -56,
           "y": 48,
-          "details": "river terr=50 -> dry(-57,48) terr=43 gap=7"
+          "details": "river terr=47 -> dry(-57,48) terr=43 gap=4"
         },
         {
           "x": -56,
           "y": 49,
-          "details": "river terr=62 -> dry(-57,49) terr=54 gap=8"
+          "details": "river terr=59 -> dry(-57,49) terr=54 gap=5"
         },
         {
           "x": -55,
@@ -1391,7 +1356,7 @@
         {
           "x": -55,
           "y": 50,
-          "details": "river terr=79 -> dry(-56,50) terr=74 gap=5"
+          "details": "river terr=77 -> dry(-56,50) terr=74 gap=3"
         },
         {
           "x": -53,
@@ -1401,7 +1366,7 @@
         {
           "x": -53,
           "y": 41,
-          "details": "river terr=9 -> dry(-53,40) terr=7 gap=2"
+          "details": "river terr=8 -> dry(-53,40) terr=7 gap=1"
         },
         {
           "x": -52,
@@ -1429,24 +1394,9 @@
           "details": "river terr=31 -> dry(-50,6) terr=27 gap=4"
         },
         {
-          "x": -50,
-          "y": 9,
-          "details": "river terr=9 -> dry(-50,10) terr=8 gap=1"
-        },
-        {
-          "x": -49,
-          "y": 6,
-          "details": "river terr=16 -> dry(-49,7) terr=14 gap=2"
-        },
-        {
-          "x": -49,
-          "y": 9,
-          "details": "river terr=7 -> dry(-49,10) terr=6 gap=1"
-        },
-        {
           "x": -47,
           "y": 41,
-          "details": "river terr=28 -> dry(-47,40) terr=24 gap=4"
+          "details": "river terr=27 -> dry(-47,40) terr=24 gap=3"
         },
         {
           "x": -46,
@@ -1459,21 +1409,6 @@
           "details": "river terr=27 -> dry(-47,40) terr=24 gap=3"
         },
         {
-          "x": -42,
-          "y": 4,
-          "details": "river terr=55 -> dry(-41,4) terr=51 gap=4"
-        },
-        {
-          "x": -42,
-          "y": 5,
-          "details": "river terr=43 -> dry(-41,5) terr=42 gap=1"
-        },
-        {
-          "x": -41,
-          "y": 3,
-          "details": "river terr=54 -> dry(-41,4) terr=51 gap=3"
-        },
-        {
           "x": -41,
           "y": 43,
           "details": "river terr=52 -> dry(-42,43) terr=51 gap=1"
@@ -1484,14 +1419,9 @@
           "details": "river terr=56 -> dry(-42,44) terr=55 gap=1"
         },
         {
-          "x": -38,
-          "y": 3,
-          "details": "river terr=30 -> dry(-38,4) terr=28 gap=2"
-        },
-        {
           "x": -37,
           "y": 38,
-          "details": "river terr=25 -> dry(-37,37) terr=19 gap=6"
+          "details": "river terr=24 -> dry(-37,37) terr=19 gap=5"
         },
         {
           "x": -36,
@@ -1546,27 +1476,22 @@
         {
           "x": -34,
           "y": 40,
-          "details": "river terr=39 -> dry(-33,40) terr=35 gap=4"
+          "details": "river terr=38 -> dry(-33,40) terr=35 gap=3"
         },
         {
           "x": -34,
           "y": 41,
-          "details": "river terr=45 -> dry(-33,41) terr=41 gap=4"
+          "details": "river terr=44 -> dry(-33,41) terr=41 gap=3"
         },
         {
           "x": -34,
           "y": 42,
-          "details": "river terr=52 -> dry(-33,42) terr=48 gap=4"
+          "details": "river terr=50 -> dry(-33,42) terr=48 gap=2"
         },
         {
           "x": -34,
           "y": 43,
-          "details": "river terr=61 -> dry(-33,43) terr=56 gap=5"
-        },
-        {
-          "x": -30,
-          "y": 2,
-          "details": "river terr=33 -> dry(-29,2) terr=32 gap=1"
+          "details": "river terr=59 -> dry(-33,43) terr=56 gap=3"
         },
         {
           "x": -29,
@@ -1581,32 +1506,12 @@
         {
           "x": -29,
           "y": -2,
-          "details": "river terr=59 -> dry(-29,-1) terr=48 gap=11"
-        },
-        {
-          "x": -28,
-          "y": -2,
-          "details": "river terr=47 -> dry(-27,-2) terr=45 gap=2"
-        },
-        {
-          "x": -28,
-          "y": -1,
-          "details": "river terr=43 -> dry(-27,-1) terr=41 gap=2"
-        },
-        {
-          "x": -28,
-          "y": 0,
-          "details": "river terr=38 -> dry(-27,0) terr=37 gap=1"
+          "details": "river terr=55 -> dry(-29,-1) terr=48 gap=7"
         },
         {
           "x": -27,
           "y": -3,
-          "details": "river terr=55 -> dry(-27,-2) terr=45 gap=10"
-        },
-        {
-          "x": -25,
-          "y": -1,
-          "details": "river terr=40 -> dry(-25,0) terr=39 gap=1"
+          "details": "river terr=50 -> dry(-27,-2) terr=45 gap=5"
         },
         {
           "x": -24,
@@ -1636,7 +1541,7 @@
         {
           "x": -17,
           "y": -4,
-          "details": "river terr=62 -> dry(-16,-4) terr=60 gap=2"
+          "details": "river terr=61 -> dry(-16,-4) terr=60 gap=1"
         },
         {
           "x": -17,
@@ -1676,7 +1581,7 @@
         {
           "x": -16,
           "y": -3,
-          "details": "river terr=52 -> dry(-15,-3) terr=49 gap=3"
+          "details": "river terr=51 -> dry(-15,-3) terr=49 gap=2"
         },
         {
           "x": -16,
@@ -1706,12 +1611,12 @@
         {
           "x": -14,
           "y": -9,
-          "details": "river terr=78 -> dry(-14,-8) terr=75 gap=3"
+          "details": "river terr=77 -> dry(-14,-8) terr=75 gap=2"
         },
         {
           "x": -14,
           "y": 0,
-          "details": "river terr=25 -> dry(-14,1) terr=23 gap=2"
+          "details": "river terr=24 -> dry(-14,1) terr=23 gap=1"
         },
         {
           "x": -13,
@@ -1721,22 +1626,22 @@
         {
           "x": -13,
           "y": -10,
-          "details": "river terr=78 -> dry(-12,-10) terr=74 gap=4"
+          "details": "river terr=77 -> dry(-12,-10) terr=74 gap=3"
         },
         {
           "x": -13,
           "y": -9,
-          "details": "river terr=72 -> dry(-13,-8) terr=69 gap=3"
+          "details": "river terr=71 -> dry(-13,-8) terr=69 gap=2"
         },
         {
           "x": -13,
           "y": 0,
-          "details": "river terr=21 -> dry(-13,1) terr=19 gap=2"
+          "details": "river terr=20 -> dry(-13,1) terr=19 gap=1"
         },
         {
           "x": -12,
           "y": -9,
-          "details": "river terr=68 -> dry(-11,-9) terr=64 gap=4"
+          "details": "river terr=67 -> dry(-11,-9) terr=64 gap=3"
         },
         {
           "x": -12,
@@ -1746,7 +1651,7 @@
         {
           "x": -12,
           "y": 0,
-          "details": "river terr=17 -> dry(-12,1) terr=15 gap=2"
+          "details": "river terr=16 -> dry(-12,1) terr=15 gap=1"
         },
         {
           "x": -11,
@@ -1760,33 +1665,18 @@
         },
         {
           "x": -11,
-          "y": -50,
-          "details": "river terr=68 -> dry(-12,-50) terr=67 gap=1"
-        },
-        {
-          "x": -11,
-          "y": -49,
-          "details": "river terr=71 -> dry(-12,-49) terr=70 gap=1"
-        },
-        {
-          "x": -11,
           "y": -6,
-          "details": "river terr=48 -> dry(-10,-6) terr=44 gap=4"
+          "details": "river terr=46 -> dry(-10,-6) terr=44 gap=2"
         },
         {
           "x": -11,
           "y": -5,
-          "details": "river terr=42 -> dry(-10,-5) terr=37 gap=5"
+          "details": "river terr=41 -> dry(-10,-5) terr=37 gap=4"
         },
         {
           "x": -11,
           "y": -4,
-          "details": "river terr=34 -> dry(-10,-4) terr=29 gap=5"
-        },
-        {
-          "x": -10,
-          "y": -50,
-          "details": "river terr=71 -> dry(-10,-51) terr=70 gap=1"
+          "details": "river terr=32 -> dry(-10,-4) terr=29 gap=3"
         },
         {
           "x": -10,
@@ -1796,12 +1686,12 @@
         {
           "x": -9,
           "y": -9,
-          "details": "river terr=55 -> dry(-8,-9) terr=51 gap=4"
+          "details": "river terr=53 -> dry(-8,-9) terr=51 gap=2"
         },
         {
           "x": -8,
           "y": -14,
-          "details": "river terr=75 -> dry(-8,-13) terr=72 gap=3"
+          "details": "river terr=74 -> dry(-8,-13) terr=72 gap=2"
         },
         {
           "x": -8,
@@ -1816,17 +1706,17 @@
         {
           "x": -8,
           "y": -6,
-          "details": "river terr=32 -> dry(-7,-6) terr=27 gap=5"
+          "details": "river terr=30 -> dry(-7,-6) terr=27 gap=3"
         },
         {
           "x": -8,
           "y": -5,
-          "details": "river terr=24 -> dry(-7,-5) terr=18 gap=6"
+          "details": "river terr=21 -> dry(-7,-5) terr=18 gap=3"
         },
         {
           "x": -7,
           "y": -13,
-          "details": "river terr=65 -> dry(-7,-12) terr=62 gap=3"
+          "details": "river terr=63 -> dry(-7,-12) terr=62 gap=1"
         },
         {
           "x": -6,
@@ -1836,17 +1726,7 @@
         {
           "x": -6,
           "y": -13,
-          "details": "river terr=60 -> dry(-6,-12) terr=57 gap=3"
-        },
-        {
-          "x": -6,
-          "y": -5,
-          "details": "river terr=10 -> dry(-5,-5) terr=8 gap=2"
-        },
-        {
-          "x": -5,
-          "y": -13,
-          "details": "river terr=53 -> dry(-5,-12) terr=51 gap=2"
+          "details": "river terr=58 -> dry(-6,-12) terr=57 gap=1"
         },
         {
           "x": -4,
@@ -1866,32 +1746,17 @@
         {
           "x": -4,
           "y": -11,
-          "details": "river terr=38 -> dry(-4,-10) terr=34 gap=4"
+          "details": "river terr=35 -> dry(-4,-10) terr=34 gap=1"
         },
         {
           "x": -3,
           "y": -9,
-          "details": "river terr=21 -> dry(-3,-8) terr=16 gap=5"
-        },
-        {
-          "x": -2,
-          "y": -9,
-          "details": "river terr=14 -> dry(-2,-8) terr=11 gap=3"
-        },
-        {
-          "x": -1,
-          "y": -10,
-          "details": "river terr=12 -> dry(0,-10) terr=9 gap=3"
+          "details": "river terr=18 -> dry(-3,-8) terr=16 gap=2"
         },
         {
           "x": 0,
           "y": -25,
           "details": "river terr=84 -> dry(0,-24) terr=82 gap=2"
-        },
-        {
-          "x": 0,
-          "y": -11,
-          "details": "river terr=12 -> dry(0,-10) terr=9 gap=3"
         },
         {
           "x": 1,
@@ -1919,69 +1784,29 @@
           "details": "river terr=62 -> dry(10,-24) terr=60 gap=2"
         },
         {
-          "x": 9,
-          "y": -21,
-          "details": "river terr=41 -> dry(10,-21) terr=39 gap=2"
-        },
-        {
-          "x": 9,
-          "y": -20,
-          "details": "river terr=34 -> dry(10,-20) terr=33 gap=1"
-        },
-        {
           "x": 10,
           "y": -22,
-          "details": "river terr=43 -> dry(10,-21) terr=39 gap=4"
-        },
-        {
-          "x": 13,
-          "y": -24,
-          "details": "river terr=52 -> dry(14,-24) terr=50 gap=2"
-        },
-        {
-          "x": 13,
-          "y": -23,
-          "details": "river terr=44 -> dry(14,-23) terr=43 gap=1"
+          "details": "river terr=41 -> dry(10,-21) terr=39 gap=2"
         },
         {
           "x": 15,
           "y": -34,
-          "details": "river terr=96 -> dry(14,-34) terr=90 gap=6"
+          "details": "river terr=92 -> dry(14,-34) terr=90 gap=2"
         },
         {
           "x": 15,
           "y": -33,
-          "details": "river terr=105 -> dry(14,-33) terr=98 gap=7"
+          "details": "river terr=102 -> dry(14,-33) terr=98 gap=4"
         },
         {
           "x": 15,
           "y": -32,
-          "details": "river terr=114 -> dry(14,-32) terr=107 gap=7"
-        },
-        {
-          "x": 15,
-          "y": -24,
-          "details": "river terr=52 -> dry(14,-24) terr=50 gap=2"
-        },
-        {
-          "x": 16,
-          "y": -37,
-          "details": "river terr=88 -> dry(16,-38) terr=85 gap=3"
+          "details": "river terr=111 -> dry(14,-32) terr=107 gap=4"
         },
         {
           "x": 16,
           "y": -31,
           "details": "river terr=129 -> dry(15,-31) terr=123 gap=6"
-        },
-        {
-          "x": 17,
-          "y": -36,
-          "details": "river terr=104 -> dry(17,-37) terr=100 gap=4"
-        },
-        {
-          "x": 18,
-          "y": -35,
-          "details": "river terr=123 -> dry(18,-36) terr=120 gap=3"
         },
         {
           "x": 18,
@@ -2004,59 +1829,29 @@
           "details": "river terr=156 -> dry(21,-29) terr=154 gap=2"
         },
         {
-          "x": 21,
-          "y": -13,
-          "details": "river terr=23 -> dry(20,-13) terr=21 gap=2"
-        },
-        {
-          "x": 21,
-          "y": -12,
-          "details": "river terr=19 -> dry(20,-12) terr=18 gap=1"
-        },
-        {
           "x": 22,
           "y": -30,
           "details": "river terr=162 -> dry(22,-29) terr=158 gap=4"
         },
         {
           "x": 22,
-          "y": -28,
-          "details": "river terr=152 -> dry(21,-28) terr=148 gap=4"
-        },
-        {
-          "x": 22,
-          "y": -27,
-          "details": "river terr=145 -> dry(21,-27) terr=142 gap=3"
-        },
-        {
-          "x": 22,
-          "y": -26,
-          "details": "river terr=138 -> dry(21,-26) terr=135 gap=3"
-        },
-        {
-          "x": 22,
           "y": -18,
-          "details": "river terr=79 -> dry(21,-18) terr=76 gap=3"
+          "details": "river terr=78 -> dry(21,-18) terr=76 gap=2"
         },
         {
           "x": 22,
           "y": -16,
-          "details": "river terr=55 -> dry(21,-16) terr=51 gap=4"
+          "details": "river terr=52 -> dry(21,-16) terr=51 gap=1"
         },
         {
           "x": 22,
           "y": -15,
-          "details": "river terr=43 -> dry(21,-15) terr=34 gap=9"
-        },
-        {
-          "x": 22,
-          "y": -14,
-          "details": "river terr=31 -> dry(21,-14) terr=29 gap=2"
+          "details": "river terr=40 -> dry(21,-15) terr=34 gap=6"
         },
         {
           "x": 23,
           "y": -30,
-          "details": "river terr=170 -> dry(23,-29) terr=167 gap=3"
+          "details": "river terr=168 -> dry(23,-29) terr=167 gap=1"
         },
         {
           "x": 23,
@@ -2066,22 +1861,7 @@
         {
           "x": 23,
           "y": -15,
-          "details": "river terr=43 -> dry(24,-15) terr=36 gap=7"
-        },
-        {
-          "x": 24,
-          "y": -17,
-          "details": "river terr=64 -> dry(24,-16) terr=62 gap=2"
-        },
-        {
-          "x": 25,
-          "y": -15,
-          "details": "river terr=35 -> dry(25,-14) terr=32 gap=3"
-        },
-        {
-          "x": 26,
-          "y": -15,
-          "details": "river terr=31 -> dry(26,-14) terr=29 gap=2"
+          "details": "river terr=40 -> dry(24,-15) terr=36 gap=4"
         },
         {
           "x": 27,
@@ -2096,127 +1876,77 @@
         {
           "x": 29,
           "y": -2,
-          "details": "river terr=23 -> dry(29,-1) terr=20 gap=3"
-        },
-        {
-          "x": 29,
-          "y": 1,
-          "details": "river terr=11 -> dry(29,2) terr=10 gap=1"
+          "details": "river terr=21 -> dry(29,-1) terr=20 gap=1"
         },
         {
           "x": 30,
           "y": -1,
-          "details": "river terr=27 -> dry(29,-1) terr=20 gap=7"
-        },
-        {
-          "x": 30,
-          "y": 1,
-          "details": "river terr=14 -> dry(30,2) terr=13 gap=1"
-        },
-        {
-          "x": 31,
-          "y": -2,
-          "details": "river terr=43 -> dry(31,-3) terr=41 gap=2"
+          "details": "river terr=24 -> dry(29,-1) terr=20 gap=4"
         },
         {
           "x": 31,
           "y": 1,
-          "details": "river terr=26 -> dry(31,2) terr=16 gap=10"
-        },
-        {
-          "x": 32,
-          "y": -12,
-          "details": "river terr=38 -> dry(31,-12) terr=37 gap=1"
-        },
-        {
-          "x": 32,
-          "y": -7,
-          "details": "river terr=27 -> dry(31,-7) terr=26 gap=1"
+          "details": "river terr=22 -> dry(31,2) terr=16 gap=6"
         },
         {
           "x": 32,
           "y": -3,
-          "details": "river terr=49 -> dry(31,-3) terr=41 gap=8"
+          "details": "river terr=46 -> dry(31,-3) terr=41 gap=5"
         },
         {
           "x": 32,
           "y": 2,
-          "details": "river terr=27 -> dry(31,2) terr=16 gap=11"
+          "details": "river terr=24 -> dry(31,2) terr=16 gap=8"
         },
         {
           "x": 33,
           "y": -3,
-          "details": "river terr=58 -> dry(33,-4) terr=51 gap=7"
+          "details": "river terr=57 -> dry(33,-4) terr=51 gap=6"
         },
         {
           "x": 33,
           "y": 4,
-          "details": "river terr=26 -> dry(33,5) terr=17 gap=9"
+          "details": "river terr=22 -> dry(33,5) terr=17 gap=5"
         },
         {
           "x": 34,
           "y": -3,
-          "details": "river terr=69 -> dry(34,-4) terr=66 gap=3"
+          "details": "river terr=67 -> dry(34,-4) terr=60 gap=7"
         },
         {
           "x": 35,
           "y": -3,
-          "details": "river terr=78 -> dry(35,-4) terr=72 gap=6"
-        },
-        {
-          "x": 36,
-          "y": -3,
-          "details": "river terr=88 -> dry(36,-4) terr=84 gap=4"
-        },
-        {
-          "x": 37,
-          "y": 8,
-          "details": "river terr=21 -> dry(36,8) terr=19 gap=2"
+          "details": "river terr=75 -> dry(35,-4) terr=72 gap=3"
         },
         {
           "x": 38,
           "y": 8,
-          "details": "river terr=33 -> dry(38,9) terr=23 gap=10"
+          "details": "river terr=28 -> dry(38,9) terr=23 gap=5"
         },
         {
           "x": 39,
           "y": 8,
-          "details": "river terr=45 -> dry(39,9) terr=38 gap=7"
+          "details": "river terr=40 -> dry(39,9) terr=38 gap=2"
         },
         {
           "x": 41,
           "y": -24,
-          "details": "river terr=127 -> dry(40,-24) terr=123 gap=4"
+          "details": "river terr=126 -> dry(40,-24) terr=123 gap=3"
         },
         {
           "x": 41,
           "y": -23,
-          "details": "river terr=119 -> dry(40,-23) terr=117 gap=2"
+          "details": "river terr=118 -> dry(40,-23) terr=117 gap=1"
         },
         {
-          "x": 41,
-          "y": -22,
-          "details": "river terr=113 -> dry(40,-22) terr=111 gap=2"
-        },
-        {
-          "x": 41,
-          "y": -21,
-          "details": "river terr=104 -> dry(40,-21) terr=103 gap=1"
+          "x": 42,
+          "y": -7,
+          "details": "lake terr=161 -> dry(41,-7) terr=155 gap=6"
         },
         {
           "x": 42,
           "y": -6,
-          "details": "lake terr=160 -> dry(42,-5) terr=150 gap=10"
-        },
-        {
-          "x": 43,
-          "y": -28,
-          "details": "river terr=162 -> dry(42,-28) terr=161 gap=1"
-        },
-        {
-          "x": 43,
-          "y": -27,
-          "details": "river terr=154 -> dry(42,-27) terr=153 gap=1"
+          "details": "lake terr=155 -> dry(42,-5) terr=143 gap=12"
         },
         {
           "x": 44,
@@ -2226,32 +1956,22 @@
         {
           "x": 44,
           "y": -30,
-          "details": "river terr=190 -> dry(43,-30) terr=185 gap=5"
+          "details": "river terr=188 -> dry(43,-30) terr=185 gap=3"
         },
         {
           "x": 44,
           "y": -29,
-          "details": "river terr=180 -> dry(43,-29) terr=172 gap=8"
+          "details": "river terr=177 -> dry(43,-29) terr=172 gap=5"
         },
         {
           "x": 44,
           "y": -28,
-          "details": "river terr=170 -> dry(44,-27) terr=164 gap=6"
-        },
-        {
-          "x": 45,
-          "y": -28,
-          "details": "river terr=182 -> dry(45,-27) terr=179 gap=3"
+          "details": "river terr=165 -> dry(44,-27) terr=164 gap=1"
         },
         {
           "x": 46,
           "y": -30,
-          "details": "river terr=205 -> dry(46,-29) terr=201 gap=4"
-        },
-        {
-          "x": 47,
-          "y": -30,
-          "details": "river terr=212 -> dry(47,-29) terr=211 gap=1"
+          "details": "river terr=203 -> dry(46,-29) terr=201 gap=2"
         }
       ],
       "ISOLATED_FLUID": [
@@ -2398,9 +2118,304 @@
       ],
       "MID_RIVER_CLIFF": [
         {
-          "x": 24,
-          "y": -13,
+          "x": -60,
+          "y": 13,
+          "details": "river surf=10 (terr=7) -> water nbr surf=8 (terr=7) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -59,
+          "y": 12,
+          "details": "river surf=12 (terr=8) -> water nbr surf=9 (terr=8) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -58,
+          "y": 12,
+          "details": "river surf=12 (terr=8) -> water nbr surf=8 (terr=7) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -57,
+          "y": 12,
+          "details": "river surf=12 (terr=9) -> water nbr surf=8 (terr=7) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -48,
+          "y": 6,
+          "details": "river surf=14 (terr=9) -> water nbr surf=11 (terr=9) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -46,
+          "y": 6,
+          "details": "river surf=13 (terr=7) -> water nbr surf=10 (terr=6) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -46,
+          "y": 7,
+          "details": "river surf=10 (terr=6) -> water nbr surf=8 (terr=6) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -45,
+          "y": 7,
+          "details": "river surf=11 (terr=6) -> water nbr surf=8 (terr=5) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -45,
+          "y": 8,
+          "details": "river surf=8 (terr=5) -> water nbr surf=6 (terr=5) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -43,
+          "y": 8,
+          "details": "river surf=10 (terr=7) -> water nbr surf=8 (terr=7) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -37,
+          "y": 3,
+          "details": "river surf=27 (terr=22) -> water nbr surf=25 (terr=22) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -37,
+          "y": 4,
+          "details": "river surf=25 (terr=22) -> water nbr surf=23 (terr=22) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -35,
+          "y": 3,
+          "details": "river surf=28 (terr=25) -> water nbr surf=24 (terr=23) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -34,
+          "y": 2,
+          "details": "river surf=32 (terr=28) -> water nbr surf=28 (terr=26) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -33,
+          "y": 2,
+          "details": "river surf=32 (terr=29) -> water nbr surf=28 (terr=27) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -32,
+          "y": 2,
+          "details": "river surf=32 (terr=29) -> water nbr surf=28 (terr=27) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -28,
+          "y": 1,
+          "details": "river surf=34 (terr=30) -> water nbr surf=31 (terr=30) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -26,
+          "y": 0,
+          "details": "river surf=36 (terr=33) -> water nbr surf=33 (terr=32) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -24,
+          "y": -1,
+          "details": "river surf=43 (terr=39) -> water nbr surf=39 (terr=38) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -23,
+          "y": -1,
+          "details": "river surf=44 (terr=40) -> water nbr surf=39 (terr=38) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -8,
+          "y": -2,
+          "details": "river surf=8 (terr=5) -> water nbr surf=6 (terr=5) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -7,
+          "y": -3,
+          "details": "river surf=8 (terr=5) -> water nbr surf=6 (terr=5) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -2,
+          "y": -16,
+          "details": "river surf=38 (terr=33) -> water nbr surf=35 (terr=32) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -1,
+          "y": -12,
+          "details": "river surf=21 (terr=17) -> water nbr surf=16 (terr=15) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": 0,
+          "y": -17,
+          "details": "river surf=34 (terr=29) -> water nbr surf=31 (terr=28) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 0,
+          "y": -15,
+          "details": "river surf=23 (terr=19) -> water nbr surf=21 (terr=19) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 1,
+          "y": -15,
+          "details": "river surf=20 (terr=15) -> water nbr surf=17 (terr=15) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 3,
+          "y": -20,
+          "details": "river surf=51 (terr=48) -> water nbr surf=49 (terr=48) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 3,
+          "y": -16,
+          "details": "river surf=14 (terr=9) -> water nbr surf=12 (terr=9) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 11,
+          "y": -21,
+          "details": "river surf=35 (terr=32) -> water nbr surf=31 (terr=30) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 14,
+          "y": -21,
+          "details": "river surf=33 (terr=30) -> water nbr surf=29 (terr=28) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 15,
+          "y": -36,
+          "details": "lake surf=84 (terr=79) -> water nbr surf=80 (terr=79) surf_diff=4 terr_diff=0"
+        },
+        {
+          "x": 15,
+          "y": -22,
+          "details": "river surf=36 (terr=30) -> water nbr surf=33 (terr=29) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 15,
+          "y": -20,
+          "details": "river surf=29 (terr=26) -> water nbr surf=27 (terr=26) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 16,
+          "y": -21,
+          "details": "river surf=35 (terr=29) -> water nbr surf=33 (terr=29) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 16,
+          "y": -20,
+          "details": "river surf=32 (terr=27) -> water nbr surf=29 (terr=26) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 16,
+          "y": -19,
+          "details": "river surf=29 (terr=24) -> water nbr surf=26 (terr=23) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 16,
+          "y": -18,
           "details": "river surf=26 (terr=23) -> water nbr surf=24 (terr=23) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 17,
+          "y": -18,
+          "details": "river surf=29 (terr=24) -> water nbr surf=26 (terr=23) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 17,
+          "y": -17,
+          "details": "river surf=26 (terr=22) -> water nbr surf=23 (terr=21) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 17,
+          "y": -17,
+          "details": "river surf=26 (terr=22) -> water nbr surf=23 (terr=21) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 19,
+          "y": -15,
+          "details": "river surf=26 (terr=22) -> water nbr surf=22 (terr=20) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 22,
+          "y": -13,
+          "details": "river surf=26 (terr=22) -> water nbr surf=22 (terr=21) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": 23,
+          "y": -13,
+          "details": "river surf=27 (terr=23) -> water nbr surf=23 (terr=22) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": 28,
+          "y": -16,
+          "details": "river surf=29 (terr=23) -> water nbr surf=26 (terr=23) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 29,
+          "y": -16,
+          "details": "river surf=28 (terr=22) -> water nbr surf=26 (terr=22) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 30,
+          "y": -16,
+          "details": "river surf=31 (terr=25) -> water nbr surf=26 (terr=25) surf_diff=5 terr_diff=0"
+        },
+        {
+          "x": 30,
+          "y": -5,
+          "details": "river surf=26 (terr=21) -> water nbr surf=22 (terr=21) surf_diff=4 terr_diff=0"
+        },
+        {
+          "x": 31,
+          "y": -15,
+          "details": "lake surf=31 (terr=27) -> water nbr surf=26 (terr=25) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": 31,
+          "y": -14,
+          "details": "river surf=31 (terr=28) -> water nbr surf=29 (terr=28) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 31,
+          "y": -6,
+          "details": "river surf=27 (terr=21) -> water nbr surf=24 (terr=20) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 31,
+          "y": 3,
+          "details": "river surf=13 (terr=8) -> water nbr surf=11 (terr=8) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 31,
+          "y": 4,
+          "details": "river surf=12 (terr=8) -> water nbr surf=10 (terr=8) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 31,
+          "y": 5,
+          "details": "river surf=11 (terr=8) -> water nbr surf=9 (terr=8) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 32,
+          "y": -13,
+          "details": "river surf=40 (terr=36) -> water nbr surf=36 (terr=34) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 34,
+          "y": -18,
+          "details": "river surf=70 (terr=66) -> water nbr surf=66 (terr=64) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 36,
+          "y": 9,
+          "details": "river surf=15 (terr=9) -> water nbr surf=11 (terr=7) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 39,
+          "y": -3,
+          "details": "river surf=123 (terr=116) -> water nbr surf=119 (terr=114) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 40,
+          "y": -17,
+          "details": "river surf=88 (terr=82) -> water nbr surf=83 (terr=81) surf_diff=5 terr_diff=1"
+        },
+        {
+          "x": 44,
+          "y": -16,
+          "details": "lake surf=86 (terr=79) -> water nbr surf=83 (terr=80) surf_diff=3 terr_diff=1"
         }
       ],
       "MULTI_ISLAND": [
@@ -2571,7 +2586,7 @@
         {
           "x": -62,
           "y": 60,
-          "details": "river surf=81 terr=80 -> land(-63,60) terr=74 cliff=7"
+          "details": "river surf=81 terr=78 -> land(-63,60) terr=74 cliff=7"
         },
         {
           "x": -62,
@@ -2586,47 +2601,47 @@
         {
           "x": -58,
           "y": 46,
-          "details": "river surf=17 terr=16 -> land(-59,46) terr=12 cliff=5"
+          "details": "river surf=17 terr=12 -> land(-59,46) terr=12 cliff=5"
         },
         {
           "x": -58,
           "y": 47,
-          "details": "river surf=25 terr=24 -> land(-59,47) terr=20 cliff=5"
+          "details": "river surf=25 terr=20 -> land(-59,47) terr=20 cliff=5"
         },
         {
           "x": -58,
           "y": 48,
-          "details": "river surf=35 terr=34 -> land(-59,48) terr=29 cliff=6"
+          "details": "river surf=35 terr=29 -> land(-59,48) terr=29 cliff=6"
         },
         {
           "x": -58,
           "y": 49,
-          "details": "river surf=45 terr=44 -> land(-59,49) terr=38 cliff=7"
+          "details": "river surf=45 terr=39 -> land(-59,49) terr=38 cliff=7"
         },
         {
           "x": -58,
           "y": 50,
-          "details": "river surf=52 terr=51 -> land(-59,50) terr=46 cliff=6"
+          "details": "river surf=52 terr=46 -> land(-59,50) terr=46 cliff=6"
         },
         {
           "x": -58,
           "y": 51,
-          "details": "river surf=64 terr=63 -> land(-59,51) terr=61 cliff=3"
+          "details": "river surf=64 terr=59 -> land(-59,51) terr=61 cliff=3"
         },
         {
           "x": -58,
           "y": 53,
-          "details": "river surf=88 terr=87 -> land(-59,53) terr=85 cliff=3"
+          "details": "river surf=88 terr=83 -> land(-59,53) terr=85 cliff=3"
         },
         {
           "x": -58,
           "y": 54,
-          "details": "river surf=94 terr=93 -> land(-59,54) terr=90 cliff=4"
+          "details": "river surf=94 terr=90 -> land(-59,54) terr=90 cliff=4"
         },
         {
           "x": -58,
           "y": 55,
-          "details": "river surf=98 terr=97 -> land(-59,55) terr=94 cliff=4"
+          "details": "river surf=98 terr=95 -> land(-59,55) terr=94 cliff=4"
         },
         {
           "x": -58,
@@ -2636,7 +2651,7 @@
         {
           "x": -58,
           "y": 64,
-          "details": "river surf=106 terr=105 -> land(-59,64) terr=101 cliff=5"
+          "details": "river surf=106 terr=104 -> land(-59,64) terr=101 cliff=5"
         },
         {
           "x": -57,
@@ -2646,22 +2661,22 @@
         {
           "x": -56,
           "y": 46,
-          "details": "river surf=28 terr=27 -> land(-57,46) terr=22 cliff=6"
+          "details": "river surf=28 terr=23 -> land(-57,46) terr=22 cliff=6"
         },
         {
           "x": -56,
           "y": 47,
-          "details": "river surf=39 terr=38 -> land(-57,47) terr=32 cliff=7"
+          "details": "river surf=39 terr=34 -> land(-57,47) terr=32 cliff=7"
         },
         {
           "x": -56,
           "y": 48,
-          "details": "river surf=51 terr=50 -> land(-57,48) terr=43 cliff=8"
+          "details": "river surf=51 terr=47 -> land(-57,48) terr=43 cliff=8"
         },
         {
           "x": -56,
           "y": 49,
-          "details": "river surf=63 terr=62 -> land(-57,49) terr=54 cliff=9"
+          "details": "river surf=63 terr=59 -> land(-57,49) terr=54 cliff=9"
         },
         {
           "x": -55,
@@ -2671,7 +2686,7 @@
         {
           "x": -55,
           "y": 50,
-          "details": "river surf=80 terr=79 -> land(-56,50) terr=74 cliff=6"
+          "details": "river surf=80 terr=77 -> land(-56,50) terr=74 cliff=6"
         },
         {
           "x": -53,
@@ -2681,7 +2696,7 @@
         {
           "x": -53,
           "y": 41,
-          "details": "river surf=10 terr=9 -> land(-53,40) terr=7 cliff=3"
+          "details": "river surf=10 terr=8 -> land(-53,40) terr=7 cliff=3"
         },
         {
           "x": -52,
@@ -2711,22 +2726,22 @@
         {
           "x": -50,
           "y": 9,
-          "details": "river surf=10 terr=9 -> land(-50,10) terr=8 cliff=2"
+          "details": "river surf=10 terr=7 -> land(-50,10) terr=8 cliff=2"
         },
         {
           "x": -49,
           "y": 6,
-          "details": "river surf=17 terr=16 -> land(-49,7) terr=14 cliff=3"
+          "details": "river surf=17 terr=12 -> land(-49,7) terr=14 cliff=3"
         },
         {
           "x": -49,
           "y": 9,
-          "details": "river surf=8 terr=7 -> land(-49,10) terr=6 cliff=2"
+          "details": "river surf=8 terr=6 -> land(-49,10) terr=6 cliff=2"
         },
         {
           "x": -47,
           "y": 41,
-          "details": "river surf=29 terr=28 -> land(-47,40) terr=24 cliff=5"
+          "details": "river surf=29 terr=27 -> land(-47,40) terr=24 cliff=5"
         },
         {
           "x": -46,
@@ -2741,17 +2756,17 @@
         {
           "x": -42,
           "y": 4,
-          "details": "river surf=56 terr=55 -> land(-41,4) terr=51 cliff=5"
+          "details": "river surf=56 terr=50 -> land(-41,4) terr=51 cliff=5"
         },
         {
           "x": -42,
           "y": 5,
-          "details": "river surf=44 terr=43 -> land(-41,5) terr=42 cliff=2"
+          "details": "river surf=44 terr=39 -> land(-41,5) terr=42 cliff=2"
         },
         {
           "x": -41,
           "y": 3,
-          "details": "river surf=55 terr=54 -> land(-41,4) terr=51 cliff=4"
+          "details": "river surf=55 terr=49 -> land(-41,4) terr=51 cliff=4"
         },
         {
           "x": -41,
@@ -2766,12 +2781,12 @@
         {
           "x": -38,
           "y": 3,
-          "details": "river surf=31 terr=30 -> land(-38,4) terr=28 cliff=3"
+          "details": "river surf=31 terr=25 -> land(-38,4) terr=28 cliff=3"
         },
         {
           "x": -37,
           "y": 38,
-          "details": "river surf=26 terr=25 -> land(-37,37) terr=19 cliff=7"
+          "details": "river surf=26 terr=24 -> land(-37,37) terr=19 cliff=7"
         },
         {
           "x": -36,
@@ -2826,27 +2841,27 @@
         {
           "x": -34,
           "y": 40,
-          "details": "river surf=40 terr=39 -> land(-33,40) terr=35 cliff=5"
+          "details": "river surf=40 terr=38 -> land(-33,40) terr=35 cliff=5"
         },
         {
           "x": -34,
           "y": 41,
-          "details": "river surf=46 terr=45 -> land(-33,41) terr=41 cliff=5"
+          "details": "river surf=46 terr=44 -> land(-33,41) terr=41 cliff=5"
         },
         {
           "x": -34,
           "y": 42,
-          "details": "river surf=53 terr=52 -> land(-33,42) terr=48 cliff=5"
+          "details": "river surf=53 terr=50 -> land(-33,42) terr=48 cliff=5"
         },
         {
           "x": -34,
           "y": 43,
-          "details": "river surf=62 terr=61 -> land(-33,43) terr=56 cliff=6"
+          "details": "river surf=62 terr=59 -> land(-33,43) terr=56 cliff=6"
         },
         {
           "x": -30,
           "y": 2,
-          "details": "river surf=34 terr=33 -> land(-29,2) terr=32 cliff=2"
+          "details": "river surf=34 terr=31 -> land(-29,2) terr=32 cliff=2"
         },
         {
           "x": -29,
@@ -2861,32 +2876,32 @@
         {
           "x": -29,
           "y": -2,
-          "details": "river surf=60 terr=59 -> land(-29,-1) terr=48 cliff=12"
+          "details": "river surf=60 terr=55 -> land(-29,-1) terr=48 cliff=12"
         },
         {
           "x": -28,
           "y": -2,
-          "details": "river surf=48 terr=47 -> land(-27,-2) terr=45 cliff=3"
+          "details": "river surf=48 terr=41 -> land(-27,-2) terr=45 cliff=3"
         },
         {
           "x": -28,
           "y": -1,
-          "details": "river surf=44 terr=43 -> land(-27,-1) terr=41 cliff=3"
+          "details": "river surf=44 terr=38 -> land(-27,-1) terr=41 cliff=3"
         },
         {
           "x": -28,
           "y": 0,
-          "details": "river surf=39 terr=38 -> land(-27,0) terr=37 cliff=2"
+          "details": "river surf=39 terr=34 -> land(-27,0) terr=37 cliff=2"
         },
         {
           "x": -27,
           "y": -3,
-          "details": "river surf=56 terr=55 -> land(-27,-2) terr=45 cliff=11"
+          "details": "river surf=56 terr=50 -> land(-27,-2) terr=45 cliff=11"
         },
         {
           "x": -25,
           "y": -1,
-          "details": "river surf=41 terr=40 -> land(-25,0) terr=39 cliff=2"
+          "details": "river surf=41 terr=37 -> land(-25,0) terr=39 cliff=2"
         },
         {
           "x": -24,
@@ -2916,7 +2931,7 @@
         {
           "x": -17,
           "y": -4,
-          "details": "river surf=63 terr=62 -> land(-16,-4) terr=60 cliff=3"
+          "details": "river surf=63 terr=61 -> land(-16,-4) terr=60 cliff=3"
         },
         {
           "x": -17,
@@ -2956,7 +2971,7 @@
         {
           "x": -16,
           "y": -3,
-          "details": "river surf=53 terr=52 -> land(-15,-3) terr=49 cliff=4"
+          "details": "river surf=53 terr=51 -> land(-15,-3) terr=49 cliff=4"
         },
         {
           "x": -16,
@@ -2986,12 +3001,12 @@
         {
           "x": -14,
           "y": -9,
-          "details": "river surf=79 terr=78 -> land(-14,-8) terr=75 cliff=4"
+          "details": "river surf=79 terr=77 -> land(-14,-8) terr=75 cliff=4"
         },
         {
           "x": -14,
           "y": 0,
-          "details": "river surf=26 terr=25 -> land(-14,1) terr=23 cliff=3"
+          "details": "river surf=26 terr=24 -> land(-14,1) terr=23 cliff=3"
         },
         {
           "x": -13,
@@ -3001,22 +3016,22 @@
         {
           "x": -13,
           "y": -10,
-          "details": "river surf=79 terr=78 -> land(-12,-10) terr=74 cliff=5"
+          "details": "river surf=79 terr=77 -> land(-12,-10) terr=74 cliff=5"
         },
         {
           "x": -13,
           "y": -9,
-          "details": "river surf=73 terr=72 -> land(-13,-8) terr=69 cliff=4"
+          "details": "river surf=73 terr=71 -> land(-13,-8) terr=69 cliff=4"
         },
         {
           "x": -13,
           "y": 0,
-          "details": "river surf=22 terr=21 -> land(-13,1) terr=19 cliff=3"
+          "details": "river surf=22 terr=20 -> land(-13,1) terr=19 cliff=3"
         },
         {
           "x": -12,
           "y": -9,
-          "details": "river surf=69 terr=68 -> land(-11,-9) terr=64 cliff=5"
+          "details": "river surf=69 terr=67 -> land(-11,-9) terr=64 cliff=5"
         },
         {
           "x": -12,
@@ -3026,7 +3041,7 @@
         {
           "x": -12,
           "y": 0,
-          "details": "river surf=18 terr=17 -> land(-12,1) terr=15 cliff=3"
+          "details": "river surf=18 terr=16 -> land(-12,1) terr=15 cliff=3"
         },
         {
           "x": -11,
@@ -3041,32 +3056,32 @@
         {
           "x": -11,
           "y": -50,
-          "details": "river surf=69 terr=68 -> land(-12,-50) terr=67 cliff=2"
+          "details": "river surf=69 terr=67 -> land(-12,-50) terr=67 cliff=2"
         },
         {
           "x": -11,
           "y": -49,
-          "details": "river surf=72 terr=71 -> land(-12,-49) terr=70 cliff=2"
+          "details": "river surf=72 terr=70 -> land(-12,-49) terr=70 cliff=2"
         },
         {
           "x": -11,
           "y": -6,
-          "details": "river surf=49 terr=48 -> land(-10,-6) terr=44 cliff=5"
+          "details": "river surf=49 terr=46 -> land(-10,-6) terr=44 cliff=5"
         },
         {
           "x": -11,
           "y": -5,
-          "details": "river surf=43 terr=42 -> land(-10,-5) terr=37 cliff=6"
+          "details": "river surf=43 terr=41 -> land(-10,-5) terr=37 cliff=6"
         },
         {
           "x": -11,
           "y": -4,
-          "details": "river surf=35 terr=34 -> land(-10,-4) terr=29 cliff=6"
+          "details": "river surf=35 terr=32 -> land(-10,-4) terr=29 cliff=6"
         },
         {
           "x": -10,
           "y": -50,
-          "details": "river surf=72 terr=71 -> land(-10,-51) terr=70 cliff=2"
+          "details": "river surf=72 terr=70 -> land(-10,-51) terr=70 cliff=2"
         },
         {
           "x": -10,
@@ -3076,12 +3091,12 @@
         {
           "x": -9,
           "y": -9,
-          "details": "river surf=56 terr=55 -> land(-8,-9) terr=51 cliff=5"
+          "details": "river surf=56 terr=53 -> land(-8,-9) terr=51 cliff=5"
         },
         {
           "x": -8,
           "y": -14,
-          "details": "river surf=76 terr=75 -> land(-8,-13) terr=72 cliff=4"
+          "details": "river surf=76 terr=74 -> land(-8,-13) terr=72 cliff=4"
         },
         {
           "x": -8,
@@ -3096,17 +3111,17 @@
         {
           "x": -8,
           "y": -6,
-          "details": "river surf=33 terr=32 -> land(-7,-6) terr=27 cliff=6"
+          "details": "river surf=33 terr=30 -> land(-7,-6) terr=27 cliff=6"
         },
         {
           "x": -8,
           "y": -5,
-          "details": "river surf=25 terr=24 -> land(-7,-5) terr=18 cliff=7"
+          "details": "river surf=25 terr=21 -> land(-7,-5) terr=18 cliff=7"
         },
         {
           "x": -7,
           "y": -13,
-          "details": "river surf=66 terr=65 -> land(-7,-12) terr=62 cliff=4"
+          "details": "river surf=66 terr=63 -> land(-7,-12) terr=62 cliff=4"
         },
         {
           "x": -6,
@@ -3116,17 +3131,17 @@
         {
           "x": -6,
           "y": -13,
-          "details": "river surf=61 terr=60 -> land(-6,-12) terr=57 cliff=4"
+          "details": "river surf=61 terr=58 -> land(-6,-12) terr=57 cliff=4"
         },
         {
           "x": -6,
           "y": -5,
-          "details": "river surf=11 terr=10 -> land(-5,-5) terr=8 cliff=3"
+          "details": "river surf=11 terr=6 -> land(-5,-5) terr=8 cliff=3"
         },
         {
           "x": -5,
           "y": -13,
-          "details": "river surf=54 terr=53 -> land(-5,-12) terr=51 cliff=3"
+          "details": "river surf=54 terr=51 -> land(-5,-12) terr=51 cliff=3"
         },
         {
           "x": -4,
@@ -3146,22 +3161,22 @@
         {
           "x": -4,
           "y": -11,
-          "details": "river surf=39 terr=38 -> land(-4,-10) terr=34 cliff=5"
+          "details": "river surf=39 terr=35 -> land(-4,-10) terr=34 cliff=5"
         },
         {
           "x": -3,
           "y": -9,
-          "details": "river surf=22 terr=21 -> land(-3,-8) terr=16 cliff=6"
+          "details": "river surf=22 terr=18 -> land(-3,-8) terr=16 cliff=6"
         },
         {
           "x": -2,
           "y": -9,
-          "details": "river surf=15 terr=14 -> land(-2,-8) terr=11 cliff=4"
+          "details": "river surf=15 terr=11 -> land(-2,-8) terr=11 cliff=4"
         },
         {
           "x": -1,
           "y": -10,
-          "details": "river surf=13 terr=12 -> land(0,-10) terr=9 cliff=4"
+          "details": "river surf=13 terr=9 -> land(0,-10) terr=9 cliff=4"
         },
         {
           "x": 0,
@@ -3171,7 +3186,7 @@
         {
           "x": 0,
           "y": -11,
-          "details": "river surf=13 terr=12 -> land(0,-10) terr=9 cliff=4"
+          "details": "river surf=13 terr=9 -> land(0,-10) terr=9 cliff=4"
         },
         {
           "x": 1,
@@ -3201,52 +3216,52 @@
         {
           "x": 9,
           "y": -21,
-          "details": "river surf=42 terr=41 -> land(10,-21) terr=39 cliff=3"
+          "details": "river surf=42 terr=39 -> land(10,-21) terr=39 cliff=3"
         },
         {
           "x": 9,
           "y": -20,
-          "details": "river surf=35 terr=34 -> land(10,-20) terr=33 cliff=2"
+          "details": "river surf=35 terr=32 -> land(10,-20) terr=33 cliff=2"
         },
         {
           "x": 10,
           "y": -22,
-          "details": "river surf=44 terr=43 -> land(10,-21) terr=39 cliff=5"
+          "details": "river surf=44 terr=41 -> land(10,-21) terr=39 cliff=5"
         },
         {
           "x": 13,
           "y": -24,
-          "details": "river surf=53 terr=52 -> land(14,-24) terr=50 cliff=3"
+          "details": "river surf=53 terr=48 -> land(14,-24) terr=50 cliff=3"
         },
         {
           "x": 13,
           "y": -23,
-          "details": "river surf=45 terr=44 -> land(14,-23) terr=43 cliff=2"
+          "details": "river surf=45 terr=41 -> land(14,-23) terr=43 cliff=2"
         },
         {
           "x": 15,
           "y": -34,
-          "details": "river surf=97 terr=96 -> land(14,-34) terr=90 cliff=7"
+          "details": "river surf=97 terr=92 -> land(14,-34) terr=90 cliff=7"
         },
         {
           "x": 15,
           "y": -33,
-          "details": "river surf=106 terr=105 -> land(14,-33) terr=98 cliff=8"
+          "details": "river surf=106 terr=102 -> land(14,-33) terr=98 cliff=8"
         },
         {
           "x": 15,
           "y": -32,
-          "details": "river surf=115 terr=114 -> land(14,-32) terr=107 cliff=8"
+          "details": "river surf=115 terr=111 -> land(14,-32) terr=107 cliff=8"
         },
         {
           "x": 15,
           "y": -24,
-          "details": "river surf=53 terr=52 -> land(14,-24) terr=50 cliff=3"
+          "details": "river surf=53 terr=46 -> land(14,-24) terr=50 cliff=3"
         },
         {
           "x": 16,
           "y": -37,
-          "details": "river surf=89 terr=88 -> land(16,-38) terr=85 cliff=4"
+          "details": "river surf=89 terr=84 -> land(16,-38) terr=85 cliff=4"
         },
         {
           "x": 16,
@@ -3256,12 +3271,12 @@
         {
           "x": 17,
           "y": -36,
-          "details": "river surf=105 terr=104 -> land(17,-37) terr=100 cliff=5"
+          "details": "river surf=105 terr=100 -> land(17,-37) terr=100 cliff=5"
         },
         {
           "x": 18,
           "y": -35,
-          "details": "river surf=124 terr=123 -> land(18,-36) terr=120 cliff=4"
+          "details": "river surf=124 terr=120 -> land(18,-36) terr=120 cliff=4"
         },
         {
           "x": 18,
@@ -3269,9 +3284,19 @@
           "details": "river surf=144 terr=143 -> land(18,-29) terr=142 cliff=2"
         },
         {
+          "x": 18,
+          "y": -23,
+          "details": "river surf=67 terr=60 -> land(18,-22) terr=64 cliff=3"
+        },
+        {
           "x": 19,
           "y": -33,
           "details": "river surf=145 terr=144 -> land(19,-34) terr=141 cliff=4"
+        },
+        {
+          "x": 19,
+          "y": -20,
+          "details": "river surf=56 terr=49 -> land(19,-19) terr=54 cliff=2"
         },
         {
           "x": 20,
@@ -3286,12 +3311,12 @@
         {
           "x": 21,
           "y": -13,
-          "details": "river surf=24 terr=23 -> land(20,-13) terr=21 cliff=3"
+          "details": "river surf=24 terr=21 -> land(20,-13) terr=21 cliff=3"
         },
         {
           "x": 21,
           "y": -12,
-          "details": "river surf=20 terr=19 -> land(20,-12) terr=18 cliff=2"
+          "details": "river surf=20 terr=18 -> land(20,-12) terr=18 cliff=2"
         },
         {
           "x": 22,
@@ -3301,42 +3326,42 @@
         {
           "x": 22,
           "y": -28,
-          "details": "river surf=153 terr=152 -> land(21,-28) terr=148 cliff=5"
+          "details": "river surf=153 terr=148 -> land(21,-28) terr=148 cliff=5"
         },
         {
           "x": 22,
           "y": -27,
-          "details": "river surf=146 terr=145 -> land(21,-27) terr=142 cliff=4"
+          "details": "river surf=146 terr=141 -> land(21,-27) terr=142 cliff=4"
         },
         {
           "x": 22,
           "y": -26,
-          "details": "river surf=139 terr=138 -> land(21,-26) terr=135 cliff=4"
+          "details": "river surf=139 terr=133 -> land(21,-26) terr=135 cliff=4"
         },
         {
           "x": 22,
           "y": -18,
-          "details": "river surf=80 terr=79 -> land(21,-18) terr=76 cliff=4"
+          "details": "river surf=80 terr=78 -> land(21,-18) terr=76 cliff=4"
         },
         {
           "x": 22,
           "y": -16,
-          "details": "river surf=56 terr=55 -> land(21,-16) terr=51 cliff=5"
+          "details": "river surf=56 terr=52 -> land(21,-16) terr=51 cliff=5"
         },
         {
           "x": 22,
           "y": -15,
-          "details": "river surf=44 terr=43 -> land(21,-15) terr=34 cliff=10"
+          "details": "river surf=44 terr=40 -> land(21,-15) terr=34 cliff=10"
         },
         {
           "x": 22,
           "y": -14,
-          "details": "river surf=32 terr=31 -> land(21,-14) terr=29 cliff=3"
+          "details": "river surf=32 terr=27 -> land(21,-14) terr=29 cliff=3"
         },
         {
           "x": 23,
           "y": -30,
-          "details": "river surf=171 terr=170 -> land(23,-29) terr=167 cliff=4"
+          "details": "river surf=171 terr=168 -> land(23,-29) terr=167 cliff=4"
         },
         {
           "x": 23,
@@ -3346,22 +3371,22 @@
         {
           "x": 23,
           "y": -15,
-          "details": "river surf=44 terr=43 -> land(24,-15) terr=36 cliff=8"
+          "details": "river surf=44 terr=40 -> land(24,-15) terr=36 cliff=8"
         },
         {
           "x": 24,
           "y": -17,
-          "details": "river surf=65 terr=64 -> land(24,-16) terr=62 cliff=3"
+          "details": "river surf=65 terr=62 -> land(24,-16) terr=62 cliff=3"
         },
         {
           "x": 25,
           "y": -15,
-          "details": "river surf=36 terr=35 -> land(25,-14) terr=32 cliff=4"
+          "details": "river surf=36 terr=30 -> land(25,-14) terr=32 cliff=4"
         },
         {
           "x": 26,
           "y": -15,
-          "details": "river surf=32 terr=31 -> land(26,-14) terr=29 cliff=3"
+          "details": "river surf=32 terr=27 -> land(26,-14) terr=29 cliff=3"
         },
         {
           "x": 27,
@@ -3381,127 +3406,157 @@
         {
           "x": 29,
           "y": -2,
-          "details": "river surf=24 terr=23 -> land(29,-1) terr=20 cliff=4"
+          "details": "river surf=24 terr=21 -> land(29,-1) terr=20 cliff=4"
         },
         {
           "x": 29,
           "y": 1,
-          "details": "river surf=12 terr=11 -> land(29,2) terr=10 cliff=2"
+          "details": "river surf=12 terr=8 -> land(29,2) terr=10 cliff=2"
         },
         {
           "x": 30,
           "y": -1,
-          "details": "river surf=28 terr=27 -> land(29,-1) terr=20 cliff=8"
+          "details": "river surf=28 terr=24 -> land(29,-1) terr=20 cliff=8"
         },
         {
           "x": 30,
           "y": 1,
-          "details": "river surf=15 terr=14 -> land(30,2) terr=13 cliff=2"
+          "details": "river surf=15 terr=10 -> land(30,2) terr=13 cliff=2"
         },
         {
           "x": 31,
           "y": -2,
-          "details": "river surf=44 terr=43 -> land(31,-3) terr=41 cliff=3"
+          "details": "river surf=44 terr=40 -> land(31,-3) terr=41 cliff=3"
         },
         {
           "x": 31,
           "y": 1,
-          "details": "river surf=27 terr=26 -> land(31,2) terr=16 cliff=11"
+          "details": "river surf=27 terr=22 -> land(31,2) terr=16 cliff=11"
         },
         {
           "x": 32,
           "y": -12,
-          "details": "river surf=39 terr=38 -> land(31,-12) terr=37 cliff=2"
+          "details": "river surf=39 terr=35 -> land(31,-12) terr=37 cliff=2"
         },
         {
           "x": 32,
           "y": -7,
-          "details": "river surf=28 terr=27 -> land(31,-7) terr=26 cliff=2"
+          "details": "river surf=28 terr=23 -> land(31,-7) terr=26 cliff=2"
         },
         {
           "x": 32,
           "y": -3,
-          "details": "river surf=50 terr=49 -> land(31,-3) terr=41 cliff=9"
+          "details": "river surf=50 terr=46 -> land(31,-3) terr=41 cliff=9"
         },
         {
           "x": 32,
           "y": 2,
-          "details": "river surf=28 terr=27 -> land(31,2) terr=16 cliff=12"
+          "details": "river surf=28 terr=24 -> land(31,2) terr=16 cliff=12"
         },
         {
           "x": 33,
           "y": -3,
-          "details": "river surf=59 terr=58 -> land(33,-4) terr=51 cliff=8"
+          "details": "river surf=59 terr=57 -> land(33,-4) terr=51 cliff=8"
         },
         {
           "x": 33,
           "y": 4,
-          "details": "river surf=27 terr=26 -> land(33,5) terr=17 cliff=10"
+          "details": "river surf=27 terr=22 -> land(33,5) terr=17 cliff=10"
         },
         {
           "x": 34,
           "y": -3,
-          "details": "river surf=70 terr=69 -> land(34,-4) terr=66 cliff=4"
+          "details": "river surf=70 terr=67 -> land(34,-4) terr=60 cliff=10"
         },
         {
           "x": 35,
           "y": -3,
-          "details": "river surf=79 terr=78 -> land(35,-4) terr=72 cliff=7"
+          "details": "river surf=79 terr=75 -> land(35,-4) terr=72 cliff=7"
         },
         {
           "x": 36,
           "y": -3,
-          "details": "river surf=89 terr=88 -> land(36,-4) terr=84 cliff=5"
+          "details": "river surf=89 terr=84 -> land(36,-4) terr=84 cliff=5"
+        },
+        {
+          "x": 37,
+          "y": -3,
+          "details": "river surf=99 terr=94 -> land(37,-4) terr=96 cliff=3"
         },
         {
           "x": 37,
           "y": 8,
-          "details": "river surf=22 terr=21 -> land(36,8) terr=19 cliff=3"
+          "details": "river surf=22 terr=16 -> land(36,8) terr=19 cliff=3"
+        },
+        {
+          "x": 38,
+          "y": -3,
+          "details": "river surf=111 terr=106 -> land(38,-4) terr=108 cliff=3"
+        },
+        {
+          "x": 38,
+          "y": 7,
+          "details": "river surf=46 terr=40 -> land(37,7) terr=44 cliff=2"
         },
         {
           "x": 38,
           "y": 8,
-          "details": "river surf=34 terr=33 -> land(38,9) terr=23 cliff=11"
+          "details": "river surf=34 terr=28 -> land(38,9) terr=23 cliff=11"
+        },
+        {
+          "x": 39,
+          "y": -4,
+          "details": "river surf=111 terr=104 -> land(38,-4) terr=108 cliff=3"
         },
         {
           "x": 39,
           "y": 8,
-          "details": "river surf=46 terr=45 -> land(39,9) terr=38 cliff=8"
+          "details": "river surf=46 terr=40 -> land(39,9) terr=38 cliff=8"
         },
         {
           "x": 41,
           "y": -24,
-          "details": "river surf=129 terr=127 -> land(40,-24) terr=123 cliff=6"
+          "details": "river surf=129 terr=126 -> land(40,-24) terr=123 cliff=6"
         },
         {
           "x": 41,
           "y": -23,
-          "details": "river surf=121 terr=119 -> land(40,-23) terr=117 cliff=4"
+          "details": "river surf=121 terr=118 -> land(40,-23) terr=117 cliff=4"
         },
         {
           "x": 41,
           "y": -22,
-          "details": "river surf=115 terr=113 -> land(40,-22) terr=111 cliff=4"
+          "details": "river surf=115 terr=111 -> land(40,-22) terr=111 cliff=4"
         },
         {
           "x": 41,
           "y": -21,
-          "details": "river surf=105 terr=104 -> land(40,-21) terr=103 cliff=2"
+          "details": "river surf=105 terr=100 -> land(40,-21) terr=103 cliff=2"
+        },
+        {
+          "x": 41,
+          "y": -6,
+          "details": "river surf=135 terr=127 -> land(40,-6) terr=131 cliff=4"
+        },
+        {
+          "x": 42,
+          "y": -7,
+          "details": "lake surf=162 terr=161 -> land(41,-7) terr=155 cliff=7"
         },
         {
           "x": 42,
           "y": -6,
-          "details": "lake surf=162 terr=160 -> land(42,-5) terr=150 cliff=12"
+          "details": "lake surf=162 terr=155 -> land(42,-5) terr=143 cliff=19"
         },
         {
           "x": 43,
           "y": -28,
-          "details": "river surf=163 terr=162 -> land(42,-28) terr=161 cliff=2"
+          "details": "river surf=163 terr=157 -> land(42,-28) terr=161 cliff=2"
         },
         {
           "x": 43,
           "y": -27,
-          "details": "river surf=155 terr=154 -> land(42,-27) terr=153 cliff=2"
+          "details": "river surf=155 terr=148 -> land(42,-27) terr=153 cliff=2"
         },
         {
           "x": 44,
@@ -3511,32 +3566,52 @@
         {
           "x": 44,
           "y": -30,
-          "details": "river surf=191 terr=190 -> land(43,-30) terr=185 cliff=6"
+          "details": "river surf=191 terr=188 -> land(43,-30) terr=185 cliff=6"
         },
         {
           "x": 44,
           "y": -29,
-          "details": "river surf=181 terr=180 -> land(43,-29) terr=172 cliff=9"
+          "details": "river surf=181 terr=177 -> land(43,-29) terr=172 cliff=9"
         },
         {
           "x": 44,
           "y": -28,
-          "details": "river surf=171 terr=170 -> land(44,-27) terr=164 cliff=7"
+          "details": "river surf=171 terr=165 -> land(44,-27) terr=164 cliff=7"
         },
         {
           "x": 45,
           "y": -28,
-          "details": "river surf=183 terr=182 -> land(45,-27) terr=179 cliff=4"
+          "details": "river surf=183 terr=178 -> land(45,-27) terr=179 cliff=4"
+        },
+        {
+          "x": 45,
+          "y": -20,
+          "details": "river surf=123 terr=116 -> land(44,-20) terr=120 cliff=3"
         },
         {
           "x": 46,
           "y": -30,
-          "details": "river surf=206 terr=205 -> land(46,-29) terr=201 cliff=5"
+          "details": "river surf=206 terr=203 -> land(46,-29) terr=201 cliff=5"
+        },
+        {
+          "x": 46,
+          "y": -13,
+          "details": "river surf=144 terr=137 -> land(46,-14) terr=141 cliff=3"
+        },
+        {
+          "x": 46,
+          "y": -12,
+          "details": "river surf=156 terr=149 -> land(45,-12) terr=153 cliff=3"
         },
         {
           "x": 47,
           "y": -30,
-          "details": "river surf=213 terr=212 -> land(47,-29) terr=211 cliff=2"
+          "details": "river surf=213 terr=210 -> land(47,-29) terr=211 cliff=2"
+        },
+        {
+          "x": 47,
+          "y": -12,
+          "details": "river surf=168 terr=161 -> land(47,-13) terr=165 cliff=3"
         }
       ],
       "WATER_CLIFF": [
@@ -4251,9 +4326,19 @@
           "details": "river surf=144 -> dry(18,-29) terr=142 cliff=2"
         },
         {
+          "x": 18,
+          "y": -23,
+          "details": "river surf=67 -> dry(18,-22) terr=64 cliff=3"
+        },
+        {
           "x": 19,
           "y": -33,
           "details": "river surf=145 -> dry(19,-34) terr=141 cliff=4"
+        },
+        {
+          "x": 19,
+          "y": -20,
+          "details": "river surf=56 -> dry(19,-19) terr=54 cliff=2"
         },
         {
           "x": 20,
@@ -4423,7 +4508,7 @@
         {
           "x": 34,
           "y": -3,
-          "details": "river surf=70 -> dry(34,-4) terr=66 cliff=4"
+          "details": "river surf=70 -> dry(34,-4) terr=60 cliff=10"
         },
         {
           "x": 35,
@@ -4437,13 +4522,33 @@
         },
         {
           "x": 37,
+          "y": -3,
+          "details": "river surf=99 -> dry(37,-4) terr=96 cliff=3"
+        },
+        {
+          "x": 37,
           "y": 8,
           "details": "river surf=22 -> dry(36,8) terr=19 cliff=3"
         },
         {
           "x": 38,
+          "y": -3,
+          "details": "river surf=111 -> dry(38,-4) terr=108 cliff=3"
+        },
+        {
+          "x": 38,
+          "y": 7,
+          "details": "river surf=46 -> dry(37,7) terr=44 cliff=2"
+        },
+        {
+          "x": 38,
           "y": 8,
           "details": "river surf=34 -> dry(38,9) terr=23 cliff=11"
+        },
+        {
+          "x": 39,
+          "y": -4,
+          "details": "river surf=111 -> dry(38,-4) terr=108 cliff=3"
         },
         {
           "x": 39,
@@ -4471,9 +4576,19 @@
           "details": "river surf=105 -> dry(40,-21) terr=103 cliff=2"
         },
         {
+          "x": 41,
+          "y": -6,
+          "details": "river surf=135 -> dry(40,-6) terr=131 cliff=4"
+        },
+        {
+          "x": 42,
+          "y": -7,
+          "details": "lake surf=162 -> dry(41,-7) terr=155 cliff=7"
+        },
+        {
           "x": 42,
           "y": -6,
-          "details": "lake surf=162 -> dry(42,-5) terr=150 cliff=12"
+          "details": "lake surf=162 -> dry(42,-5) terr=143 cliff=19"
         },
         {
           "x": 43,
@@ -4511,14 +4626,34 @@
           "details": "river surf=183 -> dry(45,-27) terr=179 cliff=4"
         },
         {
+          "x": 45,
+          "y": -20,
+          "details": "river surf=123 -> dry(44,-20) terr=120 cliff=3"
+        },
+        {
           "x": 46,
           "y": -30,
           "details": "river surf=206 -> dry(46,-29) terr=201 cliff=5"
         },
         {
+          "x": 46,
+          "y": -13,
+          "details": "river surf=144 -> dry(46,-14) terr=141 cliff=3"
+        },
+        {
+          "x": 46,
+          "y": -12,
+          "details": "river surf=156 -> dry(45,-12) terr=153 cliff=3"
+        },
+        {
           "x": 47,
           "y": -30,
           "details": "river surf=213 -> dry(47,-29) terr=211 cliff=2"
+        },
+        {
+          "x": 47,
+          "y": -12,
+          "details": "river surf=168 -> dry(47,-13) terr=165 cliff=3"
         }
       ],
       "WATER_WATER_CLIFF": [

--- a/tools/baselines/seed13579_size32_region_-4_-4_4_4.json
+++ b/tools/baselines/seed13579_size32_region_-4_-4_4_4.json
@@ -14,9 +14,9 @@
     "deterministic": true,
     "distinctHashes": 1,
     "hashes": [
-      "9a2ce3c000358c37c6a106be7e4927030e9665b5bcc006c279065fd80598ef5e",
-      "9a2ce3c000358c37c6a106be7e4927030e9665b5bcc006c279065fd80598ef5e",
-      "9a2ce3c000358c37c6a106be7e4927030e9665b5bcc006c279065fd80598ef5e"
+      "1d360ebf460675325892694e78b0d170e993158f96f7bfa19598f645155c086f",
+      "1d360ebf460675325892694e78b0d170e993158f96f7bfa19598f645155c086f",
+      "1d360ebf460675325892694e78b0d170e993158f96f7bfa19598f645155c086f"
     ]
   },
   "tileCount": 20736,
@@ -97,13 +97,13 @@
       ]
     },
     "FLAT_ISOLATED_WATER": {
-      "min": 29,
-      "max": 29,
-      "median": 29,
+      "min": 26,
+      "max": 26,
+      "median": 26,
       "all": [
-        29,
-        29,
-        29
+        26,
+        26,
+        26
       ]
     },
     "FLOATING_LAKE": {
@@ -127,13 +127,13 @@
       ]
     },
     "FLOATING_WATER": {
-      "min": 175,
-      "max": 175,
-      "median": 175,
+      "min": 123,
+      "max": 123,
+      "median": 123,
       "all": [
-        175,
-        175,
-        175
+        123,
+        123,
+        123
       ]
     },
     "ISLAND_1TILE": {
@@ -157,13 +157,13 @@
       ]
     },
     "MID_RIVER_CLIFF": {
-      "min": 8,
-      "max": 8,
-      "median": 8,
+      "min": 87,
+      "max": 87,
+      "median": 87,
       "all": [
-        8,
-        8,
-        8
+        87,
+        87,
+        87
       ]
     },
     "MULTI_ISLAND": {
@@ -177,33 +177,33 @@
       ]
     },
     "RIVER_CHUNK_GAP": {
-      "min": 17,
-      "max": 17,
-      "median": 17,
+      "min": 22,
+      "max": 22,
+      "median": 22,
       "all": [
-        17,
-        17,
-        17
+        22,
+        22,
+        22
       ]
     },
     "WATER_ABOVE_LAND": {
-      "min": 180,
-      "max": 180,
-      "median": 180,
+      "min": 250,
+      "max": 250,
+      "median": 250,
       "all": [
-        180,
-        180,
-        180
+        250,
+        250,
+        250
       ]
     },
     "WATER_CLIFF": {
-      "min": 180,
-      "max": 180,
-      "median": 180,
+      "min": 250,
+      "max": 250,
+      "median": 250,
       "all": [
-        180,
-        180,
-        180
+        250,
+        250,
+        250
       ]
     },
     "WATER_WATER_CLIFF": {
@@ -220,17 +220,17 @@
   "representativeAudit": {
     "summary": {
       "DESERT_SOIL_ON_SLOPE": 2,
-      "FLAT_ISOLATED_WATER": 29,
+      "FLAT_ISOLATED_WATER": 26,
       "FLOATING_LAKE": 26,
       "FLOATING_RIVER": 3,
-      "FLOATING_WATER": 175,
+      "FLOATING_WATER": 123,
       "ISLAND_1TILE": 1,
       "ISOLATED_FLUID": 28,
-      "MID_RIVER_CLIFF": 8,
+      "MID_RIVER_CLIFF": 87,
       "MULTI_ISLAND": 15,
-      "RIVER_CHUNK_GAP": 17,
-      "WATER_ABOVE_LAND": 180,
-      "WATER_CLIFF": 180,
+      "RIVER_CHUNK_GAP": 22,
+      "WATER_ABOVE_LAND": 250,
+      "WATER_CLIFF": 250,
       "WATER_WATER_CLIFF": 3053
     },
     "issues": {
@@ -258,19 +258,9 @@
           "details": "lake surf=0 terr=-3 water_nbrs=0 terr_range=0"
         },
         {
-          "x": -37,
-          "y": 25,
-          "details": "river surf=39 terr=38 water_nbrs=1 terr_range=1"
-        },
-        {
           "x": -33,
           "y": 30,
           "details": "river surf=39 terr=37 water_nbrs=1 terr_range=2"
-        },
-        {
-          "x": -26,
-          "y": 64,
-          "details": "river surf=21 terr=20 water_nbrs=1 terr_range=1"
         },
         {
           "x": -25,
@@ -291,11 +281,6 @@
           "x": -3,
           "y": -57,
           "details": "lake surf=0 terr=-3 water_nbrs=1 terr_range=2"
-        },
-        {
-          "x": -2,
-          "y": -6,
-          "details": "river surf=135 terr=134 water_nbrs=1 terr_range=2"
         },
         {
           "x": 27,
@@ -467,22 +452,22 @@
         {
           "x": -11,
           "y": 11,
-          "details": "lake fluidSurf=374 terrainZ=261 depth=113"
+          "details": "lake fluidSurf=374 terrainZ=255 depth=119"
         },
         {
           "x": -11,
           "y": 12,
-          "details": "lake fluidSurf=374 terrainZ=289 depth=85"
+          "details": "lake fluidSurf=374 terrainZ=283 depth=91"
         },
         {
           "x": -7,
           "y": 15,
-          "details": "lake fluidSurf=349 terrainZ=240 depth=109"
+          "details": "lake fluidSurf=349 terrainZ=234 depth=115"
         },
         {
           "x": -7,
           "y": 19,
-          "details": "lake fluidSurf=320 terrainZ=182 depth=138"
+          "details": "lake fluidSurf=320 terrainZ=176 depth=144"
         },
         {
           "x": -2,
@@ -529,17 +514,17 @@
         {
           "x": -23,
           "y": 6,
-          "details": "river fluidSurf=173 terrainZ=137 depth=36"
+          "details": "river fluidSurf=173 terrainZ=131 depth=42"
         },
         {
           "x": -18,
           "y": 24,
-          "details": "river fluidSurf=316 terrainZ=292 depth=24"
+          "details": "river fluidSurf=316 terrainZ=288 depth=28"
         },
         {
           "x": -17,
           "y": 24,
-          "details": "river fluidSurf=328 terrainZ=272 depth=56"
+          "details": "river fluidSurf=328 terrainZ=267 depth=61"
         }
       ],
       "FLOATING_WATER": [
@@ -547,11 +532,6 @@
           "x": -64,
           "y": 60,
           "details": "river terr=207 -> dry(-63,60) terr=206 gap=1"
-        },
-        {
-          "x": -63,
-          "y": 42,
-          "details": "river terr=120 -> dry(-62,42) terr=119 gap=1"
         },
         {
           "x": -63,
@@ -581,7 +561,7 @@
         {
           "x": -60,
           "y": 44,
-          "details": "river terr=115 -> dry(-60,43) terr=110 gap=5"
+          "details": "river terr=112 -> dry(-60,43) terr=110 gap=2"
         },
         {
           "x": -60,
@@ -596,42 +576,22 @@
         {
           "x": -59,
           "y": 34,
-          "details": "river terr=43 -> dry(-59,33) terr=39 gap=4"
-        },
-        {
-          "x": -59,
-          "y": 42,
-          "details": "river terr=99 -> dry(-59,41) terr=96 gap=3"
-        },
-        {
-          "x": -59,
-          "y": 59,
-          "details": "river terr=185 -> dry(-58,59) terr=184 gap=1"
+          "details": "river terr=40 -> dry(-59,33) terr=39 gap=1"
         },
         {
           "x": -58,
           "y": 29,
-          "details": "river terr=15 -> dry(-58,28) terr=6 gap=9"
+          "details": "river terr=12 -> dry(-58,28) terr=6 gap=6"
         },
         {
           "x": -58,
           "y": 33,
-          "details": "river terr=43 -> dry(-59,33) terr=39 gap=4"
-        },
-        {
-          "x": -58,
-          "y": 41,
-          "details": "river terr=90 -> dry(-58,40) terr=88 gap=2"
-        },
-        {
-          "x": -58,
-          "y": 49,
-          "details": "river terr=142 -> dry(-57,49) terr=141 gap=1"
+          "details": "river terr=41 -> dry(-59,33) terr=39 gap=2"
         },
         {
           "x": -57,
           "y": 28,
-          "details": "river terr=31 -> dry(-58,28) terr=6 gap=25"
+          "details": "river terr=27 -> dry(-58,28) terr=6 gap=21"
         },
         {
           "x": -57,
@@ -661,7 +621,7 @@
         {
           "x": -56,
           "y": 68,
-          "details": "river terr=218 -> dry(-56,67) terr=216 gap=2"
+          "details": "river terr=217 -> dry(-56,67) terr=216 gap=1"
         },
         {
           "x": -55,
@@ -716,22 +676,12 @@
         {
           "x": -52,
           "y": 48,
-          "details": "river terr=122 -> dry(-51,48) terr=118 gap=4"
-        },
-        {
-          "x": -52,
-          "y": 49,
-          "details": "river terr=134 -> dry(-51,49) terr=133 gap=1"
-        },
-        {
-          "x": -52,
-          "y": 50,
-          "details": "river terr=146 -> dry(-51,50) terr=145 gap=1"
+          "details": "river terr=119 -> dry(-51,48) terr=118 gap=1"
         },
         {
           "x": -51,
           "y": 47,
-          "details": "river terr=104 -> dry(-50,47) terr=95 gap=9"
+          "details": "river terr=100 -> dry(-50,47) terr=95 gap=5"
         },
         {
           "x": -51,
@@ -756,7 +706,7 @@
         {
           "x": -50,
           "y": 45,
-          "details": "river terr=76 -> dry(-50,44) terr=69 gap=7"
+          "details": "river terr=72 -> dry(-50,44) terr=69 gap=3"
         },
         {
           "x": -50,
@@ -766,7 +716,7 @@
         {
           "x": -49,
           "y": 45,
-          "details": "river terr=64 -> dry(-49,44) terr=57 gap=7"
+          "details": "river terr=59 -> dry(-49,44) terr=57 gap=2"
         },
         {
           "x": -49,
@@ -791,7 +741,7 @@
         {
           "x": -48,
           "y": 51,
-          "details": "river terr=113 -> dry(-48,50) terr=107 gap=6"
+          "details": "river terr=109 -> dry(-48,50) terr=107 gap=2"
         },
         {
           "x": -48,
@@ -806,12 +756,7 @@
         {
           "x": -47,
           "y": 48,
-          "details": "river terr=72 -> dry(-47,47) terr=66 gap=6"
-        },
-        {
-          "x": -47,
-          "y": 59,
-          "details": "river terr=140 -> dry(-46,59) terr=138 gap=2"
+          "details": "river terr=67 -> dry(-47,47) terr=66 gap=1"
         },
         {
           "x": -47,
@@ -830,28 +775,18 @@
         },
         {
           "x": -45,
-          "y": 49,
-          "details": "river terr=72 -> dry(-44,49) terr=70 gap=2"
-        },
-        {
-          "x": -45,
-          "y": 50,
-          "details": "river terr=83 -> dry(-44,50) terr=80 gap=3"
-        },
-        {
-          "x": -45,
           "y": 51,
-          "details": "river terr=88 -> dry(-44,51) terr=85 gap=3"
+          "details": "river terr=86 -> dry(-44,51) terr=85 gap=1"
         },
         {
           "x": -45,
           "y": 63,
-          "details": "river terr=169 -> dry(-45,62) terr=166 gap=3"
+          "details": "river terr=168 -> dry(-45,62) terr=166 gap=2"
         },
         {
           "x": -44,
           "y": 63,
-          "details": "river terr=162 -> dry(-44,62) terr=158 gap=4"
+          "details": "river terr=161 -> dry(-44,62) terr=158 gap=3"
         },
         {
           "x": -43,
@@ -861,7 +796,7 @@
         {
           "x": -43,
           "y": 63,
-          "details": "river terr=154 -> dry(-43,62) terr=151 gap=3"
+          "details": "river terr=152 -> dry(-43,62) terr=151 gap=1"
         },
         {
           "x": -42,
@@ -871,7 +806,7 @@
         {
           "x": -42,
           "y": 63,
-          "details": "river terr=146 -> dry(-42,62) terr=142 gap=4"
+          "details": "river terr=143 -> dry(-42,62) terr=142 gap=1"
         },
         {
           "x": -41,
@@ -886,7 +821,7 @@
         {
           "x": -41,
           "y": 63,
-          "details": "river terr=139 -> dry(-41,62) terr=135 gap=4"
+          "details": "river terr=137 -> dry(-41,62) terr=135 gap=2"
         },
         {
           "x": -40,
@@ -901,7 +836,7 @@
         {
           "x": -40,
           "y": 63,
-          "details": "river terr=133 -> dry(-40,62) terr=129 gap=4"
+          "details": "river terr=131 -> dry(-40,62) terr=129 gap=2"
         },
         {
           "x": -39,
@@ -911,37 +846,22 @@
         {
           "x": -39,
           "y": -2,
-          "details": "river terr=27 -> dry(-39,-1) terr=23 gap=4"
+          "details": "river terr=26 -> dry(-39,-1) terr=23 gap=3"
         },
         {
           "x": -39,
           "y": 16,
-          "details": "river terr=17 -> dry(-40,16) terr=6 gap=11"
+          "details": "river terr=10 -> dry(-40,16) terr=6 gap=4"
         },
         {
           "x": -39,
           "y": 19,
-          "details": "river terr=53 -> dry(-40,19) terr=46 gap=7"
-        },
-        {
-          "x": -39,
-          "y": 20,
-          "details": "river terr=45 -> dry(-40,20) terr=43 gap=2"
-        },
-        {
-          "x": -39,
-          "y": 21,
-          "details": "river terr=42 -> dry(-40,21) terr=40 gap=2"
-        },
-        {
-          "x": -39,
-          "y": 58,
-          "details": "river terr=84 -> dry(-38,58) terr=83 gap=1"
+          "details": "river terr=48 -> dry(-40,19) terr=46 gap=2"
         },
         {
           "x": -39,
           "y": 63,
-          "details": "river terr=125 -> dry(-39,62) terr=122 gap=3"
+          "details": "river terr=123 -> dry(-39,62) terr=122 gap=1"
         },
         {
           "x": -38,
@@ -951,17 +871,12 @@
         {
           "x": -38,
           "y": -4,
-          "details": "river terr=38 -> dry(-38,-5) terr=36 gap=2"
+          "details": "river terr=37 -> dry(-38,-5) terr=36 gap=1"
         },
         {
           "x": -38,
           "y": -2,
-          "details": "river terr=35 -> dry(-38,-1) terr=31 gap=4"
-        },
-        {
-          "x": -38,
-          "y": 63,
-          "details": "river terr=116 -> dry(-38,62) terr=115 gap=1"
+          "details": "river terr=34 -> dry(-38,-1) terr=31 gap=3"
         },
         {
           "x": -37,
@@ -974,244 +889,139 @@
           "details": "river terr=45 -> dry(-37,-1) terr=39 gap=6"
         },
         {
-          "x": -37,
-          "y": 63,
-          "details": "river terr=106 -> dry(-37,62) terr=104 gap=2"
-        },
-        {
           "x": -36,
           "y": -1,
           "details": "river terr=41 -> dry(-37,-1) terr=39 gap=2"
         },
         {
           "x": -35,
-          "y": -9,
-          "details": "river terr=22 -> dry(-36,-9) terr=21 gap=1"
-        },
-        {
-          "x": -35,
           "y": -1,
-          "details": "river terr=53 -> dry(-35,0) terr=49 gap=4"
-        },
-        {
-          "x": -34,
-          "y": -8,
-          "details": "river terr=33 -> dry(-35,-8) terr=32 gap=1"
-        },
-        {
-          "x": -34,
-          "y": -7,
-          "details": "river terr=44 -> dry(-35,-7) terr=42 gap=2"
-        },
-        {
-          "x": -34,
-          "y": 64,
-          "details": "river terr=81 -> dry(-33,64) terr=77 gap=4"
+          "details": "river terr=52 -> dry(-35,0) terr=49 gap=3"
         },
         {
           "x": -34,
           "y": 65,
-          "details": "river terr=89 -> dry(-33,65) terr=83 gap=6"
-        },
-        {
-          "x": -32,
-          "y": -10,
-          "details": "river terr=11 -> dry(-32,-11) terr=8 gap=3"
+          "details": "river terr=85 -> dry(-33,65) terr=83 gap=2"
         },
         {
           "x": -32,
           "y": 63,
-          "details": "lake terr=75 -> dry(-31,63) terr=68 gap=7"
+          "details": "lake terr=74 -> dry(-31,63) terr=62 gap=12"
         },
         {
           "x": -30,
           "y": 33,
-          "details": "river terr=71 -> dry(-31,33) terr=48 gap=23"
+          "details": "river terr=67 -> dry(-31,33) terr=48 gap=19"
         },
         {
           "x": -29,
           "y": 32,
-          "details": "river terr=56 -> dry(-30,32) terr=48 gap=8"
+          "details": "river terr=51 -> dry(-30,32) terr=48 gap=3"
         },
         {
           "x": -29,
           "y": 68,
-          "details": "river terr=37 -> dry(-28,68) terr=26 gap=11"
+          "details": "river terr=32 -> dry(-28,68) terr=26 gap=6"
         },
         {
           "x": -28,
           "y": 69,
-          "details": "river terr=31 -> dry(-28,68) terr=26 gap=5"
+          "details": "river terr=28 -> dry(-28,68) terr=26 gap=2"
         },
         {
           "x": -27,
           "y": 13,
-          "details": "river terr=133 -> dry(-28,13) terr=127 gap=6"
-        },
-        {
-          "x": -25,
-          "y": 16,
-          "details": "river terr=141 -> dry(-26,16) terr=139 gap=2"
+          "details": "river terr=129 -> dry(-28,13) terr=124 gap=5"
         },
         {
           "x": -25,
           "y": 32,
-          "details": "river terr=114 -> dry(-25,31) terr=111 gap=3"
+          "details": "river terr=110 -> dry(-25,31) terr=106 gap=4"
         },
         {
           "x": -24,
           "y": 59,
-          "details": "river terr=39 -> dry(-23,59) terr=29 gap=10"
-        },
-        {
-          "x": -24,
-          "y": 60,
-          "details": "river terr=27 -> dry(-23,60) terr=26 gap=1"
+          "details": "river terr=34 -> dry(-23,59) terr=29 gap=5"
         },
         {
           "x": -23,
           "y": 6,
-          "details": "river terr=137 -> dry(-24,6) terr=109 gap=28"
+          "details": "river terr=131 -> dry(-24,6) terr=103 gap=28"
         },
         {
           "x": -23,
           "y": 7,
-          "details": "river terr=160 -> dry(-24,7) terr=137 gap=23"
-        },
-        {
-          "x": -23,
-          "y": 42,
-          "details": "river terr=142 -> dry(-23,43) terr=141 gap=1"
-        },
-        {
-          "x": -22,
-          "y": 43,
-          "details": "river terr=124 -> dry(-22,44) terr=120 gap=4"
+          "details": "river terr=154 -> dry(-24,7) terr=131 gap=23"
         },
         {
           "x": -21,
           "y": 45,
-          "details": "river terr=90 -> dry(-21,46) terr=84 gap=6"
-        },
-        {
-          "x": -21,
-          "y": 55,
-          "details": "river terr=42 -> dry(-21,56) terr=40 gap=2"
-        },
-        {
-          "x": -21,
-          "y": 57,
-          "details": "river terr=36 -> dry(-21,58) terr=35 gap=1"
-        },
-        {
-          "x": -21,
-          "y": 61,
-          "details": "river terr=26 -> dry(-21,62) terr=25 gap=1"
-        },
-        {
-          "x": -20,
-          "y": 52,
-          "details": "river terr=48 -> dry(-20,53) terr=47 gap=1"
-        },
-        {
-          "x": -20,
-          "y": 54,
-          "details": "river terr=42 -> dry(-19,54) terr=41 gap=1"
-        },
-        {
-          "x": -20,
-          "y": 55,
-          "details": "river terr=39 -> dry(-19,55) terr=38 gap=1"
+          "details": "river terr=85 -> dry(-21,46) terr=84 gap=1"
         },
         {
           "x": -19,
           "y": 12,
-          "details": "river terr=160 -> dry(-19,11) terr=153 gap=7"
-        },
-        {
-          "x": -19,
-          "y": 52,
-          "details": "river terr=45 -> dry(-19,53) terr=44 gap=1"
-        },
-        {
-          "x": -19,
-          "y": 56,
-          "details": "river terr=36 -> dry(-19,57) terr=35 gap=1"
+          "details": "river terr=154 -> dry(-19,11) terr=153 gap=1"
         },
         {
           "x": -18,
           "y": 12,
-          "details": "river terr=172 -> dry(-18,11) terr=163 gap=9"
+          "details": "river terr=166 -> dry(-18,11) terr=163 gap=3"
         },
         {
           "x": -18,
           "y": 23,
-          "details": "river terr=303 -> dry(-19,23) terr=274 gap=29"
+          "details": "river terr=298 -> dry(-19,23) terr=268 gap=30"
         },
         {
           "x": -18,
           "y": 24,
-          "details": "river terr=292 -> dry(-19,24) terr=265 gap=27"
+          "details": "river terr=288 -> dry(-19,24) terr=259 gap=29"
         },
         {
           "x": -18,
           "y": 43,
-          "details": "river terr=78 -> dry(-18,44) terr=67 gap=11"
+          "details": "river terr=73 -> dry(-18,44) terr=67 gap=6"
         },
         {
           "x": -18,
           "y": 48,
-          "details": "river terr=55 -> dry(-18,49) terr=52 gap=3"
-        },
-        {
-          "x": -18,
-          "y": 54,
-          "details": "river terr=39 -> dry(-18,55) terr=38 gap=1"
+          "details": "river terr=54 -> dry(-18,49) terr=52 gap=2"
         },
         {
           "x": -17,
           "y": 10,
-          "details": "river terr=163 -> dry(-18,10) terr=154 gap=9"
+          "details": "river terr=157 -> dry(-18,10) terr=154 gap=3"
         },
         {
           "x": -17,
           "y": 12,
-          "details": "river terr=184 -> dry(-17,11) terr=174 gap=10"
+          "details": "river terr=178 -> dry(-17,11) terr=174 gap=4"
         },
         {
           "x": -17,
           "y": 24,
-          "details": "river terr=272 -> dry(-17,25) terr=244 gap=28"
+          "details": "river terr=267 -> dry(-17,25) terr=239 gap=28"
         },
         {
           "x": -17,
           "y": 28,
-          "details": "river terr=192 -> dry(-16,28) terr=183 gap=9"
+          "details": "river terr=188 -> dry(-16,28) terr=179 gap=9"
         },
         {
           "x": -17,
           "y": 29,
-          "details": "river terr=180 -> dry(-16,29) terr=155 gap=25"
-        },
-        {
-          "x": -17,
-          "y": 43,
-          "details": "river terr=66 -> dry(-17,44) terr=64 gap=2"
-        },
-        {
-          "x": -16,
-          "y": 44,
-          "details": "river terr=60 -> dry(-16,45) terr=58 gap=2"
+          "details": "river terr=176 -> dry(-16,29) terr=151 gap=25"
         },
         {
           "x": -14,
           "y": 18,
-          "details": "river terr=291 -> dry(-13,18) terr=267 gap=24"
+          "details": "river terr=286 -> dry(-13,18) terr=261 gap=25"
         },
         {
           "x": -14,
           "y": 19,
-          "details": "river terr=299 -> dry(-13,19) terr=271 gap=28"
+          "details": "river terr=293 -> dry(-13,19) terr=265 gap=28"
         },
         {
           "x": -12,
@@ -1226,12 +1036,12 @@
         {
           "x": -11,
           "y": 11,
-          "details": "lake terr=261 -> dry(-12,11) terr=249 gap=12"
+          "details": "lake terr=255 -> dry(-12,11) terr=243 gap=12"
         },
         {
           "x": -11,
           "y": 12,
-          "details": "lake terr=289 -> dry(-12,12) terr=276 gap=13"
+          "details": "lake terr=283 -> dry(-12,12) terr=270 gap=13"
         },
         {
           "x": -11,
@@ -1241,22 +1051,12 @@
         {
           "x": -10,
           "y": 32,
-          "details": "river terr=78 -> dry(-10,31) terr=68 gap=10"
+          "details": "river terr=73 -> dry(-10,31) terr=68 gap=5"
         },
         {
           "x": -10,
           "y": 53,
           "details": "river terr=31 -> dry(-10,54) terr=29 gap=2"
-        },
-        {
-          "x": -9,
-          "y": -16,
-          "details": "river terr=44 -> dry(-10,-16) terr=43 gap=1"
-        },
-        {
-          "x": -9,
-          "y": -15,
-          "details": "river terr=46 -> dry(-10,-15) terr=45 gap=1"
         },
         {
           "x": -9,
@@ -1266,47 +1066,22 @@
         {
           "x": -7,
           "y": 15,
-          "details": "lake terr=240 -> dry(-8,15) terr=228 gap=12"
+          "details": "lake terr=234 -> dry(-8,15) terr=222 gap=12"
         },
         {
           "x": -7,
           "y": 18,
-          "details": "river terr=188 -> dry(-6,18) terr=182 gap=6"
+          "details": "river terr=182 -> dry(-6,18) terr=176 gap=6"
         },
         {
           "x": -5,
           "y": 7,
-          "details": "river terr=266 -> dry(-5,6) terr=255 gap=11"
+          "details": "river terr=260 -> dry(-5,6) terr=249 gap=11"
         },
         {
           "x": -5,
           "y": 47,
-          "details": "river terr=34 -> dry(-5,48) terr=32 gap=2"
-        },
-        {
-          "x": -4,
-          "y": 28,
-          "details": "river terr=70 -> dry(-4,29) terr=69 gap=1"
-        },
-        {
-          "x": -4,
-          "y": 30,
-          "details": "river terr=65 -> dry(-4,31) terr=64 gap=1"
-        },
-        {
-          "x": -4,
-          "y": 47,
-          "details": "river terr=31 -> dry(-4,48) terr=29 gap=2"
-        },
-        {
-          "x": -3,
-          "y": -5,
-          "details": "river terr=138 -> dry(-3,-6) terr=137 gap=1"
-        },
-        {
-          "x": -3,
-          "y": 30,
-          "details": "river terr=68 -> dry(-3,31) terr=67 gap=1"
+          "details": "river terr=33 -> dry(-5,48) terr=32 gap=1"
         },
         {
           "x": -2,
@@ -1316,7 +1091,7 @@
         {
           "x": -2,
           "y": 30,
-          "details": "river terr=80 -> dry(-2,31) terr=70 gap=10"
+          "details": "river terr=75 -> dry(-2,31) terr=70 gap=5"
         },
         {
           "x": -1,
@@ -1334,36 +1109,6 @@
           "details": "river terr=46 -> dry(1,42) terr=35 gap=11"
         },
         {
-          "x": 0,
-          "y": 43,
-          "details": "river terr=34 -> dry(1,43) terr=32 gap=2"
-        },
-        {
-          "x": 0,
-          "y": 44,
-          "details": "river terr=31 -> dry(1,44) terr=29 gap=2"
-        },
-        {
-          "x": 0,
-          "y": 45,
-          "details": "river terr=28 -> dry(1,45) terr=26 gap=2"
-        },
-        {
-          "x": 1,
-          "y": 37,
-          "details": "river terr=62 -> dry(1,38) terr=61 gap=1"
-        },
-        {
-          "x": 2,
-          "y": 37,
-          "details": "river terr=65 -> dry(2,38) terr=64 gap=1"
-        },
-        {
-          "x": 3,
-          "y": 37,
-          "details": "river terr=68 -> dry(3,38) terr=67 gap=1"
-        },
-        {
           "x": 4,
           "y": 35,
           "details": "river terr=108 -> dry(4,36) terr=105 gap=3"
@@ -1374,49 +1119,29 @@
           "details": "river terr=104 -> dry(5,36) terr=102 gap=2"
         },
         {
-          "x": 10,
-          "y": 33,
-          "details": "river terr=68 -> dry(10,34) terr=67 gap=1"
-        },
-        {
-          "x": 11,
-          "y": 33,
-          "details": "river terr=65 -> dry(11,34) terr=64 gap=1"
-        },
-        {
           "x": 12,
           "y": 36,
-          "details": "river terr=17 -> dry(12,37) terr=6 gap=11"
-        },
-        {
-          "x": 13,
-          "y": 29,
-          "details": "river terr=69 -> dry(13,30) terr=67 gap=2"
+          "details": "river terr=12 -> dry(12,37) terr=6 gap=6"
         },
         {
           "x": 16,
           "y": 32,
-          "details": "river terr=17 -> dry(16,33) terr=6 gap=11"
+          "details": "river terr=12 -> dry(16,33) terr=6 gap=6"
         },
         {
           "x": 17,
           "y": 21,
-          "details": "river terr=155 -> dry(17,22) terr=139 gap=16"
+          "details": "river terr=150 -> dry(17,22) terr=134 gap=16"
         },
         {
           "x": 20,
           "y": 21,
-          "details": "river terr=119 -> dry(20,22) terr=103 gap=16"
+          "details": "river terr=114 -> dry(20,22) terr=98 gap=16"
         },
         {
           "x": 28,
           "y": 6,
-          "details": "river terr=37 -> dry(28,5) terr=27 gap=10"
-        },
-        {
-          "x": 29,
-          "y": 6,
-          "details": "river terr=25 -> dry(29,5) terr=24 gap=1"
+          "details": "river terr=32 -> dry(28,5) terr=27 gap=5"
         }
       ],
       "ISLAND_1TILE": [
@@ -1570,9 +1295,99 @@
       ],
       "MID_RIVER_CLIFF": [
         {
+          "x": -61,
+          "y": 56,
+          "details": "river surf=167 (terr=163) -> water nbr surf=164 (terr=164) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -60,
+          "y": 56,
+          "details": "river surf=165 (terr=161) -> water nbr surf=162 (terr=162) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -57,
+          "y": 41,
+          "details": "river surf=86 (terr=82) -> water nbr surf=84 (terr=82) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -56,
+          "y": 42,
+          "details": "river surf=82 (terr=77) -> water nbr surf=79 (terr=78) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -45,
+          "y": 48,
+          "details": "lake surf=61 (terr=55) -> water nbr surf=56 (terr=56) surf_diff=5 terr_diff=1"
+        },
+        {
+          "x": -44,
+          "y": 56,
+          "details": "river surf=87 (terr=78) -> water nbr surf=83 (terr=80) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -39,
+          "y": 11,
+          "details": "river surf=5 (terr=2) -> water nbr surf=1 (terr=0) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -39,
+          "y": 57,
+          "details": "lake surf=73 (terr=64) -> water nbr surf=66 (terr=66) surf_diff=7 terr_diff=2"
+        },
+        {
+          "x": -38,
+          "y": 2,
+          "details": "river surf=6 (terr=3) -> water nbr surf=2 (terr=1) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -38,
+          "y": 57,
+          "details": "lake surf=73 (terr=65) -> water nbr surf=66 (terr=67) surf_diff=7 terr_diff=2"
+        },
+        {
+          "x": -37,
+          "y": 2,
+          "details": "river surf=6 (terr=2) -> water nbr surf=3 (terr=1) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -37,
+          "y": 10,
+          "details": "river surf=4 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -37,
+          "y": 11,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -36,
+          "y": 3,
+          "details": "river surf=4 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
           "x": -36,
           "y": 9,
           "details": "river surf=4 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -35,
+          "y": 3,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -34,
+          "y": 3,
+          "details": "river surf=6 (terr=1) -> water nbr surf=4 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -31,
+          "y": -10,
+          "details": "river surf=6 (terr=0) -> water nbr surf=1 (terr=2) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -31,
+          "y": -10,
+          "details": "river surf=6 (terr=2) -> water nbr surf=1 (terr=0) surf_diff=5 terr_diff=2"
         },
         {
           "x": -31,
@@ -1590,14 +1405,144 @@
           "details": "river surf=102 (terr=99) -> water nbr surf=99 (terr=98) surf_diff=3 terr_diff=1"
         },
         {
+          "x": -30,
+          "y": -9,
+          "details": "river surf=6 (terr=0) -> water nbr surf=1 (terr=1) surf_diff=5 terr_diff=1"
+        },
+        {
+          "x": -30,
+          "y": -9,
+          "details": "river surf=6 (terr=1) -> water nbr surf=1 (terr=0) surf_diff=5 terr_diff=1"
+        },
+        {
           "x": -29,
-          "y": 18,
-          "details": "river surf=114 (terr=111) -> water nbr surf=111 (terr=110) surf_diff=3 terr_diff=1"
+          "y": -8,
+          "details": "river surf=6 (terr=0) -> water nbr surf=1 (terr=1) surf_diff=5 terr_diff=1"
+        },
+        {
+          "x": -29,
+          "y": -8,
+          "details": "river surf=6 (terr=1) -> water nbr surf=1 (terr=0) surf_diff=5 terr_diff=1"
+        },
+        {
+          "x": -29,
+          "y": 20,
+          "details": "river surf=110 (terr=106) -> water nbr surf=106 (terr=104) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -29,
+          "y": 65,
+          "details": "river surf=27 (terr=20) -> water nbr surf=24 (terr=19) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -28,
+          "y": -7,
+          "details": "river surf=6 (terr=0) -> water nbr surf=1 (terr=1) surf_diff=5 terr_diff=1"
+        },
+        {
+          "x": -28,
+          "y": -7,
+          "details": "river surf=6 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=4 terr_diff=0"
+        },
+        {
+          "x": -28,
+          "y": 65,
+          "details": "river surf=24 (terr=19) -> water nbr surf=21 (terr=18) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -27,
+          "y": -6,
+          "details": "river surf=6 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=4 terr_diff=0"
+        },
+        {
+          "x": -27,
+          "y": 69,
+          "details": "river surf=23 (terr=20) -> water nbr surf=20 (terr=19) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -26,
+          "y": -7,
+          "details": "river surf=4 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -26,
+          "y": -7,
+          "details": "river surf=4 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -25,
+          "y": 61,
+          "details": "river surf=25 (terr=20) -> water nbr surf=22 (terr=19) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -24,
+          "y": 60,
+          "details": "river surf=28 (terr=22) -> water nbr surf=25 (terr=21) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -21,
+          "y": 61,
+          "details": "river surf=27 (terr=24) -> water nbr surf=25 (terr=24) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -20,
+          "y": 58,
+          "details": "river surf=33 (terr=28) -> water nbr surf=31 (terr=28) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -20,
+          "y": 59,
+          "details": "river surf=31 (terr=28) -> water nbr surf=28 (terr=27) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -19,
+          "y": 56,
+          "details": "river surf=37 (terr=32) -> water nbr surf=35 (terr=32) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -18,
+          "y": 50,
+          "details": "river surf=49 (terr=44) -> water nbr surf=47 (terr=44) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -18,
+          "y": 54,
+          "details": "river surf=40 (terr=37) -> water nbr surf=38 (terr=37) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -17,
+          "y": 51,
+          "details": "river surf=46 (terr=43) -> water nbr surf=44 (terr=43) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -15,
+          "y": 44,
+          "details": "river surf=58 (terr=53) -> water nbr surf=56 (terr=53) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -14,
+          "y": 43,
+          "details": "river surf=60 (terr=55) -> water nbr surf=58 (terr=55) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -13,
+          "y": -5,
+          "details": "river surf=80 (terr=75) -> water nbr surf=77 (terr=76) surf_diff=3 terr_diff=1"
         },
         {
           "x": -12,
           "y": -14,
           "details": "river surf=41 (terr=38) -> water nbr surf=39 (terr=38) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -12,
+          "y": -5,
+          "details": "river surf=77 (terr=71) -> water nbr surf=74 (terr=72) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -12,
+          "y": 42,
+          "details": "river surf=63 (terr=58) -> water nbr surf=60 (terr=59) surf_diff=3 terr_diff=1"
         },
         {
           "x": -11,
@@ -1608,6 +1553,181 @@
           "x": -11,
           "y": -15,
           "details": "river surf=42 (terr=39) -> water nbr surf=39 (terr=38) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -11,
+          "y": -9,
+          "details": "river surf=61 (terr=57) -> water nbr surf=58 (terr=56) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -11,
+          "y": -7,
+          "details": "river surf=72 (terr=66) -> water nbr surf=69 (terr=67) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -11,
+          "y": 42,
+          "details": "river surf=63 (terr=58) -> water nbr surf=60 (terr=59) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -10,
+          "y": -7,
+          "details": "river surf=72 (terr=65) -> water nbr surf=69 (terr=66) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -10,
+          "y": 42,
+          "details": "river surf=65 (terr=60) -> water nbr surf=62 (terr=59) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -10,
+          "y": 43,
+          "details": "river surf=62 (terr=59) -> water nbr surf=60 (terr=59) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -10,
+          "y": 43,
+          "details": "river surf=62 (terr=59) -> water nbr surf=59 (terr=58) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -9,
+          "y": -12,
+          "details": "river surf=54 (terr=49) -> water nbr surf=50 (terr=47) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -9,
+          "y": 41,
+          "details": "river surf=68 (terr=62) -> water nbr surf=65 (terr=61) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -9,
+          "y": 42,
+          "details": "river surf=65 (terr=61) -> water nbr surf=62 (terr=60) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -8,
+          "y": 28,
+          "details": "river surf=66 (terr=60) -> water nbr surf=63 (terr=59) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -8,
+          "y": 32,
+          "details": "river surf=64 (terr=58) -> water nbr surf=61 (terr=59) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -7,
+          "y": 27,
+          "details": "river surf=69 (terr=63) -> water nbr surf=66 (terr=62) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -7,
+          "y": 29,
+          "details": "river surf=63 (terr=60) -> water nbr surf=61 (terr=60) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -6,
+          "y": 29,
+          "details": "river surf=64 (terr=61) -> water nbr surf=61 (terr=60) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -5,
+          "y": 28,
+          "details": "river surf=68 (terr=63) -> water nbr surf=64 (terr=61) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -5,
+          "y": 30,
+          "details": "river surf=63 (terr=60) -> water nbr surf=61 (terr=60) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 0,
+          "y": 37,
+          "details": "river surf=60 (terr=55) -> water nbr surf=58 (terr=55) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 0,
+          "y": 47,
+          "details": "river surf=25 (terr=22) -> water nbr surf=23 (terr=22) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 3,
+          "y": -9,
+          "details": "river surf=137 (terr=132) -> water nbr surf=134 (terr=131) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 3,
+          "y": -8,
+          "details": "river surf=138 (terr=135) -> water nbr surf=135 (terr=134) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 4,
+          "y": -8,
+          "details": "river surf=141 (terr=136) -> water nbr surf=138 (terr=135) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 5,
+          "y": -8,
+          "details": "river surf=144 (terr=137) -> water nbr surf=141 (terr=136) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 19,
+          "y": 29,
+          "details": "river surf=25 (terr=17) -> water nbr surf=21 (terr=15) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 19,
+          "y": 32,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 20,
+          "y": 33,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 20,
+          "y": 33,
+          "details": "river surf=5 (terr=1) -> water nbr surf=1 (terr=0) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": 21,
+          "y": 29,
+          "details": "river surf=18 (terr=13) -> water nbr surf=14 (terr=11) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 21,
+          "y": 30,
+          "details": "river surf=14 (terr=11) -> water nbr surf=11 (terr=10) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 22,
+          "y": 28,
+          "details": "river surf=21 (terr=16) -> water nbr surf=18 (terr=15) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 22,
+          "y": 29,
+          "details": "river surf=18 (terr=15) -> water nbr surf=14 (terr=13) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 23,
+          "y": 28,
+          "details": "river surf=20 (terr=16) -> water nbr surf=17 (terr=16) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 24,
+          "y": 28,
+          "details": "river surf=19 (terr=15) -> water nbr surf=16 (terr=15) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 25,
+          "y": 28,
+          "details": "river surf=19 (terr=15) -> water nbr surf=15 (terr=14) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": 26,
+          "y": 28,
+          "details": "river surf=18 (terr=15) -> water nbr surf=15 (terr=14) surf_diff=3 terr_diff=1"
         }
       ],
       "MULTI_ISLAND": [
@@ -1731,22 +1851,37 @@
         {
           "x": -25,
           "y": 32,
-          "details": "river surf=115 -> dry(-25,31) terr=111"
+          "details": "river surf=115 -> dry(-25,31) terr=106"
+        },
+        {
+          "x": -20,
+          "y": 32,
+          "details": "river surf=168 -> dry(-20,31) terr=167"
         },
         {
           "x": -17,
           "y": 24,
-          "details": "river surf=328 -> dry(-16,24) terr=300"
+          "details": "river surf=328 -> dry(-16,24) terr=295"
         },
         {
           "x": -17,
           "y": 28,
-          "details": "river surf=193 -> dry(-16,28) terr=183"
+          "details": "river surf=193 -> dry(-16,28) terr=179"
         },
         {
           "x": -17,
           "y": 29,
-          "details": "river surf=181 -> dry(-16,29) terr=155"
+          "details": "river surf=181 -> dry(-16,29) terr=151"
+        },
+        {
+          "x": -16,
+          "y": 14,
+          "details": "river surf=220 -> dry(-17,14) terr=218"
+        },
+        {
+          "x": -11,
+          "y": 32,
+          "details": "river surf=91 -> dry(-11,31) terr=90"
         },
         {
           "x": -10,
@@ -1769,6 +1904,16 @@
           "details": "river surf=60 -> dry(-1,37) terr=59"
         },
         {
+          "x": 15,
+          "y": 30,
+          "details": "river surf=54 -> dry(16,30) terr=52"
+        },
+        {
+          "x": 21,
+          "y": 16,
+          "details": "river surf=134 -> dry(21,15) terr=132"
+        },
+        {
           "x": 30,
           "y": 31,
           "details": "river surf=8 -> dry(30,32) terr=7"
@@ -1783,7 +1928,7 @@
         {
           "x": -63,
           "y": 42,
-          "details": "river surf=121 terr=120 -> land(-62,42) terr=119 cliff=2"
+          "details": "river surf=121 terr=117 -> land(-62,42) terr=119 cliff=2"
         },
         {
           "x": -63,
@@ -1813,7 +1958,7 @@
         {
           "x": -60,
           "y": 44,
-          "details": "river surf=116 terr=115 -> land(-60,43) terr=110 cliff=6"
+          "details": "river surf=116 terr=112 -> land(-60,43) terr=110 cliff=6"
         },
         {
           "x": -60,
@@ -1828,37 +1973,37 @@
         {
           "x": -59,
           "y": 34,
-          "details": "river surf=44 terr=43 -> land(-59,33) terr=39 cliff=5"
+          "details": "river surf=44 terr=40 -> land(-59,33) terr=39 cliff=5"
         },
         {
           "x": -59,
           "y": 42,
-          "details": "river surf=100 terr=99 -> land(-59,41) terr=96 cliff=4"
+          "details": "river surf=100 terr=96 -> land(-59,41) terr=96 cliff=4"
         },
         {
           "x": -59,
           "y": 59,
-          "details": "river surf=186 terr=185 -> land(-58,59) terr=184 cliff=2"
+          "details": "river surf=186 terr=182 -> land(-58,59) terr=184 cliff=2"
         },
         {
           "x": -58,
           "y": 29,
-          "details": "river surf=18 terr=15 -> land(-58,28) terr=6 cliff=12"
+          "details": "river surf=18 terr=12 -> land(-58,28) terr=6 cliff=12"
         },
         {
           "x": -58,
           "y": 33,
-          "details": "river surf=44 terr=43 -> land(-59,33) terr=39 cliff=5"
+          "details": "river surf=44 terr=41 -> land(-59,33) terr=39 cliff=5"
         },
         {
           "x": -58,
           "y": 41,
-          "details": "river surf=91 terr=90 -> land(-58,40) terr=88 cliff=3"
+          "details": "river surf=91 terr=88 -> land(-58,40) terr=88 cliff=3"
         },
         {
           "x": -58,
           "y": 49,
-          "details": "river surf=143 terr=142 -> land(-57,49) terr=141 cliff=2"
+          "details": "river surf=143 terr=141 -> land(-57,49) terr=141 cliff=2"
         },
         {
           "x": -58,
@@ -1868,7 +2013,7 @@
         {
           "x": -57,
           "y": 28,
-          "details": "river surf=34 terr=31 -> land(-58,28) terr=6 cliff=28"
+          "details": "river surf=34 terr=27 -> land(-58,28) terr=6 cliff=28"
         },
         {
           "x": -57,
@@ -1898,7 +2043,7 @@
         {
           "x": -56,
           "y": 68,
-          "details": "river surf=219 terr=218 -> land(-56,67) terr=216 cliff=3"
+          "details": "river surf=219 terr=217 -> land(-56,67) terr=216 cliff=3"
         },
         {
           "x": -55,
@@ -1968,22 +2113,22 @@
         {
           "x": -52,
           "y": 48,
-          "details": "river surf=123 terr=122 -> land(-51,48) terr=118 cliff=5"
+          "details": "river surf=123 terr=119 -> land(-51,48) terr=118 cliff=5"
         },
         {
           "x": -52,
           "y": 49,
-          "details": "river surf=135 terr=134 -> land(-51,49) terr=133 cliff=2"
+          "details": "river surf=135 terr=132 -> land(-51,49) terr=133 cliff=2"
         },
         {
           "x": -52,
           "y": 50,
-          "details": "river surf=147 terr=146 -> land(-51,50) terr=145 cliff=2"
+          "details": "river surf=147 terr=145 -> land(-51,50) terr=145 cliff=2"
         },
         {
           "x": -51,
           "y": 47,
-          "details": "river surf=105 terr=104 -> land(-50,47) terr=95 cliff=10"
+          "details": "river surf=105 terr=100 -> land(-50,47) terr=95 cliff=10"
         },
         {
           "x": -51,
@@ -2008,7 +2153,7 @@
         {
           "x": -50,
           "y": 45,
-          "details": "river surf=77 terr=76 -> land(-50,44) terr=69 cliff=8"
+          "details": "river surf=77 terr=72 -> land(-50,44) terr=69 cliff=8"
         },
         {
           "x": -50,
@@ -2018,7 +2163,7 @@
         {
           "x": -49,
           "y": 45,
-          "details": "river surf=65 terr=64 -> land(-49,44) terr=57 cliff=8"
+          "details": "river surf=65 terr=59 -> land(-49,44) terr=57 cliff=8"
         },
         {
           "x": -49,
@@ -2043,7 +2188,7 @@
         {
           "x": -48,
           "y": 51,
-          "details": "river surf=114 terr=113 -> land(-48,50) terr=107 cliff=7"
+          "details": "river surf=114 terr=109 -> land(-48,50) terr=107 cliff=7"
         },
         {
           "x": -48,
@@ -2058,12 +2203,12 @@
         {
           "x": -47,
           "y": 48,
-          "details": "river surf=73 terr=72 -> land(-47,47) terr=66 cliff=7"
+          "details": "river surf=73 terr=67 -> land(-47,47) terr=66 cliff=7"
         },
         {
           "x": -47,
           "y": 59,
-          "details": "river surf=141 terr=140 -> land(-46,59) terr=138 cliff=3"
+          "details": "river surf=141 terr=138 -> land(-46,59) terr=138 cliff=3"
         },
         {
           "x": -47,
@@ -2083,27 +2228,37 @@
         {
           "x": -45,
           "y": 49,
-          "details": "river surf=73 terr=72 -> land(-44,49) terr=70 cliff=3"
+          "details": "river surf=73 terr=68 -> land(-44,49) terr=70 cliff=3"
         },
         {
           "x": -45,
           "y": 50,
-          "details": "river surf=84 terr=83 -> land(-44,50) terr=80 cliff=4"
+          "details": "river surf=84 terr=80 -> land(-44,50) terr=80 cliff=4"
         },
         {
           "x": -45,
           "y": 51,
-          "details": "river surf=89 terr=88 -> land(-44,51) terr=85 cliff=4"
+          "details": "river surf=89 terr=86 -> land(-44,51) terr=85 cliff=4"
         },
         {
           "x": -45,
           "y": 63,
-          "details": "river surf=170 terr=169 -> land(-45,62) terr=166 cliff=4"
+          "details": "river surf=170 terr=168 -> land(-45,62) terr=166 cliff=4"
+        },
+        {
+          "x": -45,
+          "y": 74,
+          "details": "river surf=89 terr=83 -> land(-45,75) terr=87 cliff=2"
         },
         {
           "x": -44,
           "y": 63,
-          "details": "river surf=163 terr=162 -> land(-44,62) terr=158 cliff=5"
+          "details": "river surf=163 terr=161 -> land(-44,62) terr=158 cliff=5"
+        },
+        {
+          "x": -44,
+          "y": 75,
+          "details": "river surf=65 terr=59 -> land(-44,76) terr=62 cliff=3"
         },
         {
           "x": -43,
@@ -2113,7 +2268,7 @@
         {
           "x": -43,
           "y": 63,
-          "details": "river surf=155 terr=154 -> land(-43,62) terr=151 cliff=4"
+          "details": "river surf=155 terr=152 -> land(-43,62) terr=151 cliff=4"
         },
         {
           "x": -42,
@@ -2123,7 +2278,7 @@
         {
           "x": -42,
           "y": 63,
-          "details": "river surf=147 terr=146 -> land(-42,62) terr=142 cliff=5"
+          "details": "river surf=147 terr=143 -> land(-42,62) terr=142 cliff=5"
         },
         {
           "x": -41,
@@ -2138,7 +2293,7 @@
         {
           "x": -41,
           "y": 63,
-          "details": "river surf=140 terr=139 -> land(-41,62) terr=135 cliff=5"
+          "details": "river surf=140 terr=137 -> land(-41,62) terr=135 cliff=5"
         },
         {
           "x": -40,
@@ -2153,7 +2308,7 @@
         {
           "x": -40,
           "y": 63,
-          "details": "river surf=134 terr=133 -> land(-40,62) terr=129 cliff=5"
+          "details": "river surf=134 terr=131 -> land(-40,62) terr=129 cliff=5"
         },
         {
           "x": -39,
@@ -2163,37 +2318,37 @@
         {
           "x": -39,
           "y": -2,
-          "details": "river surf=28 terr=27 -> land(-39,-1) terr=23 cliff=5"
+          "details": "river surf=28 terr=26 -> land(-39,-1) terr=23 cliff=5"
         },
         {
           "x": -39,
           "y": 16,
-          "details": "river surf=18 terr=17 -> land(-40,16) terr=6 cliff=12"
+          "details": "river surf=18 terr=10 -> land(-40,16) terr=6 cliff=12"
         },
         {
           "x": -39,
           "y": 19,
-          "details": "river surf=54 terr=53 -> land(-40,19) terr=46 cliff=8"
+          "details": "river surf=54 terr=48 -> land(-40,19) terr=46 cliff=8"
         },
         {
           "x": -39,
           "y": 20,
-          "details": "river surf=46 terr=45 -> land(-40,20) terr=43 cliff=3"
+          "details": "river surf=46 terr=39 -> land(-40,20) terr=43 cliff=3"
         },
         {
           "x": -39,
           "y": 21,
-          "details": "river surf=43 terr=42 -> land(-40,21) terr=40 cliff=3"
+          "details": "river surf=43 terr=36 -> land(-40,21) terr=40 cliff=3"
         },
         {
           "x": -39,
           "y": 58,
-          "details": "river surf=85 terr=84 -> land(-38,58) terr=83 cliff=2"
+          "details": "river surf=85 terr=78 -> land(-38,58) terr=83 cliff=2"
         },
         {
           "x": -39,
           "y": 63,
-          "details": "river surf=126 terr=125 -> land(-39,62) terr=122 cliff=4"
+          "details": "river surf=126 terr=123 -> land(-39,62) terr=122 cliff=4"
         },
         {
           "x": -38,
@@ -2203,17 +2358,17 @@
         {
           "x": -38,
           "y": -4,
-          "details": "river surf=39 terr=38 -> land(-38,-5) terr=36 cliff=3"
+          "details": "river surf=39 terr=37 -> land(-38,-5) terr=36 cliff=3"
         },
         {
           "x": -38,
           "y": -2,
-          "details": "river surf=36 terr=35 -> land(-38,-1) terr=31 cliff=5"
+          "details": "river surf=36 terr=34 -> land(-38,-1) terr=31 cliff=5"
         },
         {
           "x": -38,
           "y": 63,
-          "details": "river surf=117 terr=116 -> land(-38,62) terr=115 cliff=2"
+          "details": "river surf=117 terr=113 -> land(-38,62) terr=115 cliff=2"
         },
         {
           "x": -37,
@@ -2228,7 +2383,7 @@
         {
           "x": -37,
           "y": 63,
-          "details": "river surf=107 terr=106 -> land(-37,62) terr=104 cliff=3"
+          "details": "river surf=107 terr=103 -> land(-37,62) terr=104 cliff=3"
         },
         {
           "x": -36,
@@ -2238,237 +2393,412 @@
         {
           "x": -35,
           "y": -9,
-          "details": "river surf=23 terr=22 -> land(-36,-9) terr=21 cliff=2"
+          "details": "river surf=23 terr=21 -> land(-36,-9) terr=21 cliff=2"
         },
         {
           "x": -35,
           "y": -1,
-          "details": "river surf=54 terr=53 -> land(-35,0) terr=49 cliff=5"
+          "details": "river surf=54 terr=52 -> land(-35,0) terr=49 cliff=5"
+        },
+        {
+          "x": -35,
+          "y": 15,
+          "details": "river surf=54 terr=46 -> land(-35,14) terr=49 cliff=5"
+        },
+        {
+          "x": -35,
+          "y": 66,
+          "details": "river surf=88 terr=82 -> land(-35,67) terr=86 cliff=2"
         },
         {
           "x": -34,
           "y": -8,
-          "details": "river surf=34 terr=33 -> land(-35,-8) terr=32 cliff=2"
+          "details": "river surf=34 terr=30 -> land(-35,-8) terr=32 cliff=2"
         },
         {
           "x": -34,
           "y": -7,
-          "details": "river surf=45 terr=44 -> land(-35,-7) terr=42 cliff=3"
+          "details": "river surf=45 terr=41 -> land(-35,-7) terr=42 cliff=3"
+        },
+        {
+          "x": -34,
+          "y": 13,
+          "details": "river surf=42 terr=34 -> land(-35,13) terr=37 cliff=5"
+        },
+        {
+          "x": -34,
+          "y": 14,
+          "details": "river surf=54 terr=48 -> land(-35,14) terr=49 cliff=5"
         },
         {
           "x": -34,
           "y": 64,
-          "details": "river surf=82 terr=81 -> land(-33,64) terr=77 cliff=5"
+          "details": "river surf=82 terr=77 -> land(-33,64) terr=77 cliff=5"
         },
         {
           "x": -34,
           "y": 65,
-          "details": "river surf=90 terr=89 -> land(-33,65) terr=83 cliff=7"
+          "details": "river surf=90 terr=85 -> land(-33,65) terr=83 cliff=7"
+        },
+        {
+          "x": -33,
+          "y": 22,
+          "details": "river surf=82 terr=79 -> land(-33,23) terr=79 cliff=3"
         },
         {
           "x": -32,
           "y": -10,
-          "details": "river surf=12 terr=11 -> land(-32,-11) terr=8 cliff=4"
+          "details": "river surf=12 terr=8 -> land(-32,-11) terr=8 cliff=4"
+        },
+        {
+          "x": -32,
+          "y": 61,
+          "details": "river surf=65 terr=60 -> land(-31,61) terr=62 cliff=3"
         },
         {
           "x": -32,
           "y": 63,
-          "details": "lake surf=76 terr=75 -> land(-31,63) terr=68 cliff=8"
+          "details": "lake surf=76 terr=74 -> land(-31,63) terr=62 cliff=14"
+        },
+        {
+          "x": -31,
+          "y": 1,
+          "details": "river surf=54 terr=48 -> land(-31,2) terr=52 cliff=2"
+        },
+        {
+          "x": -30,
+          "y": 12,
+          "details": "river surf=78 terr=72 -> land(-30,11) terr=75 cliff=3"
         },
         {
           "x": -30,
           "y": 33,
-          "details": "river surf=72 terr=71 -> land(-31,33) terr=48 cliff=24"
+          "details": "river surf=72 terr=67 -> land(-31,33) terr=48 cliff=24"
+        },
+        {
+          "x": -29,
+          "y": 4,
+          "details": "river surf=42 terr=36 -> land(-30,4) terr=40 cliff=2"
+        },
+        {
+          "x": -29,
+          "y": 10,
+          "details": "river surf=66 terr=59 -> land(-29,9) terr=63 cliff=3"
+        },
+        {
+          "x": -29,
+          "y": 13,
+          "details": "river surf=102 terr=96 -> land(-29,12) terr=100 cliff=2"
+        },
+        {
+          "x": -29,
+          "y": 24,
+          "details": "river surf=85 terr=79 -> land(-29,25) terr=83 cliff=2"
         },
         {
           "x": -29,
           "y": 32,
-          "details": "river surf=57 terr=56 -> land(-30,32) terr=48 cliff=9"
+          "details": "river surf=57 terr=51 -> land(-30,32) terr=48 cliff=9"
         },
         {
           "x": -29,
           "y": 68,
-          "details": "river surf=38 terr=37 -> land(-28,68) terr=26 cliff=12"
+          "details": "river surf=38 terr=32 -> land(-28,68) terr=26 cliff=12"
+        },
+        {
+          "x": -28,
+          "y": 14,
+          "details": "river surf=126 terr=120 -> land(-28,13) terr=124 cliff=2"
+        },
+        {
+          "x": -28,
+          "y": 33,
+          "details": "river surf=81 terr=75 -> land(-28,32) terr=79 cliff=2"
+        },
+        {
+          "x": -28,
+          "y": 34,
+          "details": "river surf=93 terr=87 -> land(-29,34) terr=91 cliff=2"
         },
         {
           "x": -28,
           "y": 69,
-          "details": "river surf=32 terr=31 -> land(-28,68) terr=26 cliff=6"
+          "details": "river surf=32 terr=28 -> land(-28,68) terr=26 cliff=6"
         },
         {
           "x": -27,
           "y": 13,
-          "details": "river surf=136 terr=133 -> land(-28,13) terr=127 cliff=9"
+          "details": "river surf=136 terr=129 -> land(-28,13) terr=124 cliff=12"
         },
         {
           "x": -25,
           "y": 16,
-          "details": "river surf=142 terr=141 -> land(-26,16) terr=139 cliff=3"
+          "details": "river surf=142 terr=136 -> land(-26,16) terr=139 cliff=3"
         },
         {
           "x": -25,
           "y": 32,
-          "details": "river surf=115 terr=114 -> land(-25,31) terr=111 cliff=4"
+          "details": "river surf=115 terr=110 -> land(-25,31) terr=106 cliff=9"
+        },
+        {
+          "x": -24,
+          "y": -2,
+          "details": "river surf=54 terr=48 -> land(-25,-2) terr=52 cliff=2"
+        },
+        {
+          "x": -24,
+          "y": 31,
+          "details": "river surf=108 terr=102 -> land(-25,31) terr=106 cliff=2"
         },
         {
           "x": -24,
           "y": 59,
-          "details": "river surf=40 terr=39 -> land(-23,59) terr=29 cliff=11"
+          "details": "river surf=40 terr=34 -> land(-23,59) terr=29 cliff=11"
         },
         {
           "x": -24,
           "y": 60,
-          "details": "river surf=28 terr=27 -> land(-23,60) terr=26 cliff=2"
+          "details": "river surf=28 terr=22 -> land(-23,60) terr=26 cliff=2"
+        },
+        {
+          "x": -23,
+          "y": 0,
+          "details": "river surf=90 terr=84 -> land(-24,0) terr=88 cliff=2"
         },
         {
           "x": -23,
           "y": 6,
-          "details": "river surf=173 terr=137 -> land(-24,6) terr=109 cliff=64"
+          "details": "river surf=173 terr=131 -> land(-24,6) terr=103 cliff=70"
         },
         {
           "x": -23,
           "y": 7,
-          "details": "river surf=161 terr=160 -> land(-24,7) terr=137 cliff=24"
+          "details": "river surf=161 terr=154 -> land(-24,7) terr=131 cliff=30"
         },
         {
           "x": -23,
           "y": 42,
-          "details": "river surf=143 terr=142 -> land(-23,43) terr=141 cliff=2"
+          "details": "river surf=143 terr=137 -> land(-23,43) terr=141 cliff=2"
         },
         {
           "x": -22,
           "y": 43,
-          "details": "river surf=125 terr=124 -> land(-22,44) terr=120 cliff=5"
+          "details": "river surf=125 terr=119 -> land(-22,44) terr=120 cliff=5"
+        },
+        {
+          "x": -21,
+          "y": 26,
+          "details": "river surf=154 terr=147 -> land(-21,27) terr=151 cliff=3"
         },
         {
           "x": -21,
           "y": 45,
-          "details": "river surf=91 terr=90 -> land(-21,46) terr=84 cliff=7"
+          "details": "river surf=91 terr=85 -> land(-21,46) terr=84 cliff=7"
         },
         {
           "x": -21,
           "y": 55,
-          "details": "river surf=43 terr=42 -> land(-21,56) terr=40 cliff=3"
+          "details": "river surf=43 terr=37 -> land(-21,56) terr=40 cliff=3"
         },
         {
           "x": -21,
           "y": 57,
-          "details": "river surf=37 terr=36 -> land(-21,58) terr=35 cliff=2"
+          "details": "river surf=37 terr=30 -> land(-21,58) terr=35 cliff=2"
         },
         {
           "x": -21,
           "y": 61,
-          "details": "river surf=27 terr=26 -> land(-21,62) terr=25 cliff=2"
+          "details": "river surf=27 terr=24 -> land(-21,62) terr=25 cliff=2"
+        },
+        {
+          "x": -20,
+          "y": -1,
+          "details": "river surf=114 terr=108 -> land(-20,-2) terr=112 cliff=2"
+        },
+        {
+          "x": -20,
+          "y": 17,
+          "details": "river surf=208 terr=202 -> land(-21,17) terr=206 cliff=2"
         },
         {
           "x": -20,
           "y": 52,
-          "details": "river surf=49 terr=48 -> land(-20,53) terr=47 cliff=2"
+          "details": "river surf=49 terr=42 -> land(-20,53) terr=47 cliff=2"
         },
         {
           "x": -20,
           "y": 54,
-          "details": "river surf=43 terr=42 -> land(-19,54) terr=41 cliff=2"
+          "details": "river surf=43 terr=36 -> land(-19,54) terr=41 cliff=2"
         },
         {
           "x": -20,
           "y": 55,
-          "details": "river surf=40 terr=39 -> land(-19,55) terr=38 cliff=2"
+          "details": "river surf=40 terr=34 -> land(-19,55) terr=38 cliff=2"
         },
         {
           "x": -19,
           "y": 12,
-          "details": "river surf=162 terr=160 -> land(-19,11) terr=153 cliff=9"
+          "details": "river surf=162 terr=154 -> land(-19,11) terr=153 cliff=9"
+        },
+        {
+          "x": -19,
+          "y": 20,
+          "details": "river surf=256 terr=250 -> land(-20,20) terr=254 cliff=2"
+        },
+        {
+          "x": -19,
+          "y": 42,
+          "details": "river surf=103 terr=97 -> land(-18,42) terr=101 cliff=2"
         },
         {
           "x": -19,
           "y": 46,
-          "details": "river surf=78 terr=76 -> land(-18,46) terr=76 cliff=2"
+          "details": "river surf=78 terr=75 -> land(-18,46) terr=76 cliff=2"
         },
         {
           "x": -19,
           "y": 52,
-          "details": "river surf=46 terr=45 -> land(-19,53) terr=44 cliff=2"
+          "details": "river surf=46 terr=40 -> land(-19,53) terr=44 cliff=2"
         },
         {
           "x": -19,
           "y": 56,
-          "details": "river surf=37 terr=36 -> land(-19,57) terr=35 cliff=2"
+          "details": "river surf=37 terr=32 -> land(-19,57) terr=35 cliff=2"
         },
         {
           "x": -18,
           "y": 12,
-          "details": "river surf=173 terr=172 -> land(-18,11) terr=163 cliff=10"
+          "details": "river surf=173 terr=166 -> land(-18,11) terr=163 cliff=10"
+        },
+        {
+          "x": -18,
+          "y": 22,
+          "details": "river surf=292 terr=286 -> land(-19,22) terr=290 cliff=2"
         },
         {
           "x": -18,
           "y": 23,
-          "details": "river surf=304 terr=303 -> land(-19,23) terr=274 cliff=30"
+          "details": "river surf=304 terr=298 -> land(-19,23) terr=268 cliff=36"
         },
         {
           "x": -18,
           "y": 24,
-          "details": "river surf=316 terr=292 -> land(-19,24) terr=265 cliff=51"
+          "details": "river surf=316 terr=288 -> land(-19,24) terr=259 cliff=57"
+        },
+        {
+          "x": -18,
+          "y": 38,
+          "details": "river surf=136 terr=130 -> land(-17,38) terr=133 cliff=3"
         },
         {
           "x": -18,
           "y": 43,
-          "details": "river surf=79 terr=78 -> land(-18,44) terr=67 cliff=12"
+          "details": "river surf=79 terr=73 -> land(-18,44) terr=67 cliff=12"
         },
         {
           "x": -18,
           "y": 48,
-          "details": "river surf=58 terr=55 -> land(-18,49) terr=52 cliff=6"
+          "details": "river surf=58 terr=54 -> land(-18,49) terr=52 cliff=6"
         },
         {
           "x": -18,
           "y": 54,
-          "details": "river surf=40 terr=39 -> land(-18,55) terr=38 cliff=2"
+          "details": "river surf=40 terr=37 -> land(-18,55) terr=38 cliff=2"
         },
         {
           "x": -17,
           "y": 10,
-          "details": "river surf=164 terr=163 -> land(-18,10) terr=154 cliff=10"
+          "details": "river surf=164 terr=157 -> land(-18,10) terr=154 cliff=10"
         },
         {
           "x": -17,
           "y": 12,
-          "details": "river surf=185 terr=184 -> land(-17,11) terr=174 cliff=11"
+          "details": "river surf=185 terr=178 -> land(-17,11) terr=174 cliff=11"
         },
         {
           "x": -17,
           "y": 24,
-          "details": "river surf=328 terr=272 -> land(-16,24) terr=300 cliff=28"
+          "details": "river surf=328 terr=267 -> land(-16,24) terr=295 cliff=33"
         },
         {
           "x": -17,
           "y": 28,
-          "details": "river surf=193 terr=192 -> land(-16,28) terr=183 cliff=10"
+          "details": "river surf=193 terr=188 -> land(-16,28) terr=179 cliff=14"
         },
         {
           "x": -17,
           "y": 29,
-          "details": "river surf=181 terr=180 -> land(-16,29) terr=155 cliff=26"
+          "details": "river surf=181 terr=176 -> land(-16,29) terr=151 cliff=30"
+        },
+        {
+          "x": -17,
+          "y": 35,
+          "details": "river surf=160 terr=154 -> land(-17,36) terr=157 cliff=3"
         },
         {
           "x": -17,
           "y": 43,
-          "details": "river surf=67 terr=66 -> land(-17,44) terr=64 cliff=3"
+          "details": "river surf=67 terr=61 -> land(-17,44) terr=64 cliff=3"
+        },
+        {
+          "x": -16,
+          "y": 12,
+          "details": "river surf=197 terr=190 -> land(-16,11) terr=195 cliff=2"
+        },
+        {
+          "x": -16,
+          "y": 14,
+          "details": "river surf=220 terr=214 -> land(-17,14) terr=218 cliff=2"
+        },
+        {
+          "x": -16,
+          "y": 34,
+          "details": "river surf=160 terr=154 -> land(-15,34) terr=157 cliff=3"
+        },
+        {
+          "x": -16,
+          "y": 39,
+          "details": "river surf=100 terr=93 -> land(-16,40) terr=97 cliff=3"
         },
         {
           "x": -16,
           "y": 44,
-          "details": "river surf=61 terr=60 -> land(-16,45) terr=58 cliff=3"
+          "details": "river surf=61 terr=56 -> land(-16,45) terr=58 cliff=3"
+        },
+        {
+          "x": -15,
+          "y": 2,
+          "details": "river surf=156 terr=149 -> land(-16,2) terr=154 cliff=2"
+        },
+        {
+          "x": -15,
+          "y": 12,
+          "details": "river surf=209 terr=202 -> land(-15,11) terr=207 cliff=2"
+        },
+        {
+          "x": -15,
+          "y": 15,
+          "details": "river surf=244 terr=238 -> land(-16,15) terr=242 cliff=2"
+        },
+        {
+          "x": -14,
+          "y": 12,
+          "details": "river surf=221 terr=214 -> land(-14,11) terr=219 cliff=2"
         },
         {
           "x": -14,
           "y": 18,
-          "details": "river surf=292 terr=291 -> land(-13,18) terr=267 cliff=25"
+          "details": "river surf=292 terr=286 -> land(-13,18) terr=261 cliff=31"
         },
         {
           "x": -14,
           "y": 19,
-          "details": "river surf=304 terr=299 -> land(-13,19) terr=271 cliff=33"
+          "details": "river surf=304 terr=293 -> land(-13,19) terr=265 cliff=39"
+        },
+        {
+          "x": -12,
+          "y": 26,
+          "details": "river surf=125 terr=118 -> land(-12,27) terr=123 cliff=2"
         },
         {
           "x": -12,
@@ -2483,12 +2813,27 @@
         {
           "x": -11,
           "y": 11,
-          "details": "lake surf=374 terr=261 -> land(-12,11) terr=249 cliff=125"
+          "details": "lake surf=374 terr=255 -> land(-12,11) terr=243 cliff=131"
         },
         {
           "x": -11,
           "y": 12,
-          "details": "lake surf=374 terr=289 -> land(-12,12) terr=276 cliff=98"
+          "details": "lake surf=374 terr=283 -> land(-12,12) terr=270 cliff=104"
+        },
+        {
+          "x": -11,
+          "y": 18,
+          "details": "river surf=212 terr=205 -> land(-11,19) terr=209 cliff=3"
+        },
+        {
+          "x": -11,
+          "y": 23,
+          "details": "river surf=149 terr=142 -> land(-11,24) terr=146 cliff=3"
+        },
+        {
+          "x": -11,
+          "y": 26,
+          "details": "river surf=113 terr=106 -> land(-11,27) terr=111 cliff=2"
         },
         {
           "x": -11,
@@ -2497,8 +2842,23 @@
         },
         {
           "x": -10,
+          "y": 7,
+          "details": "river surf=279 terr=272 -> land(-10,6) terr=276 cliff=3"
+        },
+        {
+          "x": -10,
+          "y": 18,
+          "details": "river surf=200 terr=193 -> land(-10,19) terr=197 cliff=3"
+        },
+        {
+          "x": -10,
+          "y": 20,
+          "details": "river surf=176 terr=169 -> land(-10,21) terr=170 cliff=6"
+        },
+        {
+          "x": -10,
           "y": 32,
-          "details": "river surf=79 terr=78 -> land(-10,31) terr=68 cliff=11"
+          "details": "river surf=79 terr=73 -> land(-10,31) terr=68 cliff=11"
         },
         {
           "x": -10,
@@ -2508,12 +2868,17 @@
         {
           "x": -9,
           "y": -16,
-          "details": "river surf=45 terr=44 -> land(-10,-16) terr=43 cliff=2"
+          "details": "river surf=45 terr=38 -> land(-10,-16) terr=43 cliff=2"
         },
         {
           "x": -9,
           "y": -15,
-          "details": "river surf=47 terr=46 -> land(-10,-15) terr=45 cliff=2"
+          "details": "river surf=47 terr=42 -> land(-10,-15) terr=45 cliff=2"
+        },
+        {
+          "x": -9,
+          "y": 6,
+          "details": "river surf=255 terr=248 -> land(-9,5) terr=252 cliff=3"
         },
         {
           "x": -9,
@@ -2521,49 +2886,79 @@
           "details": "river surf=29 terr=28 -> land(-9,54) terr=26 cliff=3"
         },
         {
+          "x": -8,
+          "y": 4,
+          "details": "river surf=219 terr=212 -> land(-8,3) terr=216 cliff=3"
+        },
+        {
+          "x": -7,
+          "y": -8,
+          "details": "river surf=106 terr=102 -> land(-8,-8) terr=104 cliff=2"
+        },
+        {
           "x": -7,
           "y": 15,
-          "details": "lake surf=349 terr=240 -> land(-8,15) terr=228 cliff=121"
+          "details": "lake surf=349 terr=234 -> land(-8,15) terr=222 cliff=127"
         },
         {
           "x": -7,
           "y": 18,
-          "details": "river surf=189 terr=188 -> land(-6,18) terr=182 cliff=7"
+          "details": "river surf=189 terr=182 -> land(-6,18) terr=176 cliff=13"
+        },
+        {
+          "x": -7,
+          "y": 21,
+          "details": "river surf=143 terr=136 -> land(-7,22) terr=140 cliff=3"
+        },
+        {
+          "x": -6,
+          "y": 4,
+          "details": "river surf=219 terr=212 -> land(-6,3) terr=216 cliff=3"
         },
         {
           "x": -5,
           "y": 7,
-          "details": "river surf=267 terr=266 -> land(-5,6) terr=255 cliff=12"
+          "details": "river surf=267 terr=260 -> land(-5,6) terr=249 cliff=18"
+        },
+        {
+          "x": -5,
+          "y": 21,
+          "details": "river surf=143 terr=137 -> land(-5,22) terr=140 cliff=3"
         },
         {
           "x": -5,
           "y": 47,
-          "details": "river surf=35 terr=34 -> land(-5,48) terr=32 cliff=3"
+          "details": "river surf=35 terr=33 -> land(-5,48) terr=32 cliff=3"
+        },
+        {
+          "x": -4,
+          "y": 20,
+          "details": "river surf=167 terr=161 -> land(-4,21) terr=165 cliff=2"
         },
         {
           "x": -4,
           "y": 28,
-          "details": "river surf=71 terr=70 -> land(-4,29) terr=69 cliff=2"
+          "details": "river surf=71 terr=66 -> land(-4,29) terr=69 cliff=2"
         },
         {
           "x": -4,
           "y": 30,
-          "details": "river surf=66 terr=65 -> land(-4,31) terr=64 cliff=2"
+          "details": "river surf=66 terr=62 -> land(-4,31) terr=64 cliff=2"
         },
         {
           "x": -4,
           "y": 47,
-          "details": "river surf=32 terr=31 -> land(-4,48) terr=29 cliff=3"
+          "details": "river surf=32 terr=29 -> land(-4,48) terr=29 cliff=3"
         },
         {
           "x": -3,
           "y": -5,
-          "details": "river surf=139 terr=138 -> land(-3,-6) terr=137 cliff=2"
+          "details": "river surf=139 terr=135 -> land(-3,-6) terr=137 cliff=2"
         },
         {
           "x": -3,
           "y": 30,
-          "details": "river surf=69 terr=68 -> land(-3,31) terr=67 cliff=2"
+          "details": "river surf=69 terr=64 -> land(-3,31) terr=67 cliff=2"
         },
         {
           "x": -2,
@@ -2573,7 +2968,7 @@
         {
           "x": -2,
           "y": 30,
-          "details": "river surf=81 terr=80 -> land(-2,31) terr=70 cliff=11"
+          "details": "river surf=81 terr=75 -> land(-2,31) terr=70 cliff=11"
         },
         {
           "x": -1,
@@ -2593,32 +2988,32 @@
         {
           "x": 0,
           "y": 43,
-          "details": "river surf=35 terr=34 -> land(1,43) terr=32 cliff=3"
+          "details": "river surf=35 terr=31 -> land(1,43) terr=32 cliff=3"
         },
         {
           "x": 0,
           "y": 44,
-          "details": "river surf=32 terr=31 -> land(1,44) terr=29 cliff=3"
+          "details": "river surf=32 terr=27 -> land(1,44) terr=29 cliff=3"
         },
         {
           "x": 0,
           "y": 45,
-          "details": "river surf=29 terr=28 -> land(1,45) terr=26 cliff=3"
+          "details": "river surf=29 terr=24 -> land(1,45) terr=26 cliff=3"
         },
         {
           "x": 1,
           "y": 37,
-          "details": "river surf=63 terr=62 -> land(1,38) terr=61 cliff=2"
+          "details": "river surf=63 terr=57 -> land(1,38) terr=61 cliff=2"
         },
         {
           "x": 2,
           "y": 37,
-          "details": "river surf=66 terr=65 -> land(2,38) terr=64 cliff=2"
+          "details": "river surf=66 terr=59 -> land(2,38) terr=64 cliff=2"
         },
         {
           "x": 3,
           "y": 37,
-          "details": "river surf=69 terr=68 -> land(3,38) terr=67 cliff=2"
+          "details": "river surf=69 terr=62 -> land(3,38) terr=67 cliff=2"
         },
         {
           "x": 4,
@@ -2631,49 +3026,149 @@
           "details": "river surf=105 terr=104 -> land(5,36) terr=102 cliff=3"
         },
         {
+          "x": 7,
+          "y": 35,
+          "details": "river surf=90 terr=85 -> land(8,35) terr=88 cliff=2"
+        },
+        {
+          "x": 8,
+          "y": 36,
+          "details": "river surf=66 terr=60 -> land(8,37) terr=64 cliff=2"
+        },
+        {
+          "x": 9,
+          "y": -8,
+          "details": "river surf=192 terr=185 -> land(9,-7) terr=189 cliff=3"
+        },
+        {
+          "x": 9,
+          "y": 37,
+          "details": "river surf=42 terr=36 -> land(10,37) terr=40 cliff=2"
+        },
+        {
           "x": 10,
           "y": 33,
-          "details": "river surf=69 terr=68 -> land(10,34) terr=67 cliff=2"
+          "details": "river surf=69 terr=62 -> land(10,34) terr=67 cliff=2"
+        },
+        {
+          "x": 10,
+          "y": 36,
+          "details": "river surf=42 terr=36 -> land(10,37) terr=40 cliff=2"
         },
         {
           "x": 11,
           "y": 33,
-          "details": "river surf=66 terr=65 -> land(11,34) terr=64 cliff=2"
+          "details": "river surf=66 terr=60 -> land(11,34) terr=64 cliff=2"
+        },
+        {
+          "x": 12,
+          "y": 33,
+          "details": "river surf=54 terr=48 -> land(12,34) terr=52 cliff=2"
         },
         {
           "x": 12,
           "y": 36,
-          "details": "river surf=18 terr=17 -> land(12,37) terr=6 cliff=12"
+          "details": "river surf=18 terr=12 -> land(12,37) terr=6 cliff=12"
         },
         {
           "x": 13,
           "y": 29,
-          "details": "river surf=70 terr=69 -> land(13,30) terr=67 cliff=3"
+          "details": "river surf=70 terr=63 -> land(13,30) terr=67 cliff=3"
+        },
+        {
+          "x": 13,
+          "y": 33,
+          "details": "river surf=42 terr=36 -> land(14,33) terr=40 cliff=2"
+        },
+        {
+          "x": 14,
+          "y": 32,
+          "details": "river surf=42 terr=36 -> land(14,33) terr=40 cliff=2"
+        },
+        {
+          "x": 15,
+          "y": 30,
+          "details": "river surf=54 terr=48 -> land(16,30) terr=52 cliff=2"
         },
         {
           "x": 16,
           "y": 32,
-          "details": "river surf=18 terr=17 -> land(16,33) terr=6 cliff=12"
+          "details": "river surf=18 terr=12 -> land(16,33) terr=6 cliff=12"
+        },
+        {
+          "x": 17,
+          "y": 18,
+          "details": "river surf=192 terr=186 -> land(17,19) terr=190 cliff=2"
         },
         {
           "x": 17,
           "y": 21,
-          "details": "river surf=156 terr=155 -> land(17,22) terr=139 cliff=17"
+          "details": "river surf=156 terr=150 -> land(17,22) terr=134 cliff=22"
+        },
+        {
+          "x": 17,
+          "y": 27,
+          "details": "river surf=64 terr=57 -> land(18,27) terr=61 cliff=3"
+        },
+        {
+          "x": 18,
+          "y": 17,
+          "details": "river surf=182 terr=176 -> land(18,16) terr=180 cliff=2"
+        },
+        {
+          "x": 19,
+          "y": 21,
+          "details": "river surf=132 terr=126 -> land(19,22) terr=126 cliff=6"
         },
         {
           "x": 20,
           "y": 21,
-          "details": "river surf=120 terr=119 -> land(20,22) terr=103 cliff=17"
+          "details": "river surf=120 terr=114 -> land(20,22) terr=98 cliff=22"
+        },
+        {
+          "x": 21,
+          "y": 16,
+          "details": "river surf=134 terr=128 -> land(21,15) terr=132 cliff=2"
+        },
+        {
+          "x": 21,
+          "y": 19,
+          "details": "river surf=132 terr=126 -> land(22,19) terr=130 cliff=2"
+        },
+        {
+          "x": 21,
+          "y": 21,
+          "details": "river surf=108 terr=102 -> land(21,22) terr=106 cliff=2"
+        },
+        {
+          "x": 24,
+          "y": 8,
+          "details": "river surf=98 terr=92 -> land(24,7) terr=96 cliff=2"
+        },
+        {
+          "x": 24,
+          "y": 17,
+          "details": "river surf=110 terr=104 -> land(25,17) terr=108 cliff=2"
+        },
+        {
+          "x": 26,
+          "y": 16,
+          "details": "river surf=74 terr=68 -> land(27,16) terr=72 cliff=2"
+        },
+        {
+          "x": 27,
+          "y": 8,
+          "details": "river surf=62 terr=56 -> land(28,8) terr=60 cliff=2"
         },
         {
           "x": 28,
           "y": 6,
-          "details": "river surf=38 terr=37 -> land(28,5) terr=27 cliff=11"
+          "details": "river surf=38 terr=32 -> land(28,5) terr=27 cliff=11"
         },
         {
           "x": 29,
           "y": 6,
-          "details": "river surf=26 terr=25 -> land(29,5) terr=24 cliff=2"
+          "details": "river surf=26 terr=20 -> land(29,5) terr=24 cliff=2"
         }
       ],
       "WATER_CLIFF": [
@@ -3003,9 +3498,19 @@
           "details": "river surf=170 -> dry(-45,62) terr=166 cliff=4"
         },
         {
+          "x": -45,
+          "y": 74,
+          "details": "river surf=89 -> dry(-45,75) terr=87 cliff=2"
+        },
+        {
           "x": -44,
           "y": 63,
           "details": "river surf=163 -> dry(-44,62) terr=158 cliff=5"
+        },
+        {
+          "x": -44,
+          "y": 75,
+          "details": "river surf=65 -> dry(-44,76) terr=62 cliff=3"
         },
         {
           "x": -43,
@@ -3148,6 +3653,16 @@
           "details": "river surf=54 -> dry(-35,0) terr=49 cliff=5"
         },
         {
+          "x": -35,
+          "y": 15,
+          "details": "river surf=54 -> dry(-35,14) terr=49 cliff=5"
+        },
+        {
+          "x": -35,
+          "y": 66,
+          "details": "river surf=88 -> dry(-35,67) terr=86 cliff=2"
+        },
+        {
           "x": -34,
           "y": -8,
           "details": "river surf=34 -> dry(-35,-8) terr=32 cliff=2"
@@ -3156,6 +3671,16 @@
           "x": -34,
           "y": -7,
           "details": "river surf=45 -> dry(-35,-7) terr=42 cliff=3"
+        },
+        {
+          "x": -34,
+          "y": 13,
+          "details": "river surf=42 -> dry(-35,13) terr=37 cliff=5"
+        },
+        {
+          "x": -34,
+          "y": 14,
+          "details": "river surf=54 -> dry(-35,14) terr=49 cliff=5"
         },
         {
           "x": -34,
@@ -3168,19 +3693,59 @@
           "details": "river surf=90 -> dry(-33,65) terr=83 cliff=7"
         },
         {
+          "x": -33,
+          "y": 22,
+          "details": "river surf=82 -> dry(-33,23) terr=79 cliff=3"
+        },
+        {
           "x": -32,
           "y": -10,
           "details": "river surf=12 -> dry(-32,-11) terr=8 cliff=4"
         },
         {
           "x": -32,
+          "y": 61,
+          "details": "river surf=65 -> dry(-31,61) terr=62 cliff=3"
+        },
+        {
+          "x": -32,
           "y": 63,
-          "details": "lake surf=76 -> dry(-31,63) terr=68 cliff=8"
+          "details": "lake surf=76 -> dry(-31,63) terr=62 cliff=14"
+        },
+        {
+          "x": -31,
+          "y": 1,
+          "details": "river surf=54 -> dry(-31,2) terr=52 cliff=2"
+        },
+        {
+          "x": -30,
+          "y": 12,
+          "details": "river surf=78 -> dry(-30,11) terr=75 cliff=3"
         },
         {
           "x": -30,
           "y": 33,
           "details": "river surf=72 -> dry(-31,33) terr=48 cliff=24"
+        },
+        {
+          "x": -29,
+          "y": 4,
+          "details": "river surf=42 -> dry(-30,4) terr=40 cliff=2"
+        },
+        {
+          "x": -29,
+          "y": 10,
+          "details": "river surf=66 -> dry(-29,9) terr=63 cliff=3"
+        },
+        {
+          "x": -29,
+          "y": 13,
+          "details": "river surf=102 -> dry(-29,12) terr=100 cliff=2"
+        },
+        {
+          "x": -29,
+          "y": 24,
+          "details": "river surf=85 -> dry(-29,25) terr=83 cliff=2"
         },
         {
           "x": -29,
@@ -3194,13 +3759,28 @@
         },
         {
           "x": -28,
+          "y": 14,
+          "details": "river surf=126 -> dry(-28,13) terr=124 cliff=2"
+        },
+        {
+          "x": -28,
+          "y": 33,
+          "details": "river surf=81 -> dry(-28,32) terr=79 cliff=2"
+        },
+        {
+          "x": -28,
+          "y": 34,
+          "details": "river surf=93 -> dry(-29,34) terr=91 cliff=2"
+        },
+        {
+          "x": -28,
           "y": 69,
           "details": "river surf=32 -> dry(-28,68) terr=26 cliff=6"
         },
         {
           "x": -27,
           "y": 13,
-          "details": "river surf=136 -> dry(-28,13) terr=127 cliff=9"
+          "details": "river surf=136 -> dry(-28,13) terr=124 cliff=12"
         },
         {
           "x": -25,
@@ -3210,7 +3790,17 @@
         {
           "x": -25,
           "y": 32,
-          "details": "river surf=115 -> dry(-25,31) terr=111 cliff=4"
+          "details": "river surf=115 -> dry(-25,31) terr=106 cliff=9"
+        },
+        {
+          "x": -24,
+          "y": -2,
+          "details": "river surf=54 -> dry(-25,-2) terr=52 cliff=2"
+        },
+        {
+          "x": -24,
+          "y": 31,
+          "details": "river surf=108 -> dry(-25,31) terr=106 cliff=2"
         },
         {
           "x": -24,
@@ -3224,13 +3814,18 @@
         },
         {
           "x": -23,
+          "y": 0,
+          "details": "river surf=90 -> dry(-24,0) terr=88 cliff=2"
+        },
+        {
+          "x": -23,
           "y": 6,
-          "details": "river surf=173 -> dry(-24,6) terr=109 cliff=64"
+          "details": "river surf=173 -> dry(-24,6) terr=103 cliff=70"
         },
         {
           "x": -23,
           "y": 7,
-          "details": "river surf=161 -> dry(-24,7) terr=137 cliff=24"
+          "details": "river surf=161 -> dry(-24,7) terr=131 cliff=30"
         },
         {
           "x": -23,
@@ -3241,6 +3836,11 @@
           "x": -22,
           "y": 43,
           "details": "river surf=125 -> dry(-22,44) terr=120 cliff=5"
+        },
+        {
+          "x": -21,
+          "y": 26,
+          "details": "river surf=154 -> dry(-21,27) terr=151 cliff=3"
         },
         {
           "x": -21,
@@ -3264,6 +3864,16 @@
         },
         {
           "x": -20,
+          "y": -1,
+          "details": "river surf=114 -> dry(-20,-2) terr=112 cliff=2"
+        },
+        {
+          "x": -20,
+          "y": 17,
+          "details": "river surf=208 -> dry(-21,17) terr=206 cliff=2"
+        },
+        {
+          "x": -20,
           "y": 52,
           "details": "river surf=49 -> dry(-20,53) terr=47 cliff=2"
         },
@@ -3281,6 +3891,16 @@
           "x": -19,
           "y": 12,
           "details": "river surf=162 -> dry(-19,11) terr=153 cliff=9"
+        },
+        {
+          "x": -19,
+          "y": 20,
+          "details": "river surf=256 -> dry(-20,20) terr=254 cliff=2"
+        },
+        {
+          "x": -19,
+          "y": 42,
+          "details": "river surf=103 -> dry(-18,42) terr=101 cliff=2"
         },
         {
           "x": -19,
@@ -3304,13 +3924,23 @@
         },
         {
           "x": -18,
+          "y": 22,
+          "details": "river surf=292 -> dry(-19,22) terr=290 cliff=2"
+        },
+        {
+          "x": -18,
           "y": 23,
-          "details": "river surf=304 -> dry(-19,23) terr=274 cliff=30"
+          "details": "river surf=304 -> dry(-19,23) terr=268 cliff=36"
         },
         {
           "x": -18,
           "y": 24,
-          "details": "river surf=316 -> dry(-19,24) terr=265 cliff=51"
+          "details": "river surf=316 -> dry(-19,24) terr=259 cliff=57"
+        },
+        {
+          "x": -18,
+          "y": 38,
+          "details": "river surf=136 -> dry(-17,38) terr=133 cliff=3"
         },
         {
           "x": -18,
@@ -3340,17 +3970,22 @@
         {
           "x": -17,
           "y": 24,
-          "details": "river surf=328 -> dry(-16,24) terr=300 cliff=28"
+          "details": "river surf=328 -> dry(-16,24) terr=295 cliff=33"
         },
         {
           "x": -17,
           "y": 28,
-          "details": "river surf=193 -> dry(-16,28) terr=183 cliff=10"
+          "details": "river surf=193 -> dry(-16,28) terr=179 cliff=14"
         },
         {
           "x": -17,
           "y": 29,
-          "details": "river surf=181 -> dry(-16,29) terr=155 cliff=26"
+          "details": "river surf=181 -> dry(-16,29) terr=151 cliff=30"
+        },
+        {
+          "x": -17,
+          "y": 35,
+          "details": "river surf=160 -> dry(-17,36) terr=157 cliff=3"
         },
         {
           "x": -17,
@@ -3359,18 +3994,63 @@
         },
         {
           "x": -16,
+          "y": 12,
+          "details": "river surf=197 -> dry(-16,11) terr=195 cliff=2"
+        },
+        {
+          "x": -16,
+          "y": 14,
+          "details": "river surf=220 -> dry(-17,14) terr=218 cliff=2"
+        },
+        {
+          "x": -16,
+          "y": 34,
+          "details": "river surf=160 -> dry(-15,34) terr=157 cliff=3"
+        },
+        {
+          "x": -16,
+          "y": 39,
+          "details": "river surf=100 -> dry(-16,40) terr=97 cliff=3"
+        },
+        {
+          "x": -16,
           "y": 44,
           "details": "river surf=61 -> dry(-16,45) terr=58 cliff=3"
         },
         {
+          "x": -15,
+          "y": 2,
+          "details": "river surf=156 -> dry(-16,2) terr=154 cliff=2"
+        },
+        {
+          "x": -15,
+          "y": 12,
+          "details": "river surf=209 -> dry(-15,11) terr=207 cliff=2"
+        },
+        {
+          "x": -15,
+          "y": 15,
+          "details": "river surf=244 -> dry(-16,15) terr=242 cliff=2"
+        },
+        {
+          "x": -14,
+          "y": 12,
+          "details": "river surf=221 -> dry(-14,11) terr=219 cliff=2"
+        },
+        {
           "x": -14,
           "y": 18,
-          "details": "river surf=292 -> dry(-13,18) terr=267 cliff=25"
+          "details": "river surf=292 -> dry(-13,18) terr=261 cliff=31"
         },
         {
           "x": -14,
           "y": 19,
-          "details": "river surf=304 -> dry(-13,19) terr=271 cliff=33"
+          "details": "river surf=304 -> dry(-13,19) terr=265 cliff=39"
+        },
+        {
+          "x": -12,
+          "y": 26,
+          "details": "river surf=125 -> dry(-12,27) terr=123 cliff=2"
         },
         {
           "x": -12,
@@ -3385,17 +4065,47 @@
         {
           "x": -11,
           "y": 11,
-          "details": "lake surf=374 -> dry(-12,11) terr=249 cliff=125"
+          "details": "lake surf=374 -> dry(-12,11) terr=243 cliff=131"
         },
         {
           "x": -11,
           "y": 12,
-          "details": "lake surf=374 -> dry(-12,12) terr=276 cliff=98"
+          "details": "lake surf=374 -> dry(-12,12) terr=270 cliff=104"
+        },
+        {
+          "x": -11,
+          "y": 18,
+          "details": "river surf=212 -> dry(-11,19) terr=209 cliff=3"
+        },
+        {
+          "x": -11,
+          "y": 23,
+          "details": "river surf=149 -> dry(-11,24) terr=146 cliff=3"
+        },
+        {
+          "x": -11,
+          "y": 26,
+          "details": "river surf=113 -> dry(-11,27) terr=111 cliff=2"
         },
         {
           "x": -11,
           "y": 53,
           "details": "river surf=43 -> dry(-11,54) terr=32 cliff=11"
+        },
+        {
+          "x": -10,
+          "y": 7,
+          "details": "river surf=279 -> dry(-10,6) terr=276 cliff=3"
+        },
+        {
+          "x": -10,
+          "y": 18,
+          "details": "river surf=200 -> dry(-10,19) terr=197 cliff=3"
+        },
+        {
+          "x": -10,
+          "y": 20,
+          "details": "river surf=176 -> dry(-10,21) terr=170 cliff=6"
         },
         {
           "x": -10,
@@ -3419,28 +4129,63 @@
         },
         {
           "x": -9,
+          "y": 6,
+          "details": "river surf=255 -> dry(-9,5) terr=252 cliff=3"
+        },
+        {
+          "x": -9,
           "y": 53,
           "details": "river surf=29 -> dry(-9,54) terr=26 cliff=3"
         },
         {
+          "x": -8,
+          "y": 4,
+          "details": "river surf=219 -> dry(-8,3) terr=216 cliff=3"
+        },
+        {
+          "x": -7,
+          "y": -8,
+          "details": "river surf=106 -> dry(-8,-8) terr=104 cliff=2"
+        },
+        {
           "x": -7,
           "y": 15,
-          "details": "lake surf=349 -> dry(-8,15) terr=228 cliff=121"
+          "details": "lake surf=349 -> dry(-8,15) terr=222 cliff=127"
         },
         {
           "x": -7,
           "y": 18,
-          "details": "river surf=189 -> dry(-6,18) terr=182 cliff=7"
+          "details": "river surf=189 -> dry(-6,18) terr=176 cliff=13"
+        },
+        {
+          "x": -7,
+          "y": 21,
+          "details": "river surf=143 -> dry(-7,22) terr=140 cliff=3"
+        },
+        {
+          "x": -6,
+          "y": 4,
+          "details": "river surf=219 -> dry(-6,3) terr=216 cliff=3"
         },
         {
           "x": -5,
           "y": 7,
-          "details": "river surf=267 -> dry(-5,6) terr=255 cliff=12"
+          "details": "river surf=267 -> dry(-5,6) terr=249 cliff=18"
+        },
+        {
+          "x": -5,
+          "y": 21,
+          "details": "river surf=143 -> dry(-5,22) terr=140 cliff=3"
         },
         {
           "x": -5,
           "y": 47,
           "details": "river surf=35 -> dry(-5,48) terr=32 cliff=3"
+        },
+        {
+          "x": -4,
+          "y": 20,
+          "details": "river surf=167 -> dry(-4,21) terr=165 cliff=2"
         },
         {
           "x": -4,
@@ -3533,14 +4278,44 @@
           "details": "river surf=105 -> dry(5,36) terr=102 cliff=3"
         },
         {
+          "x": 7,
+          "y": 35,
+          "details": "river surf=90 -> dry(8,35) terr=88 cliff=2"
+        },
+        {
+          "x": 8,
+          "y": 36,
+          "details": "river surf=66 -> dry(8,37) terr=64 cliff=2"
+        },
+        {
+          "x": 9,
+          "y": -8,
+          "details": "river surf=192 -> dry(9,-7) terr=189 cliff=3"
+        },
+        {
+          "x": 9,
+          "y": 37,
+          "details": "river surf=42 -> dry(10,37) terr=40 cliff=2"
+        },
+        {
           "x": 10,
           "y": 33,
           "details": "river surf=69 -> dry(10,34) terr=67 cliff=2"
         },
         {
+          "x": 10,
+          "y": 36,
+          "details": "river surf=42 -> dry(10,37) terr=40 cliff=2"
+        },
+        {
           "x": 11,
           "y": 33,
           "details": "river surf=66 -> dry(11,34) terr=64 cliff=2"
+        },
+        {
+          "x": 12,
+          "y": 33,
+          "details": "river surf=54 -> dry(12,34) terr=52 cliff=2"
         },
         {
           "x": 12,
@@ -3553,19 +4328,89 @@
           "details": "river surf=70 -> dry(13,30) terr=67 cliff=3"
         },
         {
+          "x": 13,
+          "y": 33,
+          "details": "river surf=42 -> dry(14,33) terr=40 cliff=2"
+        },
+        {
+          "x": 14,
+          "y": 32,
+          "details": "river surf=42 -> dry(14,33) terr=40 cliff=2"
+        },
+        {
+          "x": 15,
+          "y": 30,
+          "details": "river surf=54 -> dry(16,30) terr=52 cliff=2"
+        },
+        {
           "x": 16,
           "y": 32,
           "details": "river surf=18 -> dry(16,33) terr=6 cliff=12"
         },
         {
           "x": 17,
+          "y": 18,
+          "details": "river surf=192 -> dry(17,19) terr=190 cliff=2"
+        },
+        {
+          "x": 17,
           "y": 21,
-          "details": "river surf=156 -> dry(17,22) terr=139 cliff=17"
+          "details": "river surf=156 -> dry(17,22) terr=134 cliff=22"
+        },
+        {
+          "x": 17,
+          "y": 27,
+          "details": "river surf=64 -> dry(18,27) terr=61 cliff=3"
+        },
+        {
+          "x": 18,
+          "y": 17,
+          "details": "river surf=182 -> dry(18,16) terr=180 cliff=2"
+        },
+        {
+          "x": 19,
+          "y": 21,
+          "details": "river surf=132 -> dry(19,22) terr=126 cliff=6"
         },
         {
           "x": 20,
           "y": 21,
-          "details": "river surf=120 -> dry(20,22) terr=103 cliff=17"
+          "details": "river surf=120 -> dry(20,22) terr=98 cliff=22"
+        },
+        {
+          "x": 21,
+          "y": 16,
+          "details": "river surf=134 -> dry(21,15) terr=132 cliff=2"
+        },
+        {
+          "x": 21,
+          "y": 19,
+          "details": "river surf=132 -> dry(22,19) terr=130 cliff=2"
+        },
+        {
+          "x": 21,
+          "y": 21,
+          "details": "river surf=108 -> dry(21,22) terr=106 cliff=2"
+        },
+        {
+          "x": 24,
+          "y": 8,
+          "details": "river surf=98 -> dry(24,7) terr=96 cliff=2"
+        },
+        {
+          "x": 24,
+          "y": 17,
+          "details": "river surf=110 -> dry(25,17) terr=108 cliff=2"
+        },
+        {
+          "x": 26,
+          "y": 16,
+          "details": "river surf=74 -> dry(27,16) terr=72 cliff=2"
+        },
+        {
+          "x": 27,
+          "y": 8,
+          "details": "river surf=62 -> dry(28,8) terr=60 cliff=2"
         },
         {
           "x": 28,

--- a/tools/baselines/seed137_size32_region_-4_-4_4_4.json
+++ b/tools/baselines/seed137_size32_region_-4_-4_4_4.json
@@ -14,9 +14,9 @@
     "deterministic": true,
     "distinctHashes": 1,
     "hashes": [
-      "84679f3e308c65ed09220adc0ccbd39b94a8ff50089f545e5c747830554a8e9b",
-      "84679f3e308c65ed09220adc0ccbd39b94a8ff50089f545e5c747830554a8e9b",
-      "84679f3e308c65ed09220adc0ccbd39b94a8ff50089f545e5c747830554a8e9b"
+      "0ad4864b310b4bf5128227bbf33e556a7ae194fe867a16e70028a42ee25db8d1",
+      "0ad4864b310b4bf5128227bbf33e556a7ae194fe867a16e70028a42ee25db8d1",
+      "0ad4864b310b4bf5128227bbf33e556a7ae194fe867a16e70028a42ee25db8d1"
     ]
   },
   "tileCount": 20736,
@@ -107,13 +107,13 @@
       ]
     },
     "FLOATING_WATER": {
-      "min": 80,
-      "max": 80,
-      "median": 80,
+      "min": 64,
+      "max": 64,
+      "median": 64,
       "all": [
-        80,
-        80,
-        80
+        64,
+        64,
+        64
       ]
     },
     "ISOLATED_FLUID": {
@@ -124,6 +124,16 @@
         3,
         3,
         3
+      ]
+    },
+    "MID_RIVER_CLIFF": {
+      "min": 14,
+      "max": 14,
+      "median": 14,
+      "all": [
+        14,
+        14,
+        14
       ]
     },
     "MULTI_ISLAND": {
@@ -181,8 +191,9 @@
     "summary": {
       "FLAT_ISOLATED_WATER": 27,
       "FLOATING_LAKE": 1478,
-      "FLOATING_WATER": 80,
+      "FLOATING_WATER": 64,
       "ISOLATED_FLUID": 3,
+      "MID_RIVER_CLIFF": 14,
       "MULTI_ISLAND": 5,
       "RIVER_CHUNK_GAP": 20,
       "WATER_ABOVE_LAND": 80,
@@ -7726,16 +7737,6 @@
           "details": "river terr=94 -> dry(-64,-16) terr=93 gap=1"
         },
         {
-          "x": -63,
-          "y": -7,
-          "details": "river terr=21 -> dry(-64,-7) terr=20 gap=1"
-        },
-        {
-          "x": -61,
-          "y": -8,
-          "details": "river terr=35 -> dry(-60,-8) terr=31 gap=4"
-        },
-        {
           "x": -60,
           "y": -14,
           "details": "river terr=91 -> dry(-60,-13) terr=90 gap=1"
@@ -7768,17 +7769,12 @@
         {
           "x": -58,
           "y": -13,
-          "details": "river terr=75 -> dry(-57,-13) terr=71 gap=4"
+          "details": "river terr=73 -> dry(-57,-13) terr=71 gap=2"
         },
         {
           "x": -58,
           "y": -12,
-          "details": "river terr=67 -> dry(-57,-12) terr=63 gap=4"
-        },
-        {
-          "x": -58,
-          "y": -10,
-          "details": "river terr=43 -> dry(-57,-10) terr=40 gap=3"
+          "details": "river terr=64 -> dry(-57,-12) terr=63 gap=1"
         },
         {
           "x": -58,
@@ -7803,12 +7799,12 @@
         {
           "x": -55,
           "y": 76,
-          "details": "river terr=18 -> dry(-55,75) terr=16 gap=2"
+          "details": "river terr=17 -> dry(-55,75) terr=16 gap=1"
         },
         {
           "x": -55,
           "y": 77,
-          "details": "river terr=22 -> dry(-56,77) terr=19 gap=3"
+          "details": "river terr=21 -> dry(-56,77) terr=19 gap=2"
         },
         {
           "x": -54,
@@ -7819,16 +7815,6 @@
           "x": -54,
           "y": 76,
           "details": "river terr=23 -> dry(-54,75) terr=20 gap=3"
-        },
-        {
-          "x": -53,
-          "y": -17,
-          "details": "river terr=57 -> dry(-52,-17) terr=56 gap=1"
-        },
-        {
-          "x": -53,
-          "y": -16,
-          "details": "river terr=54 -> dry(-53,-15) terr=53 gap=1"
         },
         {
           "x": -53,
@@ -7847,18 +7833,8 @@
         },
         {
           "x": -53,
-          "y": 71,
-          "details": "river terr=12 -> dry(-54,71) terr=10 gap=2"
-        },
-        {
-          "x": -53,
           "y": 75,
           "details": "river terr=24 -> dry(-54,75) terr=20 gap=4"
-        },
-        {
-          "x": -52,
-          "y": -16,
-          "details": "river terr=52 -> dry(-51,-16) terr=51 gap=1"
         },
         {
           "x": -52,
@@ -7868,7 +7844,7 @@
         {
           "x": -52,
           "y": 71,
-          "details": "river terr=17 -> dry(-52,70) terr=14 gap=3"
+          "details": "river terr=15 -> dry(-52,70) terr=14 gap=1"
         },
         {
           "x": -52,
@@ -7892,23 +7868,8 @@
         },
         {
           "x": -51,
-          "y": 67,
-          "details": "river terr=7 -> dry(-52,67) terr=6 gap=1"
-        },
-        {
-          "x": -51,
-          "y": 68,
-          "details": "river terr=9 -> dry(-52,68) terr=8 gap=1"
-        },
-        {
-          "x": -51,
-          "y": 69,
-          "details": "river terr=13 -> dry(-52,69) terr=10 gap=3"
-        },
-        {
-          "x": -51,
           "y": 70,
-          "details": "river terr=19 -> dry(-52,70) terr=14 gap=5"
+          "details": "river terr=16 -> dry(-52,70) terr=14 gap=2"
         },
         {
           "x": -51,
@@ -7938,7 +7899,7 @@
         {
           "x": -48,
           "y": 67,
-          "details": "river terr=20 -> dry(-49,67) terr=13 gap=7"
+          "details": "river terr=17 -> dry(-49,67) terr=13 gap=4"
         },
         {
           "x": -48,
@@ -7953,7 +7914,7 @@
         {
           "x": -43,
           "y": 63,
-          "details": "river terr=49 -> dry(-43,62) terr=46 gap=3"
+          "details": "river terr=48 -> dry(-43,62) terr=46 gap=2"
         },
         {
           "x": -36,
@@ -8071,54 +8032,24 @@
           "details": "river terr=18 -> dry(70,-37) terr=17 gap=1"
         },
         {
-          "x": 72,
-          "y": -62,
-          "details": "river terr=56 -> dry(71,-62) terr=53 gap=3"
-        },
-        {
-          "x": 72,
-          "y": -61,
-          "details": "river terr=50 -> dry(71,-61) terr=47 gap=3"
-        },
-        {
-          "x": 73,
-          "y": -63,
-          "details": "river terr=69 -> dry(72,-63) terr=65 gap=4"
-        },
-        {
-          "x": 73,
-          "y": -57,
-          "details": "river terr=33 -> dry(72,-57) terr=30 gap=3"
-        },
-        {
-          "x": 74,
-          "y": -64,
-          "details": "river terr=83 -> dry(73,-64) terr=78 gap=5"
-        },
-        {
-          "x": 74,
-          "y": -60,
-          "details": "river terr=53 -> dry(74,-59) terr=50 gap=3"
-        },
-        {
           "x": 75,
           "y": -60,
-          "details": "river terr=59 -> dry(75,-59) terr=55 gap=4"
+          "details": "river terr=56 -> dry(75,-59) terr=55 gap=1"
         },
         {
           "x": 76,
           "y": -59,
-          "details": "river terr=59 -> dry(75,-59) terr=55 gap=4"
+          "details": "river terr=57 -> dry(75,-59) terr=55 gap=2"
         },
         {
           "x": 76,
           "y": -58,
-          "details": "river terr=53 -> dry(75,-58) terr=49 gap=4"
+          "details": "river terr=51 -> dry(75,-58) terr=49 gap=2"
         },
         {
           "x": 76,
           "y": -57,
-          "details": "river terr=46 -> dry(75,-57) terr=42 gap=4"
+          "details": "river terr=45 -> dry(75,-57) terr=42 gap=3"
         }
       ],
       "ISOLATED_FLUID": [
@@ -8136,6 +8067,78 @@
           "x": 78,
           "y": -39,
           "details": "lake surf=24 surrounded by dry"
+        }
+      ],
+      "MID_RIVER_CLIFF": [
+        {
+          "x": -58,
+          "y": -7,
+          "details": "river surf=23 (terr=20) -> water nbr surf=19 (terr=18) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -54,
+          "y": 74,
+          "details": "river surf=16 (terr=13) -> water nbr surf=14 (terr=13) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -53,
+          "y": 71,
+          "details": "river surf=13 (terr=9) -> water nbr surf=10 (terr=10) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -53,
+          "y": 73,
+          "details": "river surf=17 (terr=14) -> water nbr surf=15 (terr=14) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -53,
+          "y": 73,
+          "details": "river surf=17 (terr=14) -> water nbr surf=14 (terr=13) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -52,
+          "y": -16,
+          "details": "river surf=53 (terr=50) -> water nbr surf=50 (terr=49) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -51,
+          "y": 67,
+          "details": "river surf=8 (terr=5) -> water nbr surf=6 (terr=5) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -47,
+          "y": 62,
+          "details": "river surf=11 (terr=8) -> water nbr surf=7 (terr=6) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 67,
+          "y": -56,
+          "details": "river surf=23 (terr=19) -> water nbr surf=20 (terr=19) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 68,
+          "y": -56,
+          "details": "river surf=25 (terr=21) -> water nbr surf=21 (terr=20) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": 69,
+          "y": -56,
+          "details": "river surf=24 (terr=19) -> water nbr surf=21 (terr=20) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 72,
+          "y": -56,
+          "details": "river surf=26 (terr=22) -> water nbr surf=22 (terr=21) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": 73,
+          "y": -55,
+          "details": "river surf=23 (terr=20) -> water nbr surf=19 (terr=18) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 74,
+          "y": -56,
+          "details": "river surf=29 (terr=25) -> water nbr surf=25 (terr=23) surf_diff=4 terr_diff=2"
         }
       ],
       "MULTI_ISLAND": [
@@ -8276,12 +8279,12 @@
         {
           "x": -63,
           "y": -7,
-          "details": "river surf=22 terr=21 -> land(-64,-7) terr=20 cliff=2"
+          "details": "river surf=22 terr=18 -> land(-64,-7) terr=20 cliff=2"
         },
         {
           "x": -61,
           "y": -8,
-          "details": "river surf=36 terr=35 -> land(-60,-8) terr=31 cliff=5"
+          "details": "river surf=36 terr=31 -> land(-60,-8) terr=31 cliff=5"
         },
         {
           "x": -60,
@@ -8316,17 +8319,17 @@
         {
           "x": -58,
           "y": -13,
-          "details": "river surf=76 terr=75 -> land(-57,-13) terr=71 cliff=5"
+          "details": "river surf=76 terr=73 -> land(-57,-13) terr=71 cliff=5"
         },
         {
           "x": -58,
           "y": -12,
-          "details": "river surf=68 terr=67 -> land(-57,-12) terr=63 cliff=5"
+          "details": "river surf=68 terr=64 -> land(-57,-12) terr=63 cliff=5"
         },
         {
           "x": -58,
           "y": -10,
-          "details": "river surf=44 terr=43 -> land(-57,-10) terr=40 cliff=4"
+          "details": "river surf=44 terr=38 -> land(-57,-10) terr=40 cliff=4"
         },
         {
           "x": -58,
@@ -8351,12 +8354,12 @@
         {
           "x": -55,
           "y": 76,
-          "details": "river surf=19 terr=18 -> land(-55,75) terr=16 cliff=3"
+          "details": "river surf=19 terr=17 -> land(-55,75) terr=16 cliff=3"
         },
         {
           "x": -55,
           "y": 77,
-          "details": "river surf=23 terr=22 -> land(-56,77) terr=19 cliff=4"
+          "details": "river surf=23 terr=21 -> land(-56,77) terr=19 cliff=4"
         },
         {
           "x": -54,
@@ -8371,12 +8374,12 @@
         {
           "x": -53,
           "y": -17,
-          "details": "river surf=58 terr=57 -> land(-52,-17) terr=56 cliff=2"
+          "details": "river surf=58 terr=53 -> land(-52,-17) terr=56 cliff=2"
         },
         {
           "x": -53,
           "y": -16,
-          "details": "river surf=55 terr=54 -> land(-53,-15) terr=53 cliff=2"
+          "details": "river surf=55 terr=51 -> land(-53,-15) terr=53 cliff=2"
         },
         {
           "x": -53,
@@ -8396,7 +8399,7 @@
         {
           "x": -53,
           "y": 71,
-          "details": "river surf=13 terr=12 -> land(-54,71) terr=10 cliff=3"
+          "details": "river surf=13 terr=10 -> land(-54,71) terr=10 cliff=3"
         },
         {
           "x": -53,
@@ -8406,7 +8409,7 @@
         {
           "x": -52,
           "y": -16,
-          "details": "river surf=53 terr=52 -> land(-51,-16) terr=51 cliff=2"
+          "details": "river surf=53 terr=50 -> land(-51,-16) terr=51 cliff=2"
         },
         {
           "x": -52,
@@ -8416,7 +8419,7 @@
         {
           "x": -52,
           "y": 71,
-          "details": "river surf=18 terr=17 -> land(-52,70) terr=14 cliff=4"
+          "details": "river surf=18 terr=15 -> land(-52,70) terr=14 cliff=4"
         },
         {
           "x": -52,
@@ -8441,22 +8444,22 @@
         {
           "x": -51,
           "y": 67,
-          "details": "river surf=8 terr=7 -> land(-52,67) terr=6 cliff=2"
+          "details": "river surf=8 terr=5 -> land(-52,67) terr=6 cliff=2"
         },
         {
           "x": -51,
           "y": 68,
-          "details": "river surf=10 terr=9 -> land(-52,68) terr=8 cliff=2"
+          "details": "river surf=10 terr=6 -> land(-52,68) terr=8 cliff=2"
         },
         {
           "x": -51,
           "y": 69,
-          "details": "river surf=14 terr=13 -> land(-52,69) terr=10 cliff=4"
+          "details": "river surf=14 terr=10 -> land(-52,69) terr=10 cliff=4"
         },
         {
           "x": -51,
           "y": 70,
-          "details": "river surf=20 terr=19 -> land(-52,70) terr=14 cliff=6"
+          "details": "river surf=20 terr=16 -> land(-52,70) terr=14 cliff=6"
         },
         {
           "x": -51,
@@ -8486,7 +8489,7 @@
         {
           "x": -48,
           "y": 67,
-          "details": "river surf=21 terr=20 -> land(-49,67) terr=13 cliff=8"
+          "details": "river surf=21 terr=17 -> land(-49,67) terr=13 cliff=8"
         },
         {
           "x": -48,
@@ -8501,7 +8504,7 @@
         {
           "x": -43,
           "y": 63,
-          "details": "river surf=50 terr=49 -> land(-43,62) terr=46 cliff=4"
+          "details": "river surf=50 terr=48 -> land(-43,62) terr=46 cliff=4"
         },
         {
           "x": -36,
@@ -8621,52 +8624,52 @@
         {
           "x": 72,
           "y": -62,
-          "details": "river surf=57 terr=56 -> land(71,-62) terr=53 cliff=4"
+          "details": "river surf=57 terr=52 -> land(71,-62) terr=53 cliff=4"
         },
         {
           "x": 72,
           "y": -61,
-          "details": "river surf=51 terr=50 -> land(71,-61) terr=47 cliff=4"
+          "details": "river surf=51 terr=46 -> land(71,-61) terr=47 cliff=4"
         },
         {
           "x": 73,
           "y": -63,
-          "details": "river surf=70 terr=69 -> land(72,-63) terr=65 cliff=5"
+          "details": "river surf=70 terr=64 -> land(72,-63) terr=65 cliff=5"
         },
         {
           "x": 73,
           "y": -57,
-          "details": "river surf=34 terr=33 -> land(72,-57) terr=30 cliff=4"
+          "details": "river surf=34 terr=30 -> land(72,-57) terr=30 cliff=4"
         },
         {
           "x": 74,
           "y": -64,
-          "details": "river surf=84 terr=83 -> land(73,-64) terr=78 cliff=6"
+          "details": "river surf=84 terr=77 -> land(73,-64) terr=78 cliff=6"
         },
         {
           "x": 74,
           "y": -60,
-          "details": "river surf=54 terr=53 -> land(74,-59) terr=50 cliff=4"
+          "details": "river surf=54 terr=49 -> land(74,-59) terr=50 cliff=4"
         },
         {
           "x": 75,
           "y": -60,
-          "details": "river surf=60 terr=59 -> land(75,-59) terr=55 cliff=5"
+          "details": "river surf=60 terr=56 -> land(75,-59) terr=55 cliff=5"
         },
         {
           "x": 76,
           "y": -59,
-          "details": "river surf=60 terr=59 -> land(75,-59) terr=55 cliff=5"
+          "details": "river surf=60 terr=57 -> land(75,-59) terr=55 cliff=5"
         },
         {
           "x": 76,
           "y": -58,
-          "details": "river surf=54 terr=53 -> land(75,-58) terr=49 cliff=5"
+          "details": "river surf=54 terr=51 -> land(75,-58) terr=49 cliff=5"
         },
         {
           "x": 76,
           "y": -57,
-          "details": "river surf=47 terr=46 -> land(75,-57) terr=42 cliff=5"
+          "details": "river surf=47 terr=45 -> land(75,-57) terr=42 cliff=5"
         }
       ],
       "WATER_CLIFF": [

--- a/tools/baselines/seed250_size32_region_-4_-4_4_4.json
+++ b/tools/baselines/seed250_size32_region_-4_-4_4_4.json
@@ -14,9 +14,9 @@
     "deterministic": true,
     "distinctHashes": 1,
     "hashes": [
-      "334713e4341ebdfd47f8c37005b465bd6f0c637d63c51b2a55a73f7649cff71b",
-      "334713e4341ebdfd47f8c37005b465bd6f0c637d63c51b2a55a73f7649cff71b",
-      "334713e4341ebdfd47f8c37005b465bd6f0c637d63c51b2a55a73f7649cff71b"
+      "eea238e7f5a283e57a65e0a6ee7a782ccbbb90ed590396f42471904ef2dfd1c5",
+      "eea238e7f5a283e57a65e0a6ee7a782ccbbb90ed590396f42471904ef2dfd1c5",
+      "eea238e7f5a283e57a65e0a6ee7a782ccbbb90ed590396f42471904ef2dfd1c5"
     ]
   },
   "tileCount": 20736,
@@ -97,23 +97,23 @@
       ]
     },
     "FLAT_ISOLATED_WATER": {
-      "min": 11,
-      "max": 11,
-      "median": 11,
+      "min": 10,
+      "max": 10,
+      "median": 10,
       "all": [
-        11,
-        11,
-        11
+        10,
+        10,
+        10
       ]
     },
     "FLOATING_LAKE": {
-      "min": 2244,
-      "max": 2244,
-      "median": 2244,
+      "min": 2245,
+      "max": 2245,
+      "median": 2245,
       "all": [
-        2244,
-        2244,
-        2244
+        2245,
+        2245,
+        2245
       ]
     },
     "FLOATING_RIVER": {
@@ -127,13 +127,13 @@
       ]
     },
     "FLOATING_WATER": {
-      "min": 173,
-      "max": 173,
-      "median": 173,
+      "min": 127,
+      "max": 127,
+      "median": 127,
       "all": [
-        173,
-        173,
-        173
+        127,
+        127,
+        127
       ]
     },
     "ISOLATED_FLUID": {
@@ -147,13 +147,13 @@
       ]
     },
     "MID_RIVER_CLIFF": {
-      "min": 1,
-      "max": 1,
-      "median": 1,
+      "min": 54,
+      "max": 54,
+      "median": 54,
       "all": [
-        1,
-        1,
-        1
+        54,
+        54,
+        54
       ]
     },
     "MULTI_ISLAND": {
@@ -167,33 +167,33 @@
       ]
     },
     "RIVER_CHUNK_GAP": {
-      "min": 11,
-      "max": 11,
-      "median": 11,
+      "min": 15,
+      "max": 15,
+      "median": 15,
       "all": [
-        11,
-        11,
-        11
+        15,
+        15,
+        15
       ]
     },
     "WATER_ABOVE_LAND": {
-      "min": 175,
-      "max": 175,
-      "median": 175,
+      "min": 199,
+      "max": 199,
+      "median": 199,
       "all": [
-        175,
-        175,
-        175
+        199,
+        199,
+        199
       ]
     },
     "WATER_CLIFF": {
-      "min": 175,
-      "max": 175,
-      "median": 175,
+      "min": 199,
+      "max": 199,
+      "median": 199,
       "all": [
-        175,
-        175,
-        175
+        199,
+        199,
+        199
       ]
     },
     "WATER_WATER_CLIFF": {
@@ -210,16 +210,16 @@
   "representativeAudit": {
     "summary": {
       "DESERT_SOIL_ON_SLOPE": 5,
-      "FLAT_ISOLATED_WATER": 11,
-      "FLOATING_LAKE": 2244,
+      "FLAT_ISOLATED_WATER": 10,
+      "FLOATING_LAKE": 2245,
       "FLOATING_RIVER": 4,
-      "FLOATING_WATER": 173,
+      "FLOATING_WATER": 127,
       "ISOLATED_FLUID": 16,
-      "MID_RIVER_CLIFF": 1,
+      "MID_RIVER_CLIFF": 54,
       "MULTI_ISLAND": 2,
-      "RIVER_CHUNK_GAP": 11,
-      "WATER_ABOVE_LAND": 175,
-      "WATER_CLIFF": 175,
+      "RIVER_CHUNK_GAP": 15,
+      "WATER_ABOVE_LAND": 199,
+      "WATER_CLIFF": 199,
       "WATER_WATER_CLIFF": 2280
     },
     "issues": {
@@ -280,11 +280,6 @@
           "x": 10,
           "y": 60,
           "details": "lake surf=31 terr=30 water_nbrs=0 terr_range=2"
-        },
-        {
-          "x": 11,
-          "y": -39,
-          "details": "river surf=6 terr=4 water_nbrs=1 terr_range=2"
         },
         {
           "x": 12,
@@ -499,6 +494,11 @@
           "details": "lake fluidSurf=198 terrainZ=175 depth=23"
         },
         {
+          "x": -6,
+          "y": -31,
+          "details": "lake fluidSurf=311 terrainZ=290 depth=21"
+        },
+        {
           "x": 1,
           "y": 10,
           "details": "lake fluidSurf=144 terrainZ=125 depth=19"
@@ -521,7 +521,7 @@
         {
           "x": 3,
           "y": -39,
-          "details": "lake fluidSurf=179 terrainZ=92 depth=87"
+          "details": "lake fluidSurf=179 terrainZ=86 depth=93"
         },
         {
           "x": 8,
@@ -771,7 +771,7 @@
         {
           "x": 18,
           "y": -32,
-          "details": "lake fluidSurf=120 terrainZ=93 depth=27"
+          "details": "lake fluidSurf=120 terrainZ=87 depth=33"
         },
         {
           "x": 18,
@@ -11533,7 +11533,7 @@
         {
           "x": 3,
           "y": -40,
-          "details": "river fluidSurf=138 terrainZ=120 depth=18"
+          "details": "river fluidSurf=138 terrainZ=114 depth=24"
         },
         {
           "x": 19,
@@ -11555,12 +11555,7 @@
         {
           "x": -64,
           "y": 32,
-          "details": "river terr=41 -> dry(-64,33) terr=36 gap=5"
-        },
-        {
-          "x": -64,
-          "y": 34,
-          "details": "river terr=41 -> dry(-64,33) terr=36 gap=5"
+          "details": "river terr=39 -> dry(-64,33) terr=36 gap=3"
         },
         {
           "x": -64,
@@ -11570,7 +11565,7 @@
         {
           "x": -63,
           "y": 40,
-          "details": "river terr=34 -> dry(-64,40) terr=30 gap=4"
+          "details": "river terr=33 -> dry(-64,40) terr=30 gap=3"
         },
         {
           "x": -63,
@@ -11583,54 +11578,19 @@
           "details": "river terr=11 -> dry(-63,61) terr=10 gap=1"
         },
         {
-          "x": -63,
-          "y": 69,
-          "details": "river terr=29 -> dry(-63,68) terr=27 gap=2"
-        },
-        {
           "x": -62,
           "y": 43,
           "details": "river terr=27 -> dry(-62,44) terr=26 gap=1"
         },
         {
-          "x": -62,
-          "y": 69,
-          "details": "river terr=33 -> dry(-62,68) terr=31 gap=2"
-        },
-        {
-          "x": -62,
-          "y": 71,
-          "details": "river terr=42 -> dry(-63,71) terr=37 gap=5"
-        },
-        {
-          "x": -62,
-          "y": 72,
-          "details": "river terr=49 -> dry(-63,72) terr=44 gap=5"
-        },
-        {
-          "x": -61,
-          "y": 54,
-          "details": "river terr=11 -> dry(-62,54) terr=8 gap=3"
-        },
-        {
-          "x": -61,
-          "y": 57,
-          "details": "river terr=9 -> dry(-62,57) terr=7 gap=2"
-        },
-        {
           "x": -61,
           "y": 61,
-          "details": "river terr=23 -> dry(-62,61) terr=15 gap=8"
-        },
-        {
-          "x": -61,
-          "y": 68,
-          "details": "river terr=34 -> dry(-62,68) terr=31 gap=3"
+          "details": "river terr=18 -> dry(-62,61) terr=15 gap=3"
         },
         {
           "x": -61,
           "y": 73,
-          "details": "river terr=70 -> dry(-62,73) terr=62 gap=8"
+          "details": "river terr=65 -> dry(-62,73) terr=62 gap=3"
         },
         {
           "x": -61,
@@ -11645,37 +11605,32 @@
         {
           "x": -61,
           "y": 79,
-          "details": "river terr=94 -> dry(-62,79) terr=89 gap=5"
-        },
-        {
-          "x": -60,
-          "y": 26,
-          "details": "river terr=59 -> dry(-61,26) terr=58 gap=1"
+          "details": "river terr=92 -> dry(-62,79) terr=89 gap=3"
         },
         {
           "x": -60,
           "y": 64,
-          "details": "river terr=36 -> dry(-61,64) terr=28 gap=8"
+          "details": "river terr=31 -> dry(-61,64) terr=28 gap=3"
         },
         {
           "x": -60,
           "y": 74,
-          "details": "river terr=90 -> dry(-61,74) terr=82 gap=8"
+          "details": "river terr=86 -> dry(-61,74) terr=82 gap=4"
         },
         {
           "x": -60,
           "y": 75,
-          "details": "river terr=98 -> dry(-61,75) terr=92 gap=6"
+          "details": "river terr=95 -> dry(-61,75) terr=92 gap=3"
         },
         {
           "x": -60,
           "y": 76,
-          "details": "river terr=105 -> dry(-61,76) terr=100 gap=5"
+          "details": "river terr=103 -> dry(-61,76) terr=100 gap=3"
         },
         {
           "x": -55,
           "y": 60,
-          "details": "river terr=91 -> dry(-56,60) terr=87 gap=4"
+          "details": "river terr=89 -> dry(-56,60) terr=87 gap=2"
         },
         {
           "x": -53,
@@ -11694,73 +11649,23 @@
         },
         {
           "x": -47,
-          "y": 77,
-          "details": "river terr=173 -> dry(-48,77) terr=170 gap=3"
-        },
-        {
-          "x": -47,
-          "y": 78,
-          "details": "river terr=181 -> dry(-48,78) terr=178 gap=3"
-        },
-        {
-          "x": -47,
           "y": 79,
-          "details": "river terr=188 -> dry(-48,79) terr=183 gap=5"
-        },
-        {
-          "x": -45,
-          "y": 77,
-          "details": "river terr=192 -> dry(-45,76) terr=191 gap=1"
-        },
-        {
-          "x": -44,
-          "y": 67,
-          "details": "river terr=140 -> dry(-44,66) terr=137 gap=3"
-        },
-        {
-          "x": -44,
-          "y": 72,
-          "details": "river terr=155 -> dry(-44,71) terr=150 gap=5"
+          "details": "river terr=186 -> dry(-48,79) terr=183 gap=3"
         },
         {
           "x": -42,
           "y": 73,
-          "details": "river terr=191 -> dry(-43,73) terr=186 gap=5"
-        },
-        {
-          "x": -41,
-          "y": 68,
-          "details": "river terr=144 -> dry(-42,68) terr=141 gap=3"
-        },
-        {
-          "x": -41,
-          "y": 74,
-          "details": "river terr=214 -> dry(-42,74) terr=213 gap=1"
+          "details": "river terr=187 -> dry(-43,73) terr=186 gap=1"
         },
         {
           "x": -40,
           "y": 62,
-          "details": "river terr=111 -> dry(-40,61) terr=105 gap=6"
-        },
-        {
-          "x": -40,
-          "y": 65,
-          "details": "river terr=129 -> dry(-40,64) terr=125 gap=4"
-        },
-        {
-          "x": -39,
-          "y": 60,
-          "details": "river terr=106 -> dry(-39,59) terr=103 gap=3"
+          "details": "river terr=106 -> dry(-40,61) terr=105 gap=1"
         },
         {
           "x": -39,
           "y": 65,
-          "details": "river terr=141 -> dry(-39,64) terr=135 gap=6"
-        },
-        {
-          "x": -38,
-          "y": 60,
-          "details": "river terr=112 -> dry(-38,59) terr=109 gap=3"
+          "details": "river terr=136 -> dry(-39,64) terr=135 gap=1"
         },
         {
           "x": -38,
@@ -11773,44 +11678,34 @@
           "details": "river terr=101 -> dry(-38,56) terr=100 gap=1"
         },
         {
-          "x": -37,
-          "y": 60,
-          "details": "river terr=117 -> dry(-37,59) terr=114 gap=3"
-        },
-        {
-          "x": -37,
-          "y": 61,
-          "details": "river terr=122 -> dry(-38,61) terr=118 gap=4"
-        },
-        {
           "x": -36,
           "y": 57,
-          "details": "river terr=109 -> dry(-37,57) terr=106 gap=3"
+          "details": "river terr=107 -> dry(-37,57) terr=106 gap=1"
         },
         {
           "x": -36,
           "y": 58,
-          "details": "river terr=113 -> dry(-37,58) terr=110 gap=3"
+          "details": "river terr=111 -> dry(-37,58) terr=110 gap=1"
         },
         {
           "x": -36,
           "y": 60,
-          "details": "river terr=123 -> dry(-36,59) terr=119 gap=4"
+          "details": "river terr=120 -> dry(-36,59) terr=119 gap=1"
         },
         {
           "x": -35,
           "y": 60,
-          "details": "river terr=130 -> dry(-35,59) terr=125 gap=5"
+          "details": "river terr=127 -> dry(-35,59) terr=125 gap=2"
         },
         {
           "x": -35,
           "y": 62,
-          "details": "river terr=150 -> dry(-36,62) terr=143 gap=7"
+          "details": "river terr=148 -> dry(-36,62) terr=143 gap=5"
         },
         {
           "x": -35,
           "y": 63,
-          "details": "river terr=162 -> dry(-36,63) terr=159 gap=3"
+          "details": "river terr=160 -> dry(-36,63) terr=159 gap=1"
         },
         {
           "x": -34,
@@ -11820,7 +11715,7 @@
         {
           "x": -34,
           "y": 60,
-          "details": "river terr=138 -> dry(-34,59) terr=132 gap=6"
+          "details": "river terr=136 -> dry(-34,59) terr=132 gap=4"
         },
         {
           "x": -33,
@@ -11850,12 +11745,12 @@
         {
           "x": -27,
           "y": 43,
-          "details": "river terr=32 -> dry(-26,43) terr=30 gap=2"
+          "details": "river terr=31 -> dry(-26,43) terr=30 gap=1"
         },
         {
           "x": -27,
           "y": 46,
-          "details": "river terr=58 -> dry(-26,46) terr=52 gap=6"
+          "details": "river terr=54 -> dry(-26,46) terr=52 gap=2"
         },
         {
           "x": -27,
@@ -11880,7 +11775,7 @@
         {
           "x": -25,
           "y": 58,
-          "details": "river terr=120 -> dry(-24,58) terr=117 gap=3"
+          "details": "river terr=119 -> dry(-24,58) terr=117 gap=2"
         },
         {
           "x": -25,
@@ -11900,12 +11795,12 @@
         {
           "x": -25,
           "y": 62,
-          "details": "river terr=157 -> dry(-24,62) terr=151 gap=6"
+          "details": "river terr=156 -> dry(-24,62) terr=151 gap=5"
         },
         {
           "x": -25,
           "y": 63,
-          "details": "river terr=166 -> dry(-24,63) terr=159 gap=7"
+          "details": "river terr=165 -> dry(-24,63) terr=159 gap=6"
         },
         {
           "x": -25,
@@ -11930,17 +11825,12 @@
         {
           "x": -23,
           "y": 64,
-          "details": "river terr=157 -> dry(-23,63) terr=150 gap=7"
+          "details": "river terr=152 -> dry(-23,63) terr=150 gap=2"
         },
         {
           "x": -22,
           "y": 50,
-          "details": "river terr=54 -> dry(-22,49) terr=47 gap=7"
-        },
-        {
-          "x": -22,
-          "y": 68,
-          "details": "river terr=178 -> dry(-22,67) terr=175 gap=3"
+          "details": "river terr=51 -> dry(-22,49) terr=47 gap=4"
         },
         {
           "x": -21,
@@ -11958,39 +11848,14 @@
           "details": "river terr=215 -> dry(-21,0) terr=213 gap=2"
         },
         {
-          "x": -21,
-          "y": 66,
-          "details": "river terr=158 -> dry(-20,66) terr=154 gap=4"
-        },
-        {
-          "x": -21,
-          "y": 67,
-          "details": "river terr=165 -> dry(-20,67) terr=162 gap=3"
-        },
-        {
-          "x": -20,
-          "y": 50,
-          "details": "river terr=35 -> dry(-19,50) terr=33 gap=2"
-        },
-        {
-          "x": -20,
-          "y": 51,
-          "details": "river terr=43 -> dry(-19,51) terr=42 gap=1"
-        },
-        {
-          "x": -20,
-          "y": 52,
-          "details": "river terr=53 -> dry(-19,52) terr=51 gap=2"
-        },
-        {
           "x": -20,
           "y": 53,
-          "details": "river terr=63 -> dry(-19,53) terr=60 gap=3"
+          "details": "river terr=62 -> dry(-19,53) terr=60 gap=2"
         },
         {
           "x": -20,
           "y": 54,
-          "details": "river terr=73 -> dry(-19,54) terr=69 gap=4"
+          "details": "river terr=72 -> dry(-19,54) terr=69 gap=3"
         },
         {
           "x": -20,
@@ -12015,112 +11880,67 @@
         {
           "x": -20,
           "y": 59,
-          "details": "river terr=112 -> dry(-19,59) terr=110 gap=2"
+          "details": "river terr=111 -> dry(-19,59) terr=110 gap=1"
         },
         {
           "x": -20,
           "y": 60,
-          "details": "river terr=117 -> dry(-19,60) terr=114 gap=3"
+          "details": "river terr=116 -> dry(-19,60) terr=114 gap=2"
         },
         {
           "x": -19,
           "y": 61,
-          "details": "river terr=118 -> dry(-19,60) terr=114 gap=4"
-        },
-        {
-          "x": -18,
-          "y": 52,
-          "details": "river terr=40 -> dry(-18,51) terr=39 gap=1"
+          "details": "river terr=117 -> dry(-19,60) terr=114 gap=3"
         },
         {
           "x": -18,
           "y": 61,
-          "details": "river terr=111 -> dry(-18,60) terr=108 gap=3"
-        },
-        {
-          "x": -18,
-          "y": 66,
-          "details": "river terr=157 -> dry(-19,66) terr=155 gap=2"
-        },
-        {
-          "x": -17,
-          "y": 52,
-          "details": "river terr=40 -> dry(-17,51) terr=39 gap=1"
+          "details": "river terr=109 -> dry(-18,60) terr=108 gap=1"
         },
         {
           "x": -17,
           "y": 57,
-          "details": "river terr=72 -> dry(-17,56) terr=63 gap=9"
+          "details": "river terr=67 -> dry(-17,56) terr=63 gap=4"
         },
         {
           "x": -17,
           "y": 61,
-          "details": "river terr=105 -> dry(-17,60) terr=99 gap=6"
+          "details": "river terr=102 -> dry(-17,60) terr=99 gap=3"
         },
         {
           "x": -16,
           "y": 5,
-          "details": "river terr=167 -> dry(-16,6) terr=165 gap=2"
-        },
-        {
-          "x": -16,
-          "y": 50,
-          "details": "river terr=36 -> dry(-17,50) terr=33 gap=3"
-        },
-        {
-          "x": -16,
-          "y": 51,
-          "details": "river terr=40 -> dry(-17,51) terr=39 gap=1"
-        },
-        {
-          "x": -16,
-          "y": 62,
-          "details": "river terr=108 -> dry(-15,62) terr=107 gap=1"
+          "details": "river terr=166 -> dry(-16,6) terr=165 gap=1"
         },
         {
           "x": -15,
           "y": 7,
-          "details": "river terr=155 -> dry(-15,8) terr=152 gap=3"
+          "details": "river terr=154 -> dry(-15,8) terr=152 gap=2"
         },
         {
           "x": -15,
           "y": 50,
-          "details": "river terr=46 -> dry(-15,49) terr=40 gap=6"
+          "details": "river terr=43 -> dry(-15,49) terr=40 gap=3"
         },
         {
           "x": -13,
           "y": 56,
-          "details": "river terr=60 -> dry(-13,55) terr=57 gap=3"
-        },
-        {
-          "x": -12,
-          "y": -5,
-          "details": "river terr=229 -> dry(-13,-5) terr=228 gap=1"
-        },
-        {
-          "x": -12,
-          "y": 56,
-          "details": "river terr=68 -> dry(-12,55) terr=67 gap=1"
+          "details": "river terr=58 -> dry(-13,55) terr=57 gap=1"
         },
         {
           "x": -11,
           "y": 8,
-          "details": "river terr=147 -> dry(-11,9) terr=142 gap=5"
-        },
-        {
-          "x": -11,
-          "y": 68,
-          "details": "river terr=133 -> dry(-11,67) terr=129 gap=4"
+          "details": "river terr=144 -> dry(-11,9) terr=142 gap=2"
         },
         {
           "x": -11,
           "y": 69,
-          "details": "river terr=141 -> dry(-10,69) terr=134 gap=7"
+          "details": "river terr=138 -> dry(-10,69) terr=134 gap=4"
         },
         {
           "x": -11,
           "y": 70,
-          "details": "river terr=148 -> dry(-10,70) terr=142 gap=6"
+          "details": "river terr=146 -> dry(-10,70) terr=142 gap=4"
         },
         {
           "x": -11,
@@ -12138,29 +11958,19 @@
           "details": "river terr=79 -> dry(-9,57) terr=76 gap=3"
         },
         {
-          "x": -10,
-          "y": 67,
-          "details": "river terr=119 -> dry(-10,66) terr=117 gap=2"
-        },
-        {
-          "x": -10,
-          "y": 68,
-          "details": "river terr=125 -> dry(-9,68) terr=122 gap=3"
-        },
-        {
           "x": -9,
           "y": 5,
           "details": "river terr=176 -> dry(-9,6) terr=173 gap=3"
         },
         {
-          "x": -9,
-          "y": 67,
-          "details": "river terr=115 -> dry(-8,67) terr=112 gap=3"
-        },
-        {
           "x": -8,
           "y": 5,
           "details": "river terr=182 -> dry(-8,6) terr=180 gap=2"
+        },
+        {
+          "x": -7,
+          "y": -31,
+          "details": "lake terr=308 -> dry(-7,-32) terr=306 gap=2"
         },
         {
           "x": -7,
@@ -12170,7 +11980,7 @@
         {
           "x": -6,
           "y": -31,
-          "details": "lake terr=297 -> dry(-6,-32) terr=285 gap=12"
+          "details": "lake terr=290 -> dry(-6,-32) terr=278 gap=12"
         },
         {
           "x": -6,
@@ -12180,22 +11990,17 @@
         {
           "x": -6,
           "y": 64,
-          "details": "river terr=90 -> dry(-6,63) terr=86 gap=4"
-        },
-        {
-          "x": -5,
-          "y": 61,
-          "details": "river terr=57 -> dry(-5,60) terr=53 gap=4"
+          "details": "river terr=88 -> dry(-6,63) terr=86 gap=2"
         },
         {
           "x": -5,
           "y": 62,
-          "details": "river terr=66 -> dry(-4,62) terr=60 gap=6"
+          "details": "river terr=61 -> dry(-4,62) terr=60 gap=1"
         },
         {
           "x": -5,
           "y": 63,
-          "details": "river terr=75 -> dry(-4,63) terr=68 gap=7"
+          "details": "river terr=71 -> dry(-4,63) terr=68 gap=3"
         },
         {
           "x": -4,
@@ -12205,12 +12010,7 @@
         {
           "x": -4,
           "y": 64,
-          "details": "river terr=73 -> dry(-4,63) terr=68 gap=5"
-        },
-        {
-          "x": -3,
-          "y": -25,
-          "details": "river terr=306 -> dry(-3,-26) terr=301 gap=5"
+          "details": "river terr=70 -> dry(-4,63) terr=68 gap=2"
         },
         {
           "x": -3,
@@ -12219,18 +12019,13 @@
         },
         {
           "x": -2,
-          "y": -27,
-          "details": "river terr=281 -> dry(-2,-28) terr=279 gap=2"
-        },
-        {
-          "x": -2,
           "y": 4,
-          "details": "river terr=185 -> dry(-2,5) terr=182 gap=3"
+          "details": "river terr=183 -> dry(-2,5) terr=182 gap=1"
         },
         {
           "x": -2,
           "y": 62,
-          "details": "river terr=48 -> dry(-1,62) terr=44 gap=4"
+          "details": "river terr=45 -> dry(-1,62) terr=44 gap=1"
         },
         {
           "x": -2,
@@ -12265,7 +12060,7 @@
         {
           "x": 3,
           "y": -40,
-          "details": "river terr=120 -> dry(4,-40) terr=92 gap=28"
+          "details": "river terr=114 -> dry(4,-40) terr=86 gap=28"
         },
         {
           "x": 5,
@@ -12310,12 +12105,7 @@
         {
           "x": 8,
           "y": -4,
-          "details": "river terr=226 -> dry(8,-3) terr=224 gap=2"
-        },
-        {
-          "x": 9,
-          "y": 5,
-          "details": "river terr=194 -> dry(9,6) terr=193 gap=1"
+          "details": "river terr=225 -> dry(8,-3) terr=224 gap=1"
         },
         {
           "x": 10,
@@ -12325,7 +12115,7 @@
         {
           "x": 13,
           "y": -16,
-          "details": "river terr=276 -> dry(13,-17) terr=269 gap=7"
+          "details": "river terr=276 -> dry(13,-17) terr=263 gap=13"
         },
         {
           "x": 15,
@@ -12340,22 +12130,22 @@
         {
           "x": 18,
           "y": -32,
-          "details": "lake terr=93 -> dry(18,-33) terr=81 gap=12"
+          "details": "lake terr=87 -> dry(18,-33) terr=75 gap=12"
         },
         {
           "x": 18,
           "y": -17,
-          "details": "river terr=238 -> dry(19,-17) terr=230 gap=8"
+          "details": "river terr=236 -> dry(19,-17) terr=230 gap=6"
         },
         {
           "x": 18,
           "y": -9,
-          "details": "river terr=259 -> dry(19,-9) terr=257 gap=2"
+          "details": "river terr=258 -> dry(19,-9) terr=257 gap=1"
         },
         {
           "x": 18,
           "y": -8,
-          "details": "river terr=249 -> dry(19,-8) terr=247 gap=2"
+          "details": "river terr=248 -> dry(19,-8) terr=247 gap=1"
         },
         {
           "x": 19,
@@ -12383,34 +12173,14 @@
           "details": "river terr=256 -> dry(23,-10) terr=230 gap=26"
         },
         {
-          "x": 22,
-          "y": -9,
-          "details": "river terr=248 -> dry(23,-9) terr=247 gap=1"
-        },
-        {
           "x": 25,
           "y": -8,
           "details": "river terr=230 -> dry(26,-8) terr=202 gap=28"
         },
         {
-          "x": 25,
-          "y": -7,
-          "details": "river terr=232 -> dry(26,-7) terr=230 gap=2"
-        },
-        {
-          "x": 25,
-          "y": -6,
-          "details": "river terr=226 -> dry(25,-5) terr=225 gap=1"
-        },
-        {
-          "x": 25,
-          "y": -3,
-          "details": "river terr=226 -> dry(25,-4) terr=225 gap=1"
-        },
-        {
           "x": 26,
           "y": -3,
-          "details": "river terr=237 -> dry(26,-4) terr=235 gap=2"
+          "details": "river terr=236 -> dry(26,-4) terr=235 gap=1"
         },
         {
           "x": 26,
@@ -12502,9 +12272,274 @@
       ],
       "MID_RIVER_CLIFF": [
         {
+          "x": -63,
+          "y": 59,
+          "details": "river surf=7 (terr=4) -> water nbr surf=5 (terr=4) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -63,
+          "y": 60,
+          "details": "river surf=8 (terr=5) -> water nbr surf=6 (terr=5) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -62,
+          "y": 55,
+          "details": "river surf=6 (terr=3) -> water nbr surf=4 (terr=3) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -62,
+          "y": 56,
+          "details": "river surf=6 (terr=3) -> water nbr surf=4 (terr=3) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -62,
+          "y": 62,
+          "details": "river surf=16 (terr=12) -> water nbr surf=12 (terr=11) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -62,
+          "y": 69,
+          "details": "river surf=34 (terr=29) -> water nbr surf=30 (terr=27) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -61,
+          "y": 60,
+          "details": "river surf=13 (terr=7) -> water nbr surf=11 (terr=7) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -60,
+          "y": 51,
+          "details": "river surf=21 (terr=17) -> water nbr surf=17 (terr=16) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -60,
+          "y": 52,
+          "details": "river surf=19 (terr=15) -> water nbr surf=15 (terr=14) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -60,
+          "y": 67,
+          "details": "river surf=36 (terr=28) -> water nbr surf=33 (terr=29) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -59,
+          "y": 28,
+          "details": "river surf=59 (terr=54) -> water nbr surf=55 (terr=52) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -59,
+          "y": 52,
+          "details": "river surf=22 (terr=16) -> water nbr surf=19 (terr=15) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -44,
+          "y": 61,
+          "details": "lake surf=103 (terr=97) -> water nbr surf=99 (terr=97) surf_diff=4 terr_diff=0"
+        },
+        {
+          "x": -42,
+          "y": 44,
+          "details": "river surf=31 (terr=26) -> water nbr surf=29 (terr=26) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -41,
+          "y": 62,
+          "details": "lake surf=104 (terr=97) -> water nbr surf=99 (terr=98) surf_diff=5 terr_diff=1"
+        },
+        {
+          "x": -38,
+          "y": 70,
+          "details": "river surf=179 (terr=173) -> water nbr surf=174 (terr=175) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -37,
+          "y": 71,
+          "details": "river surf=186 (terr=180) -> water nbr surf=181 (terr=182) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -36,
+          "y": 56,
+          "details": "river surf=106 (terr=102) -> water nbr surf=103 (terr=103) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -36,
+          "y": 56,
+          "details": "river surf=106 (terr=103) -> water nbr surf=102 (terr=101) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -36,
+          "y": 71,
+          "details": "river surf=189 (terr=183) -> water nbr surf=184 (terr=185) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -34,
+          "y": 71,
+          "details": "river surf=188 (terr=183) -> water nbr surf=184 (terr=184) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -33,
+          "y": 71,
+          "details": "river surf=186 (terr=180) -> water nbr surf=181 (terr=182) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -32,
+          "y": 70,
+          "details": "river surf=179 (terr=175) -> water nbr surf=176 (terr=176) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -31,
+          "y": 70,
+          "details": "river surf=178 (terr=174) -> water nbr surf=175 (terr=175) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -30,
+          "y": 70,
+          "details": "river surf=181 (terr=176) -> water nbr surf=177 (terr=178) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -29,
+          "y": 44,
+          "details": "river surf=46 (terr=43) -> water nbr surf=44 (terr=43) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -25,
+          "y": 72,
+          "details": "lake surf=188 (terr=182) -> water nbr surf=183 (terr=184) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -24,
+          "y": 72,
+          "details": "river surf=187 (terr=182) -> water nbr surf=183 (terr=183) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -21,
+          "y": 49,
+          "details": "river surf=34 (terr=27) -> water nbr surf=32 (terr=27) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -16,
+          "y": 50,
+          "details": "lake surf=38 (terr=31) -> water nbr surf=32 (terr=33) surf_diff=6 terr_diff=2"
+        },
+        {
+          "x": -13,
+          "y": 9,
+          "details": "river surf=132 (terr=127) -> water nbr surf=129 (terr=126) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -12,
+          "y": -5,
+          "details": "river surf=230 (terr=227) -> water nbr surf=226 (terr=225) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -12,
+          "y": 2,
+          "details": "river surf=185 (terr=179) -> water nbr surf=183 (terr=179) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -12,
+          "y": 9,
+          "details": "river surf=132 (terr=127) -> water nbr surf=129 (terr=127) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -11,
+          "y": -4,
+          "details": "river surf=229 (terr=226) -> water nbr surf=226 (terr=225) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -11,
+          "y": -4,
+          "details": "river surf=229 (terr=226) -> water nbr surf=226 (terr=225) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -4,
+          "y": 55,
+          "details": "river surf=48 (terr=45) -> water nbr surf=44 (terr=43) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -3,
+          "y": 59,
+          "details": "river surf=42 (terr=39) -> water nbr surf=38 (terr=37) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -2,
+          "y": 60,
+          "details": "river surf=40 (terr=37) -> water nbr surf=38 (terr=37) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -2,
+          "y": 72,
+          "details": "river surf=56 (terr=51) -> water nbr surf=51 (terr=49) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -2,
+          "y": 73,
+          "details": "river surf=56 (terr=50) -> water nbr surf=51 (terr=48) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -1,
+          "y": 74,
+          "details": "river surf=51 (terr=46) -> water nbr surf=46 (terr=44) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": 0,
+          "y": 76,
+          "details": "river surf=46 (terr=40) -> water nbr surf=42 (terr=38) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 1,
+          "y": 70,
+          "details": "river surf=46 (terr=41) -> water nbr surf=42 (terr=40) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": 2,
+          "y": 70,
+          "details": "river surf=42 (terr=37) -> water nbr surf=39 (terr=36) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 3,
+          "y": 70,
+          "details": "river surf=39 (terr=35) -> water nbr surf=36 (terr=34) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 4,
+          "y": 70,
+          "details": "river surf=36 (terr=32) -> water nbr surf=33 (terr=31) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 16,
+          "y": -18,
+          "details": "river surf=217 (terr=210) -> water nbr surf=215 (terr=210) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 18,
+          "y": -23,
+          "details": "river surf=161 (terr=154) -> water nbr surf=155 (terr=156) surf_diff=6 terr_diff=2"
+        },
+        {
+          "x": 19,
+          "y": -23,
+          "details": "river surf=159 (terr=155) -> water nbr surf=156 (terr=154) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 20,
+          "y": -23,
+          "details": "river surf=158 (terr=154) -> water nbr surf=155 (terr=154) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 20,
+          "y": -6,
+          "details": "river surf=217 (terr=213) -> water nbr surf=215 (terr=213) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 21,
+          "y": -23,
+          "details": "river surf=157 (terr=153) -> water nbr surf=154 (terr=154) surf_diff=3 terr_diff=1"
+        },
+        {
           "x": 25,
           "y": -8,
-          "details": "river surf=237 (terr=230) -> water nbr surf=233 (terr=232) surf_diff=4 terr_diff=2"
+          "details": "river surf=237 (terr=230) -> water nbr surf=233 (terr=229) surf_diff=4 terr_diff=1"
         }
       ],
       "MULTI_ISLAND": [
@@ -12561,9 +12596,29 @@
           "details": "river surf=74 -> dry(-4,63) terr=68"
         },
         {
+          "x": -2,
+          "y": -32,
+          "details": "river surf=222 -> dry(-2,-33) terr=220"
+        },
+        {
+          "x": -1,
+          "y": -30,
+          "details": "river surf=234 -> dry(0,-30) terr=232"
+        },
+        {
+          "x": 4,
+          "y": -32,
+          "details": "river surf=174 -> dry(4,-33) terr=173"
+        },
+        {
           "x": 13,
           "y": -16,
-          "details": "river surf=277 -> dry(13,-17) terr=269"
+          "details": "river surf=277 -> dry(13,-17) terr=263"
+        },
+        {
+          "x": 15,
+          "y": -15,
+          "details": "river surf=265 -> dry(16,-15) terr=264"
         },
         {
           "x": 15,
@@ -12580,12 +12635,12 @@
         {
           "x": -64,
           "y": 32,
-          "details": "river surf=42 terr=41 -> land(-64,33) terr=36 cliff=6"
+          "details": "river surf=42 terr=39 -> land(-64,33) terr=36 cliff=6"
         },
         {
           "x": -64,
           "y": 34,
-          "details": "river surf=42 terr=41 -> land(-64,33) terr=36 cliff=6"
+          "details": "river surf=42 terr=36 -> land(-64,33) terr=36 cliff=6"
         },
         {
           "x": -64,
@@ -12595,7 +12650,7 @@
         {
           "x": -63,
           "y": 40,
-          "details": "river surf=35 terr=34 -> land(-64,40) terr=30 cliff=5"
+          "details": "river surf=35 terr=33 -> land(-64,40) terr=30 cliff=5"
         },
         {
           "x": -63,
@@ -12610,7 +12665,7 @@
         {
           "x": -63,
           "y": 69,
-          "details": "river surf=30 terr=29 -> land(-63,68) terr=27 cliff=3"
+          "details": "river surf=30 terr=27 -> land(-63,68) terr=27 cliff=3"
         },
         {
           "x": -62,
@@ -12620,42 +12675,42 @@
         {
           "x": -62,
           "y": 69,
-          "details": "river surf=34 terr=33 -> land(-62,68) terr=31 cliff=3"
+          "details": "river surf=34 terr=29 -> land(-62,68) terr=31 cliff=3"
         },
         {
           "x": -62,
           "y": 71,
-          "details": "river surf=43 terr=42 -> land(-63,71) terr=37 cliff=6"
+          "details": "river surf=43 terr=37 -> land(-63,71) terr=37 cliff=6"
         },
         {
           "x": -62,
           "y": 72,
-          "details": "river surf=50 terr=49 -> land(-63,72) terr=44 cliff=6"
+          "details": "river surf=50 terr=43 -> land(-63,72) terr=44 cliff=6"
         },
         {
           "x": -61,
           "y": 54,
-          "details": "river surf=12 terr=11 -> land(-62,54) terr=8 cliff=4"
+          "details": "river surf=12 terr=8 -> land(-62,54) terr=8 cliff=4"
         },
         {
           "x": -61,
           "y": 57,
-          "details": "river surf=10 terr=9 -> land(-62,57) terr=7 cliff=3"
+          "details": "river surf=10 terr=4 -> land(-62,57) terr=7 cliff=3"
         },
         {
           "x": -61,
           "y": 61,
-          "details": "river surf=24 terr=23 -> land(-62,61) terr=15 cliff=9"
+          "details": "river surf=24 terr=18 -> land(-62,61) terr=15 cliff=9"
         },
         {
           "x": -61,
           "y": 68,
-          "details": "river surf=35 terr=34 -> land(-62,68) terr=31 cliff=4"
+          "details": "river surf=35 terr=29 -> land(-62,68) terr=31 cliff=4"
         },
         {
           "x": -61,
           "y": 73,
-          "details": "river surf=71 terr=70 -> land(-62,73) terr=62 cliff=9"
+          "details": "river surf=71 terr=65 -> land(-62,73) terr=62 cliff=9"
         },
         {
           "x": -61,
@@ -12670,37 +12725,42 @@
         {
           "x": -61,
           "y": 79,
-          "details": "river surf=95 terr=94 -> land(-62,79) terr=89 cliff=6"
+          "details": "river surf=95 terr=92 -> land(-62,79) terr=89 cliff=6"
         },
         {
           "x": -60,
           "y": 26,
-          "details": "river surf=60 terr=59 -> land(-61,26) terr=58 cliff=2"
+          "details": "river surf=60 terr=56 -> land(-61,26) terr=58 cliff=2"
         },
         {
           "x": -60,
           "y": 64,
-          "details": "river surf=37 terr=36 -> land(-61,64) terr=28 cliff=9"
+          "details": "river surf=37 terr=31 -> land(-61,64) terr=28 cliff=9"
         },
         {
           "x": -60,
           "y": 74,
-          "details": "river surf=91 terr=90 -> land(-61,74) terr=82 cliff=9"
+          "details": "river surf=91 terr=86 -> land(-61,74) terr=82 cliff=9"
         },
         {
           "x": -60,
           "y": 75,
-          "details": "river surf=99 terr=98 -> land(-61,75) terr=92 cliff=7"
+          "details": "river surf=99 terr=95 -> land(-61,75) terr=92 cliff=7"
         },
         {
           "x": -60,
           "y": 76,
-          "details": "river surf=106 terr=105 -> land(-61,76) terr=100 cliff=6"
+          "details": "river surf=106 terr=103 -> land(-61,76) terr=100 cliff=6"
+        },
+        {
+          "x": -58,
+          "y": 61,
+          "details": "river surf=60 terr=54 -> land(-58,60) terr=57 cliff=3"
         },
         {
           "x": -55,
           "y": 60,
-          "details": "river surf=92 terr=91 -> land(-56,60) terr=87 cliff=5"
+          "details": "river surf=92 terr=89 -> land(-56,60) terr=87 cliff=5"
         },
         {
           "x": -53,
@@ -12715,7 +12775,7 @@
         {
           "x": -51,
           "y": 66,
-          "details": "river surf=134 terr=132 -> land(-51,65) terr=132 cliff=2"
+          "details": "river surf=134 terr=131 -> land(-51,65) terr=132 cliff=2"
         },
         {
           "x": -50,
@@ -12725,72 +12785,72 @@
         {
           "x": -47,
           "y": 77,
-          "details": "river surf=174 terr=173 -> land(-48,77) terr=170 cliff=4"
+          "details": "river surf=174 terr=169 -> land(-48,77) terr=170 cliff=4"
         },
         {
           "x": -47,
           "y": 78,
-          "details": "river surf=182 terr=181 -> land(-48,78) terr=178 cliff=4"
+          "details": "river surf=182 terr=178 -> land(-48,78) terr=178 cliff=4"
         },
         {
           "x": -47,
           "y": 79,
-          "details": "river surf=189 terr=188 -> land(-48,79) terr=183 cliff=6"
+          "details": "river surf=189 terr=186 -> land(-48,79) terr=183 cliff=6"
         },
         {
           "x": -45,
           "y": 77,
-          "details": "river surf=193 terr=192 -> land(-45,76) terr=191 cliff=2"
+          "details": "river surf=193 terr=187 -> land(-45,76) terr=191 cliff=2"
         },
         {
           "x": -44,
           "y": 67,
-          "details": "river surf=141 terr=140 -> land(-44,66) terr=137 cliff=4"
+          "details": "river surf=141 terr=136 -> land(-44,66) terr=137 cliff=4"
         },
         {
           "x": -44,
           "y": 72,
-          "details": "river surf=156 terr=155 -> land(-44,71) terr=150 cliff=6"
+          "details": "river surf=156 terr=149 -> land(-44,71) terr=150 cliff=6"
         },
         {
           "x": -42,
           "y": 73,
-          "details": "river surf=192 terr=191 -> land(-43,73) terr=186 cliff=6"
+          "details": "river surf=192 terr=187 -> land(-43,73) terr=186 cliff=6"
         },
         {
           "x": -41,
           "y": 68,
-          "details": "river surf=145 terr=144 -> land(-42,68) terr=141 cliff=4"
+          "details": "river surf=145 terr=140 -> land(-42,68) terr=141 cliff=4"
         },
         {
           "x": -41,
           "y": 74,
-          "details": "river surf=215 terr=214 -> land(-42,74) terr=213 cliff=2"
+          "details": "river surf=215 terr=212 -> land(-42,74) terr=213 cliff=2"
         },
         {
           "x": -40,
           "y": 62,
-          "details": "river surf=112 terr=111 -> land(-40,61) terr=105 cliff=7"
+          "details": "river surf=112 terr=106 -> land(-40,61) terr=105 cliff=7"
         },
         {
           "x": -40,
           "y": 65,
-          "details": "river surf=130 terr=129 -> land(-40,64) terr=125 cliff=5"
+          "details": "river surf=130 terr=124 -> land(-40,64) terr=125 cliff=5"
         },
         {
           "x": -39,
           "y": 60,
-          "details": "river surf=107 terr=106 -> land(-39,59) terr=103 cliff=4"
+          "details": "river surf=107 terr=102 -> land(-39,59) terr=103 cliff=4"
         },
         {
           "x": -39,
           "y": 65,
-          "details": "river surf=142 terr=141 -> land(-39,64) terr=135 cliff=7"
+          "details": "river surf=142 terr=136 -> land(-39,64) terr=135 cliff=7"
         },
         {
           "x": -38,
           "y": 60,
-          "details": "river surf=113 terr=112 -> land(-38,59) terr=109 cliff=4"
+          "details": "river surf=113 terr=108 -> land(-38,59) terr=109 cliff=4"
         },
         {
           "x": -38,
@@ -12805,42 +12865,42 @@
         {
           "x": -37,
           "y": 60,
-          "details": "river surf=118 terr=117 -> land(-37,59) terr=114 cliff=4"
+          "details": "river surf=118 terr=113 -> land(-37,59) terr=114 cliff=4"
         },
         {
           "x": -37,
           "y": 61,
-          "details": "river surf=123 terr=122 -> land(-38,61) terr=118 cliff=5"
+          "details": "river surf=123 terr=118 -> land(-38,61) terr=118 cliff=5"
         },
         {
           "x": -36,
           "y": 57,
-          "details": "river surf=110 terr=109 -> land(-37,57) terr=106 cliff=4"
+          "details": "river surf=110 terr=107 -> land(-37,57) terr=106 cliff=4"
         },
         {
           "x": -36,
           "y": 58,
-          "details": "river surf=114 terr=113 -> land(-37,58) terr=110 cliff=4"
+          "details": "river surf=114 terr=111 -> land(-37,58) terr=110 cliff=4"
         },
         {
           "x": -36,
           "y": 60,
-          "details": "river surf=124 terr=123 -> land(-36,59) terr=119 cliff=5"
+          "details": "river surf=124 terr=120 -> land(-36,59) terr=119 cliff=5"
         },
         {
           "x": -35,
           "y": 60,
-          "details": "river surf=131 terr=130 -> land(-35,59) terr=125 cliff=6"
+          "details": "river surf=131 terr=127 -> land(-35,59) terr=125 cliff=6"
         },
         {
           "x": -35,
           "y": 62,
-          "details": "river surf=151 terr=150 -> land(-36,62) terr=143 cliff=8"
+          "details": "river surf=151 terr=148 -> land(-36,62) terr=143 cliff=8"
         },
         {
           "x": -35,
           "y": 63,
-          "details": "river surf=163 terr=162 -> land(-36,63) terr=159 cliff=4"
+          "details": "river surf=163 terr=160 -> land(-36,63) terr=159 cliff=4"
         },
         {
           "x": -34,
@@ -12850,7 +12910,7 @@
         {
           "x": -34,
           "y": 60,
-          "details": "river surf=139 terr=138 -> land(-34,59) terr=132 cliff=7"
+          "details": "river surf=139 terr=136 -> land(-34,59) terr=132 cliff=7"
         },
         {
           "x": -33,
@@ -12880,12 +12940,12 @@
         {
           "x": -27,
           "y": 43,
-          "details": "river surf=33 terr=32 -> land(-26,43) terr=30 cliff=3"
+          "details": "river surf=33 terr=31 -> land(-26,43) terr=30 cliff=3"
         },
         {
           "x": -27,
           "y": 46,
-          "details": "river surf=59 terr=58 -> land(-26,46) terr=52 cliff=7"
+          "details": "river surf=59 terr=54 -> land(-26,46) terr=52 cliff=7"
         },
         {
           "x": -27,
@@ -12910,7 +12970,7 @@
         {
           "x": -25,
           "y": 58,
-          "details": "river surf=121 terr=120 -> land(-24,58) terr=117 cliff=4"
+          "details": "river surf=121 terr=119 -> land(-24,58) terr=117 cliff=4"
         },
         {
           "x": -25,
@@ -12930,12 +12990,12 @@
         {
           "x": -25,
           "y": 62,
-          "details": "river surf=158 terr=157 -> land(-24,62) terr=151 cliff=7"
+          "details": "river surf=158 terr=156 -> land(-24,62) terr=151 cliff=7"
         },
         {
           "x": -25,
           "y": 63,
-          "details": "river surf=167 terr=166 -> land(-24,63) terr=159 cliff=8"
+          "details": "river surf=167 terr=165 -> land(-24,63) terr=159 cliff=8"
         },
         {
           "x": -25,
@@ -12960,17 +13020,17 @@
         {
           "x": -23,
           "y": 64,
-          "details": "river surf=158 terr=157 -> land(-23,63) terr=150 cliff=8"
+          "details": "river surf=158 terr=152 -> land(-23,63) terr=150 cliff=8"
         },
         {
           "x": -22,
           "y": 50,
-          "details": "river surf=55 terr=54 -> land(-22,49) terr=47 cliff=8"
+          "details": "river surf=55 terr=51 -> land(-22,49) terr=47 cliff=8"
         },
         {
           "x": -22,
           "y": 68,
-          "details": "river surf=179 terr=178 -> land(-22,67) terr=175 cliff=4"
+          "details": "river surf=179 terr=174 -> land(-22,67) terr=175 cliff=4"
         },
         {
           "x": -21,
@@ -12990,37 +13050,37 @@
         {
           "x": -21,
           "y": 66,
-          "details": "river surf=159 terr=158 -> land(-20,66) terr=154 cliff=5"
+          "details": "river surf=159 terr=153 -> land(-20,66) terr=154 cliff=5"
         },
         {
           "x": -21,
           "y": 67,
-          "details": "river surf=166 terr=165 -> land(-20,67) terr=162 cliff=4"
+          "details": "river surf=166 terr=160 -> land(-20,67) terr=162 cliff=4"
         },
         {
           "x": -20,
           "y": 50,
-          "details": "river surf=36 terr=35 -> land(-19,50) terr=33 cliff=3"
+          "details": "river surf=36 terr=32 -> land(-19,50) terr=33 cliff=3"
         },
         {
           "x": -20,
           "y": 51,
-          "details": "river surf=46 terr=43 -> land(-19,51) terr=42 cliff=4"
+          "details": "river surf=46 terr=40 -> land(-19,51) terr=42 cliff=4"
         },
         {
           "x": -20,
           "y": 52,
-          "details": "river surf=56 terr=53 -> land(-19,52) terr=51 cliff=5"
+          "details": "river surf=56 terr=51 -> land(-19,52) terr=51 cliff=5"
         },
         {
           "x": -20,
           "y": 53,
-          "details": "river surf=66 terr=63 -> land(-19,53) terr=60 cliff=6"
+          "details": "river surf=66 terr=62 -> land(-19,53) terr=60 cliff=6"
         },
         {
           "x": -20,
           "y": 54,
-          "details": "river surf=76 terr=73 -> land(-19,54) terr=69 cliff=7"
+          "details": "river surf=76 terr=72 -> land(-19,54) terr=69 cliff=7"
         },
         {
           "x": -20,
@@ -13045,32 +13105,32 @@
         {
           "x": -20,
           "y": 59,
-          "details": "river surf=113 terr=112 -> land(-19,59) terr=110 cliff=3"
+          "details": "river surf=113 terr=111 -> land(-19,59) terr=110 cliff=3"
         },
         {
           "x": -20,
           "y": 60,
-          "details": "river surf=118 terr=117 -> land(-19,60) terr=114 cliff=4"
+          "details": "river surf=118 terr=116 -> land(-19,60) terr=114 cliff=4"
         },
         {
           "x": -19,
           "y": 61,
-          "details": "river surf=119 terr=118 -> land(-19,60) terr=114 cliff=5"
+          "details": "river surf=119 terr=117 -> land(-19,60) terr=114 cliff=5"
         },
         {
           "x": -18,
           "y": 52,
-          "details": "river surf=42 terr=40 -> land(-18,51) terr=39 cliff=3"
+          "details": "river surf=42 terr=39 -> land(-18,51) terr=39 cliff=3"
         },
         {
           "x": -18,
           "y": 61,
-          "details": "river surf=112 terr=111 -> land(-18,60) terr=108 cliff=4"
+          "details": "river surf=112 terr=109 -> land(-18,60) terr=108 cliff=4"
         },
         {
           "x": -18,
           "y": 66,
-          "details": "river surf=158 terr=157 -> land(-19,66) terr=155 cliff=3"
+          "details": "river surf=158 terr=153 -> land(-19,66) terr=155 cliff=3"
         },
         {
           "x": -17,
@@ -13080,82 +13140,82 @@
         {
           "x": -17,
           "y": 52,
-          "details": "river surf=42 terr=40 -> land(-17,51) terr=39 cliff=3"
+          "details": "river surf=42 terr=38 -> land(-17,51) terr=39 cliff=3"
         },
         {
           "x": -17,
           "y": 57,
-          "details": "river surf=73 terr=72 -> land(-17,56) terr=63 cliff=10"
+          "details": "river surf=73 terr=67 -> land(-17,56) terr=63 cliff=10"
         },
         {
           "x": -17,
           "y": 61,
-          "details": "river surf=106 terr=105 -> land(-17,60) terr=99 cliff=7"
+          "details": "river surf=106 terr=102 -> land(-17,60) terr=99 cliff=7"
         },
         {
           "x": -16,
           "y": 5,
-          "details": "river surf=168 terr=167 -> land(-16,6) terr=165 cliff=3"
+          "details": "river surf=168 terr=166 -> land(-16,6) terr=165 cliff=3"
         },
         {
           "x": -16,
           "y": 50,
-          "details": "river surf=38 terr=36 -> land(-17,50) terr=33 cliff=5"
+          "details": "river surf=38 terr=33 -> land(-17,50) terr=33 cliff=5"
         },
         {
           "x": -16,
           "y": 51,
-          "details": "river surf=42 terr=40 -> land(-17,51) terr=39 cliff=3"
+          "details": "river surf=42 terr=38 -> land(-17,51) terr=39 cliff=3"
         },
         {
           "x": -16,
           "y": 62,
-          "details": "river surf=109 terr=108 -> land(-15,62) terr=107 cliff=2"
+          "details": "river surf=109 terr=104 -> land(-15,62) terr=107 cliff=2"
         },
         {
           "x": -15,
           "y": 7,
-          "details": "river surf=156 terr=155 -> land(-15,8) terr=152 cliff=4"
+          "details": "river surf=156 terr=154 -> land(-15,8) terr=152 cliff=4"
         },
         {
           "x": -15,
           "y": 50,
-          "details": "river surf=47 terr=46 -> land(-15,49) terr=40 cliff=7"
+          "details": "river surf=47 terr=43 -> land(-15,49) terr=40 cliff=7"
         },
         {
           "x": -13,
           "y": 56,
-          "details": "river surf=61 terr=60 -> land(-13,55) terr=57 cliff=4"
+          "details": "river surf=61 terr=58 -> land(-13,55) terr=57 cliff=4"
         },
         {
           "x": -12,
           "y": -5,
-          "details": "river surf=230 terr=229 -> land(-13,-5) terr=228 cliff=2"
+          "details": "river surf=230 terr=227 -> land(-13,-5) terr=228 cliff=2"
         },
         {
           "x": -12,
           "y": 56,
-          "details": "river surf=69 terr=68 -> land(-12,55) terr=67 cliff=2"
+          "details": "river surf=69 terr=67 -> land(-12,55) terr=67 cliff=2"
         },
         {
           "x": -11,
           "y": 8,
-          "details": "river surf=148 terr=147 -> land(-11,9) terr=142 cliff=6"
+          "details": "river surf=148 terr=144 -> land(-11,9) terr=142 cliff=6"
         },
         {
           "x": -11,
           "y": 68,
-          "details": "river surf=134 terr=133 -> land(-11,67) terr=129 cliff=5"
+          "details": "river surf=134 terr=129 -> land(-11,67) terr=129 cliff=5"
         },
         {
           "x": -11,
           "y": 69,
-          "details": "river surf=142 terr=141 -> land(-10,69) terr=134 cliff=8"
+          "details": "river surf=142 terr=138 -> land(-10,69) terr=134 cliff=8"
         },
         {
           "x": -11,
           "y": 70,
-          "details": "river surf=149 terr=148 -> land(-10,70) terr=142 cliff=7"
+          "details": "river surf=149 terr=146 -> land(-10,70) terr=142 cliff=7"
         },
         {
           "x": -11,
@@ -13175,12 +13235,12 @@
         {
           "x": -10,
           "y": 67,
-          "details": "river surf=120 terr=119 -> land(-10,66) terr=117 cliff=3"
+          "details": "river surf=120 terr=115 -> land(-10,66) terr=117 cliff=3"
         },
         {
           "x": -10,
           "y": 68,
-          "details": "river surf=126 terr=125 -> land(-9,68) terr=122 cliff=4"
+          "details": "river surf=126 terr=121 -> land(-9,68) terr=122 cliff=4"
         },
         {
           "x": -9,
@@ -13190,12 +13250,17 @@
         {
           "x": -9,
           "y": 67,
-          "details": "river surf=116 terr=115 -> land(-8,67) terr=112 cliff=4"
+          "details": "river surf=116 terr=112 -> land(-8,67) terr=112 cliff=4"
         },
         {
           "x": -8,
           "y": 5,
           "details": "river surf=186 terr=182 -> land(-8,6) terr=180 cliff=6"
+        },
+        {
+          "x": -7,
+          "y": -31,
+          "details": "lake surf=311 terr=308 -> land(-7,-32) terr=306 cliff=5"
         },
         {
           "x": -7,
@@ -13205,7 +13270,7 @@
         {
           "x": -6,
           "y": -31,
-          "details": "lake surf=311 terr=297 -> land(-6,-32) terr=285 cliff=26"
+          "details": "lake surf=311 terr=290 -> land(-6,-32) terr=278 cliff=33"
         },
         {
           "x": -6,
@@ -13215,22 +13280,32 @@
         {
           "x": -6,
           "y": 64,
-          "details": "river surf=91 terr=90 -> land(-6,63) terr=86 cliff=5"
+          "details": "river surf=91 terr=88 -> land(-6,63) terr=86 cliff=5"
+        },
+        {
+          "x": -5,
+          "y": -31,
+          "details": "river surf=270 terr=262 -> land(-4,-31) terr=267 cliff=3"
         },
         {
           "x": -5,
           "y": 61,
-          "details": "river surf=58 terr=57 -> land(-5,60) terr=53 cliff=5"
+          "details": "river surf=58 terr=52 -> land(-5,60) terr=53 cliff=5"
         },
         {
           "x": -5,
           "y": 62,
-          "details": "river surf=67 terr=66 -> land(-4,62) terr=60 cliff=7"
+          "details": "river surf=67 terr=61 -> land(-4,62) terr=60 cliff=7"
         },
         {
           "x": -5,
           "y": 63,
-          "details": "river surf=76 terr=75 -> land(-4,63) terr=68 cliff=8"
+          "details": "river surf=76 terr=71 -> land(-4,63) terr=68 cliff=8"
+        },
+        {
+          "x": -5,
+          "y": 77,
+          "details": "river surf=104 terr=99 -> land(-5,76) terr=101 cliff=3"
         },
         {
           "x": -4,
@@ -13240,12 +13315,17 @@
         {
           "x": -4,
           "y": 64,
-          "details": "river surf=74 terr=73 -> land(-4,63) terr=68 cliff=6"
+          "details": "river surf=74 terr=70 -> land(-4,63) terr=68 cliff=6"
+        },
+        {
+          "x": -4,
+          "y": 77,
+          "details": "river surf=92 terr=85 -> land(-3,77) terr=90 cliff=2"
         },
         {
           "x": -3,
           "y": -25,
-          "details": "river surf=307 terr=306 -> land(-3,-26) terr=301 cliff=6"
+          "details": "river surf=307 terr=300 -> land(-3,-26) terr=301 cliff=6"
         },
         {
           "x": -3,
@@ -13254,18 +13334,28 @@
         },
         {
           "x": -2,
+          "y": -37,
+          "details": "river surf=162 terr=156 -> land(-2,-38) terr=160 cliff=2"
+        },
+        {
+          "x": -2,
+          "y": -32,
+          "details": "river surf=222 terr=215 -> land(-2,-33) terr=220 cliff=2"
+        },
+        {
+          "x": -2,
           "y": -27,
-          "details": "river surf=282 terr=281 -> land(-2,-28) terr=279 cliff=3"
+          "details": "river surf=282 terr=275 -> land(-2,-28) terr=279 cliff=3"
         },
         {
           "x": -2,
           "y": 4,
-          "details": "river surf=186 terr=185 -> land(-2,5) terr=182 cliff=4"
+          "details": "river surf=186 terr=183 -> land(-2,5) terr=182 cliff=4"
         },
         {
           "x": -2,
           "y": 62,
-          "details": "river surf=49 terr=48 -> land(-1,62) terr=44 cliff=5"
+          "details": "river surf=49 terr=45 -> land(-1,62) terr=44 cliff=5"
         },
         {
           "x": -2,
@@ -13289,8 +13379,18 @@
         },
         {
           "x": -1,
+          "y": -30,
+          "details": "river surf=234 terr=227 -> land(0,-30) terr=232 cliff=2"
+        },
+        {
+          "x": -1,
           "y": 5,
           "details": "river surf=179 terr=174 -> land(-1,6) terr=170 cliff=9"
+        },
+        {
+          "x": 0,
+          "y": -31,
+          "details": "river surf=210 terr=204 -> land(1,-31) terr=208 cliff=2"
         },
         {
           "x": 0,
@@ -13300,7 +13400,17 @@
         {
           "x": 3,
           "y": -40,
-          "details": "river surf=138 terr=120 -> land(4,-40) terr=92 cliff=46"
+          "details": "river surf=138 terr=114 -> land(4,-40) terr=86 cliff=52"
+        },
+        {
+          "x": 3,
+          "y": -37,
+          "details": "river surf=102 terr=96 -> land(4,-37) terr=100 cliff=2"
+        },
+        {
+          "x": 4,
+          "y": -38,
+          "details": "river surf=78 terr=72 -> land(5,-38) terr=74 cliff=4"
         },
         {
           "x": 5,
@@ -13329,6 +13439,11 @@
         },
         {
           "x": 8,
+          "y": -22,
+          "details": "river surf=222 terr=215 -> land(8,-23) terr=219 cliff=3"
+        },
+        {
+          "x": 8,
           "y": -10,
           "details": "river surf=279 terr=278 -> land(9,-10) terr=277 cliff=2"
         },
@@ -13345,12 +13460,22 @@
         {
           "x": 8,
           "y": -4,
-          "details": "river surf=227 terr=226 -> land(8,-3) terr=224 cliff=3"
+          "details": "river surf=227 terr=225 -> land(8,-3) terr=224 cliff=3"
+        },
+        {
+          "x": 9,
+          "y": -23,
+          "details": "river surf=198 terr=191 -> land(10,-23) terr=195 cliff=3"
         },
         {
           "x": 9,
           "y": 5,
-          "details": "river surf=195 terr=194 -> land(9,6) terr=193 cliff=2"
+          "details": "river surf=195 terr=192 -> land(9,6) terr=193 cliff=2"
+        },
+        {
+          "x": 10,
+          "y": -24,
+          "details": "river surf=174 terr=167 -> land(10,-25) terr=171 cliff=3"
         },
         {
           "x": 10,
@@ -13358,9 +13483,19 @@
           "details": "river surf=269 terr=268 -> land(11,-9) terr=267 cliff=2"
         },
         {
+          "x": 11,
+          "y": -31,
+          "details": "river surf=78 terr=72 -> land(11,-32) terr=75 cliff=3"
+        },
+        {
           "x": 13,
           "y": -16,
-          "details": "river surf=277 terr=276 -> land(13,-17) terr=269 cliff=8"
+          "details": "river surf=277 terr=276 -> land(13,-17) terr=263 cliff=14"
+        },
+        {
+          "x": 15,
+          "y": -17,
+          "details": "river surf=241 terr=236 -> land(15,-18) terr=238 cliff=3"
         },
         {
           "x": 15,
@@ -13373,24 +13508,64 @@
           "details": "river surf=220 terr=219 -> land(15,-3) terr=216 cliff=4"
         },
         {
+          "x": 16,
+          "y": -26,
+          "details": "river surf=126 terr=121 -> land(16,-27) terr=123 cliff=3"
+        },
+        {
+          "x": 17,
+          "y": -33,
+          "details": "river surf=54 terr=47 -> land(16,-33) terr=51 cliff=3"
+        },
+        {
+          "x": 17,
+          "y": -32,
+          "details": "river surf=66 terr=59 -> land(16,-32) terr=63 cliff=3"
+        },
+        {
+          "x": 17,
+          "y": -31,
+          "details": "river surf=78 terr=71 -> land(16,-31) terr=75 cliff=3"
+        },
+        {
+          "x": 17,
+          "y": -30,
+          "details": "river surf=90 terr=84 -> land(16,-30) terr=87 cliff=3"
+        },
+        {
+          "x": 17,
+          "y": -29,
+          "details": "river surf=102 terr=96 -> land(16,-29) terr=99 cliff=3"
+        },
+        {
+          "x": 17,
+          "y": -28,
+          "details": "river surf=114 terr=109 -> land(16,-28) terr=111 cliff=3"
+        },
+        {
+          "x": 17,
+          "y": -27,
+          "details": "river surf=126 terr=122 -> land(16,-27) terr=123 cliff=3"
+        },
+        {
           "x": 18,
           "y": -32,
-          "details": "lake surf=120 terr=93 -> land(18,-33) terr=81 cliff=39"
+          "details": "lake surf=120 terr=87 -> land(19,-32) terr=115 cliff=5"
         },
         {
           "x": 18,
           "y": -17,
-          "details": "river surf=239 terr=238 -> land(19,-17) terr=230 cliff=9"
+          "details": "river surf=239 terr=236 -> land(19,-17) terr=230 cliff=9"
         },
         {
           "x": 18,
           "y": -9,
-          "details": "river surf=260 terr=259 -> land(19,-9) terr=257 cliff=3"
+          "details": "river surf=260 terr=258 -> land(19,-9) terr=257 cliff=3"
         },
         {
           "x": 18,
           "y": -8,
-          "details": "river surf=250 terr=249 -> land(19,-8) terr=247 cliff=3"
+          "details": "river surf=250 terr=248 -> land(19,-8) terr=247 cliff=3"
         },
         {
           "x": 19,
@@ -13420,7 +13595,7 @@
         {
           "x": 22,
           "y": -9,
-          "details": "river surf=249 terr=248 -> land(23,-9) terr=247 cliff=2"
+          "details": "river surf=249 terr=246 -> land(23,-9) terr=247 cliff=2"
         },
         {
           "x": 25,
@@ -13430,22 +13605,22 @@
         {
           "x": 25,
           "y": -7,
-          "details": "river surf=233 terr=232 -> land(26,-7) terr=230 cliff=3"
+          "details": "river surf=233 terr=229 -> land(26,-7) terr=230 cliff=3"
         },
         {
           "x": 25,
           "y": -6,
-          "details": "river surf=227 terr=226 -> land(25,-5) terr=225 cliff=2"
+          "details": "river surf=227 terr=223 -> land(25,-5) terr=225 cliff=2"
         },
         {
           "x": 25,
           "y": -3,
-          "details": "river surf=227 terr=226 -> land(25,-4) terr=225 cliff=2"
+          "details": "river surf=227 terr=224 -> land(25,-4) terr=225 cliff=2"
         },
         {
           "x": 26,
           "y": -3,
-          "details": "river surf=238 terr=237 -> land(26,-4) terr=235 cliff=3"
+          "details": "river surf=238 terr=236 -> land(26,-4) terr=235 cliff=3"
         },
         {
           "x": 26,
@@ -13573,6 +13748,11 @@
           "x": -60,
           "y": 76,
           "details": "river surf=106 -> dry(-61,76) terr=100 cliff=6"
+        },
+        {
+          "x": -58,
+          "y": 61,
+          "details": "river surf=60 -> dry(-58,60) terr=57 cliff=3"
         },
         {
           "x": -55,
@@ -14076,13 +14256,18 @@
         },
         {
           "x": -7,
+          "y": -31,
+          "details": "lake surf=311 -> dry(-7,-32) terr=306 cliff=5"
+        },
+        {
+          "x": -7,
           "y": 4,
           "details": "river surf=190 -> dry(-7,5) terr=187 cliff=3"
         },
         {
           "x": -6,
           "y": -31,
-          "details": "lake surf=311 -> dry(-6,-32) terr=285 cliff=26"
+          "details": "lake surf=311 -> dry(-6,-32) terr=278 cliff=33"
         },
         {
           "x": -6,
@@ -14093,6 +14278,11 @@
           "x": -6,
           "y": 64,
           "details": "river surf=91 -> dry(-6,63) terr=86 cliff=5"
+        },
+        {
+          "x": -5,
+          "y": -31,
+          "details": "river surf=270 -> dry(-4,-31) terr=267 cliff=3"
         },
         {
           "x": -5,
@@ -14110,6 +14300,11 @@
           "details": "river surf=76 -> dry(-4,63) terr=68 cliff=8"
         },
         {
+          "x": -5,
+          "y": 77,
+          "details": "river surf=104 -> dry(-5,76) terr=101 cliff=3"
+        },
+        {
           "x": -4,
           "y": 4,
           "details": "river surf=195 -> dry(-4,5) terr=193 cliff=2"
@@ -14120,6 +14315,11 @@
           "details": "river surf=74 -> dry(-4,63) terr=68 cliff=6"
         },
         {
+          "x": -4,
+          "y": 77,
+          "details": "river surf=92 -> dry(-3,77) terr=90 cliff=2"
+        },
+        {
           "x": -3,
           "y": -25,
           "details": "river surf=307 -> dry(-3,-26) terr=301 cliff=6"
@@ -14128,6 +14328,16 @@
           "x": -3,
           "y": 4,
           "details": "river surf=191 -> dry(-3,5) terr=189 cliff=2"
+        },
+        {
+          "x": -2,
+          "y": -37,
+          "details": "river surf=162 -> dry(-2,-38) terr=160 cliff=2"
+        },
+        {
+          "x": -2,
+          "y": -32,
+          "details": "river surf=222 -> dry(-2,-33) terr=220 cliff=2"
         },
         {
           "x": -2,
@@ -14166,8 +14376,18 @@
         },
         {
           "x": -1,
+          "y": -30,
+          "details": "river surf=234 -> dry(0,-30) terr=232 cliff=2"
+        },
+        {
+          "x": -1,
           "y": 5,
           "details": "river surf=179 -> dry(-1,6) terr=170 cliff=9"
+        },
+        {
+          "x": 0,
+          "y": -31,
+          "details": "river surf=210 -> dry(1,-31) terr=208 cliff=2"
         },
         {
           "x": 0,
@@ -14177,7 +14397,17 @@
         {
           "x": 3,
           "y": -40,
-          "details": "river surf=138 -> dry(4,-40) terr=92 cliff=46"
+          "details": "river surf=138 -> dry(4,-40) terr=86 cliff=52"
+        },
+        {
+          "x": 3,
+          "y": -37,
+          "details": "river surf=102 -> dry(4,-37) terr=100 cliff=2"
+        },
+        {
+          "x": 4,
+          "y": -38,
+          "details": "river surf=78 -> dry(5,-38) terr=74 cliff=4"
         },
         {
           "x": 5,
@@ -14206,6 +14436,11 @@
         },
         {
           "x": 8,
+          "y": -22,
+          "details": "river surf=222 -> dry(8,-23) terr=219 cliff=3"
+        },
+        {
+          "x": 8,
           "y": -10,
           "details": "river surf=279 -> dry(9,-10) terr=277 cliff=2"
         },
@@ -14226,8 +14461,18 @@
         },
         {
           "x": 9,
+          "y": -23,
+          "details": "river surf=198 -> dry(10,-23) terr=195 cliff=3"
+        },
+        {
+          "x": 9,
           "y": 5,
           "details": "river surf=195 -> dry(9,6) terr=193 cliff=2"
+        },
+        {
+          "x": 10,
+          "y": -24,
+          "details": "river surf=174 -> dry(10,-25) terr=171 cliff=3"
         },
         {
           "x": 10,
@@ -14235,9 +14480,19 @@
           "details": "river surf=269 -> dry(11,-9) terr=267 cliff=2"
         },
         {
+          "x": 11,
+          "y": -31,
+          "details": "river surf=78 -> dry(11,-32) terr=75 cliff=3"
+        },
+        {
           "x": 13,
           "y": -16,
-          "details": "river surf=277 -> dry(13,-17) terr=269 cliff=8"
+          "details": "river surf=277 -> dry(13,-17) terr=263 cliff=14"
+        },
+        {
+          "x": 15,
+          "y": -17,
+          "details": "river surf=241 -> dry(15,-18) terr=238 cliff=3"
         },
         {
           "x": 15,
@@ -14250,9 +14505,49 @@
           "details": "river surf=220 -> dry(15,-3) terr=216 cliff=4"
         },
         {
+          "x": 16,
+          "y": -26,
+          "details": "river surf=126 -> dry(16,-27) terr=123 cliff=3"
+        },
+        {
+          "x": 17,
+          "y": -33,
+          "details": "river surf=54 -> dry(16,-33) terr=51 cliff=3"
+        },
+        {
+          "x": 17,
+          "y": -32,
+          "details": "river surf=66 -> dry(16,-32) terr=63 cliff=3"
+        },
+        {
+          "x": 17,
+          "y": -31,
+          "details": "river surf=78 -> dry(16,-31) terr=75 cliff=3"
+        },
+        {
+          "x": 17,
+          "y": -30,
+          "details": "river surf=90 -> dry(16,-30) terr=87 cliff=3"
+        },
+        {
+          "x": 17,
+          "y": -29,
+          "details": "river surf=102 -> dry(16,-29) terr=99 cliff=3"
+        },
+        {
+          "x": 17,
+          "y": -28,
+          "details": "river surf=114 -> dry(16,-28) terr=111 cliff=3"
+        },
+        {
+          "x": 17,
+          "y": -27,
+          "details": "river surf=126 -> dry(16,-27) terr=123 cliff=3"
+        },
+        {
           "x": 18,
           "y": -32,
-          "details": "lake surf=120 -> dry(18,-33) terr=81 cliff=39"
+          "details": "lake surf=120 -> dry(19,-32) terr=115 cliff=5"
         },
         {
           "x": 18,

--- a/tools/baselines/seed2718_size32_region_-4_-4_4_4.json
+++ b/tools/baselines/seed2718_size32_region_-4_-4_4_4.json
@@ -14,16 +14,16 @@
     "deterministic": true,
     "distinctHashes": 1,
     "hashes": [
-      "ce9de9c739f9255bfe1b1ecf681b52639d09fa69656870c434bfd4737373af85",
-      "ce9de9c739f9255bfe1b1ecf681b52639d09fa69656870c434bfd4737373af85",
-      "ce9de9c739f9255bfe1b1ecf681b52639d09fa69656870c434bfd4737373af85"
+      "08f28f877d7f597d79c2c5c932a76f72a5c7ae17ac12b5b9a222afa0289aafde",
+      "08f28f877d7f597d79c2c5c932a76f72a5c7ae17ac12b5b9a222afa0289aafde",
+      "08f28f877d7f597d79c2c5c932a76f72a5c7ae17ac12b5b9a222afa0289aafde"
     ]
   },
   "tileCount": 20736,
   "elevationStats": {
     "min": -22,
     "max": 347,
-    "median": 15,
+    "median": 14,
     "count": 20736
   },
   "fluidStats": {
@@ -86,33 +86,33 @@
       ]
     },
     "FLAT_ISOLATED_WATER": {
-      "min": 16,
-      "max": 16,
-      "median": 16,
+      "min": 15,
+      "max": 15,
+      "median": 15,
       "all": [
-        16,
-        16,
-        16
+        15,
+        15,
+        15
       ]
     },
     "FLOATING_LAKE": {
-      "min": 112,
-      "max": 112,
-      "median": 112,
+      "min": 113,
+      "max": 113,
+      "median": 113,
       "all": [
-        112,
-        112,
-        112
+        113,
+        113,
+        113
       ]
     },
     "FLOATING_WATER": {
-      "min": 152,
-      "max": 152,
-      "median": 152,
+      "min": 108,
+      "max": 108,
+      "median": 108,
       "all": [
-        152,
-        152,
-        152
+        108,
+        108,
+        108
       ]
     },
     "ISOLATED_FLUID": {
@@ -126,13 +126,13 @@
       ]
     },
     "MID_RIVER_CLIFF": {
-      "min": 6,
-      "max": 6,
-      "median": 6,
+      "min": 37,
+      "max": 37,
+      "median": 37,
       "all": [
-        6,
-        6,
-        6
+        37,
+        37,
+        37
       ]
     },
     "MULTI_ISLAND": {
@@ -146,33 +146,33 @@
       ]
     },
     "RIVER_CHUNK_GAP": {
-      "min": 14,
-      "max": 14,
-      "median": 14,
+      "min": 15,
+      "max": 15,
+      "median": 15,
       "all": [
-        14,
-        14,
-        14
+        15,
+        15,
+        15
       ]
     },
     "WATER_ABOVE_LAND": {
-      "min": 156,
-      "max": 156,
-      "median": 156,
+      "min": 187,
+      "max": 187,
+      "median": 187,
       "all": [
-        156,
-        156,
-        156
+        187,
+        187,
+        187
       ]
     },
     "WATER_CLIFF": {
-      "min": 156,
-      "max": 156,
-      "median": 156,
+      "min": 187,
+      "max": 187,
+      "median": 187,
       "all": [
-        156,
-        156,
-        156
+        187,
+        187,
+        187
       ]
     },
     "WATER_WATER_CLIFF": {
@@ -189,15 +189,15 @@
   "representativeAudit": {
     "summary": {
       "DESERT_SOIL_ON_SLOPE": 37,
-      "FLAT_ISOLATED_WATER": 16,
-      "FLOATING_LAKE": 112,
-      "FLOATING_WATER": 152,
+      "FLAT_ISOLATED_WATER": 15,
+      "FLOATING_LAKE": 113,
+      "FLOATING_WATER": 108,
       "ISOLATED_FLUID": 12,
-      "MID_RIVER_CLIFF": 6,
+      "MID_RIVER_CLIFF": 37,
       "MULTI_ISLAND": 4,
-      "RIVER_CHUNK_GAP": 14,
-      "WATER_ABOVE_LAND": 156,
-      "WATER_CLIFF": 156,
+      "RIVER_CHUNK_GAP": 15,
+      "WATER_ABOVE_LAND": 187,
+      "WATER_CLIFF": 187,
       "WATER_WATER_CLIFF": 1481
     },
     "issues": {
@@ -260,7 +260,7 @@
         {
           "x": -56,
           "y": 55,
-          "details": "sand maxNbrDelta=4"
+          "details": "sand maxNbrDelta=3"
         },
         {
           "x": -48,
@@ -280,7 +280,7 @@
         {
           "x": -42,
           "y": 45,
-          "details": "sand maxNbrDelta=7"
+          "details": "sand maxNbrDelta=11"
         },
         {
           "x": -42,
@@ -290,12 +290,12 @@
         {
           "x": -41,
           "y": 44,
-          "details": "sand maxNbrDelta=8"
+          "details": "sand maxNbrDelta=11"
         },
         {
           "x": -41,
           "y": 45,
-          "details": "sand maxNbrDelta=5"
+          "details": "sand maxNbrDelta=4"
         },
         {
           "x": -41,
@@ -320,12 +320,12 @@
         {
           "x": -39,
           "y": 42,
-          "details": "sand maxNbrDelta=5"
+          "details": "sand maxNbrDelta=4"
         },
         {
           "x": -39,
           "y": 43,
-          "details": "sand maxNbrDelta=4"
+          "details": "sand maxNbrDelta=3"
         },
         {
           "x": -38,
@@ -340,7 +340,7 @@
         {
           "x": -38,
           "y": 41,
-          "details": "sand maxNbrDelta=5"
+          "details": "sand maxNbrDelta=4"
         },
         {
           "x": -37,
@@ -350,7 +350,7 @@
         {
           "x": -37,
           "y": 40,
-          "details": "sand maxNbrDelta=5"
+          "details": "sand maxNbrDelta=4"
         },
         {
           "x": -36,
@@ -418,11 +418,6 @@
           "x": -33,
           "y": 26,
           "details": "river surf=1 terr=0 water_nbrs=1 terr_range=1"
-        },
-        {
-          "x": -32,
-          "y": -31,
-          "details": "river surf=13 terr=12 water_nbrs=1 terr_range=1"
         },
         {
           "x": -31,
@@ -504,12 +499,12 @@
         {
           "x": -55,
           "y": -28,
-          "details": "lake fluidSurf=307 terrainZ=285 depth=22"
+          "details": "lake fluidSurf=307 terrainZ=281 depth=26"
         },
         {
           "x": -55,
           "y": -27,
-          "details": "lake fluidSurf=307 terrainZ=273 depth=34"
+          "details": "lake fluidSurf=307 terrainZ=270 depth=37"
         },
         {
           "x": -55,
@@ -524,7 +519,7 @@
         {
           "x": -54,
           "y": -26,
-          "details": "lake fluidSurf=307 terrainZ=273 depth=34"
+          "details": "lake fluidSurf=307 terrainZ=270 depth=37"
         },
         {
           "x": -54,
@@ -754,32 +749,37 @@
         {
           "x": -44,
           "y": -23,
-          "details": "lake fluidSurf=189 terrainZ=116 depth=73"
+          "details": "lake fluidSurf=189 terrainZ=111 depth=78"
         },
         {
           "x": -44,
           "y": -22,
-          "details": "lake fluidSurf=189 terrainZ=144 depth=45"
+          "details": "lake fluidSurf=189 terrainZ=139 depth=50"
         },
         {
           "x": -44,
           "y": -21,
-          "details": "lake fluidSurf=189 terrainZ=165 depth=24"
+          "details": "lake fluidSurf=189 terrainZ=160 depth=29"
+        },
+        {
+          "x": -44,
+          "y": -20,
+          "details": "lake fluidSurf=189 terrainZ=172 depth=17"
         },
         {
           "x": -43,
           "y": -23,
-          "details": "lake fluidSurf=189 terrainZ=104 depth=85"
+          "details": "lake fluidSurf=189 terrainZ=99 depth=90"
         },
         {
           "x": -43,
           "y": -22,
-          "details": "lake fluidSurf=189 terrainZ=132 depth=57"
+          "details": "lake fluidSurf=189 terrainZ=127 depth=62"
         },
         {
           "x": -43,
           "y": -21,
-          "details": "lake fluidSurf=189 terrainZ=160 depth=29"
+          "details": "lake fluidSurf=189 terrainZ=155 depth=34"
         },
         {
           "x": -34,
@@ -1041,7 +1041,7 @@
         {
           "x": -64,
           "y": 41,
-          "details": "river terr=98 -> dry(-64,42) terr=93 gap=5"
+          "details": "river terr=96 -> dry(-64,42) terr=93 gap=3"
         },
         {
           "x": -63,
@@ -1071,7 +1071,7 @@
         {
           "x": -62,
           "y": 47,
-          "details": "river terr=76 -> dry(-63,47) terr=72 gap=4"
+          "details": "river terr=75 -> dry(-63,47) terr=72 gap=3"
         },
         {
           "x": -61,
@@ -1101,7 +1101,7 @@
         {
           "x": -59,
           "y": 34,
-          "details": "river terr=126 -> dry(-58,34) terr=123 gap=3"
+          "details": "river terr=124 -> dry(-58,34) terr=123 gap=1"
         },
         {
           "x": -59,
@@ -1116,42 +1116,42 @@
         {
           "x": -56,
           "y": -29,
-          "details": "lake terr=303 -> dry(-55,-29) terr=297 gap=6"
+          "details": "lake terr=303 -> dry(-55,-29) terr=294 gap=9"
         },
         {
           "x": -56,
           "y": 48,
-          "details": "river terr=61 -> dry(-55,48) terr=52 gap=9"
+          "details": "river terr=58 -> dry(-55,48) terr=52 gap=6"
         },
         {
           "x": -56,
           "y": 49,
-          "details": "river terr=49 -> dry(-55,49) terr=41 gap=8"
+          "details": "river terr=46 -> dry(-55,49) terr=41 gap=5"
         },
         {
           "x": -56,
           "y": 50,
-          "details": "river terr=38 -> dry(-55,50) terr=31 gap=7"
+          "details": "river terr=35 -> dry(-55,50) terr=31 gap=4"
         },
         {
           "x": -56,
           "y": 51,
-          "details": "river terr=29 -> dry(-55,51) terr=22 gap=7"
+          "details": "river terr=26 -> dry(-55,51) terr=22 gap=4"
         },
         {
           "x": -56,
           "y": 52,
-          "details": "river terr=20 -> dry(-55,52) terr=16 gap=4"
+          "details": "river terr=18 -> dry(-55,52) terr=16 gap=2"
         },
         {
           "x": -56,
           "y": 53,
-          "details": "river terr=14 -> dry(-55,53) terr=11 gap=3"
+          "details": "river terr=13 -> dry(-55,53) terr=11 gap=2"
         },
         {
           "x": -56,
           "y": 54,
-          "details": "river terr=8 -> dry(-55,54) terr=6 gap=2"
+          "details": "river terr=7 -> dry(-55,54) terr=6 gap=1"
         },
         {
           "x": -56,
@@ -1166,27 +1166,22 @@
         {
           "x": -55,
           "y": 47,
-          "details": "river terr=57 -> dry(-55,48) terr=52 gap=5"
+          "details": "river terr=53 -> dry(-55,48) terr=52 gap=1"
         },
         {
           "x": -54,
           "y": -26,
-          "details": "lake terr=273 -> dry(-53,-26) terr=261 gap=12"
+          "details": "lake terr=270 -> dry(-53,-26) terr=258 gap=12"
         },
         {
           "x": -54,
           "y": 38,
-          "details": "river terr=91 -> dry(-53,38) terr=86 gap=5"
+          "details": "river terr=88 -> dry(-53,38) terr=86 gap=2"
         },
         {
           "x": -54,
           "y": 47,
-          "details": "river terr=45 -> dry(-54,48) terr=39 gap=6"
-        },
-        {
-          "x": -54,
-          "y": 51,
-          "details": "river terr=12 -> dry(-54,52) terr=10 gap=2"
+          "details": "river terr=40 -> dry(-54,48) terr=39 gap=1"
         },
         {
           "x": -53,
@@ -1196,22 +1191,12 @@
         {
           "x": -53,
           "y": 47,
-          "details": "river terr=33 -> dry(-53,48) terr=22 gap=11"
-        },
-        {
-          "x": -53,
-          "y": 51,
-          "details": "river terr=9 -> dry(-53,52) terr=7 gap=2"
+          "details": "river terr=27 -> dry(-53,48) terr=22 gap=5"
         },
         {
           "x": -52,
           "y": 41,
           "details": "river terr=100 -> dry(-52,40) terr=98 gap=2"
-        },
-        {
-          "x": -51,
-          "y": -40,
-          "details": "river terr=291 -> dry(-51,-41) terr=287 gap=4"
         },
         {
           "x": -50,
@@ -1220,33 +1205,18 @@
         },
         {
           "x": -50,
-          "y": -45,
-          "details": "river terr=245 -> dry(-50,-46) terr=243 gap=2"
-        },
-        {
-          "x": -50,
           "y": -44,
-          "details": "river terr=251 -> dry(-49,-44) terr=246 gap=5"
-        },
-        {
-          "x": -50,
-          "y": -43,
-          "details": "river terr=257 -> dry(-49,-43) terr=252 gap=5"
+          "details": "river terr=247 -> dry(-49,-44) terr=246 gap=1"
         },
         {
           "x": -50,
           "y": -40,
-          "details": "river terr=284 -> dry(-50,-41) terr=278 gap=6"
-        },
-        {
-          "x": -49,
-          "y": -45,
-          "details": "river terr=241 -> dry(-49,-46) terr=240 gap=1"
+          "details": "river terr=280 -> dry(-50,-41) terr=278 gap=2"
         },
         {
           "x": -49,
           "y": -40,
-          "details": "river terr=274 -> dry(-49,-41) terr=269 gap=5"
+          "details": "river terr=270 -> dry(-49,-41) terr=269 gap=1"
         },
         {
           "x": -48,
@@ -1255,48 +1225,13 @@
         },
         {
           "x": -48,
-          "y": -45,
-          "details": "river terr=238 -> dry(-48,-46) terr=236 gap=2"
-        },
-        {
-          "x": -48,
-          "y": -44,
-          "details": "river terr=241 -> dry(-47,-44) terr=239 gap=2"
-        },
-        {
-          "x": -48,
           "y": -43,
-          "details": "river terr=247 -> dry(-47,-43) terr=243 gap=4"
-        },
-        {
-          "x": -48,
-          "y": -42,
-          "details": "river terr=252 -> dry(-47,-42) terr=248 gap=4"
-        },
-        {
-          "x": -48,
-          "y": -41,
-          "details": "river terr=258 -> dry(-47,-41) terr=254 gap=4"
-        },
-        {
-          "x": -48,
-          "y": -40,
-          "details": "river terr=264 -> dry(-47,-40) terr=259 gap=5"
-        },
-        {
-          "x": -48,
-          "y": -39,
-          "details": "river terr=276 -> dry(-47,-39) terr=272 gap=4"
+          "details": "river terr=244 -> dry(-47,-43) terr=243 gap=1"
         },
         {
           "x": -48,
           "y": -38,
-          "details": "river terr=288 -> dry(-47,-38) terr=283 gap=5"
-        },
-        {
-          "x": -48,
-          "y": 44,
-          "details": "river terr=58 -> dry(-47,44) terr=55 gap=3"
+          "details": "river terr=284 -> dry(-47,-38) terr=283 gap=1"
         },
         {
           "x": -47,
@@ -1306,17 +1241,7 @@
         {
           "x": -47,
           "y": -16,
-          "details": "river terr=221 -> dry(-48,-16) terr=202 gap=19"
-        },
-        {
-          "x": -47,
-          "y": 45,
-          "details": "river terr=43 -> dry(-46,45) terr=39 gap=4"
-        },
-        {
-          "x": -46,
-          "y": -51,
-          "details": "river terr=242 -> dry(-46,-50) terr=240 gap=2"
+          "details": "river terr=216 -> dry(-48,-16) terr=202 gap=14"
         },
         {
           "x": -46,
@@ -1325,58 +1250,28 @@
         },
         {
           "x": -46,
-          "y": -41,
-          "details": "river terr=246 -> dry(-46,-42) terr=243 gap=3"
-        },
-        {
-          "x": -46,
           "y": -40,
-          "details": "river terr=252 -> dry(-45,-40) terr=247 gap=5"
-        },
-        {
-          "x": -46,
-          "y": 46,
-          "details": "river terr=28 -> dry(-45,46) terr=25 gap=3"
-        },
-        {
-          "x": -46,
-          "y": 47,
-          "details": "river terr=21 -> dry(-45,47) terr=18 gap=3"
-        },
-        {
-          "x": -46,
-          "y": 48,
-          "details": "river terr=14 -> dry(-45,48) terr=13 gap=1"
-        },
-        {
-          "x": -45,
-          "y": -51,
-          "details": "river terr=238 -> dry(-44,-51) terr=235 gap=3"
-        },
-        {
-          "x": -45,
-          "y": -50,
-          "details": "river terr=233 -> dry(-45,-49) terr=230 gap=3"
+          "details": "river terr=248 -> dry(-45,-40) terr=247 gap=1"
         },
         {
           "x": -45,
           "y": -43,
-          "details": "river terr=231 -> dry(-45,-44) terr=226 gap=5"
+          "details": "river terr=228 -> dry(-45,-44) terr=226 gap=2"
         },
         {
           "x": -45,
           "y": -42,
-          "details": "river terr=236 -> dry(-44,-42) terr=232 gap=4"
+          "details": "river terr=233 -> dry(-44,-42) terr=232 gap=1"
         },
         {
           "x": -45,
           "y": -41,
-          "details": "river terr=241 -> dry(-44,-41) terr=237 gap=4"
+          "details": "river terr=238 -> dry(-44,-41) terr=237 gap=1"
         },
         {
           "x": -45,
           "y": 40,
-          "details": "river terr=74 -> dry(-45,41) terr=68 gap=6"
+          "details": "river terr=73 -> dry(-45,41) terr=68 gap=5"
         },
         {
           "x": -45,
@@ -1390,43 +1285,38 @@
         },
         {
           "x": -44,
-          "y": -50,
-          "details": "river terr=224 -> dry(-44,-49) terr=223 gap=1"
-        },
-        {
-          "x": -44,
           "y": -43,
-          "details": "river terr=224 -> dry(-44,-44) terr=220 gap=4"
+          "details": "river terr=221 -> dry(-44,-44) terr=220 gap=1"
         },
         {
           "x": -44,
           "y": -16,
-          "details": "river terr=198 -> dry(-43,-16) terr=186 gap=12"
+          "details": "river terr=195 -> dry(-43,-16) terr=186 gap=9"
         },
         {
           "x": -44,
           "y": 41,
-          "details": "river terr=57 -> dry(-44,42) terr=50 gap=7"
+          "details": "river terr=54 -> dry(-44,42) terr=50 gap=4"
         },
         {
           "x": -43,
           "y": -43,
-          "details": "river terr=218 -> dry(-42,-43) terr=214 gap=4"
+          "details": "river terr=215 -> dry(-42,-43) terr=214 gap=1"
         },
         {
           "x": -43,
           "y": -23,
-          "details": "lake terr=104 -> dry(-42,-23) terr=92 gap=12"
+          "details": "lake terr=99 -> dry(-42,-23) terr=87 gap=12"
         },
         {
           "x": -43,
           "y": -22,
-          "details": "lake terr=132 -> dry(-42,-22) terr=120 gap=12"
+          "details": "lake terr=127 -> dry(-42,-22) terr=115 gap=12"
         },
         {
           "x": -43,
           "y": -21,
-          "details": "lake terr=160 -> dry(-42,-21) terr=148 gap=12"
+          "details": "lake terr=155 -> dry(-42,-21) terr=143 gap=12"
         },
         {
           "x": -43,
@@ -1451,97 +1341,57 @@
         {
           "x": -43,
           "y": 31,
-          "details": "river terr=85 -> dry(-43,30) terr=82 gap=3"
+          "details": "river terr=83 -> dry(-43,30) terr=82 gap=1"
         },
         {
           "x": -43,
           "y": 42,
-          "details": "river terr=38 -> dry(-43,43) terr=32 gap=6"
-        },
-        {
-          "x": -43,
-          "y": 45,
-          "details": "river terr=16 -> dry(-43,46) terr=13 gap=3"
+          "details": "river terr=34 -> dry(-43,43) terr=32 gap=2"
         },
         {
           "x": -42,
           "y": 29,
-          "details": "river terr=64 -> dry(-42,28) terr=57 gap=7"
-        },
-        {
-          "x": -42,
-          "y": 43,
-          "details": "river terr=21 -> dry(-42,44) terr=17 gap=4"
-        },
-        {
-          "x": -42,
-          "y": 45,
-          "details": "river terr=10 -> dry(-42,46) terr=8 gap=2"
+          "details": "river terr=60 -> dry(-42,28) terr=57 gap=3"
         },
         {
           "x": -41,
           "y": 28,
-          "details": "river terr=46 -> dry(-41,27) terr=39 gap=7"
+          "details": "river terr=41 -> dry(-41,27) terr=39 gap=2"
         },
         {
           "x": -40,
           "y": 27,
-          "details": "river terr=29 -> dry(-40,26) terr=23 gap=6"
-        },
-        {
-          "x": -39,
-          "y": 26,
-          "details": "river terr=14 -> dry(-38,26) terr=10 gap=4"
+          "details": "river terr=24 -> dry(-40,26) terr=23 gap=1"
         },
         {
           "x": -39,
           "y": 38,
-          "details": "river terr=27 -> dry(-38,38) terr=21 gap=6"
-        },
-        {
-          "x": -38,
-          "y": 27,
-          "details": "river terr=13 -> dry(-38,26) terr=10 gap=3"
+          "details": "river terr=24 -> dry(-38,38) terr=21 gap=3"
         },
         {
           "x": -38,
           "y": 28,
-          "details": "river terr=19 -> dry(-37,28) terr=14 gap=5"
+          "details": "river terr=15 -> dry(-37,28) terr=14 gap=1"
         },
         {
           "x": -38,
           "y": 37,
-          "details": "river terr=26 -> dry(-38,38) terr=21 gap=5"
-        },
-        {
-          "x": -37,
-          "y": 26,
-          "details": "river terr=5 -> dry(-36,26) terr=4 gap=1"
-        },
-        {
-          "x": -37,
-          "y": 27,
-          "details": "river terr=8 -> dry(-36,27) terr=6 gap=2"
+          "details": "river terr=24 -> dry(-38,38) terr=21 gap=3"
         },
         {
           "x": -37,
           "y": 29,
-          "details": "river terr=18 -> dry(-37,28) terr=14 gap=4"
+          "details": "river terr=15 -> dry(-37,28) terr=14 gap=1"
         },
         {
           "x": -37,
           "y": 37,
-          "details": "river terr=20 -> dry(-36,37) terr=16 gap=4"
+          "details": "river terr=18 -> dry(-36,37) terr=16 gap=2"
         },
         {
           "x": -37,
           "y": 38,
-          "details": "river terr=14 -> dry(-36,38) terr=11 gap=3"
-        },
-        {
-          "x": -36,
-          "y": 29,
-          "details": "river terr=11 -> dry(-36,28) terr=9 gap=2"
+          "details": "river terr=12 -> dry(-36,38) terr=11 gap=1"
         },
         {
           "x": -36,
@@ -1550,23 +1400,8 @@
         },
         {
           "x": -35,
-          "y": -12,
-          "details": "river terr=19 -> dry(-34,-12) terr=17 gap=2"
-        },
-        {
-          "x": -35,
-          "y": 3,
-          "details": "river terr=19 -> dry(-34,3) terr=17 gap=2"
-        },
-        {
-          "x": -35,
-          "y": 4,
-          "details": "river terr=15 -> dry(-35,5) terr=13 gap=2"
-        },
-        {
-          "x": -35,
           "y": 31,
-          "details": "river terr=13 -> dry(-34,31) terr=10 gap=3"
+          "details": "river terr=11 -> dry(-34,31) terr=10 gap=1"
         },
         {
           "x": -35,
@@ -1586,17 +1421,12 @@
         {
           "x": -33,
           "y": -43,
-          "details": "river terr=159 -> dry(-33,-42) terr=139 gap=20"
+          "details": "river terr=154 -> dry(-33,-42) terr=134 gap=20"
         },
         {
           "x": -33,
           "y": -15,
           "details": "river terr=10 -> dry(-32,-15) terr=9 gap=1"
-        },
-        {
-          "x": -33,
-          "y": -14,
-          "details": "river terr=12 -> dry(-32,-14) terr=11 gap=1"
         },
         {
           "x": -33,
@@ -1610,63 +1440,33 @@
         },
         {
           "x": -32,
-          "y": -35,
-          "details": "river terr=28 -> dry(-31,-35) terr=23 gap=5"
-        },
-        {
-          "x": -32,
           "y": 36,
           "details": "river terr=5 -> dry(-32,37) terr=4 gap=1"
         },
         {
           "x": -30,
           "y": -37,
-          "details": "river terr=70 -> dry(-30,-36) terr=49 gap=21"
+          "details": "river terr=68 -> dry(-30,-36) terr=49 gap=19"
         },
         {
           "x": -29,
           "y": -37,
-          "details": "river terr=67 -> dry(-29,-36) terr=47 gap=20"
-        },
-        {
-          "x": -24,
-          "y": -52,
-          "details": "river terr=147 -> dry(-23,-52) terr=146 gap=1"
+          "details": "river terr=66 -> dry(-28,-37) terr=64 gap=2"
         },
         {
           "x": -23,
           "y": -51,
-          "details": "river terr=137 -> dry(-23,-50) terr=134 gap=3"
+          "details": "river terr=135 -> dry(-23,-50) terr=134 gap=1"
         },
         {
           "x": -22,
           "y": -51,
-          "details": "river terr=132 -> dry(-21,-51) terr=128 gap=4"
+          "details": "river terr=130 -> dry(-21,-51) terr=128 gap=2"
         },
         {
           "x": -22,
           "y": -50,
-          "details": "river terr=125 -> dry(-22,-49) terr=122 gap=3"
-        },
-        {
-          "x": -21,
-          "y": -50,
-          "details": "river terr=120 -> dry(-20,-50) terr=118 gap=2"
-        },
-        {
-          "x": -21,
-          "y": -49,
-          "details": "river terr=113 -> dry(-20,-49) terr=110 gap=3"
-        },
-        {
-          "x": -21,
-          "y": -48,
-          "details": "river terr=106 -> dry(-20,-48) terr=103 gap=3"
-        },
-        {
-          "x": -21,
-          "y": -47,
-          "details": "river terr=101 -> dry(-21,-46) terr=97 gap=4"
+          "details": "river terr=123 -> dry(-22,-49) terr=122 gap=1"
         },
         {
           "x": -20,
@@ -1686,17 +1486,12 @@
         {
           "x": -19,
           "y": -39,
-          "details": "river terr=49 -> dry(-18,-39) terr=43 gap=6"
+          "details": "river terr=47 -> dry(-18,-39) terr=43 gap=4"
         },
         {
           "x": -18,
           "y": -40,
           "details": "river terr=54 -> dry(-17,-40) terr=53 gap=1"
-        },
-        {
-          "x": -17,
-          "y": -39,
-          "details": "river terr=44 -> dry(-18,-39) terr=43 gap=1"
         },
         {
           "x": -16,
@@ -1744,11 +1539,6 @@
           "details": "river terr=25 -> dry(-13,-34) terr=24 gap=1"
         },
         {
-          "x": 55,
-          "y": -64,
-          "details": "river terr=123 -> dry(55,-63) terr=121 gap=2"
-        },
-        {
           "x": 57,
           "y": -62,
           "details": "river terr=109 -> dry(57,-61) terr=108 gap=1"
@@ -1757,16 +1547,6 @@
           "x": 58,
           "y": -61,
           "details": "river terr=100 -> dry(58,-60) terr=99 gap=1"
-        },
-        {
-          "x": 60,
-          "y": -59,
-          "details": "river terr=66 -> dry(60,-58) terr=65 gap=1"
-        },
-        {
-          "x": 61,
-          "y": -58,
-          "details": "river terr=50 -> dry(61,-57) terr=47 gap=3"
         },
         {
           "x": 68,
@@ -1858,14 +1638,144 @@
       ],
       "MID_RIVER_CLIFF": [
         {
+          "x": -63,
+          "y": 37,
+          "details": "river surf=123 (terr=120) -> water nbr surf=119 (terr=118) surf_diff=4 terr_diff=2"
+        },
+        {
           "x": -62,
           "y": 34,
           "details": "river surf=146 (terr=141) -> water nbr surf=142 (terr=142) surf_diff=4 terr_diff=1"
         },
         {
+          "x": -54,
+          "y": 37,
+          "details": "lake surf=81 (terr=76) -> water nbr surf=79 (terr=76) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -52,
+          "y": 49,
+          "details": "river surf=8 (terr=4) -> water nbr surf=6 (terr=4) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -50,
+          "y": -45,
+          "details": "river surf=246 (terr=240) -> water nbr surf=242 (terr=238) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -50,
+          "y": 48,
+          "details": "river surf=13 (terr=8) -> water nbr surf=8 (terr=6) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -49,
+          "y": 48,
+          "details": "river surf=13 (terr=9) -> water nbr surf=9 (terr=8) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -48,
+          "y": -45,
+          "details": "river surf=239 (terr=236) -> water nbr surf=235 (terr=234) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -44,
+          "y": -48,
+          "details": "river surf=220 (terr=217) -> water nbr surf=218 (terr=217) surf_diff=2 terr_diff=0"
+        },
+        {
           "x": -43,
+          "y": -49,
+          "details": "river surf=218 (terr=213) -> water nbr surf=214 (terr=211) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -42,
+          "y": -44,
+          "details": "river surf=207 (terr=203) -> water nbr surf=203 (terr=202) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -40,
+          "y": 44,
+          "details": "river surf=6 (terr=2) -> water nbr surf=3 (terr=2) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -40,
+          "y": 45,
+          "details": "river surf=4 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -39,
+          "y": -47,
+          "details": "river surf=200 (terr=195) -> water nbr surf=198 (terr=195) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -39,
+          "y": 24,
+          "details": "river surf=9 (terr=6) -> water nbr surf=7 (terr=6) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -39,
+          "y": 43,
+          "details": "river surf=5 (terr=2) -> water nbr surf=3 (terr=2) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -39,
+          "y": 43,
+          "details": "river surf=5 (terr=2) -> water nbr surf=3 (terr=2) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -38,
+          "y": 24,
+          "details": "river surf=5 (terr=2) -> water nbr surf=3 (terr=2) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -38,
+          "y": 40,
+          "details": "river surf=7 (terr=3) -> water nbr surf=5 (terr=3) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -36,
+          "y": -25,
+          "details": "river surf=13 (terr=6) -> water nbr surf=11 (terr=6) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -36,
           "y": -18,
-          "details": "river surf=189 (terr=184) -> water nbr surf=186 (terr=185) surf_diff=3 terr_diff=1"
+          "details": "river surf=13 (terr=9) -> water nbr surf=11 (terr=9) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -36,
+          "y": -17,
+          "details": "river surf=14 (terr=9) -> water nbr surf=12 (terr=9) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -35,
+          "y": -17,
+          "details": "river surf=12 (terr=9) -> water nbr surf=10 (terr=9) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -35,
+          "y": -16,
+          "details": "river surf=13 (terr=9) -> water nbr surf=11 (terr=9) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -35,
+          "y": 29,
+          "details": "river surf=7 (terr=4) -> water nbr surf=5 (terr=4) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -35,
+          "y": 29,
+          "details": "river surf=7 (terr=4) -> water nbr surf=5 (terr=4) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -33,
+          "y": -28,
+          "details": "river surf=13 (terr=10) -> water nbr surf=11 (terr=10) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -32,
+          "y": 4,
+          "details": "river surf=7 (terr=2) -> water nbr surf=4 (terr=1) surf_diff=3 terr_diff=1"
         },
         {
           "x": -28,
@@ -1873,14 +1783,39 @@
           "details": "lake surf=1 (terr=-3) -> water nbr surf=-1 (terr=-3) surf_diff=2 terr_diff=0"
         },
         {
-          "x": -26,
-          "y": -39,
-          "details": "river surf=68 (terr=65) -> water nbr surf=66 (terr=65) surf_diff=2 terr_diff=0"
+          "x": -20,
+          "y": -35,
+          "details": "river surf=17 (terr=13) -> water nbr surf=15 (terr=13) surf_diff=2 terr_diff=0"
         },
         {
           "x": -19,
-          "y": -43,
-          "details": "river surf=77 (terr=74) -> water nbr surf=73 (terr=72) surf_diff=4 terr_diff=2"
+          "y": -36,
+          "details": "river surf=20 (terr=14) -> water nbr surf=17 (terr=13) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -18,
+          "y": -34,
+          "details": "river surf=15 (terr=12) -> water nbr surf=13 (terr=12) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -17,
+          "y": -34,
+          "details": "river surf=18 (terr=15) -> water nbr surf=16 (terr=15) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 65,
+          "y": -64,
+          "details": "river surf=48 (terr=42) -> water nbr surf=44 (terr=40) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 66,
+          "y": -63,
+          "details": "river surf=44 (terr=41) -> water nbr surf=41 (terr=40) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 67,
+          "y": -64,
+          "details": "river surf=46 (terr=43) -> water nbr surf=43 (terr=42) surf_diff=3 terr_diff=1"
         },
         {
           "x": 73,
@@ -1953,6 +1888,11 @@
         },
         {
           "x": -33,
+          "y": -41,
+          "details": "river surf=113 -> dry(-32,-41) terr=109"
+        },
+        {
+          "x": -33,
           "y": -15,
           "details": "river surf=11 -> dry(-32,-15) terr=9"
         },
@@ -1991,7 +1931,7 @@
         {
           "x": -64,
           "y": 41,
-          "details": "river surf=99 terr=98 -> land(-64,42) terr=93 cliff=6"
+          "details": "river surf=99 terr=96 -> land(-64,42) terr=93 cliff=6"
         },
         {
           "x": -63,
@@ -2007,6 +1947,16 @@
           "x": -63,
           "y": 41,
           "details": "river surf=105 terr=104 -> land(-63,42) terr=101 cliff=4"
+        },
+        {
+          "x": -62,
+          "y": -60,
+          "details": "river surf=114 terr=108 -> land(-62,-61) terr=112 cliff=2"
+        },
+        {
+          "x": -62,
+          "y": -52,
+          "details": "river surf=210 terr=204 -> land(-61,-52) terr=208 cliff=2"
         },
         {
           "x": -62,
@@ -2026,7 +1976,7 @@
         {
           "x": -62,
           "y": 47,
-          "details": "river surf=77 terr=76 -> land(-63,47) terr=72 cliff=5"
+          "details": "river surf=77 terr=75 -> land(-63,47) terr=72 cliff=5"
         },
         {
           "x": -61,
@@ -2050,6 +2000,11 @@
         },
         {
           "x": -60,
+          "y": -61,
+          "details": "river surf=102 terr=96 -> land(-60,-62) terr=100 cliff=2"
+        },
+        {
+          "x": -60,
           "y": 33,
           "details": "river surf=138 terr=137 -> land(-59,33) terr=134 cliff=4"
         },
@@ -2060,8 +2015,13 @@
         },
         {
           "x": -59,
+          "y": -61,
+          "details": "river surf=90 terr=84 -> land(-59,-62) terr=88 cliff=2"
+        },
+        {
+          "x": -59,
           "y": 34,
-          "details": "river surf=127 terr=126 -> land(-58,34) terr=123 cliff=4"
+          "details": "river surf=127 terr=124 -> land(-58,34) terr=123 cliff=4"
         },
         {
           "x": -59,
@@ -2075,43 +2035,48 @@
         },
         {
           "x": -56,
+          "y": -63,
+          "details": "river surf=78 terr=72 -> land(-56,-64) terr=76 cliff=2"
+        },
+        {
+          "x": -56,
           "y": -29,
-          "details": "lake surf=307 terr=303 -> land(-55,-29) terr=297 cliff=10"
+          "details": "lake surf=307 terr=303 -> land(-55,-29) terr=294 cliff=13"
         },
         {
           "x": -56,
           "y": 48,
-          "details": "river surf=62 terr=61 -> land(-55,48) terr=52 cliff=10"
+          "details": "river surf=62 terr=58 -> land(-55,48) terr=52 cliff=10"
         },
         {
           "x": -56,
           "y": 49,
-          "details": "river surf=50 terr=49 -> land(-55,49) terr=41 cliff=9"
+          "details": "river surf=50 terr=46 -> land(-55,49) terr=41 cliff=9"
         },
         {
           "x": -56,
           "y": 50,
-          "details": "river surf=39 terr=38 -> land(-55,50) terr=31 cliff=8"
+          "details": "river surf=39 terr=35 -> land(-55,50) terr=31 cliff=8"
         },
         {
           "x": -56,
           "y": 51,
-          "details": "river surf=30 terr=29 -> land(-55,51) terr=22 cliff=8"
+          "details": "river surf=30 terr=26 -> land(-55,51) terr=22 cliff=8"
         },
         {
           "x": -56,
           "y": 52,
-          "details": "river surf=21 terr=20 -> land(-55,52) terr=16 cliff=5"
+          "details": "river surf=21 terr=18 -> land(-55,52) terr=16 cliff=5"
         },
         {
           "x": -56,
           "y": 53,
-          "details": "river surf=15 terr=14 -> land(-55,53) terr=11 cliff=4"
+          "details": "river surf=15 terr=13 -> land(-55,53) terr=11 cliff=4"
         },
         {
           "x": -56,
           "y": 54,
-          "details": "river surf=9 terr=8 -> land(-55,54) terr=6 cliff=3"
+          "details": "river surf=9 terr=7 -> land(-55,54) terr=6 cliff=3"
         },
         {
           "x": -56,
@@ -2120,8 +2085,18 @@
         },
         {
           "x": -55,
+          "y": -63,
+          "details": "river surf=78 terr=71 -> land(-55,-64) terr=75 cliff=3"
+        },
+        {
+          "x": -55,
+          "y": -57,
+          "details": "river surf=150 terr=145 -> land(-54,-57) terr=148 cliff=2"
+        },
+        {
+          "x": -55,
           "y": -28,
-          "details": "lake surf=307 terr=285 -> land(-55,-29) terr=297 cliff=10"
+          "details": "lake surf=307 terr=281 -> land(-55,-29) terr=294 cliff=13"
         },
         {
           "x": -55,
@@ -2131,27 +2106,27 @@
         {
           "x": -55,
           "y": 47,
-          "details": "river surf=58 terr=57 -> land(-55,48) terr=52 cliff=6"
+          "details": "river surf=58 terr=53 -> land(-55,48) terr=52 cliff=6"
         },
         {
           "x": -54,
           "y": -26,
-          "details": "lake surf=307 terr=273 -> land(-53,-26) terr=261 cliff=46"
+          "details": "lake surf=307 terr=270 -> land(-53,-26) terr=258 cliff=49"
         },
         {
           "x": -54,
           "y": 38,
-          "details": "river surf=92 terr=91 -> land(-53,38) terr=86 cliff=6"
+          "details": "river surf=92 terr=88 -> land(-53,38) terr=86 cliff=6"
         },
         {
           "x": -54,
           "y": 47,
-          "details": "river surf=46 terr=45 -> land(-54,48) terr=39 cliff=7"
+          "details": "river surf=46 terr=40 -> land(-54,48) terr=39 cliff=7"
         },
         {
           "x": -54,
           "y": 51,
-          "details": "river surf=13 terr=12 -> land(-54,52) terr=10 cliff=3"
+          "details": "river surf=13 terr=8 -> land(-54,52) terr=10 cliff=3"
         },
         {
           "x": -53,
@@ -2161,12 +2136,17 @@
         {
           "x": -53,
           "y": 47,
-          "details": "river surf=34 terr=33 -> land(-53,48) terr=22 cliff=12"
+          "details": "river surf=34 terr=27 -> land(-53,48) terr=22 cliff=12"
         },
         {
           "x": -53,
           "y": 51,
-          "details": "river surf=10 terr=9 -> land(-53,52) terr=7 cliff=3"
+          "details": "river surf=10 terr=6 -> land(-53,52) terr=7 cliff=3"
+        },
+        {
+          "x": -52,
+          "y": -61,
+          "details": "river surf=102 terr=95 -> land(-52,-62) terr=99 cliff=3"
         },
         {
           "x": -52,
@@ -2175,8 +2155,33 @@
         },
         {
           "x": -51,
+          "y": -60,
+          "details": "river surf=126 terr=119 -> land(-51,-61) terr=123 cliff=3"
+        },
+        {
+          "x": -51,
+          "y": -59,
+          "details": "river surf=138 terr=131 -> land(-52,-59) terr=135 cliff=3"
+        },
+        {
+          "x": -51,
           "y": -40,
-          "details": "river surf=292 terr=291 -> land(-51,-41) terr=287 cliff=5"
+          "details": "river surf=292 terr=287 -> land(-51,-41) terr=287 cliff=5"
+        },
+        {
+          "x": -51,
+          "y": -29,
+          "details": "river surf=234 terr=229 -> land(-50,-29) terr=232 cliff=2"
+        },
+        {
+          "x": -50,
+          "y": -58,
+          "details": "river surf=162 terr=155 -> land(-50,-59) terr=159 cliff=3"
+        },
+        {
+          "x": -50,
+          "y": -57,
+          "details": "river surf=174 terr=167 -> land(-51,-57) terr=171 cliff=3"
         },
         {
           "x": -50,
@@ -2186,32 +2191,37 @@
         {
           "x": -50,
           "y": -45,
-          "details": "river surf=246 terr=245 -> land(-50,-46) terr=243 cliff=3"
+          "details": "river surf=246 terr=240 -> land(-50,-46) terr=243 cliff=3"
         },
         {
           "x": -50,
           "y": -44,
-          "details": "river surf=252 terr=251 -> land(-49,-44) terr=246 cliff=6"
+          "details": "river surf=252 terr=247 -> land(-49,-44) terr=246 cliff=6"
         },
         {
           "x": -50,
           "y": -43,
-          "details": "river surf=258 terr=257 -> land(-49,-43) terr=252 cliff=6"
+          "details": "river surf=258 terr=252 -> land(-49,-43) terr=252 cliff=6"
         },
         {
           "x": -50,
           "y": -40,
-          "details": "river surf=285 terr=284 -> land(-50,-41) terr=278 cliff=7"
+          "details": "river surf=285 terr=280 -> land(-50,-41) terr=278 cliff=7"
+        },
+        {
+          "x": -49,
+          "y": -57,
+          "details": "river surf=186 terr=179 -> land(-49,-58) terr=183 cliff=3"
         },
         {
           "x": -49,
           "y": -45,
-          "details": "river surf=242 terr=241 -> land(-49,-46) terr=240 cliff=2"
+          "details": "river surf=242 terr=238 -> land(-49,-46) terr=240 cliff=2"
         },
         {
           "x": -49,
           "y": -40,
-          "details": "river surf=275 terr=274 -> land(-49,-41) terr=269 cliff=6"
+          "details": "river surf=275 terr=270 -> land(-49,-41) terr=269 cliff=6"
         },
         {
           "x": -48,
@@ -2221,47 +2231,47 @@
         {
           "x": -48,
           "y": -45,
-          "details": "river surf=239 terr=238 -> land(-48,-46) terr=236 cliff=3"
+          "details": "river surf=239 terr=236 -> land(-48,-46) terr=236 cliff=3"
         },
         {
           "x": -48,
           "y": -44,
-          "details": "river surf=242 terr=241 -> land(-47,-44) terr=239 cliff=3"
+          "details": "river surf=242 terr=238 -> land(-47,-44) terr=239 cliff=3"
         },
         {
           "x": -48,
           "y": -43,
-          "details": "river surf=248 terr=247 -> land(-47,-43) terr=243 cliff=5"
+          "details": "river surf=248 terr=244 -> land(-47,-43) terr=243 cliff=5"
         },
         {
           "x": -48,
           "y": -42,
-          "details": "river surf=253 terr=252 -> land(-47,-42) terr=248 cliff=5"
+          "details": "river surf=253 terr=248 -> land(-47,-42) terr=248 cliff=5"
         },
         {
           "x": -48,
           "y": -41,
-          "details": "river surf=259 terr=258 -> land(-47,-41) terr=254 cliff=5"
+          "details": "river surf=259 terr=254 -> land(-47,-41) terr=254 cliff=5"
         },
         {
           "x": -48,
           "y": -40,
-          "details": "river surf=265 terr=264 -> land(-47,-40) terr=259 cliff=6"
+          "details": "river surf=265 terr=259 -> land(-47,-40) terr=259 cliff=6"
         },
         {
           "x": -48,
           "y": -39,
-          "details": "river surf=277 terr=276 -> land(-47,-39) terr=272 cliff=5"
+          "details": "river surf=277 terr=272 -> land(-47,-39) terr=272 cliff=5"
         },
         {
           "x": -48,
           "y": -38,
-          "details": "river surf=289 terr=288 -> land(-47,-38) terr=283 cliff=6"
+          "details": "river surf=289 terr=284 -> land(-47,-38) terr=283 cliff=6"
         },
         {
           "x": -48,
           "y": 44,
-          "details": "river surf=59 terr=58 -> land(-47,44) terr=55 cliff=4"
+          "details": "river surf=59 terr=53 -> land(-47,44) terr=55 cliff=4"
         },
         {
           "x": -47,
@@ -2270,18 +2280,23 @@
         },
         {
           "x": -47,
+          "y": -27,
+          "details": "river surf=162 terr=157 -> land(-46,-27) terr=160 cliff=2"
+        },
+        {
+          "x": -47,
           "y": -16,
-          "details": "river surf=222 terr=221 -> land(-48,-16) terr=202 cliff=20"
+          "details": "river surf=222 terr=216 -> land(-48,-16) terr=202 cliff=20"
         },
         {
           "x": -47,
           "y": 45,
-          "details": "river surf=44 terr=43 -> land(-46,45) terr=39 cliff=5"
+          "details": "river surf=44 terr=38 -> land(-46,45) terr=39 cliff=5"
         },
         {
           "x": -46,
           "y": -51,
-          "details": "river surf=243 terr=242 -> land(-46,-50) terr=240 cliff=3"
+          "details": "river surf=243 terr=237 -> land(-46,-50) terr=240 cliff=3"
         },
         {
           "x": -46,
@@ -2291,57 +2306,72 @@
         {
           "x": -46,
           "y": -41,
-          "details": "river surf=247 terr=246 -> land(-46,-42) terr=243 cliff=4"
+          "details": "river surf=247 terr=243 -> land(-46,-42) terr=243 cliff=4"
         },
         {
           "x": -46,
           "y": -40,
-          "details": "river surf=253 terr=252 -> land(-45,-40) terr=247 cliff=6"
+          "details": "river surf=253 terr=248 -> land(-45,-40) terr=247 cliff=6"
+        },
+        {
+          "x": -46,
+          "y": -25,
+          "details": "river surf=126 terr=120 -> land(-46,-24) terr=124 cliff=2"
+        },
+        {
+          "x": -46,
+          "y": -23,
+          "details": "river surf=126 terr=120 -> land(-46,-24) terr=124 cliff=2"
+        },
+        {
+          "x": -46,
+          "y": -20,
+          "details": "river surf=162 terr=156 -> land(-46,-21) terr=160 cliff=2"
         },
         {
           "x": -46,
           "y": 46,
-          "details": "river surf=29 terr=28 -> land(-45,46) terr=25 cliff=4"
+          "details": "river surf=29 terr=24 -> land(-45,46) terr=25 cliff=4"
         },
         {
           "x": -46,
           "y": 47,
-          "details": "river surf=22 terr=21 -> land(-45,47) terr=18 cliff=4"
+          "details": "river surf=22 terr=18 -> land(-45,47) terr=18 cliff=4"
         },
         {
           "x": -46,
           "y": 48,
-          "details": "river surf=15 terr=14 -> land(-45,48) terr=13 cliff=2"
+          "details": "river surf=15 terr=12 -> land(-45,48) terr=13 cliff=2"
         },
         {
           "x": -45,
           "y": -51,
-          "details": "river surf=239 terr=238 -> land(-44,-51) terr=235 cliff=4"
+          "details": "river surf=239 terr=233 -> land(-44,-51) terr=235 cliff=4"
         },
         {
           "x": -45,
           "y": -50,
-          "details": "river surf=234 terr=233 -> land(-45,-49) terr=230 cliff=4"
+          "details": "river surf=234 terr=228 -> land(-45,-49) terr=230 cliff=4"
         },
         {
           "x": -45,
           "y": -43,
-          "details": "river surf=232 terr=231 -> land(-45,-44) terr=226 cliff=6"
+          "details": "river surf=232 terr=228 -> land(-45,-44) terr=226 cliff=6"
         },
         {
           "x": -45,
           "y": -42,
-          "details": "river surf=237 terr=236 -> land(-44,-42) terr=232 cliff=5"
+          "details": "river surf=237 terr=233 -> land(-44,-42) terr=232 cliff=5"
         },
         {
           "x": -45,
           "y": -41,
-          "details": "river surf=242 terr=241 -> land(-44,-41) terr=237 cliff=5"
+          "details": "river surf=242 terr=238 -> land(-44,-41) terr=237 cliff=5"
         },
         {
           "x": -45,
           "y": 40,
-          "details": "river surf=75 terr=74 -> land(-45,41) terr=68 cliff=7"
+          "details": "river surf=75 terr=73 -> land(-45,41) terr=68 cliff=7"
         },
         {
           "x": -45,
@@ -2356,42 +2386,52 @@
         {
           "x": -44,
           "y": -50,
-          "details": "river surf=225 terr=224 -> land(-44,-49) terr=223 cliff=2"
+          "details": "river surf=225 terr=219 -> land(-44,-49) terr=223 cliff=2"
         },
         {
           "x": -44,
           "y": -43,
-          "details": "river surf=225 terr=224 -> land(-44,-44) terr=220 cliff=5"
+          "details": "river surf=225 terr=221 -> land(-44,-44) terr=220 cliff=5"
+        },
+        {
+          "x": -44,
+          "y": -26,
+          "details": "river surf=114 terr=108 -> land(-43,-26) terr=112 cliff=2"
         },
         {
           "x": -44,
           "y": -16,
-          "details": "river surf=199 terr=198 -> land(-43,-16) terr=186 cliff=13"
+          "details": "river surf=199 terr=195 -> land(-43,-16) terr=186 cliff=13"
         },
         {
           "x": -44,
           "y": 41,
-          "details": "river surf=58 terr=57 -> land(-44,42) terr=50 cliff=8"
+          "details": "river surf=58 terr=54 -> land(-44,42) terr=50 cliff=8"
         },
         {
           "x": -43,
           "y": -43,
-          "details": "river surf=219 terr=218 -> land(-42,-43) terr=214 cliff=5"
+          "details": "river surf=219 terr=215 -> land(-42,-43) terr=214 cliff=5"
+        },
+        {
+          "x": -43,
+          "y": -25,
+          "details": "river surf=90 terr=84 -> land(-42,-25) terr=87 cliff=3"
         },
         {
           "x": -43,
           "y": -23,
-          "details": "lake surf=189 terr=104 -> land(-42,-23) terr=92 cliff=97"
+          "details": "lake surf=189 terr=99 -> land(-42,-23) terr=87 cliff=102"
         },
         {
           "x": -43,
           "y": -22,
-          "details": "lake surf=189 terr=132 -> land(-42,-22) terr=120 cliff=69"
+          "details": "lake surf=189 terr=127 -> land(-42,-22) terr=115 cliff=74"
         },
         {
           "x": -43,
           "y": -21,
-          "details": "lake surf=189 terr=160 -> land(-42,-21) terr=148 cliff=41"
+          "details": "lake surf=189 terr=155 -> land(-42,-21) terr=143 cliff=46"
         },
         {
           "x": -43,
@@ -2416,97 +2456,102 @@
         {
           "x": -43,
           "y": 31,
-          "details": "river surf=86 terr=85 -> land(-43,30) terr=82 cliff=4"
+          "details": "river surf=86 terr=83 -> land(-43,30) terr=82 cliff=4"
         },
         {
           "x": -43,
           "y": 42,
-          "details": "river surf=39 terr=38 -> land(-43,43) terr=32 cliff=7"
+          "details": "river surf=39 terr=34 -> land(-43,43) terr=32 cliff=7"
         },
         {
           "x": -43,
           "y": 45,
-          "details": "river surf=17 terr=16 -> land(-43,46) terr=13 cliff=4"
+          "details": "river surf=17 terr=11 -> land(-43,46) terr=13 cliff=4"
         },
         {
           "x": -42,
           "y": 29,
-          "details": "river surf=65 terr=64 -> land(-42,28) terr=57 cliff=8"
+          "details": "river surf=65 terr=60 -> land(-42,28) terr=57 cliff=8"
         },
         {
           "x": -42,
           "y": 43,
-          "details": "river surf=22 terr=21 -> land(-42,44) terr=17 cliff=5"
+          "details": "river surf=22 terr=17 -> land(-42,44) terr=17 cliff=5"
         },
         {
           "x": -42,
           "y": 45,
-          "details": "river surf=11 terr=10 -> land(-42,46) terr=8 cliff=3"
+          "details": "river surf=11 terr=6 -> land(-42,46) terr=8 cliff=3"
         },
         {
           "x": -41,
           "y": 28,
-          "details": "river surf=47 terr=46 -> land(-41,27) terr=39 cliff=8"
+          "details": "river surf=47 terr=41 -> land(-41,27) terr=39 cliff=8"
         },
         {
           "x": -40,
           "y": 27,
-          "details": "river surf=30 terr=29 -> land(-40,26) terr=23 cliff=7"
+          "details": "river surf=30 terr=24 -> land(-40,26) terr=23 cliff=7"
         },
         {
           "x": -39,
           "y": 26,
-          "details": "river surf=15 terr=14 -> land(-38,26) terr=10 cliff=5"
+          "details": "river surf=15 terr=10 -> land(-38,26) terr=10 cliff=5"
         },
         {
           "x": -39,
           "y": 38,
-          "details": "river surf=28 terr=27 -> land(-38,38) terr=21 cliff=7"
+          "details": "river surf=28 terr=24 -> land(-38,38) terr=21 cliff=7"
         },
         {
           "x": -38,
           "y": 27,
-          "details": "river surf=14 terr=13 -> land(-38,26) terr=10 cliff=4"
+          "details": "river surf=14 terr=9 -> land(-38,26) terr=10 cliff=4"
         },
         {
           "x": -38,
           "y": 28,
-          "details": "river surf=20 terr=19 -> land(-37,28) terr=14 cliff=6"
+          "details": "river surf=20 terr=15 -> land(-37,28) terr=14 cliff=6"
         },
         {
           "x": -38,
           "y": 37,
-          "details": "river surf=27 terr=26 -> land(-38,38) terr=21 cliff=6"
+          "details": "river surf=27 terr=24 -> land(-38,38) terr=21 cliff=6"
         },
         {
           "x": -37,
           "y": 26,
-          "details": "river surf=6 terr=5 -> land(-36,26) terr=4 cliff=2"
+          "details": "river surf=6 terr=2 -> land(-36,26) terr=4 cliff=2"
         },
         {
           "x": -37,
           "y": 27,
-          "details": "river surf=9 terr=8 -> land(-36,27) terr=6 cliff=3"
+          "details": "river surf=9 terr=4 -> land(-36,27) terr=6 cliff=3"
         },
         {
           "x": -37,
           "y": 29,
-          "details": "river surf=19 terr=18 -> land(-37,28) terr=14 cliff=5"
+          "details": "river surf=19 terr=15 -> land(-37,28) terr=14 cliff=5"
         },
         {
           "x": -37,
           "y": 37,
-          "details": "river surf=21 terr=20 -> land(-36,37) terr=16 cliff=5"
+          "details": "river surf=21 terr=18 -> land(-36,37) terr=16 cliff=5"
         },
         {
           "x": -37,
           "y": 38,
-          "details": "river surf=15 terr=14 -> land(-36,38) terr=11 cliff=4"
+          "details": "river surf=15 terr=12 -> land(-36,38) terr=11 cliff=4"
+        },
+        {
+          "x": -36,
+          "y": -42,
+          "details": "river surf=161 terr=156 -> land(-36,-41) terr=158 cliff=3"
         },
         {
           "x": -36,
           "y": 29,
-          "details": "river surf=12 terr=11 -> land(-36,28) terr=9 cliff=3"
+          "details": "river surf=12 terr=8 -> land(-36,28) terr=9 cliff=3"
         },
         {
           "x": -36,
@@ -2515,28 +2560,43 @@
         },
         {
           "x": -35,
+          "y": -44,
+          "details": "river surf=173 terr=165 -> land(-34,-44) terr=170 cliff=3"
+        },
+        {
+          "x": -35,
           "y": -12,
-          "details": "river surf=20 terr=19 -> land(-34,-12) terr=17 cliff=3"
+          "details": "river surf=20 terr=14 -> land(-34,-12) terr=17 cliff=3"
         },
         {
           "x": -35,
           "y": 3,
-          "details": "river surf=20 terr=19 -> land(-34,3) terr=17 cliff=3"
+          "details": "river surf=20 terr=16 -> land(-34,3) terr=17 cliff=3"
         },
         {
           "x": -35,
           "y": 4,
-          "details": "river surf=16 terr=15 -> land(-35,5) terr=13 cliff=3"
+          "details": "river surf=16 terr=12 -> land(-35,5) terr=13 cliff=3"
         },
         {
           "x": -35,
           "y": 31,
-          "details": "river surf=14 terr=13 -> land(-34,31) terr=10 cliff=4"
+          "details": "river surf=14 terr=11 -> land(-34,31) terr=10 cliff=4"
         },
         {
           "x": -35,
           "y": 36,
           "details": "river surf=15 terr=14 -> land(-35,37) terr=12 cliff=3"
+        },
+        {
+          "x": -34,
+          "y": -42,
+          "details": "river surf=137 terr=129 -> land(-33,-42) terr=134 cliff=3"
+        },
+        {
+          "x": -34,
+          "y": -40,
+          "details": "river surf=113 terr=105 -> land(-34,-39) terr=109 cliff=4"
         },
         {
           "x": -34,
@@ -2551,7 +2611,12 @@
         {
           "x": -33,
           "y": -43,
-          "details": "river surf=161 terr=159 -> land(-33,-42) terr=139 cliff=22"
+          "details": "river surf=161 terr=154 -> land(-33,-42) terr=134 cliff=27"
+        },
+        {
+          "x": -33,
+          "y": -41,
+          "details": "river surf=113 terr=106 -> land(-32,-41) terr=109 cliff=4"
         },
         {
           "x": -33,
@@ -2561,7 +2626,7 @@
         {
           "x": -33,
           "y": -14,
-          "details": "river surf=13 terr=12 -> land(-32,-14) terr=11 cliff=2"
+          "details": "river surf=13 terr=11 -> land(-32,-14) terr=11 cliff=2"
         },
         {
           "x": -33,
@@ -2576,7 +2641,7 @@
         {
           "x": -32,
           "y": -35,
-          "details": "river surf=29 terr=28 -> land(-31,-35) terr=23 cliff=6"
+          "details": "river surf=29 terr=22 -> land(-31,-35) terr=23 cliff=6"
         },
         {
           "x": -32,
@@ -2584,54 +2649,84 @@
           "details": "river surf=6 terr=5 -> land(-32,37) terr=4 cliff=2"
         },
         {
+          "x": -31,
+          "y": -44,
+          "details": "river surf=154 terr=146 -> land(-31,-43) terr=150 cliff=4"
+        },
+        {
+          "x": -31,
+          "y": -38,
+          "details": "river surf=77 terr=71 -> land(-31,-37) terr=74 cliff=3"
+        },
+        {
+          "x": -30,
+          "y": -44,
+          "details": "river surf=142 terr=134 -> land(-29,-44) terr=138 cliff=4"
+        },
+        {
+          "x": -30,
+          "y": -43,
+          "details": "river surf=130 terr=122 -> land(-30,-42) terr=126 cliff=4"
+        },
+        {
           "x": -30,
           "y": -37,
-          "details": "river surf=73 terr=70 -> land(-30,-36) terr=49 cliff=24"
+          "details": "river surf=73 terr=68 -> land(-30,-36) terr=49 cliff=24"
         },
         {
           "x": -29,
           "y": -37,
-          "details": "river surf=70 terr=67 -> land(-29,-36) terr=47 cliff=23"
+          "details": "river surf=70 terr=66 -> land(-28,-37) terr=64 cliff=6"
+        },
+        {
+          "x": -28,
+          "y": -38,
+          "details": "river surf=66 terr=60 -> land(-28,-37) terr=64 cliff=2"
+        },
+        {
+          "x": -26,
+          "y": -38,
+          "details": "river surf=66 terr=63 -> land(-26,-37) terr=64 cliff=2"
         },
         {
           "x": -24,
           "y": -52,
-          "details": "river surf=148 terr=147 -> land(-23,-52) terr=146 cliff=2"
+          "details": "river surf=148 terr=145 -> land(-23,-52) terr=146 cliff=2"
         },
         {
           "x": -23,
           "y": -51,
-          "details": "river surf=138 terr=137 -> land(-23,-50) terr=134 cliff=4"
+          "details": "river surf=138 terr=135 -> land(-23,-50) terr=134 cliff=4"
         },
         {
           "x": -22,
           "y": -51,
-          "details": "river surf=133 terr=132 -> land(-21,-51) terr=128 cliff=5"
+          "details": "river surf=133 terr=130 -> land(-21,-51) terr=128 cliff=5"
         },
         {
           "x": -22,
           "y": -50,
-          "details": "river surf=126 terr=125 -> land(-22,-49) terr=122 cliff=4"
+          "details": "river surf=126 terr=123 -> land(-22,-49) terr=122 cliff=4"
         },
         {
           "x": -21,
           "y": -50,
-          "details": "river surf=121 terr=120 -> land(-20,-50) terr=118 cliff=3"
+          "details": "river surf=121 terr=117 -> land(-20,-50) terr=118 cliff=3"
         },
         {
           "x": -21,
           "y": -49,
-          "details": "river surf=114 terr=113 -> land(-20,-49) terr=110 cliff=4"
+          "details": "river surf=114 terr=110 -> land(-20,-49) terr=110 cliff=4"
         },
         {
           "x": -21,
           "y": -48,
-          "details": "river surf=107 terr=106 -> land(-20,-48) terr=103 cliff=4"
+          "details": "river surf=107 terr=102 -> land(-20,-48) terr=103 cliff=4"
         },
         {
           "x": -21,
           "y": -47,
-          "details": "river surf=102 terr=101 -> land(-21,-46) terr=97 cliff=5"
+          "details": "river surf=102 terr=97 -> land(-21,-46) terr=97 cliff=5"
         },
         {
           "x": -20,
@@ -2651,7 +2746,7 @@
         {
           "x": -19,
           "y": -39,
-          "details": "river surf=50 terr=49 -> land(-18,-39) terr=43 cliff=7"
+          "details": "river surf=50 terr=47 -> land(-18,-39) terr=43 cliff=7"
         },
         {
           "x": -18,
@@ -2661,7 +2756,7 @@
         {
           "x": -17,
           "y": -39,
-          "details": "river surf=45 terr=44 -> land(-18,-39) terr=43 cliff=2"
+          "details": "river surf=45 terr=43 -> land(-18,-39) terr=43 cliff=2"
         },
         {
           "x": -16,
@@ -2711,7 +2806,7 @@
         {
           "x": 55,
           "y": -64,
-          "details": "river surf=124 terr=123 -> land(55,-63) terr=121 cliff=3"
+          "details": "river surf=124 terr=120 -> land(55,-63) terr=121 cliff=3"
         },
         {
           "x": 57,
@@ -2726,12 +2821,12 @@
         {
           "x": 60,
           "y": -59,
-          "details": "river surf=67 terr=66 -> land(60,-58) terr=65 cliff=2"
+          "details": "river surf=67 terr=63 -> land(60,-58) terr=65 cliff=2"
         },
         {
           "x": 61,
           "y": -58,
-          "details": "river surf=51 terr=50 -> land(61,-57) terr=47 cliff=4"
+          "details": "river surf=51 terr=46 -> land(61,-57) terr=47 cliff=4"
         },
         {
           "x": 68,
@@ -2792,6 +2887,16 @@
         },
         {
           "x": -62,
+          "y": -60,
+          "details": "river surf=114 -> dry(-62,-61) terr=112 cliff=2"
+        },
+        {
+          "x": -62,
+          "y": -52,
+          "details": "river surf=210 -> dry(-61,-52) terr=208 cliff=2"
+        },
+        {
+          "x": -62,
           "y": 7,
           "details": "lake surf=229 -> dry(-61,7) terr=146 cliff=83"
         },
@@ -2832,6 +2937,11 @@
         },
         {
           "x": -60,
+          "y": -61,
+          "details": "river surf=102 -> dry(-60,-62) terr=100 cliff=2"
+        },
+        {
+          "x": -60,
           "y": 33,
           "details": "river surf=138 -> dry(-59,33) terr=134 cliff=4"
         },
@@ -2839,6 +2949,11 @@
           "x": -60,
           "y": 44,
           "details": "river surf=105 -> dry(-61,44) terr=102 cliff=3"
+        },
+        {
+          "x": -59,
+          "y": -61,
+          "details": "river surf=90 -> dry(-59,-62) terr=88 cliff=2"
         },
         {
           "x": -59,
@@ -2857,8 +2972,13 @@
         },
         {
           "x": -56,
+          "y": -63,
+          "details": "river surf=78 -> dry(-56,-64) terr=76 cliff=2"
+        },
+        {
+          "x": -56,
           "y": -29,
-          "details": "lake surf=307 -> dry(-55,-29) terr=297 cliff=10"
+          "details": "lake surf=307 -> dry(-55,-29) terr=294 cliff=13"
         },
         {
           "x": -56,
@@ -2902,8 +3022,18 @@
         },
         {
           "x": -55,
+          "y": -63,
+          "details": "river surf=78 -> dry(-55,-64) terr=75 cliff=3"
+        },
+        {
+          "x": -55,
+          "y": -57,
+          "details": "river surf=150 -> dry(-54,-57) terr=148 cliff=2"
+        },
+        {
+          "x": -55,
           "y": -28,
-          "details": "lake surf=307 -> dry(-55,-29) terr=297 cliff=10"
+          "details": "lake surf=307 -> dry(-55,-29) terr=294 cliff=13"
         },
         {
           "x": -55,
@@ -2918,7 +3048,7 @@
         {
           "x": -54,
           "y": -26,
-          "details": "lake surf=307 -> dry(-53,-26) terr=261 cliff=46"
+          "details": "lake surf=307 -> dry(-53,-26) terr=258 cliff=49"
         },
         {
           "x": -54,
@@ -2952,13 +3082,43 @@
         },
         {
           "x": -52,
+          "y": -61,
+          "details": "river surf=102 -> dry(-52,-62) terr=99 cliff=3"
+        },
+        {
+          "x": -52,
           "y": 41,
           "details": "river surf=101 -> dry(-52,40) terr=98 cliff=3"
         },
         {
           "x": -51,
+          "y": -60,
+          "details": "river surf=126 -> dry(-51,-61) terr=123 cliff=3"
+        },
+        {
+          "x": -51,
+          "y": -59,
+          "details": "river surf=138 -> dry(-52,-59) terr=135 cliff=3"
+        },
+        {
+          "x": -51,
           "y": -40,
           "details": "river surf=292 -> dry(-51,-41) terr=287 cliff=5"
+        },
+        {
+          "x": -51,
+          "y": -29,
+          "details": "river surf=234 -> dry(-50,-29) terr=232 cliff=2"
+        },
+        {
+          "x": -50,
+          "y": -58,
+          "details": "river surf=162 -> dry(-50,-59) terr=159 cliff=3"
+        },
+        {
+          "x": -50,
+          "y": -57,
+          "details": "river surf=174 -> dry(-51,-57) terr=171 cliff=3"
         },
         {
           "x": -50,
@@ -2984,6 +3144,11 @@
           "x": -50,
           "y": -40,
           "details": "river surf=285 -> dry(-50,-41) terr=278 cliff=7"
+        },
+        {
+          "x": -49,
+          "y": -57,
+          "details": "river surf=186 -> dry(-49,-58) terr=183 cliff=3"
         },
         {
           "x": -49,
@@ -3052,6 +3217,11 @@
         },
         {
           "x": -47,
+          "y": -27,
+          "details": "river surf=162 -> dry(-46,-27) terr=160 cliff=2"
+        },
+        {
+          "x": -47,
           "y": -16,
           "details": "river surf=222 -> dry(-48,-16) terr=202 cliff=20"
         },
@@ -3079,6 +3249,21 @@
           "x": -46,
           "y": -40,
           "details": "river surf=253 -> dry(-45,-40) terr=247 cliff=6"
+        },
+        {
+          "x": -46,
+          "y": -25,
+          "details": "river surf=126 -> dry(-46,-24) terr=124 cliff=2"
+        },
+        {
+          "x": -46,
+          "y": -23,
+          "details": "river surf=126 -> dry(-46,-24) terr=124 cliff=2"
+        },
+        {
+          "x": -46,
+          "y": -20,
+          "details": "river surf=162 -> dry(-46,-21) terr=160 cliff=2"
         },
         {
           "x": -46,
@@ -3147,6 +3332,11 @@
         },
         {
           "x": -44,
+          "y": -26,
+          "details": "river surf=114 -> dry(-43,-26) terr=112 cliff=2"
+        },
+        {
+          "x": -44,
           "y": -16,
           "details": "river surf=199 -> dry(-43,-16) terr=186 cliff=13"
         },
@@ -3162,18 +3352,23 @@
         },
         {
           "x": -43,
+          "y": -25,
+          "details": "river surf=90 -> dry(-42,-25) terr=87 cliff=3"
+        },
+        {
+          "x": -43,
           "y": -23,
-          "details": "lake surf=189 -> dry(-42,-23) terr=92 cliff=97"
+          "details": "lake surf=189 -> dry(-42,-23) terr=87 cliff=102"
         },
         {
           "x": -43,
           "y": -22,
-          "details": "lake surf=189 -> dry(-42,-22) terr=120 cliff=69"
+          "details": "lake surf=189 -> dry(-42,-22) terr=115 cliff=74"
         },
         {
           "x": -43,
           "y": -21,
-          "details": "lake surf=189 -> dry(-42,-21) terr=148 cliff=41"
+          "details": "lake surf=189 -> dry(-42,-21) terr=143 cliff=46"
         },
         {
           "x": -43,
@@ -3287,6 +3482,11 @@
         },
         {
           "x": -36,
+          "y": -42,
+          "details": "river surf=161 -> dry(-36,-41) terr=158 cliff=3"
+        },
+        {
+          "x": -36,
           "y": 29,
           "details": "river surf=12 -> dry(-36,28) terr=9 cliff=3"
         },
@@ -3294,6 +3494,11 @@
           "x": -36,
           "y": 36,
           "details": "river surf=20 -> dry(-36,37) terr=16 cliff=4"
+        },
+        {
+          "x": -35,
+          "y": -44,
+          "details": "river surf=173 -> dry(-34,-44) terr=170 cliff=3"
         },
         {
           "x": -35,
@@ -3322,6 +3527,16 @@
         },
         {
           "x": -34,
+          "y": -42,
+          "details": "river surf=137 -> dry(-33,-42) terr=134 cliff=3"
+        },
+        {
+          "x": -34,
+          "y": -40,
+          "details": "river surf=113 -> dry(-34,-39) terr=109 cliff=4"
+        },
+        {
+          "x": -34,
           "y": 32,
           "details": "river surf=13 -> dry(-34,31) terr=10 cliff=3"
         },
@@ -3333,7 +3548,12 @@
         {
           "x": -33,
           "y": -43,
-          "details": "river surf=161 -> dry(-33,-42) terr=139 cliff=22"
+          "details": "river surf=161 -> dry(-33,-42) terr=134 cliff=27"
+        },
+        {
+          "x": -33,
+          "y": -41,
+          "details": "river surf=113 -> dry(-32,-41) terr=109 cliff=4"
         },
         {
           "x": -33,
@@ -3366,6 +3586,26 @@
           "details": "river surf=6 -> dry(-32,37) terr=4 cliff=2"
         },
         {
+          "x": -31,
+          "y": -44,
+          "details": "river surf=154 -> dry(-31,-43) terr=150 cliff=4"
+        },
+        {
+          "x": -31,
+          "y": -38,
+          "details": "river surf=77 -> dry(-31,-37) terr=74 cliff=3"
+        },
+        {
+          "x": -30,
+          "y": -44,
+          "details": "river surf=142 -> dry(-29,-44) terr=138 cliff=4"
+        },
+        {
+          "x": -30,
+          "y": -43,
+          "details": "river surf=130 -> dry(-30,-42) terr=126 cliff=4"
+        },
+        {
           "x": -30,
           "y": -37,
           "details": "river surf=73 -> dry(-30,-36) terr=49 cliff=24"
@@ -3373,7 +3613,17 @@
         {
           "x": -29,
           "y": -37,
-          "details": "river surf=70 -> dry(-29,-36) terr=47 cliff=23"
+          "details": "river surf=70 -> dry(-28,-37) terr=64 cliff=6"
+        },
+        {
+          "x": -28,
+          "y": -38,
+          "details": "river surf=66 -> dry(-28,-37) terr=64 cliff=2"
+        },
+        {
+          "x": -26,
+          "y": -38,
+          "details": "river surf=66 -> dry(-26,-37) terr=64 cliff=2"
         },
         {
           "x": -24,

--- a/tools/baselines/seed314_size32_region_-4_-4_4_4.json
+++ b/tools/baselines/seed314_size32_region_-4_-4_4_4.json
@@ -14,9 +14,9 @@
     "deterministic": true,
     "distinctHashes": 1,
     "hashes": [
-      "ddbb28981b96b059d6aa398c20b90eafa1f9459c58cca71744dd015d8574a761",
-      "ddbb28981b96b059d6aa398c20b90eafa1f9459c58cca71744dd015d8574a761",
-      "ddbb28981b96b059d6aa398c20b90eafa1f9459c58cca71744dd015d8574a761"
+      "d365914b70bbc075066b61661f097432462d6e0110b42036db6e896f2de1d5f0",
+      "d365914b70bbc075066b61661f097432462d6e0110b42036db6e896f2de1d5f0",
+      "d365914b70bbc075066b61661f097432462d6e0110b42036db6e896f2de1d5f0"
     ]
   },
   "tileCount": 20736,
@@ -87,23 +87,23 @@
   },
   "auditEnvelope": {
     "DESERT_SOIL_ON_SLOPE": {
-      "min": 91,
-      "max": 91,
-      "median": 91,
+      "min": 86,
+      "max": 86,
+      "median": 86,
       "all": [
-        91,
-        91,
-        91
+        86,
+        86,
+        86
       ]
     },
     "FLAT_ISOLATED_WATER": {
-      "min": 4,
-      "max": 4,
-      "median": 4,
+      "min": 3,
+      "max": 3,
+      "median": 3,
       "all": [
-        4,
-        4,
-        4
+        3,
+        3,
+        3
       ]
     },
     "FLOATING_LAKE": {
@@ -117,13 +117,13 @@
       ]
     },
     "FLOATING_WATER": {
-      "min": 155,
-      "max": 155,
-      "median": 155,
+      "min": 96,
+      "max": 96,
+      "median": 96,
       "all": [
-        155,
-        155,
-        155
+        96,
+        96,
+        96
       ]
     },
     "ISOLATED_FLUID": {
@@ -134,6 +134,16 @@
         6,
         6,
         6
+      ]
+    },
+    "MID_RIVER_CLIFF": {
+      "min": 83,
+      "max": 83,
+      "median": 83,
+      "all": [
+        83,
+        83,
+        83
       ]
     },
     "MULTI_ISLAND": {
@@ -147,13 +157,13 @@
       ]
     },
     "RIVER_CHUNK_GAP": {
-      "min": 3,
-      "max": 3,
-      "median": 3,
+      "min": 6,
+      "max": 6,
+      "median": 6,
       "all": [
-        3,
-        3,
-        3
+        6,
+        6,
+        6
       ]
     },
     "RIVER_MOUTH_DROP": {
@@ -167,23 +177,23 @@
       ]
     },
     "WATER_ABOVE_LAND": {
-      "min": 155,
-      "max": 155,
-      "median": 155,
+      "min": 195,
+      "max": 195,
+      "median": 195,
       "all": [
-        155,
-        155,
-        155
+        195,
+        195,
+        195
       ]
     },
     "WATER_CLIFF": {
-      "min": 155,
-      "max": 155,
-      "median": 155,
+      "min": 195,
+      "max": 195,
+      "median": 195,
       "all": [
-        155,
-        155,
-        155
+        195,
+        195,
+        195
       ]
     },
     "WATER_WATER_CLIFF": {
@@ -199,16 +209,17 @@
   },
   "representativeAudit": {
     "summary": {
-      "DESERT_SOIL_ON_SLOPE": 91,
-      "FLAT_ISOLATED_WATER": 4,
+      "DESERT_SOIL_ON_SLOPE": 86,
+      "FLAT_ISOLATED_WATER": 3,
       "FLOATING_LAKE": 2,
-      "FLOATING_WATER": 155,
+      "FLOATING_WATER": 96,
       "ISOLATED_FLUID": 6,
+      "MID_RIVER_CLIFF": 83,
       "MULTI_ISLAND": 10,
-      "RIVER_CHUNK_GAP": 3,
+      "RIVER_CHUNK_GAP": 6,
       "RIVER_MOUTH_DROP": 4,
-      "WATER_ABOVE_LAND": 155,
-      "WATER_CLIFF": 155,
+      "WATER_ABOVE_LAND": 195,
+      "WATER_CLIFF": 195,
       "WATER_WATER_CLIFF": 2062
     },
     "issues": {
@@ -291,7 +302,7 @@
         {
           "x": -61,
           "y": 37,
-          "details": "sand maxNbrDelta=4"
+          "details": "sand maxNbrDelta=3"
         },
         {
           "x": -60,
@@ -305,18 +316,13 @@
         },
         {
           "x": -60,
-          "y": 34,
-          "details": "sand maxNbrDelta=4"
-        },
-        {
-          "x": -60,
           "y": 35,
-          "details": "sand maxNbrDelta=4"
+          "details": "sand maxNbrDelta=3"
         },
         {
           "x": -60,
           "y": 38,
-          "details": "sand maxNbrDelta=4"
+          "details": "sand maxNbrDelta=3"
         },
         {
           "x": -59,
@@ -421,7 +427,7 @@
         {
           "x": -53,
           "y": 44,
-          "details": "sand maxNbrDelta=4"
+          "details": "sand maxNbrDelta=3"
         },
         {
           "x": -52,
@@ -436,17 +442,17 @@
         {
           "x": -52,
           "y": 43,
-          "details": "sand maxNbrDelta=4"
+          "details": "sand maxNbrDelta=5"
         },
         {
           "x": -52,
           "y": 44,
-          "details": "sand maxNbrDelta=4"
+          "details": "sand maxNbrDelta=5"
         },
         {
           "x": -51,
           "y": 43,
-          "details": "sand maxNbrDelta=6"
+          "details": "sand maxNbrDelta=4"
         },
         {
           "x": -51,
@@ -456,11 +462,6 @@
         {
           "x": -50,
           "y": -50,
-          "details": "sand maxNbrDelta=3"
-        },
-        {
-          "x": -49,
-          "y": 40,
           "details": "sand maxNbrDelta=3"
         },
         {
@@ -481,17 +482,17 @@
         {
           "x": -48,
           "y": 39,
-          "details": "sand maxNbrDelta=10"
+          "details": "sand maxNbrDelta=8"
         },
         {
           "x": -48,
           "y": 40,
-          "details": "sand maxNbrDelta=12"
+          "details": "sand maxNbrDelta=11"
         },
         {
           "x": -48,
           "y": 41,
-          "details": "sand maxNbrDelta=12"
+          "details": "sand maxNbrDelta=11"
         },
         {
           "x": -47,
@@ -609,16 +610,6 @@
           "details": "sand maxNbrDelta=3"
         },
         {
-          "x": -28,
-          "y": 28,
-          "details": "sand maxNbrDelta=5"
-        },
-        {
-          "x": -27,
-          "y": 28,
-          "details": "sand maxNbrDelta=4"
-        },
-        {
           "x": -26,
           "y": -64,
           "details": "sand maxNbrDelta=4"
@@ -627,11 +618,6 @@
           "x": -26,
           "y": -62,
           "details": "sand maxNbrDelta=5"
-        },
-        {
-          "x": -26,
-          "y": 28,
-          "details": "sand maxNbrDelta=4"
         },
         {
           "x": -25,
@@ -671,11 +657,6 @@
       ],
       "FLAT_ISOLATED_WATER": [
         {
-          "x": -13,
-          "y": 73,
-          "details": "river surf=141 terr=140 water_nbrs=1 terr_range=2"
-        },
-        {
           "x": 52,
           "y": 60,
           "details": "lake surf=231 terr=230 water_nbrs=0 terr_range=1"
@@ -705,124 +686,44 @@
       ],
       "FLOATING_WATER": [
         {
-          "x": -64,
-          "y": 6,
-          "details": "river terr=70 -> dry(-64,5) terr=68 gap=2"
-        },
-        {
-          "x": -64,
-          "y": 8,
-          "details": "river terr=76 -> dry(-64,7) terr=74 gap=2"
-        },
-        {
-          "x": -64,
-          "y": 51,
-          "details": "river terr=44 -> dry(-64,52) terr=42 gap=2"
-        },
-        {
-          "x": -63,
-          "y": 6,
-          "details": "river terr=60 -> dry(-63,5) terr=58 gap=2"
-        },
-        {
-          "x": -63,
-          "y": 8,
-          "details": "river terr=65 -> dry(-63,7) terr=64 gap=1"
-        },
-        {
-          "x": -63,
-          "y": 24,
-          "details": "river terr=67 -> dry(-62,24) terr=64 gap=3"
-        },
-        {
-          "x": -63,
-          "y": 25,
-          "details": "river terr=55 -> dry(-62,25) terr=52 gap=3"
-        },
-        {
           "x": -63,
           "y": 27,
-          "details": "river terr=55 -> dry(-62,27) terr=45 gap=10"
-        },
-        {
-          "x": -63,
-          "y": 29,
-          "details": "river terr=60 -> dry(-63,30) terr=59 gap=1"
+          "details": "river terr=50 -> dry(-62,27) terr=45 gap=5"
         },
         {
           "x": -63,
           "y": 46,
-          "details": "river terr=51 -> dry(-62,46) terr=46 gap=5"
-        },
-        {
-          "x": -62,
-          "y": 6,
-          "details": "river terr=50 -> dry(-62,5) terr=48 gap=2"
+          "details": "river terr=49 -> dry(-62,46) terr=46 gap=3"
         },
         {
           "x": -62,
           "y": 23,
-          "details": "river terr=73 -> dry(-62,24) terr=64 gap=9"
-        },
-        {
-          "x": -62,
-          "y": 28,
-          "details": "river terr=48 -> dry(-62,27) terr=45 gap=3"
-        },
-        {
-          "x": -62,
-          "y": 29,
-          "details": "river terr=48 -> dry(-62,30) terr=46 gap=2"
+          "details": "river terr=69 -> dry(-62,24) terr=64 gap=5"
         },
         {
           "x": -61,
           "y": 5,
-          "details": "river terr=37 -> dry(-61,4) terr=34 gap=3"
-        },
-        {
-          "x": -61,
-          "y": 17,
-          "details": "river terr=49 -> dry(-61,16) terr=44 gap=5"
+          "details": "river terr=35 -> dry(-61,4) terr=34 gap=1"
         },
         {
           "x": -61,
           "y": 23,
-          "details": "river terr=62 -> dry(-61,24) terr=54 gap=8"
-        },
-        {
-          "x": -61,
-          "y": 28,
-          "details": "river terr=38 -> dry(-61,27) terr=36 gap=2"
+          "details": "river terr=57 -> dry(-61,24) terr=54 gap=3"
         },
         {
           "x": -61,
           "y": 30,
-          "details": "river terr=34 -> dry(-61,31) terr=29 gap=5"
+          "details": "river terr=31 -> dry(-61,31) terr=29 gap=2"
         },
         {
           "x": -61,
           "y": 59,
-          "details": "river terr=26 -> dry(-62,59) terr=21 gap=5"
-        },
-        {
-          "x": -61,
-          "y": 60,
-          "details": "river terr=17 -> dry(-62,60) terr=13 gap=4"
-        },
-        {
-          "x": -60,
-          "y": 5,
-          "details": "river terr=28 -> dry(-60,4) terr=25 gap=3"
+          "details": "river terr=23 -> dry(-62,59) terr=21 gap=2"
         },
         {
           "x": -60,
           "y": 23,
-          "details": "river terr=51 -> dry(-60,24) terr=45 gap=6"
-        },
-        {
-          "x": -60,
-          "y": 46,
-          "details": "river terr=41 -> dry(-61,46) terr=39 gap=2"
+          "details": "river terr=46 -> dry(-60,24) terr=45 gap=1"
         },
         {
           "x": -60,
@@ -837,32 +738,27 @@
         {
           "x": -60,
           "y": 58,
-          "details": "river terr=40 -> dry(-61,58) terr=35 gap=5"
+          "details": "river terr=38 -> dry(-61,58) terr=35 gap=3"
         },
         {
           "x": -59,
           "y": 4,
-          "details": "river terr=17 -> dry(-59,3) terr=14 gap=3"
+          "details": "river terr=16 -> dry(-59,3) terr=14 gap=2"
         },
         {
           "x": -59,
           "y": 17,
-          "details": "river terr=25 -> dry(-58,17) terr=19 gap=6"
+          "details": "river terr=20 -> dry(-58,17) terr=19 gap=1"
         },
         {
           "x": -59,
           "y": 18,
-          "details": "river terr=36 -> dry(-58,18) terr=28 gap=8"
-        },
-        {
-          "x": -59,
-          "y": 23,
-          "details": "river terr=40 -> dry(-59,24) terr=35 gap=5"
+          "details": "river terr=31 -> dry(-58,18) terr=28 gap=3"
         },
         {
           "x": -59,
           "y": 45,
-          "details": "river terr=31 -> dry(-58,45) terr=27 gap=4"
+          "details": "river terr=29 -> dry(-58,45) terr=27 gap=2"
         },
         {
           "x": -59,
@@ -882,27 +778,17 @@
         {
           "x": -58,
           "y": 3,
-          "details": "river terr=8 -> dry(-57,3) terr=6 gap=2"
-        },
-        {
-          "x": -58,
-          "y": 19,
-          "details": "river terr=33 -> dry(-58,18) terr=28 gap=5"
-        },
-        {
-          "x": -58,
-          "y": 23,
-          "details": "river terr=29 -> dry(-58,24) terr=24 gap=5"
+          "details": "river terr=7 -> dry(-57,3) terr=6 gap=1"
         },
         {
           "x": -58,
           "y": 43,
-          "details": "river terr=13 -> dry(-57,43) terr=9 gap=4"
+          "details": "river terr=11 -> dry(-57,43) terr=9 gap=2"
         },
         {
           "x": -58,
           "y": 44,
-          "details": "river terr=19 -> dry(-57,44) terr=15 gap=4"
+          "details": "river terr=17 -> dry(-57,44) terr=15 gap=2"
         },
         {
           "x": -58,
@@ -922,12 +808,7 @@
         {
           "x": -57,
           "y": 19,
-          "details": "river terr=25 -> dry(-57,18) terr=20 gap=5"
-        },
-        {
-          "x": -57,
-          "y": 23,
-          "details": "river terr=18 -> dry(-56,23) terr=13 gap=5"
+          "details": "river terr=21 -> dry(-57,18) terr=20 gap=1"
         },
         {
           "x": -57,
@@ -956,28 +837,8 @@
         },
         {
           "x": -56,
-          "y": 19,
-          "details": "river terr=18 -> dry(-56,18) terr=15 gap=3"
-        },
-        {
-          "x": -56,
-          "y": 22,
-          "details": "river terr=16 -> dry(-56,23) terr=13 gap=3"
-        },
-        {
-          "x": -56,
-          "y": 45,
-          "details": "river terr=13 -> dry(-56,44) terr=9 gap=4"
-        },
-        {
-          "x": -56,
-          "y": 51,
-          "details": "river terr=49 -> dry(-56,50) terr=48 gap=1"
-        },
-        {
-          "x": -56,
           "y": 59,
-          "details": "river terr=53 -> dry(-56,60) terr=49 gap=4"
+          "details": "river terr=51 -> dry(-56,60) terr=49 gap=2"
         },
         {
           "x": -55,
@@ -996,18 +857,8 @@
         },
         {
           "x": -55,
-          "y": 50,
-          "details": "river terr=36 -> dry(-55,49) terr=34 gap=2"
-        },
-        {
-          "x": -55,
-          "y": 56,
-          "details": "river terr=68 -> dry(-55,55) terr=67 gap=1"
-        },
-        {
-          "x": -55,
           "y": 59,
-          "details": "river terr=59 -> dry(-55,60) terr=55 gap=4"
+          "details": "river terr=56 -> dry(-55,60) terr=55 gap=1"
         },
         {
           "x": -54,
@@ -1021,233 +872,128 @@
         },
         {
           "x": -54,
-          "y": 54,
-          "details": "river terr=66 -> dry(-55,54) terr=63 gap=3"
-        },
-        {
-          "x": -54,
           "y": 55,
-          "details": "river terr=72 -> dry(-55,55) terr=67 gap=5"
-        },
-        {
-          "x": -54,
-          "y": 59,
-          "details": "river terr=66 -> dry(-54,60) terr=63 gap=3"
+          "details": "river terr=69 -> dry(-55,55) terr=67 gap=2"
         },
         {
           "x": -53,
           "y": 55,
-          "details": "river terr=79 -> dry(-53,54) terr=74 gap=5"
-        },
-        {
-          "x": -52,
-          "y": 48,
-          "details": "river terr=25 -> dry(-52,47) terr=21 gap=4"
+          "details": "river terr=75 -> dry(-53,54) terr=74 gap=1"
         },
         {
           "x": -52,
           "y": 51,
-          "details": "river terr=49 -> dry(-53,51) terr=42 gap=7"
+          "details": "river terr=43 -> dry(-53,51) terr=42 gap=1"
         },
         {
           "x": -52,
           "y": 52,
-          "details": "river terr=61 -> dry(-53,52) terr=54 gap=7"
+          "details": "river terr=55 -> dry(-53,52) terr=54 gap=1"
         },
         {
           "x": -52,
           "y": 53,
-          "details": "river terr=72 -> dry(-53,53) terr=65 gap=7"
+          "details": "river terr=66 -> dry(-53,53) terr=65 gap=1"
         },
         {
           "x": -52,
           "y": 54,
-          "details": "river terr=81 -> dry(-53,54) terr=74 gap=7"
-        },
-        {
-          "x": -51,
-          "y": 45,
-          "details": "river terr=11 -> dry(-52,45) terr=10 gap=1"
-        },
-        {
-          "x": -51,
-          "y": 46,
-          "details": "river terr=18 -> dry(-52,46) terr=15 gap=3"
-        },
-        {
-          "x": -51,
-          "y": 47,
-          "details": "river terr=26 -> dry(-52,47) terr=21 gap=5"
-        },
-        {
-          "x": -44,
-          "y": 32,
-          "details": "river terr=4 -> dry(-44,31) terr=3 gap=1"
-        },
-        {
-          "x": -39,
-          "y": 28,
-          "details": "river terr=14 -> dry(-40,28) terr=11 gap=3"
+          "details": "river terr=76 -> dry(-53,54) terr=74 gap=2"
         },
         {
           "x": -32,
           "y": 54,
-          "details": "river terr=315 -> dry(-32,53) terr=312 gap=3"
+          "details": "river terr=313 -> dry(-32,53) terr=312 gap=1"
         },
         {
           "x": -30,
           "y": 56,
-          "details": "river terr=304 -> dry(-29,56) terr=297 gap=7"
-        },
-        {
-          "x": -30,
-          "y": 57,
-          "details": "river terr=316 -> dry(-29,57) terr=314 gap=2"
-        },
-        {
-          "x": -29,
-          "y": 51,
-          "details": "river terr=288 -> dry(-29,50) terr=287 gap=1"
+          "details": "river terr=298 -> dry(-29,56) terr=297 gap=1"
         },
         {
           "x": -28,
           "y": 37,
-          "details": "river terr=148 -> dry(-27,37) terr=128 gap=20"
-        },
-        {
-          "x": -28,
-          "y": 50,
-          "details": "river terr=280 -> dry(-27,50) terr=278 gap=2"
+          "details": "river terr=144 -> dry(-27,37) terr=123 gap=21"
         },
         {
           "x": -27,
           "y": 76,
-          "details": "river terr=166 -> dry(-28,76) terr=162 gap=4"
+          "details": "river terr=161 -> dry(-28,76) terr=157 gap=4"
         },
         {
           "x": -27,
           "y": 77,
-          "details": "river terr=178 -> dry(-28,77) terr=166 gap=12"
-        },
-        {
-          "x": -26,
-          "y": 30,
-          "details": "river terr=16 -> dry(-25,30) terr=13 gap=3"
-        },
-        {
-          "x": -25,
-          "y": 50,
-          "details": "river terr=268 -> dry(-24,50) terr=267 gap=1"
+          "details": "river terr=173 -> dry(-28,77) terr=160 gap=13"
         },
         {
           "x": -25,
           "y": 51,
-          "details": "river terr=277 -> dry(-24,51) terr=272 gap=5"
-        },
-        {
-          "x": -16,
-          "y": 74,
-          "details": "river terr=146 -> dry(-15,74) terr=145 gap=1"
-        },
-        {
-          "x": -15,
-          "y": 73,
-          "details": "river terr=146 -> dry(-15,74) terr=145 gap=1"
-        },
-        {
-          "x": -14,
-          "y": 73,
-          "details": "river terr=143 -> dry(-14,74) terr=142 gap=1"
-        },
-        {
-          "x": 46,
-          "y": 28,
-          "details": "river terr=4 -> dry(45,28) terr=3 gap=1"
-        },
-        {
-          "x": 47,
-          "y": 29,
-          "details": "river terr=12 -> dry(46,29) terr=9 gap=3"
+          "details": "river terr=274 -> dry(-24,51) terr=272 gap=2"
         },
         {
           "x": 47,
           "y": 30,
-          "details": "river terr=19 -> dry(46,30) terr=14 gap=5"
+          "details": "river terr=15 -> dry(46,30) terr=14 gap=1"
         },
         {
           "x": 47,
           "y": 31,
-          "details": "river terr=26 -> dry(46,31) terr=20 gap=6"
+          "details": "river terr=21 -> dry(46,31) terr=20 gap=1"
         },
         {
           "x": 47,
           "y": 32,
-          "details": "river terr=36 -> dry(46,32) terr=27 gap=9"
+          "details": "river terr=31 -> dry(46,32) terr=27 gap=4"
         },
         {
           "x": 47,
           "y": 33,
-          "details": "river terr=46 -> dry(46,33) terr=37 gap=9"
+          "details": "river terr=41 -> dry(46,33) terr=37 gap=4"
         },
         {
           "x": 47,
           "y": 34,
-          "details": "river terr=57 -> dry(46,34) terr=47 gap=10"
+          "details": "river terr=52 -> dry(46,34) terr=47 gap=5"
         },
         {
           "x": 48,
           "y": 34,
-          "details": "river terr=68 -> dry(48,33) terr=59 gap=9"
+          "details": "river terr=63 -> dry(48,33) terr=59 gap=4"
         },
         {
           "x": 49,
           "y": 34,
-          "details": "river terr=80 -> dry(49,33) terr=70 gap=10"
-        },
-        {
-          "x": 50,
-          "y": 25,
-          "details": "river terr=6 -> dry(49,25) terr=5 gap=1"
+          "details": "river terr=75 -> dry(49,33) terr=70 gap=5"
         },
         {
           "x": 50,
           "y": 34,
-          "details": "river terr=91 -> dry(50,33) terr=82 gap=9"
-        },
-        {
-          "x": 51,
-          "y": 26,
-          "details": "river terr=14 -> dry(50,26) terr=11 gap=3"
-        },
-        {
-          "x": 51,
-          "y": 27,
-          "details": "river terr=23 -> dry(50,27) terr=18 gap=5"
+          "details": "river terr=87 -> dry(50,33) terr=82 gap=5"
         },
         {
           "x": 51,
           "y": 34,
-          "details": "river terr=102 -> dry(51,33) terr=93 gap=9"
+          "details": "river terr=98 -> dry(51,33) terr=93 gap=5"
         },
         {
           "x": 51,
           "y": 35,
-          "details": "river terr=111 -> dry(50,35) terr=103 gap=8"
+          "details": "river terr=108 -> dry(50,35) terr=103 gap=5"
         },
         {
           "x": 51,
           "y": 36,
-          "details": "river terr=120 -> dry(50,36) terr=112 gap=8"
+          "details": "river terr=118 -> dry(50,36) terr=112 gap=6"
         },
         {
           "x": 51,
           "y": 37,
-          "details": "river terr=127 -> dry(50,37) terr=121 gap=6"
+          "details": "river terr=126 -> dry(50,37) terr=121 gap=5"
         },
         {
           "x": 52,
           "y": 35,
-          "details": "river terr=120 -> dry(52,34) terr=113 gap=7"
+          "details": "river terr=117 -> dry(52,34) terr=113 gap=4"
         },
         {
           "x": 52,
@@ -1275,19 +1021,9 @@
           "details": "river terr=149 -> dry(52,40) terr=147 gap=2"
         },
         {
-          "x": 54,
-          "y": 25,
-          "details": "river terr=21 -> dry(53,25) terr=18 gap=3"
-        },
-        {
           "x": 55,
           "y": 40,
           "details": "river terr=154 -> dry(55,41) terr=153 gap=1"
-        },
-        {
-          "x": 56,
-          "y": 26,
-          "details": "river terr=37 -> dry(55,26) terr=36 gap=1"
         },
         {
           "x": 56,
@@ -1300,79 +1036,44 @@
           "details": "river terr=166 -> dry(57,41) terr=165 gap=1"
         },
         {
-          "x": 61,
-          "y": 24,
-          "details": "river terr=21 -> dry(61,23) terr=20 gap=1"
-        },
-        {
           "x": 62,
           "y": 23,
           "details": "river terr=21 -> dry(61,23) terr=20 gap=1"
         },
         {
-          "x": 63,
-          "y": 67,
-          "details": "river terr=211 -> dry(63,68) terr=209 gap=2"
-        },
-        {
           "x": 64,
           "y": 67,
-          "details": "river terr=202 -> dry(64,68) terr=198 gap=4"
-        },
-        {
-          "x": 66,
-          "y": 64,
-          "details": "river terr=197 -> dry(66,65) terr=196 gap=1"
-        },
-        {
-          "x": 70,
-          "y": 23,
-          "details": "river terr=21 -> dry(71,23) terr=20 gap=1"
-        },
-        {
-          "x": 74,
-          "y": 44,
-          "details": "river terr=177 -> dry(74,43) terr=176 gap=1"
-        },
-        {
-          "x": 74,
-          "y": 54,
-          "details": "river terr=190 -> dry(75,54) terr=189 gap=1"
+          "details": "river terr=199 -> dry(64,68) terr=198 gap=1"
         },
         {
           "x": 75,
           "y": 35,
-          "details": "river terr=135 -> dry(75,34) terr=128 gap=7"
+          "details": "river terr=130 -> dry(75,34) terr=128 gap=2"
         },
         {
           "x": 75,
           "y": 36,
-          "details": "river terr=143 -> dry(76,36) terr=136 gap=7"
+          "details": "river terr=139 -> dry(76,36) terr=136 gap=3"
         },
         {
           "x": 75,
           "y": 37,
-          "details": "river terr=150 -> dry(76,37) terr=144 gap=6"
+          "details": "river terr=146 -> dry(76,37) terr=144 gap=2"
         },
         {
           "x": 75,
           "y": 38,
-          "details": "river terr=157 -> dry(76,38) terr=151 gap=6"
+          "details": "river terr=154 -> dry(76,38) terr=151 gap=3"
         },
         {
           "x": 75,
           "y": 39,
-          "details": "river terr=162 -> dry(76,39) terr=158 gap=4"
+          "details": "river terr=160 -> dry(76,39) terr=158 gap=2"
         },
         {
           "x": 75,
           "y": 79,
-          "details": "river terr=178 -> dry(76,79) terr=175 gap=3"
-        },
-        {
-          "x": 76,
-          "y": 45,
-          "details": "river terr=171 -> dry(77,45) terr=169 gap=2"
+          "details": "river terr=177 -> dry(76,79) terr=175 gap=2"
         },
         {
           "x": 76,
@@ -1386,63 +1087,48 @@
         },
         {
           "x": 77,
-          "y": 25,
-          "details": "river terr=16 -> dry(78,25) terr=14 gap=2"
-        },
-        {
-          "x": 77,
-          "y": 26,
-          "details": "river terr=25 -> dry(78,26) terr=21 gap=4"
-        },
-        {
-          "x": 77,
-          "y": 27,
-          "details": "river terr=34 -> dry(78,27) terr=29 gap=5"
-        },
-        {
-          "x": 77,
           "y": 28,
-          "details": "river terr=43 -> dry(78,28) terr=36 gap=7"
+          "details": "river terr=37 -> dry(78,28) terr=36 gap=1"
         },
         {
           "x": 77,
           "y": 29,
-          "details": "river terr=53 -> dry(78,29) terr=45 gap=8"
+          "details": "river terr=47 -> dry(78,29) terr=45 gap=2"
         },
         {
           "x": 77,
           "y": 31,
-          "details": "river terr=74 -> dry(78,31) terr=65 gap=9"
+          "details": "river terr=69 -> dry(78,31) terr=65 gap=4"
         },
         {
           "x": 77,
           "y": 32,
-          "details": "river terr=86 -> dry(78,32) terr=76 gap=10"
+          "details": "river terr=81 -> dry(78,32) terr=76 gap=5"
         },
         {
           "x": 77,
           "y": 33,
-          "details": "river terr=96 -> dry(78,33) terr=88 gap=8"
+          "details": "river terr=91 -> dry(78,33) terr=88 gap=3"
         },
         {
           "x": 77,
           "y": 34,
-          "details": "river terr=107 -> dry(78,34) terr=99 gap=8"
+          "details": "river terr=103 -> dry(78,34) terr=99 gap=4"
         },
         {
           "x": 77,
           "y": 35,
-          "details": "river terr=117 -> dry(78,35) terr=111 gap=6"
+          "details": "river terr=113 -> dry(78,35) terr=111 gap=2"
         },
         {
           "x": 77,
           "y": 36,
-          "details": "river terr=128 -> dry(78,36) terr=122 gap=6"
+          "details": "river terr=125 -> dry(78,36) terr=122 gap=3"
         },
         {
           "x": 77,
           "y": 37,
-          "details": "river terr=137 -> dry(78,37) terr=133 gap=4"
+          "details": "river terr=134 -> dry(78,37) terr=133 gap=1"
         },
         {
           "x": 77,
@@ -1452,7 +1138,7 @@
         {
           "x": 78,
           "y": 30,
-          "details": "river terr=53 -> dry(78,29) terr=45 gap=8"
+          "details": "river terr=47 -> dry(78,29) terr=45 gap=2"
         },
         {
           "x": 78,
@@ -1472,7 +1158,7 @@
         {
           "x": 79,
           "y": 30,
-          "details": "river terr=43 -> dry(79,29) terr=36 gap=7"
+          "details": "river terr=37 -> dry(79,29) terr=36 gap=1"
         },
         {
           "x": 79,
@@ -1510,6 +1196,423 @@
           "x": 67,
           "y": 73,
           "details": "lake surf=194 surrounded by dry"
+        }
+      ],
+      "MID_RIVER_CLIFF": [
+        {
+          "x": -62,
+          "y": 36,
+          "details": "river surf=10 (terr=5) -> water nbr surf=6 (terr=3) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -61,
+          "y": 34,
+          "details": "river surf=10 (terr=4) -> water nbr surf=6 (terr=2) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -61,
+          "y": 34,
+          "details": "river surf=10 (terr=4) -> water nbr surf=8 (terr=4) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -61,
+          "y": 36,
+          "details": "river surf=6 (terr=3) -> water nbr surf=4 (terr=3) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -61,
+          "y": 37,
+          "details": "river surf=6 (terr=3) -> water nbr surf=4 (terr=3) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -61,
+          "y": 38,
+          "details": "river surf=9 (terr=6) -> water nbr surf=5 (terr=4) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -61,
+          "y": 43,
+          "details": "river surf=23 (terr=18) -> water nbr surf=19 (terr=20) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -61,
+          "y": 43,
+          "details": "river surf=23 (terr=20) -> water nbr surf=21 (terr=20) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -59,
+          "y": 32,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -59,
+          "y": 34,
+          "details": "river surf=4 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -58,
+          "y": 4,
+          "details": "river surf=12 (terr=9) -> water nbr surf=8 (terr=7) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -58,
+          "y": 5,
+          "details": "river surf=13 (terr=10) -> water nbr surf=9 (terr=8) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -58,
+          "y": 11,
+          "details": "river surf=13 (terr=9) -> water nbr surf=8 (terr=7) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -58,
+          "y": 12,
+          "details": "river surf=9 (terr=5) -> water nbr surf=4 (terr=3) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -58,
+          "y": 13,
+          "details": "river surf=8 (terr=4) -> water nbr surf=4 (terr=3) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -58,
+          "y": 14,
+          "details": "river surf=9 (terr=4) -> water nbr surf=5 (terr=4) surf_diff=4 terr_diff=0"
+        },
+        {
+          "x": -58,
+          "y": 31,
+          "details": "river surf=8 (terr=5) -> water nbr surf=5 (terr=4) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -57,
+          "y": 15,
+          "details": "river surf=7 (terr=3) -> water nbr surf=4 (terr=3) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -57,
+          "y": 24,
+          "details": "river surf=12 (terr=6) -> water nbr surf=9 (terr=5) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -57,
+          "y": 24,
+          "details": "river surf=12 (terr=6) -> water nbr surf=8 (terr=4) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -57,
+          "y": 27,
+          "details": "river surf=8 (terr=5) -> water nbr surf=6 (terr=5) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -56,
+          "y": 16,
+          "details": "river surf=6 (terr=3) -> water nbr surf=4 (terr=3) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -56,
+          "y": 20,
+          "details": "river surf=20 (terr=16) -> water nbr surf=15 (terr=14) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -56,
+          "y": 22,
+          "details": "river surf=17 (terr=13) -> water nbr surf=12 (terr=11) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -56,
+          "y": 26,
+          "details": "river surf=6 (terr=3) -> water nbr surf=4 (terr=3) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -55,
+          "y": 24,
+          "details": "river surf=6 (terr=3) -> water nbr surf=4 (terr=3) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -55,
+          "y": 24,
+          "details": "river surf=6 (terr=3) -> water nbr surf=4 (terr=3) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -55,
+          "y": 45,
+          "details": "river surf=6 (terr=1) -> water nbr surf=3 (terr=2) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -54,
+          "y": 65,
+          "details": "river surf=6 (terr=3) -> water nbr surf=3 (terr=2) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -53,
+          "y": 46,
+          "details": "river surf=13 (terr=6) -> water nbr surf=8 (terr=8) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -53,
+          "y": 65,
+          "details": "river surf=6 (terr=2) -> water nbr surf=4 (terr=2) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -52,
+          "y": 65,
+          "details": "river surf=6 (terr=1) -> water nbr surf=4 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -51,
+          "y": 66,
+          "details": "river surf=6 (terr=1) -> water nbr surf=4 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -51,
+          "y": 66,
+          "details": "river surf=6 (terr=1) -> water nbr surf=4 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -50,
+          "y": 66,
+          "details": "river surf=9 (terr=3) -> water nbr surf=5 (terr=1) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -50,
+          "y": 67,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -49,
+          "y": 41,
+          "details": "river surf=6 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -49,
+          "y": 41,
+          "details": "river surf=6 (terr=1) -> water nbr surf=1 (terr=0) surf_diff=5 terr_diff=1"
+        },
+        {
+          "x": -48,
+          "y": 39,
+          "details": "river surf=6 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=4 terr_diff=0"
+        },
+        {
+          "x": -48,
+          "y": 39,
+          "details": "river surf=6 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=4 terr_diff=0"
+        },
+        {
+          "x": -47,
+          "y": 38,
+          "details": "river surf=8 (terr=1) -> water nbr surf=2 (terr=2) surf_diff=6 terr_diff=1"
+        },
+        {
+          "x": -47,
+          "y": 38,
+          "details": "river surf=8 (terr=2) -> water nbr surf=2 (terr=1) surf_diff=6 terr_diff=1"
+        },
+        {
+          "x": -47,
+          "y": 68,
+          "details": "river surf=6 (terr=1) -> water nbr surf=4 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -47,
+          "y": 69,
+          "details": "river surf=4 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -46,
+          "y": 36,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -46,
+          "y": 36,
+          "details": "river surf=5 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -46,
+          "y": 69,
+          "details": "river surf=6 (terr=2) -> water nbr surf=3 (terr=2) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -45,
+          "y": 34,
+          "details": "river surf=5 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -45,
+          "y": 68,
+          "details": "river surf=9 (terr=3) -> water nbr surf=6 (terr=2) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -45,
+          "y": 69,
+          "details": "river surf=6 (terr=2) -> water nbr surf=3 (terr=2) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -44,
+          "y": 33,
+          "details": "river surf=9 (terr=1) -> water nbr surf=5 (terr=2) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -44,
+          "y": 33,
+          "details": "river surf=9 (terr=2) -> water nbr surf=2 (terr=1) surf_diff=7 terr_diff=1"
+        },
+        {
+          "x": -43,
+          "y": 69,
+          "details": "river surf=7 (terr=3) -> water nbr surf=5 (terr=3) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -38,
+          "y": 27,
+          "details": "river surf=5 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -38,
+          "y": 27,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -38,
+          "y": 77,
+          "details": "river surf=8 (terr=1) -> water nbr surf=5 (terr=1) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -38,
+          "y": 78,
+          "details": "river surf=8 (terr=2) -> water nbr surf=5 (terr=1) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -28,
+          "y": 29,
+          "details": "river surf=7 (terr=1) -> water nbr surf=2 (terr=3) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -27,
+          "y": 29,
+          "details": "river surf=6 (terr=1) -> water nbr surf=2 (terr=2) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -26,
+          "y": 29,
+          "details": "river surf=6 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=4 terr_diff=0"
+        },
+        {
+          "x": 47,
+          "y": 27,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 47,
+          "y": 27,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 47,
+          "y": 29,
+          "details": "river surf=13 (terr=6) -> water nbr surf=9 (terr=8) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 50,
+          "y": 25,
+          "details": "river surf=7 (terr=3) -> water nbr surf=4 (terr=3) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 51,
+          "y": 24,
+          "details": "river surf=6 (terr=3) -> water nbr surf=4 (terr=3) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 51,
+          "y": 24,
+          "details": "river surf=6 (terr=3) -> water nbr surf=4 (terr=3) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 52,
+          "y": 24,
+          "details": "river surf=9 (terr=4) -> water nbr surf=5 (terr=6) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 59,
+          "y": 24,
+          "details": "river surf=18 (terr=15) -> water nbr surf=16 (terr=15) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 59,
+          "y": 25,
+          "details": "river surf=21 (terr=15) -> water nbr surf=18 (terr=15) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 60,
+          "y": 25,
+          "details": "river surf=23 (terr=15) -> water nbr surf=19 (terr=17) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 62,
+          "y": 25,
+          "details": "river surf=27 (terr=20) -> water nbr surf=24 (terr=21) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 63,
+          "y": 23,
+          "details": "river surf=24 (terr=21) -> water nbr surf=22 (terr=21) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 63,
+          "y": 23,
+          "details": "river surf=24 (terr=21) -> water nbr surf=22 (terr=21) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 63,
+          "y": 24,
+          "details": "river surf=26 (terr=21) -> water nbr surf=24 (terr=21) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 64,
+          "y": 23,
+          "details": "river surf=26 (terr=23) -> water nbr surf=24 (terr=23) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 64,
+          "y": 24,
+          "details": "river surf=29 (terr=23) -> water nbr surf=26 (terr=24) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 65,
+          "y": 23,
+          "details": "river surf=27 (terr=24) -> water nbr surf=25 (terr=24) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 65,
+          "y": 24,
+          "details": "river surf=31 (terr=24) -> water nbr surf=27 (terr=26) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 66,
+          "y": 23,
+          "details": "river surf=28 (terr=24) -> water nbr surf=25 (terr=24) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 66,
+          "y": 67,
+          "details": "river surf=193 (terr=190) -> water nbr surf=191 (terr=190) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 70,
+          "y": 23,
+          "details": "river surf=22 (terr=18) -> water nbr surf=19 (terr=19) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 75,
+          "y": 53,
+          "details": "river surf=186 (terr=182) -> water nbr surf=182 (terr=181) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": 77,
+          "y": 24,
+          "details": "river surf=8 (terr=3) -> water nbr surf=5 (terr=4) surf_diff=3 terr_diff=1"
         }
       ],
       "MULTI_ISLAND": [
@@ -1576,6 +1679,21 @@
           "details": "river surf=5 -> dry(-44,31) terr=3"
         },
         {
+          "x": -37,
+          "y": 63,
+          "details": "river surf=102 -> dry(-37,64) terr=100"
+        },
+        {
+          "x": -32,
+          "y": 54,
+          "details": "river surf=316 -> dry(-33,54) terr=315"
+        },
+        {
+          "x": -17,
+          "y": 72,
+          "details": "river surf=183 -> dry(-16,72) terr=180"
+        },
+        {
           "x": 76,
           "y": 63,
           "details": "river surf=183 -> dry(76,64) terr=181"
@@ -1607,122 +1725,122 @@
         {
           "x": -64,
           "y": 6,
-          "details": "river surf=71 terr=70 -> land(-64,5) terr=68 cliff=3"
+          "details": "river surf=71 terr=66 -> land(-64,5) terr=68 cliff=3"
         },
         {
           "x": -64,
           "y": 8,
-          "details": "river surf=77 terr=76 -> land(-64,7) terr=74 cliff=3"
+          "details": "river surf=77 terr=72 -> land(-64,7) terr=74 cliff=3"
         },
         {
           "x": -64,
           "y": 51,
-          "details": "river surf=45 terr=44 -> land(-64,52) terr=42 cliff=3"
+          "details": "river surf=45 terr=40 -> land(-64,52) terr=42 cliff=3"
         },
         {
           "x": -63,
           "y": 6,
-          "details": "river surf=61 terr=60 -> land(-63,5) terr=58 cliff=3"
+          "details": "river surf=61 terr=56 -> land(-63,5) terr=58 cliff=3"
         },
         {
           "x": -63,
           "y": 8,
-          "details": "river surf=66 terr=65 -> land(-63,7) terr=64 cliff=2"
+          "details": "river surf=66 terr=62 -> land(-63,7) terr=64 cliff=2"
         },
         {
           "x": -63,
           "y": 24,
-          "details": "river surf=68 terr=67 -> land(-62,24) terr=64 cliff=4"
+          "details": "river surf=68 terr=62 -> land(-62,24) terr=64 cliff=4"
         },
         {
           "x": -63,
           "y": 25,
-          "details": "river surf=56 terr=55 -> land(-62,25) terr=52 cliff=4"
+          "details": "river surf=56 terr=49 -> land(-62,25) terr=52 cliff=4"
         },
         {
           "x": -63,
           "y": 27,
-          "details": "river surf=56 terr=55 -> land(-62,27) terr=45 cliff=11"
+          "details": "river surf=56 terr=50 -> land(-62,27) terr=45 cliff=11"
         },
         {
           "x": -63,
           "y": 29,
-          "details": "river surf=61 terr=60 -> land(-63,30) terr=59 cliff=2"
+          "details": "river surf=61 terr=57 -> land(-63,30) terr=59 cliff=2"
         },
         {
           "x": -63,
           "y": 46,
-          "details": "river surf=52 terr=51 -> land(-62,46) terr=46 cliff=6"
+          "details": "river surf=52 terr=49 -> land(-62,46) terr=46 cliff=6"
         },
         {
           "x": -62,
           "y": 6,
-          "details": "river surf=51 terr=50 -> land(-62,5) terr=48 cliff=3"
+          "details": "river surf=51 terr=47 -> land(-62,5) terr=48 cliff=3"
         },
         {
           "x": -62,
           "y": 23,
-          "details": "river surf=74 terr=73 -> land(-62,24) terr=64 cliff=10"
+          "details": "river surf=74 terr=69 -> land(-62,24) terr=64 cliff=10"
         },
         {
           "x": -62,
           "y": 28,
-          "details": "river surf=49 terr=48 -> land(-62,27) terr=45 cliff=4"
+          "details": "river surf=49 terr=44 -> land(-62,27) terr=45 cliff=4"
         },
         {
           "x": -62,
           "y": 29,
-          "details": "river surf=49 terr=48 -> land(-62,30) terr=46 cliff=3"
+          "details": "river surf=49 terr=46 -> land(-62,30) terr=46 cliff=3"
         },
         {
           "x": -61,
           "y": 5,
-          "details": "river surf=38 terr=37 -> land(-61,4) terr=34 cliff=4"
+          "details": "river surf=38 terr=35 -> land(-61,4) terr=34 cliff=4"
         },
         {
           "x": -61,
           "y": 17,
-          "details": "river surf=50 terr=49 -> land(-61,16) terr=44 cliff=6"
+          "details": "river surf=50 terr=44 -> land(-61,16) terr=44 cliff=6"
         },
         {
           "x": -61,
           "y": 23,
-          "details": "river surf=63 terr=62 -> land(-61,24) terr=54 cliff=9"
+          "details": "river surf=63 terr=57 -> land(-61,24) terr=54 cliff=9"
         },
         {
           "x": -61,
           "y": 28,
-          "details": "river surf=39 terr=38 -> land(-61,27) terr=36 cliff=3"
+          "details": "river surf=39 terr=35 -> land(-61,27) terr=36 cliff=3"
         },
         {
           "x": -61,
           "y": 30,
-          "details": "river surf=35 terr=34 -> land(-61,31) terr=29 cliff=6"
+          "details": "river surf=35 terr=31 -> land(-61,31) terr=29 cliff=6"
         },
         {
           "x": -61,
           "y": 59,
-          "details": "river surf=27 terr=26 -> land(-62,59) terr=21 cliff=6"
+          "details": "river surf=27 terr=23 -> land(-62,59) terr=21 cliff=6"
         },
         {
           "x": -61,
           "y": 60,
-          "details": "river surf=18 terr=17 -> land(-62,60) terr=13 cliff=5"
+          "details": "river surf=18 terr=13 -> land(-62,60) terr=13 cliff=5"
         },
         {
           "x": -60,
           "y": 5,
-          "details": "river surf=29 terr=28 -> land(-60,4) terr=25 cliff=4"
+          "details": "river surf=29 terr=25 -> land(-60,4) terr=25 cliff=4"
         },
         {
           "x": -60,
           "y": 23,
-          "details": "river surf=52 terr=51 -> land(-60,24) terr=45 cliff=7"
+          "details": "river surf=52 terr=46 -> land(-60,24) terr=45 cliff=7"
         },
         {
           "x": -60,
           "y": 46,
-          "details": "river surf=42 terr=41 -> land(-61,46) terr=39 cliff=3"
+          "details": "river surf=42 terr=37 -> land(-61,46) terr=39 cliff=3"
         },
         {
           "x": -60,
@@ -1737,32 +1855,32 @@
         {
           "x": -60,
           "y": 58,
-          "details": "river surf=41 terr=40 -> land(-61,58) terr=35 cliff=6"
+          "details": "river surf=41 terr=38 -> land(-61,58) terr=35 cliff=6"
         },
         {
           "x": -59,
           "y": 4,
-          "details": "river surf=18 terr=17 -> land(-59,3) terr=14 cliff=4"
+          "details": "river surf=18 terr=16 -> land(-59,3) terr=14 cliff=4"
         },
         {
           "x": -59,
           "y": 17,
-          "details": "river surf=26 terr=25 -> land(-58,17) terr=19 cliff=7"
+          "details": "river surf=26 terr=20 -> land(-58,17) terr=19 cliff=7"
         },
         {
           "x": -59,
           "y": 18,
-          "details": "river surf=37 terr=36 -> land(-58,18) terr=28 cliff=9"
+          "details": "river surf=37 terr=31 -> land(-58,18) terr=28 cliff=9"
         },
         {
           "x": -59,
           "y": 23,
-          "details": "river surf=41 terr=40 -> land(-59,24) terr=35 cliff=6"
+          "details": "river surf=41 terr=34 -> land(-59,24) terr=35 cliff=6"
         },
         {
           "x": -59,
           "y": 45,
-          "details": "river surf=32 terr=31 -> land(-58,45) terr=27 cliff=5"
+          "details": "river surf=32 terr=29 -> land(-58,45) terr=27 cliff=5"
         },
         {
           "x": -59,
@@ -1782,27 +1900,27 @@
         {
           "x": -58,
           "y": 3,
-          "details": "river surf=9 terr=8 -> land(-57,3) terr=6 cliff=3"
+          "details": "river surf=9 terr=7 -> land(-57,3) terr=6 cliff=3"
         },
         {
           "x": -58,
           "y": 19,
-          "details": "river surf=34 terr=33 -> land(-58,18) terr=28 cliff=6"
+          "details": "river surf=34 terr=28 -> land(-58,18) terr=28 cliff=6"
         },
         {
           "x": -58,
           "y": 23,
-          "details": "river surf=30 terr=29 -> land(-58,24) terr=24 cliff=6"
+          "details": "river surf=30 terr=24 -> land(-58,24) terr=24 cliff=6"
         },
         {
           "x": -58,
           "y": 43,
-          "details": "river surf=14 terr=13 -> land(-57,43) terr=9 cliff=5"
+          "details": "river surf=14 terr=11 -> land(-57,43) terr=9 cliff=5"
         },
         {
           "x": -58,
           "y": 44,
-          "details": "river surf=20 terr=19 -> land(-57,44) terr=15 cliff=5"
+          "details": "river surf=20 terr=17 -> land(-57,44) terr=15 cliff=5"
         },
         {
           "x": -58,
@@ -1822,12 +1940,12 @@
         {
           "x": -57,
           "y": 19,
-          "details": "river surf=26 terr=25 -> land(-57,18) terr=20 cliff=6"
+          "details": "river surf=26 terr=21 -> land(-57,18) terr=20 cliff=6"
         },
         {
           "x": -57,
           "y": 23,
-          "details": "river surf=19 terr=18 -> land(-56,23) terr=13 cliff=6"
+          "details": "river surf=19 terr=13 -> land(-56,23) terr=13 cliff=6"
         },
         {
           "x": -57,
@@ -1857,27 +1975,27 @@
         {
           "x": -56,
           "y": 19,
-          "details": "river surf=19 terr=18 -> land(-56,18) terr=15 cliff=4"
+          "details": "river surf=19 terr=15 -> land(-56,18) terr=15 cliff=4"
         },
         {
           "x": -56,
           "y": 22,
-          "details": "river surf=17 terr=16 -> land(-56,23) terr=13 cliff=4"
+          "details": "river surf=17 terr=13 -> land(-56,23) terr=13 cliff=4"
         },
         {
           "x": -56,
           "y": 45,
-          "details": "river surf=14 terr=13 -> land(-56,44) terr=9 cliff=5"
+          "details": "river surf=14 terr=9 -> land(-56,44) terr=9 cliff=5"
         },
         {
           "x": -56,
           "y": 51,
-          "details": "river surf=50 terr=49 -> land(-56,50) terr=48 cliff=2"
+          "details": "river surf=50 terr=46 -> land(-56,50) terr=48 cliff=2"
         },
         {
           "x": -56,
           "y": 59,
-          "details": "river surf=54 terr=53 -> land(-56,60) terr=49 cliff=5"
+          "details": "river surf=54 terr=51 -> land(-56,60) terr=49 cliff=5"
         },
         {
           "x": -55,
@@ -1897,17 +2015,17 @@
         {
           "x": -55,
           "y": 50,
-          "details": "river surf=37 terr=36 -> land(-55,49) terr=34 cliff=3"
+          "details": "river surf=37 terr=32 -> land(-55,49) terr=34 cliff=3"
         },
         {
           "x": -55,
           "y": 56,
-          "details": "river surf=69 terr=68 -> land(-55,55) terr=67 cliff=2"
+          "details": "river surf=69 terr=66 -> land(-55,55) terr=67 cliff=2"
         },
         {
           "x": -55,
           "y": 59,
-          "details": "river surf=60 terr=59 -> land(-55,60) terr=55 cliff=5"
+          "details": "river surf=60 terr=56 -> land(-55,60) terr=55 cliff=5"
         },
         {
           "x": -54,
@@ -1922,232 +2040,432 @@
         {
           "x": -54,
           "y": 54,
-          "details": "river surf=67 terr=66 -> land(-55,54) terr=63 cliff=4"
+          "details": "river surf=67 terr=62 -> land(-55,54) terr=63 cliff=4"
         },
         {
           "x": -54,
           "y": 55,
-          "details": "river surf=73 terr=72 -> land(-55,55) terr=67 cliff=6"
+          "details": "river surf=73 terr=69 -> land(-55,55) terr=67 cliff=6"
         },
         {
           "x": -54,
           "y": 59,
-          "details": "river surf=67 terr=66 -> land(-54,60) terr=63 cliff=4"
+          "details": "river surf=67 terr=63 -> land(-54,60) terr=63 cliff=4"
         },
         {
           "x": -53,
           "y": 55,
-          "details": "river surf=80 terr=79 -> land(-53,54) terr=74 cliff=6"
+          "details": "river surf=80 terr=75 -> land(-53,54) terr=74 cliff=6"
+        },
+        {
+          "x": -53,
+          "y": 59,
+          "details": "river surf=72 terr=68 -> land(-53,60) terr=70 cliff=2"
         },
         {
           "x": -52,
           "y": 48,
-          "details": "river surf=26 terr=25 -> land(-52,47) terr=21 cliff=5"
+          "details": "river surf=26 terr=21 -> land(-52,47) terr=21 cliff=5"
         },
         {
           "x": -52,
           "y": 51,
-          "details": "river surf=50 terr=49 -> land(-53,51) terr=42 cliff=8"
+          "details": "river surf=50 terr=43 -> land(-53,51) terr=42 cliff=8"
         },
         {
           "x": -52,
           "y": 52,
-          "details": "river surf=62 terr=61 -> land(-53,52) terr=54 cliff=8"
+          "details": "river surf=62 terr=55 -> land(-53,52) terr=54 cliff=8"
         },
         {
           "x": -52,
           "y": 53,
-          "details": "river surf=73 terr=72 -> land(-53,53) terr=65 cliff=8"
+          "details": "river surf=73 terr=66 -> land(-53,53) terr=65 cliff=8"
         },
         {
           "x": -52,
           "y": 54,
-          "details": "river surf=82 terr=81 -> land(-53,54) terr=74 cliff=8"
+          "details": "river surf=82 terr=76 -> land(-53,54) terr=74 cliff=8"
         },
         {
           "x": -51,
           "y": 45,
-          "details": "river surf=12 terr=11 -> land(-52,45) terr=10 cliff=2"
+          "details": "river surf=12 terr=8 -> land(-52,45) terr=10 cliff=2"
         },
         {
           "x": -51,
           "y": 46,
-          "details": "river surf=19 terr=18 -> land(-52,46) terr=15 cliff=4"
+          "details": "river surf=19 terr=14 -> land(-52,46) terr=15 cliff=4"
         },
         {
           "x": -51,
           "y": 47,
-          "details": "river surf=27 terr=26 -> land(-52,47) terr=21 cliff=6"
+          "details": "river surf=27 terr=21 -> land(-52,47) terr=21 cliff=6"
+        },
+        {
+          "x": -51,
+          "y": 60,
+          "details": "river surf=60 terr=54 -> land(-51,61) terr=58 cliff=2"
+        },
+        {
+          "x": -47,
+          "y": 59,
+          "details": "river surf=120 terr=114 -> land(-47,60) terr=118 cliff=2"
+        },
+        {
+          "x": -46,
+          "y": 58,
+          "details": "river surf=144 terr=138 -> land(-46,59) terr=142 cliff=2"
+        },
+        {
+          "x": -45,
+          "y": 57,
+          "details": "river surf=168 terr=161 -> land(-45,58) terr=166 cliff=2"
         },
         {
           "x": -44,
           "y": 32,
-          "details": "river surf=5 terr=4 -> land(-44,31) terr=3 cliff=2"
+          "details": "river surf=5 terr=1 -> land(-44,31) terr=3 cliff=2"
+        },
+        {
+          "x": -41,
+          "y": 51,
+          "details": "river surf=182 terr=175 -> land(-42,51) terr=179 cliff=3"
+        },
+        {
+          "x": -41,
+          "y": 62,
+          "details": "river surf=72 terr=66 -> land(-42,62) terr=70 cliff=2"
+        },
+        {
+          "x": -40,
+          "y": 37,
+          "details": "river surf=89 terr=82 -> land(-41,37) terr=86 cliff=3"
+        },
+        {
+          "x": -40,
+          "y": 56,
+          "details": "river surf=174 terr=167 -> land(-40,57) terr=171 cliff=3"
         },
         {
           "x": -39,
           "y": 28,
-          "details": "river surf=15 terr=14 -> land(-40,28) terr=11 cliff=4"
+          "details": "river surf=15 terr=8 -> land(-40,28) terr=11 cliff=4"
+        },
+        {
+          "x": -39,
+          "y": 34,
+          "details": "river surf=81 terr=74 -> land(-40,34) terr=78 cliff=3"
+        },
+        {
+          "x": -39,
+          "y": 41,
+          "details": "river surf=149 terr=143 -> land(-40,41) terr=147 cliff=2"
+        },
+        {
+          "x": -39,
+          "y": 61,
+          "details": "river surf=102 terr=96 -> land(-40,61) terr=100 cliff=2"
+        },
+        {
+          "x": -38,
+          "y": 42,
+          "details": "river surf=173 terr=167 -> land(-39,42) terr=171 cliff=2"
+        },
+        {
+          "x": -38,
+          "y": 55,
+          "details": "river surf=186 terr=179 -> land(-38,56) terr=183 cliff=3"
+        },
+        {
+          "x": -37,
+          "y": 43,
+          "details": "river surf=197 terr=191 -> land(-38,43) terr=195 cliff=2"
+        },
+        {
+          "x": -37,
+          "y": 63,
+          "details": "river surf=102 terr=96 -> land(-37,64) terr=100 cliff=2"
+        },
+        {
+          "x": -36,
+          "y": 64,
+          "details": "river surf=102 terr=96 -> land(-37,64) terr=100 cliff=2"
+        },
+        {
+          "x": -36,
+          "y": 65,
+          "details": "river surf=90 terr=85 -> land(-37,65) terr=88 cliff=2"
+        },
+        {
+          "x": -32,
+          "y": 36,
+          "details": "river surf=133 terr=127 -> land(-32,35) terr=130 cliff=3"
         },
         {
           "x": -32,
           "y": 54,
-          "details": "river surf=316 terr=315 -> land(-32,53) terr=312 cliff=4"
+          "details": "river surf=316 terr=313 -> land(-32,53) terr=312 cliff=4"
+        },
+        {
+          "x": -31,
+          "y": 37,
+          "details": "river surf=157 terr=152 -> land(-31,36) terr=155 cliff=2"
+        },
+        {
+          "x": -31,
+          "y": 76,
+          "details": "river surf=95 terr=89 -> land(-32,76) terr=93 cliff=2"
         },
         {
           "x": -30,
           "y": 56,
-          "details": "river surf=305 terr=304 -> land(-29,56) terr=297 cliff=8"
+          "details": "river surf=305 terr=298 -> land(-29,56) terr=297 cliff=8"
         },
         {
           "x": -30,
           "y": 57,
-          "details": "river surf=317 terr=316 -> land(-29,57) terr=314 cliff=3"
+          "details": "river surf=317 terr=310 -> land(-29,57) terr=314 cliff=3"
+        },
+        {
+          "x": -30,
+          "y": 73,
+          "details": "river surf=143 terr=137 -> land(-31,73) terr=141 cliff=2"
+        },
+        {
+          "x": -30,
+          "y": 76,
+          "details": "river surf=107 terr=101 -> land(-30,77) terr=104 cliff=3"
         },
         {
           "x": -29,
           "y": 51,
-          "details": "river surf=289 terr=288 -> land(-29,50) terr=287 cliff=2"
+          "details": "river surf=289 terr=286 -> land(-29,50) terr=287 cliff=2"
+        },
+        {
+          "x": -29,
+          "y": 73,
+          "details": "river surf=155 terr=149 -> land(-29,74) terr=153 cliff=2"
+        },
+        {
+          "x": -29,
+          "y": 75,
+          "details": "river surf=131 terr=125 -> land(-29,76) terr=129 cliff=2"
         },
         {
           "x": -28,
           "y": 37,
-          "details": "river surf=149 terr=148 -> land(-27,37) terr=128 cliff=21"
+          "details": "river surf=149 terr=144 -> land(-27,37) terr=123 cliff=26"
+        },
+        {
+          "x": -28,
+          "y": 40,
+          "details": "river surf=161 terr=155 -> land(-27,40) terr=158 cliff=3"
+        },
+        {
+          "x": -28,
+          "y": 41,
+          "details": "river surf=173 terr=166 -> land(-27,41) terr=170 cliff=3"
+        },
+        {
+          "x": -28,
+          "y": 49,
+          "details": "river surf=269 terr=264 -> land(-27,49) terr=266 cliff=3"
         },
         {
           "x": -28,
           "y": 50,
-          "details": "river surf=281 terr=280 -> land(-27,50) terr=278 cliff=3"
+          "details": "river surf=281 terr=277 -> land(-27,50) terr=278 cliff=3"
+        },
+        {
+          "x": -28,
+          "y": 72,
+          "details": "river surf=179 terr=173 -> land(-29,72) terr=177 cliff=2"
+        },
+        {
+          "x": -28,
+          "y": 74,
+          "details": "river surf=155 terr=149 -> land(-29,74) terr=153 cliff=2"
+        },
+        {
+          "x": -27,
+          "y": 38,
+          "details": "river surf=125 terr=118 -> land(-27,37) terr=123 cliff=2"
+        },
+        {
+          "x": -27,
+          "y": 42,
+          "details": "river surf=173 terr=165 -> land(-27,41) terr=170 cliff=3"
+        },
+        {
+          "x": -27,
+          "y": 71,
+          "details": "river surf=203 terr=198 -> land(-27,72) terr=201 cliff=2"
         },
         {
           "x": -27,
           "y": 76,
-          "details": "river surf=167 terr=166 -> land(-28,76) terr=162 cliff=5"
+          "details": "river surf=167 terr=161 -> land(-28,76) terr=157 cliff=10"
         },
         {
           "x": -27,
           "y": 77,
-          "details": "river surf=179 terr=178 -> land(-28,77) terr=166 cliff=13"
+          "details": "river surf=179 terr=173 -> land(-28,77) terr=160 cliff=19"
         },
         {
           "x": -26,
           "y": 30,
-          "details": "river surf=17 terr=16 -> land(-25,30) terr=13 cliff=4"
+          "details": "river surf=17 terr=12 -> land(-25,30) terr=13 cliff=4"
+        },
+        {
+          "x": -26,
+          "y": 77,
+          "details": "river surf=191 terr=185 -> land(-26,76) terr=189 cliff=2"
+        },
+        {
+          "x": -25,
+          "y": 44,
+          "details": "river surf=197 terr=189 -> land(-25,43) terr=193 cliff=4"
         },
         {
           "x": -25,
           "y": 50,
-          "details": "river surf=269 terr=268 -> land(-24,50) terr=267 cliff=2"
+          "details": "river surf=269 terr=265 -> land(-26,50) terr=266 cliff=3"
         },
         {
           "x": -25,
           "y": 51,
-          "details": "river surf=278 terr=277 -> land(-24,51) terr=272 cliff=6"
+          "details": "river surf=278 terr=274 -> land(-24,51) terr=272 cliff=6"
+        },
+        {
+          "x": -21,
+          "y": 70,
+          "details": "river surf=255 terr=249 -> land(-21,71) terr=253 cliff=2"
+        },
+        {
+          "x": -20,
+          "y": 71,
+          "details": "river surf=231 terr=225 -> land(-20,72) terr=229 cliff=2"
+        },
+        {
+          "x": -20,
+          "y": 77,
+          "details": "river surf=180 terr=173 -> land(-20,78) terr=177 cliff=3"
+        },
+        {
+          "x": -18,
+          "y": 71,
+          "details": "river surf=207 terr=200 -> land(-17,71) terr=204 cliff=3"
+        },
+        {
+          "x": -17,
+          "y": 72,
+          "details": "river surf=183 terr=176 -> land(-16,72) terr=180 cliff=3"
         },
         {
           "x": -16,
           "y": 74,
-          "details": "river surf=147 terr=146 -> land(-15,74) terr=145 cliff=2"
+          "details": "river surf=147 terr=140 -> land(-15,74) terr=145 cliff=2"
         },
         {
           "x": -15,
           "y": 73,
-          "details": "river surf=147 terr=146 -> land(-15,74) terr=145 cliff=2"
+          "details": "river surf=147 terr=140 -> land(-15,74) terr=145 cliff=2"
         },
         {
           "x": -14,
           "y": 73,
-          "details": "river surf=144 terr=143 -> land(-14,74) terr=142 cliff=2"
+          "details": "river surf=144 terr=138 -> land(-14,74) terr=142 cliff=2"
         },
         {
           "x": 46,
           "y": 28,
-          "details": "river surf=5 terr=4 -> land(45,28) terr=3 cliff=2"
+          "details": "river surf=5 terr=2 -> land(45,28) terr=3 cliff=2"
         },
         {
           "x": 47,
           "y": 29,
-          "details": "river surf=13 terr=12 -> land(46,29) terr=9 cliff=4"
+          "details": "river surf=13 terr=8 -> land(46,29) terr=9 cliff=4"
         },
         {
           "x": 47,
           "y": 30,
-          "details": "river surf=20 terr=19 -> land(46,30) terr=14 cliff=6"
+          "details": "river surf=20 terr=15 -> land(46,30) terr=14 cliff=6"
         },
         {
           "x": 47,
           "y": 31,
-          "details": "river surf=27 terr=26 -> land(46,31) terr=20 cliff=7"
+          "details": "river surf=27 terr=21 -> land(46,31) terr=20 cliff=7"
         },
         {
           "x": 47,
           "y": 32,
-          "details": "river surf=37 terr=36 -> land(46,32) terr=27 cliff=10"
+          "details": "river surf=37 terr=31 -> land(46,32) terr=27 cliff=10"
         },
         {
           "x": 47,
           "y": 33,
-          "details": "river surf=47 terr=46 -> land(46,33) terr=37 cliff=10"
+          "details": "river surf=47 terr=41 -> land(46,33) terr=37 cliff=10"
         },
         {
           "x": 47,
           "y": 34,
-          "details": "river surf=58 terr=57 -> land(46,34) terr=47 cliff=11"
+          "details": "river surf=58 terr=52 -> land(46,34) terr=47 cliff=11"
         },
         {
           "x": 48,
           "y": 34,
-          "details": "river surf=69 terr=68 -> land(48,33) terr=59 cliff=10"
+          "details": "river surf=69 terr=63 -> land(48,33) terr=59 cliff=10"
         },
         {
           "x": 49,
           "y": 34,
-          "details": "river surf=81 terr=80 -> land(49,33) terr=70 cliff=11"
+          "details": "river surf=81 terr=75 -> land(49,33) terr=70 cliff=11"
         },
         {
           "x": 50,
           "y": 25,
-          "details": "river surf=7 terr=6 -> land(49,25) terr=5 cliff=2"
+          "details": "river surf=7 terr=3 -> land(49,25) terr=5 cliff=2"
         },
         {
           "x": 50,
           "y": 34,
-          "details": "river surf=92 terr=91 -> land(50,33) terr=82 cliff=10"
+          "details": "river surf=92 terr=87 -> land(50,33) terr=82 cliff=10"
         },
         {
           "x": 51,
           "y": 26,
-          "details": "river surf=15 terr=14 -> land(50,26) terr=11 cliff=4"
+          "details": "river surf=15 terr=9 -> land(50,26) terr=11 cliff=4"
         },
         {
           "x": 51,
           "y": 27,
-          "details": "river surf=24 terr=23 -> land(50,27) terr=18 cliff=6"
+          "details": "river surf=24 terr=18 -> land(50,27) terr=18 cliff=6"
         },
         {
           "x": 51,
           "y": 34,
-          "details": "river surf=103 terr=102 -> land(51,33) terr=93 cliff=10"
+          "details": "river surf=103 terr=98 -> land(51,33) terr=93 cliff=10"
         },
         {
           "x": 51,
           "y": 35,
-          "details": "river surf=112 terr=111 -> land(50,35) terr=103 cliff=9"
+          "details": "river surf=112 terr=108 -> land(50,35) terr=103 cliff=9"
         },
         {
           "x": 51,
           "y": 36,
-          "details": "river surf=121 terr=120 -> land(50,36) terr=112 cliff=9"
+          "details": "river surf=121 terr=118 -> land(50,36) terr=112 cliff=9"
         },
         {
           "x": 51,
           "y": 37,
-          "details": "river surf=128 terr=127 -> land(50,37) terr=121 cliff=7"
+          "details": "river surf=128 terr=126 -> land(50,37) terr=121 cliff=7"
         },
         {
           "x": 52,
           "y": 35,
-          "details": "river surf=121 terr=120 -> land(52,34) terr=113 cliff=8"
+          "details": "river surf=121 terr=117 -> land(52,34) terr=113 cliff=8"
         },
         {
           "x": 52,
@@ -2177,7 +2495,7 @@
         {
           "x": 54,
           "y": 25,
-          "details": "river surf=22 terr=21 -> land(53,25) terr=18 cliff=4"
+          "details": "river surf=22 terr=18 -> land(53,25) terr=18 cliff=4"
         },
         {
           "x": 55,
@@ -2187,7 +2505,7 @@
         {
           "x": 56,
           "y": 26,
-          "details": "river surf=38 terr=37 -> land(55,26) terr=36 cliff=2"
+          "details": "river surf=38 terr=33 -> land(55,26) terr=36 cliff=2"
         },
         {
           "x": 56,
@@ -2202,7 +2520,7 @@
         {
           "x": 61,
           "y": 24,
-          "details": "river surf=22 terr=21 -> land(61,23) terr=20 cliff=2"
+          "details": "river surf=22 terr=18 -> land(61,23) terr=20 cliff=2"
         },
         {
           "x": 62,
@@ -2212,67 +2530,67 @@
         {
           "x": 63,
           "y": 67,
-          "details": "river surf=212 terr=211 -> land(63,68) terr=209 cliff=3"
+          "details": "river surf=212 terr=209 -> land(63,68) terr=209 cliff=3"
         },
         {
           "x": 64,
           "y": 67,
-          "details": "river surf=203 terr=202 -> land(64,68) terr=198 cliff=5"
+          "details": "river surf=203 terr=199 -> land(64,68) terr=198 cliff=5"
         },
         {
           "x": 66,
           "y": 64,
-          "details": "river surf=198 terr=197 -> land(66,65) terr=196 cliff=2"
+          "details": "river surf=198 terr=196 -> land(66,65) terr=196 cliff=2"
         },
         {
           "x": 70,
           "y": 23,
-          "details": "river surf=22 terr=21 -> land(71,23) terr=20 cliff=2"
+          "details": "river surf=22 terr=19 -> land(71,23) terr=20 cliff=2"
         },
         {
           "x": 74,
           "y": 44,
-          "details": "river surf=178 terr=177 -> land(74,43) terr=176 cliff=2"
+          "details": "river surf=178 terr=176 -> land(74,43) terr=176 cliff=2"
         },
         {
           "x": 74,
           "y": 54,
-          "details": "river surf=191 terr=190 -> land(75,54) terr=189 cliff=2"
+          "details": "river surf=191 terr=186 -> land(75,54) terr=189 cliff=2"
         },
         {
           "x": 75,
           "y": 35,
-          "details": "river surf=136 terr=135 -> land(75,34) terr=128 cliff=8"
+          "details": "river surf=136 terr=130 -> land(75,34) terr=128 cliff=8"
         },
         {
           "x": 75,
           "y": 36,
-          "details": "river surf=144 terr=143 -> land(76,36) terr=136 cliff=8"
+          "details": "river surf=144 terr=139 -> land(76,36) terr=136 cliff=8"
         },
         {
           "x": 75,
           "y": 37,
-          "details": "river surf=151 terr=150 -> land(76,37) terr=144 cliff=7"
+          "details": "river surf=151 terr=146 -> land(76,37) terr=144 cliff=7"
         },
         {
           "x": 75,
           "y": 38,
-          "details": "river surf=158 terr=157 -> land(76,38) terr=151 cliff=7"
+          "details": "river surf=158 terr=154 -> land(76,38) terr=151 cliff=7"
         },
         {
           "x": 75,
           "y": 39,
-          "details": "river surf=163 terr=162 -> land(76,39) terr=158 cliff=5"
+          "details": "river surf=163 terr=160 -> land(76,39) terr=158 cliff=5"
         },
         {
           "x": 75,
           "y": 79,
-          "details": "river surf=179 terr=178 -> land(76,79) terr=175 cliff=4"
+          "details": "river surf=179 terr=177 -> land(76,79) terr=175 cliff=4"
         },
         {
           "x": 76,
           "y": 45,
-          "details": "river surf=172 terr=171 -> land(77,45) terr=169 cliff=3"
+          "details": "river surf=172 terr=169 -> land(77,45) terr=169 cliff=3"
         },
         {
           "x": 76,
@@ -2287,62 +2605,62 @@
         {
           "x": 77,
           "y": 25,
-          "details": "river surf=17 terr=16 -> land(78,25) terr=14 cliff=3"
+          "details": "river surf=17 terr=12 -> land(78,25) terr=14 cliff=3"
         },
         {
           "x": 77,
           "y": 26,
-          "details": "river surf=26 terr=25 -> land(78,26) terr=21 cliff=5"
+          "details": "river surf=26 terr=20 -> land(78,26) terr=21 cliff=5"
         },
         {
           "x": 77,
           "y": 27,
-          "details": "river surf=35 terr=34 -> land(78,27) terr=29 cliff=6"
+          "details": "river surf=35 terr=29 -> land(78,27) terr=29 cliff=6"
         },
         {
           "x": 77,
           "y": 28,
-          "details": "river surf=44 terr=43 -> land(78,28) terr=36 cliff=8"
+          "details": "river surf=44 terr=37 -> land(78,28) terr=36 cliff=8"
         },
         {
           "x": 77,
           "y": 29,
-          "details": "river surf=54 terr=53 -> land(78,29) terr=45 cliff=9"
+          "details": "river surf=54 terr=47 -> land(78,29) terr=45 cliff=9"
         },
         {
           "x": 77,
           "y": 31,
-          "details": "river surf=75 terr=74 -> land(78,31) terr=65 cliff=10"
+          "details": "river surf=75 terr=69 -> land(78,31) terr=65 cliff=10"
         },
         {
           "x": 77,
           "y": 32,
-          "details": "river surf=87 terr=86 -> land(78,32) terr=76 cliff=11"
+          "details": "river surf=87 terr=81 -> land(78,32) terr=76 cliff=11"
         },
         {
           "x": 77,
           "y": 33,
-          "details": "river surf=97 terr=96 -> land(78,33) terr=88 cliff=9"
+          "details": "river surf=97 terr=91 -> land(78,33) terr=88 cliff=9"
         },
         {
           "x": 77,
           "y": 34,
-          "details": "river surf=108 terr=107 -> land(78,34) terr=99 cliff=9"
+          "details": "river surf=108 terr=103 -> land(78,34) terr=99 cliff=9"
         },
         {
           "x": 77,
           "y": 35,
-          "details": "river surf=118 terr=117 -> land(78,35) terr=111 cliff=7"
+          "details": "river surf=118 terr=113 -> land(78,35) terr=111 cliff=7"
         },
         {
           "x": 77,
           "y": 36,
-          "details": "river surf=129 terr=128 -> land(78,36) terr=122 cliff=7"
+          "details": "river surf=129 terr=125 -> land(78,36) terr=122 cliff=7"
         },
         {
           "x": 77,
           "y": 37,
-          "details": "river surf=138 terr=137 -> land(78,37) terr=133 cliff=5"
+          "details": "river surf=138 terr=134 -> land(78,37) terr=133 cliff=5"
         },
         {
           "x": 77,
@@ -2352,7 +2670,7 @@
         {
           "x": 78,
           "y": 30,
-          "details": "river surf=54 terr=53 -> land(78,29) terr=45 cliff=9"
+          "details": "river surf=54 terr=47 -> land(78,29) terr=45 cliff=9"
         },
         {
           "x": 78,
@@ -2372,7 +2690,7 @@
         {
           "x": 79,
           "y": 30,
-          "details": "river surf=44 terr=43 -> land(79,29) terr=36 cliff=8"
+          "details": "river surf=44 terr=37 -> land(79,29) terr=36 cliff=8"
         },
         {
           "x": 79,
@@ -2717,6 +3035,11 @@
           "details": "river surf=80 -> dry(-53,54) terr=74 cliff=6"
         },
         {
+          "x": -53,
+          "y": 59,
+          "details": "river surf=72 -> dry(-53,60) terr=70 cliff=2"
+        },
+        {
           "x": -52,
           "y": 48,
           "details": "river surf=26 -> dry(-52,47) terr=21 cliff=5"
@@ -2757,9 +3080,49 @@
           "details": "river surf=27 -> dry(-52,47) terr=21 cliff=6"
         },
         {
+          "x": -51,
+          "y": 60,
+          "details": "river surf=60 -> dry(-51,61) terr=58 cliff=2"
+        },
+        {
+          "x": -47,
+          "y": 59,
+          "details": "river surf=120 -> dry(-47,60) terr=118 cliff=2"
+        },
+        {
+          "x": -46,
+          "y": 58,
+          "details": "river surf=144 -> dry(-46,59) terr=142 cliff=2"
+        },
+        {
+          "x": -45,
+          "y": 57,
+          "details": "river surf=168 -> dry(-45,58) terr=166 cliff=2"
+        },
+        {
           "x": -44,
           "y": 32,
           "details": "river surf=5 -> dry(-44,31) terr=3 cliff=2"
+        },
+        {
+          "x": -41,
+          "y": 51,
+          "details": "river surf=182 -> dry(-42,51) terr=179 cliff=3"
+        },
+        {
+          "x": -41,
+          "y": 62,
+          "details": "river surf=72 -> dry(-42,62) terr=70 cliff=2"
+        },
+        {
+          "x": -40,
+          "y": 37,
+          "details": "river surf=89 -> dry(-41,37) terr=86 cliff=3"
+        },
+        {
+          "x": -40,
+          "y": 56,
+          "details": "river surf=174 -> dry(-40,57) terr=171 cliff=3"
         },
         {
           "x": -39,
@@ -2767,9 +3130,69 @@
           "details": "river surf=15 -> dry(-40,28) terr=11 cliff=4"
         },
         {
+          "x": -39,
+          "y": 34,
+          "details": "river surf=81 -> dry(-40,34) terr=78 cliff=3"
+        },
+        {
+          "x": -39,
+          "y": 41,
+          "details": "river surf=149 -> dry(-40,41) terr=147 cliff=2"
+        },
+        {
+          "x": -39,
+          "y": 61,
+          "details": "river surf=102 -> dry(-40,61) terr=100 cliff=2"
+        },
+        {
+          "x": -38,
+          "y": 42,
+          "details": "river surf=173 -> dry(-39,42) terr=171 cliff=2"
+        },
+        {
+          "x": -38,
+          "y": 55,
+          "details": "river surf=186 -> dry(-38,56) terr=183 cliff=3"
+        },
+        {
+          "x": -37,
+          "y": 43,
+          "details": "river surf=197 -> dry(-38,43) terr=195 cliff=2"
+        },
+        {
+          "x": -37,
+          "y": 63,
+          "details": "river surf=102 -> dry(-37,64) terr=100 cliff=2"
+        },
+        {
+          "x": -36,
+          "y": 64,
+          "details": "river surf=102 -> dry(-37,64) terr=100 cliff=2"
+        },
+        {
+          "x": -36,
+          "y": 65,
+          "details": "river surf=90 -> dry(-37,65) terr=88 cliff=2"
+        },
+        {
+          "x": -32,
+          "y": 36,
+          "details": "river surf=133 -> dry(-32,35) terr=130 cliff=3"
+        },
+        {
           "x": -32,
           "y": 54,
           "details": "river surf=316 -> dry(-32,53) terr=312 cliff=4"
+        },
+        {
+          "x": -31,
+          "y": 37,
+          "details": "river surf=157 -> dry(-31,36) terr=155 cliff=2"
+        },
+        {
+          "x": -31,
+          "y": 76,
+          "details": "river surf=95 -> dry(-32,76) terr=93 cliff=2"
         },
         {
           "x": -30,
@@ -2782,14 +3205,49 @@
           "details": "river surf=317 -> dry(-29,57) terr=314 cliff=3"
         },
         {
+          "x": -30,
+          "y": 73,
+          "details": "river surf=143 -> dry(-31,73) terr=141 cliff=2"
+        },
+        {
+          "x": -30,
+          "y": 76,
+          "details": "river surf=107 -> dry(-30,77) terr=104 cliff=3"
+        },
+        {
           "x": -29,
           "y": 51,
           "details": "river surf=289 -> dry(-29,50) terr=287 cliff=2"
         },
         {
+          "x": -29,
+          "y": 73,
+          "details": "river surf=155 -> dry(-29,74) terr=153 cliff=2"
+        },
+        {
+          "x": -29,
+          "y": 75,
+          "details": "river surf=131 -> dry(-29,76) terr=129 cliff=2"
+        },
+        {
           "x": -28,
           "y": 37,
-          "details": "river surf=149 -> dry(-27,37) terr=128 cliff=21"
+          "details": "river surf=149 -> dry(-27,37) terr=123 cliff=26"
+        },
+        {
+          "x": -28,
+          "y": 40,
+          "details": "river surf=161 -> dry(-27,40) terr=158 cliff=3"
+        },
+        {
+          "x": -28,
+          "y": 41,
+          "details": "river surf=173 -> dry(-27,41) terr=170 cliff=3"
+        },
+        {
+          "x": -28,
+          "y": 49,
+          "details": "river surf=269 -> dry(-27,49) terr=266 cliff=3"
         },
         {
           "x": -28,
@@ -2797,14 +3255,39 @@
           "details": "river surf=281 -> dry(-27,50) terr=278 cliff=3"
         },
         {
+          "x": -28,
+          "y": 72,
+          "details": "river surf=179 -> dry(-29,72) terr=177 cliff=2"
+        },
+        {
+          "x": -28,
+          "y": 74,
+          "details": "river surf=155 -> dry(-29,74) terr=153 cliff=2"
+        },
+        {
+          "x": -27,
+          "y": 38,
+          "details": "river surf=125 -> dry(-27,37) terr=123 cliff=2"
+        },
+        {
+          "x": -27,
+          "y": 42,
+          "details": "river surf=173 -> dry(-27,41) terr=170 cliff=3"
+        },
+        {
+          "x": -27,
+          "y": 71,
+          "details": "river surf=203 -> dry(-27,72) terr=201 cliff=2"
+        },
+        {
           "x": -27,
           "y": 76,
-          "details": "river surf=167 -> dry(-28,76) terr=162 cliff=5"
+          "details": "river surf=167 -> dry(-28,76) terr=157 cliff=10"
         },
         {
           "x": -27,
           "y": 77,
-          "details": "river surf=179 -> dry(-28,77) terr=166 cliff=13"
+          "details": "river surf=179 -> dry(-28,77) terr=160 cliff=19"
         },
         {
           "x": -26,
@@ -2812,14 +3295,49 @@
           "details": "river surf=17 -> dry(-25,30) terr=13 cliff=4"
         },
         {
+          "x": -26,
+          "y": 77,
+          "details": "river surf=191 -> dry(-26,76) terr=189 cliff=2"
+        },
+        {
+          "x": -25,
+          "y": 44,
+          "details": "river surf=197 -> dry(-25,43) terr=193 cliff=4"
+        },
+        {
           "x": -25,
           "y": 50,
-          "details": "river surf=269 -> dry(-24,50) terr=267 cliff=2"
+          "details": "river surf=269 -> dry(-26,50) terr=266 cliff=3"
         },
         {
           "x": -25,
           "y": 51,
           "details": "river surf=278 -> dry(-24,51) terr=272 cliff=6"
+        },
+        {
+          "x": -21,
+          "y": 70,
+          "details": "river surf=255 -> dry(-21,71) terr=253 cliff=2"
+        },
+        {
+          "x": -20,
+          "y": 71,
+          "details": "river surf=231 -> dry(-20,72) terr=229 cliff=2"
+        },
+        {
+          "x": -20,
+          "y": 77,
+          "details": "river surf=180 -> dry(-20,78) terr=177 cliff=3"
+        },
+        {
+          "x": -18,
+          "y": 71,
+          "details": "river surf=207 -> dry(-17,71) terr=204 cliff=3"
+        },
+        {
+          "x": -17,
+          "y": 72,
+          "details": "river surf=183 -> dry(-16,72) terr=180 cliff=3"
         },
         {
           "x": -16,

--- a/tools/baselines/seed4096_size32_region_-4_-4_4_4.json
+++ b/tools/baselines/seed4096_size32_region_-4_-4_4_4.json
@@ -14,9 +14,9 @@
     "deterministic": true,
     "distinctHashes": 1,
     "hashes": [
-      "49d0a02c32b3959f35f9ba00e46174169f8b0f36af4b365155bbf8e934efa23a",
-      "49d0a02c32b3959f35f9ba00e46174169f8b0f36af4b365155bbf8e934efa23a",
-      "49d0a02c32b3959f35f9ba00e46174169f8b0f36af4b365155bbf8e934efa23a"
+      "b1601af6444225216b44c1514678cfbc9cba16da9735852c11bbe8617391f4e3",
+      "b1601af6444225216b44c1514678cfbc9cba16da9735852c11bbe8617391f4e3",
+      "b1601af6444225216b44c1514678cfbc9cba16da9735852c11bbe8617391f4e3"
     ]
   },
   "tileCount": 20736,
@@ -97,13 +97,13 @@
       ]
     },
     "FLAT_ISOLATED_WATER": {
-      "min": 18,
-      "max": 18,
-      "median": 18,
+      "min": 15,
+      "max": 15,
+      "median": 15,
       "all": [
-        18,
-        18,
-        18
+        15,
+        15,
+        15
       ]
     },
     "FLOATING_LAKE": {
@@ -117,13 +117,13 @@
       ]
     },
     "FLOATING_WATER": {
-      "min": 203,
-      "max": 203,
-      "median": 203,
+      "min": 142,
+      "max": 142,
+      "median": 142,
       "all": [
-        203,
-        203,
-        203
+        142,
+        142,
+        142
       ]
     },
     "ISLAND_1TILE": {
@@ -147,13 +147,13 @@
       ]
     },
     "MID_RIVER_CLIFF": {
-      "min": 18,
-      "max": 18,
-      "median": 18,
+      "min": 70,
+      "max": 70,
+      "median": 70,
       "all": [
-        18,
-        18,
-        18
+        70,
+        70,
+        70
       ]
     },
     "MULTI_ISLAND": {
@@ -167,33 +167,33 @@
       ]
     },
     "RIVER_CHUNK_GAP": {
-      "min": 24,
-      "max": 24,
-      "median": 24,
+      "min": 26,
+      "max": 26,
+      "median": 26,
       "all": [
-        24,
-        24,
-        24
+        26,
+        26,
+        26
       ]
     },
     "WATER_ABOVE_LAND": {
-      "min": 204,
-      "max": 204,
-      "median": 204,
+      "min": 220,
+      "max": 220,
+      "median": 220,
       "all": [
-        204,
-        204,
-        204
+        220,
+        220,
+        220
       ]
     },
     "WATER_CLIFF": {
-      "min": 204,
-      "max": 204,
-      "median": 204,
+      "min": 220,
+      "max": 220,
+      "median": 220,
       "all": [
-        204,
-        204,
-        204
+        220,
+        220,
+        220
       ]
     },
     "WATER_WATER_CLIFF": {
@@ -210,16 +210,16 @@
   "representativeAudit": {
     "summary": {
       "DESERT_SOIL_ON_SLOPE": 4,
-      "FLAT_ISOLATED_WATER": 18,
+      "FLAT_ISOLATED_WATER": 15,
       "FLOATING_LAKE": 1138,
-      "FLOATING_WATER": 203,
+      "FLOATING_WATER": 142,
       "ISLAND_1TILE": 5,
       "ISOLATED_FLUID": 40,
-      "MID_RIVER_CLIFF": 18,
+      "MID_RIVER_CLIFF": 70,
       "MULTI_ISLAND": 8,
-      "RIVER_CHUNK_GAP": 24,
-      "WATER_ABOVE_LAND": 204,
-      "WATER_CLIFF": 204,
+      "RIVER_CHUNK_GAP": 26,
+      "WATER_ABOVE_LAND": 220,
+      "WATER_CLIFF": 220,
       "WATER_WATER_CLIFF": 2583
     },
     "issues": {
@@ -272,11 +272,6 @@
           "details": "lake surf=227 terr=226 water_nbrs=0 terr_range=2"
         },
         {
-          "x": -23,
-          "y": 40,
-          "details": "river surf=4 terr=3 water_nbrs=1 terr_range=2"
-        },
-        {
           "x": -17,
           "y": -28,
           "details": "lake surf=200 terr=199 water_nbrs=1 terr_range=1"
@@ -297,19 +292,9 @@
           "details": "lake surf=32 terr=31 water_nbrs=0 terr_range=2"
         },
         {
-          "x": 26,
-          "y": -8,
-          "details": "lake surf=143 terr=142 water_nbrs=1 terr_range=2"
-        },
-        {
           "x": 31,
           "y": 47,
           "details": "river surf=1 terr=0 water_nbrs=1 terr_range=1"
-        },
-        {
-          "x": 35,
-          "y": 19,
-          "details": "river surf=60 terr=59 water_nbrs=1 terr_range=1"
         },
         {
           "x": 38,
@@ -5176,17 +5161,17 @@
         {
           "x": 14,
           "y": 10,
-          "details": "lake fluidSurf=266 terrainZ=247 depth=19"
+          "details": "lake fluidSurf=266 terrainZ=241 depth=25"
         },
         {
           "x": 15,
           "y": 10,
-          "details": "lake fluidSurf=266 terrainZ=219 depth=47"
+          "details": "lake fluidSurf=266 terrainZ=213 depth=53"
         },
         {
           "x": 15,
           "y": 13,
-          "details": "lake fluidSurf=274 terrainZ=175 depth=99"
+          "details": "lake fluidSurf=274 terrainZ=170 depth=104"
         },
         {
           "x": 18,
@@ -6068,7 +6053,7 @@
         {
           "x": -47,
           "y": -17,
-          "details": "river terr=55 -> dry(-47,-16) terr=49 gap=6"
+          "details": "river terr=54 -> dry(-47,-16) terr=49 gap=5"
         },
         {
           "x": -40,
@@ -6081,19 +6066,9 @@
           "details": "river terr=114 -> dry(-39,-22) terr=111 gap=3"
         },
         {
-          "x": -36,
-          "y": 31,
-          "details": "river terr=40 -> dry(-37,31) terr=38 gap=2"
-        },
-        {
-          "x": -35,
-          "y": -16,
-          "details": "river terr=53 -> dry(-35,-15) terr=48 gap=5"
-        },
-        {
           "x": -35,
           "y": 32,
-          "details": "river terr=41 -> dry(-36,32) terr=38 gap=3"
+          "details": "river terr=39 -> dry(-36,32) terr=38 gap=1"
         },
         {
           "x": -34,
@@ -6103,22 +6078,12 @@
         {
           "x": -33,
           "y": -18,
-          "details": "river terr=97 -> dry(-34,-18) terr=89 gap=8"
+          "details": "river terr=91 -> dry(-34,-18) terr=89 gap=2"
         },
         {
           "x": -33,
           "y": -17,
-          "details": "river terr=85 -> dry(-34,-17) terr=76 gap=9"
-        },
-        {
-          "x": -33,
-          "y": -16,
-          "details": "river terr=73 -> dry(-34,-16) terr=66 gap=7"
-        },
-        {
-          "x": -33,
-          "y": -15,
-          "details": "river terr=62 -> dry(-34,-15) terr=58 gap=4"
+          "details": "river terr=78 -> dry(-34,-17) terr=76 gap=2"
         },
         {
           "x": -33,
@@ -6139,11 +6104,6 @@
           "x": -31,
           "y": 15,
           "details": "river terr=86 -> dry(-32,15) terr=83 gap=3"
-        },
-        {
-          "x": -30,
-          "y": -19,
-          "details": "river terr=128 -> dry(-31,-19) terr=127 gap=1"
         },
         {
           "x": -29,
@@ -6173,7 +6133,7 @@
         {
           "x": -28,
           "y": 18,
-          "details": "river terr=81 -> dry(-29,18) terr=70 gap=11"
+          "details": "river terr=78 -> dry(-29,18) terr=70 gap=8"
         },
         {
           "x": -28,
@@ -6183,32 +6143,12 @@
         {
           "x": -27,
           "y": -23,
-          "details": "river terr=153 -> dry(-27,-22) terr=147 gap=6"
+          "details": "river terr=151 -> dry(-27,-22) terr=147 gap=4"
         },
         {
           "x": -27,
           "y": -21,
-          "details": "river terr=139 -> dry(-27,-20) terr=136 gap=3"
-        },
-        {
-          "x": -27,
-          "y": -15,
-          "details": "river terr=85 -> dry(-28,-15) terr=83 gap=2"
-        },
-        {
-          "x": -27,
-          "y": 23,
-          "details": "river terr=72 -> dry(-28,23) terr=69 gap=3"
-        },
-        {
-          "x": -27,
-          "y": 24,
-          "details": "river terr=78 -> dry(-28,24) terr=75 gap=3"
-        },
-        {
-          "x": -27,
-          "y": 31,
-          "details": "river terr=81 -> dry(-28,31) terr=79 gap=2"
+          "details": "river terr=137 -> dry(-27,-20) terr=136 gap=1"
         },
         {
           "x": -26,
@@ -6218,17 +6158,12 @@
         {
           "x": -26,
           "y": -14,
-          "details": "river terr=85 -> dry(-26,-13) terr=76 gap=9"
-        },
-        {
-          "x": -25,
-          "y": -13,
-          "details": "river terr=81 -> dry(-26,-13) terr=76 gap=5"
+          "details": "river terr=80 -> dry(-26,-13) terr=76 gap=4"
         },
         {
           "x": -25,
           "y": 24,
-          "details": "river terr=96 -> dry(-25,23) terr=91 gap=5"
+          "details": "river terr=93 -> dry(-25,23) terr=91 gap=2"
         },
         {
           "x": -24,
@@ -6236,74 +6171,34 @@
           "details": "river terr=181 -> dry(-25,-27) terr=179 gap=2"
         },
         {
-          "x": -24,
-          "y": -26,
-          "details": "river terr=175 -> dry(-25,-26) terr=174 gap=1"
-        },
-        {
-          "x": -24,
-          "y": -25,
-          "details": "river terr=166 -> dry(-25,-25) terr=165 gap=1"
-        },
-        {
-          "x": -24,
-          "y": -18,
-          "details": "river terr=126 -> dry(-25,-18) terr=124 gap=2"
-        },
-        {
-          "x": -24,
-          "y": -17,
-          "details": "river terr=123 -> dry(-25,-17) terr=119 gap=4"
-        },
-        {
-          "x": -24,
-          "y": -16,
-          "details": "river terr=116 -> dry(-25,-16) terr=111 gap=5"
-        },
-        {
           "x": -22,
           "y": -24,
-          "details": "river terr=168 -> dry(-23,-24) terr=163 gap=5"
+          "details": "river terr=165 -> dry(-23,-24) terr=163 gap=2"
         },
         {
           "x": -22,
           "y": -23,
-          "details": "river terr=160 -> dry(-22,-22) terr=153 gap=7"
-        },
-        {
-          "x": -22,
-          "y": 20,
-          "details": "river terr=128 -> dry(-23,20) terr=127 gap=1"
+          "details": "river terr=156 -> dry(-22,-22) terr=153 gap=3"
         },
         {
           "x": -21,
           "y": -24,
-          "details": "river terr=176 -> dry(-21,-23) terr=170 gap=6"
-        },
-        {
-          "x": -21,
-          "y": -21,
-          "details": "river terr=160 -> dry(-21,-20) terr=158 gap=2"
+          "details": "river terr=174 -> dry(-21,-23) terr=170 gap=4"
         },
         {
           "x": -21,
           "y": 19,
-          "details": "river terr=147 -> dry(-22,19) terr=141 gap=6"
+          "details": "river terr=146 -> dry(-22,19) terr=141 gap=5"
         },
         {
           "x": -21,
           "y": 23,
-          "details": "river terr=132 -> dry(-22,23) terr=126 gap=6"
+          "details": "river terr=130 -> dry(-22,23) terr=126 gap=4"
         },
         {
           "x": -21,
           "y": 24,
-          "details": "river terr=140 -> dry(-22,24) terr=134 gap=6"
-        },
-        {
-          "x": -21,
-          "y": 27,
-          "details": "river terr=137 -> dry(-21,28) terr=135 gap=2"
+          "details": "river terr=139 -> dry(-22,24) terr=134 gap=5"
         },
         {
           "x": -20,
@@ -6317,33 +6212,13 @@
         },
         {
           "x": -20,
-          "y": -38,
-          "details": "river terr=222 -> dry(-21,-38) terr=220 gap=2"
-        },
-        {
-          "x": -20,
-          "y": -37,
-          "details": "river terr=210 -> dry(-21,-37) terr=207 gap=3"
-        },
-        {
-          "x": -20,
-          "y": -36,
-          "details": "river terr=199 -> dry(-21,-36) terr=197 gap=2"
-        },
-        {
-          "x": -20,
           "y": -24,
           "details": "river terr=184 -> dry(-20,-23) terr=181 gap=3"
         },
         {
           "x": -20,
           "y": -22,
-          "details": "river terr=171 -> dry(-21,-22) terr=168 gap=3"
-        },
-        {
-          "x": -20,
-          "y": -21,
-          "details": "river terr=167 -> dry(-20,-20) terr=166 gap=1"
+          "details": "river terr=169 -> dry(-21,-22) terr=168 gap=1"
         },
         {
           "x": -20,
@@ -6358,7 +6233,7 @@
         {
           "x": -20,
           "y": 37,
-          "details": "river terr=53 -> dry(-21,37) terr=45 gap=8"
+          "details": "river terr=47 -> dry(-21,37) terr=39 gap=8"
         },
         {
           "x": -19,
@@ -6373,7 +6248,7 @@
         {
           "x": -19,
           "y": -22,
-          "details": "river terr=179 -> dry(-19,-21) terr=175 gap=4"
+          "details": "river terr=177 -> dry(-19,-21) terr=175 gap=2"
         },
         {
           "x": -19,
@@ -6397,31 +6272,6 @@
         },
         {
           "x": -16,
-          "y": -49,
-          "details": "river terr=315 -> dry(-17,-49) terr=310 gap=5"
-        },
-        {
-          "x": -16,
-          "y": -48,
-          "details": "river terr=307 -> dry(-17,-48) terr=302 gap=5"
-        },
-        {
-          "x": -16,
-          "y": -47,
-          "details": "river terr=299 -> dry(-17,-47) terr=296 gap=3"
-        },
-        {
-          "x": -16,
-          "y": -46,
-          "details": "river terr=292 -> dry(-17,-46) terr=289 gap=3"
-        },
-        {
-          "x": -16,
-          "y": -41,
-          "details": "river terr=256 -> dry(-15,-41) terr=255 gap=1"
-        },
-        {
-          "x": -16,
           "y": 9,
           "details": "river terr=182 -> dry(-17,9) terr=179 gap=3"
         },
@@ -6433,17 +6283,17 @@
         {
           "x": -15,
           "y": -51,
-          "details": "river terr=343 -> dry(-16,-51) terr=335 gap=8"
+          "details": "river terr=340 -> dry(-16,-51) terr=335 gap=5"
         },
         {
           "x": -15,
           "y": -50,
-          "details": "river terr=334 -> dry(-16,-50) terr=326 gap=8"
+          "details": "river terr=330 -> dry(-16,-50) terr=326 gap=4"
         },
         {
           "x": -15,
           "y": -49,
-          "details": "river terr=324 -> dry(-15,-48) terr=317 gap=7"
+          "details": "river terr=319 -> dry(-15,-48) terr=317 gap=2"
         },
         {
           "x": -15,
@@ -6451,19 +6301,14 @@
           "details": "river terr=223 -> dry(-15,-35) terr=220 gap=3"
         },
         {
-          "x": -15,
-          "y": -34,
-          "details": "river terr=215 -> dry(-15,-33) terr=214 gap=1"
-        },
-        {
           "x": -14,
           "y": -51,
-          "details": "river terr=351 -> dry(-14,-50) terr=345 gap=6"
+          "details": "river terr=349 -> dry(-14,-50) terr=345 gap=4"
         },
         {
           "x": -14,
           "y": -49,
-          "details": "river terr=335 -> dry(-14,-48) terr=328 gap=7"
+          "details": "river terr=331 -> dry(-14,-48) terr=328 gap=3"
         },
         {
           "x": -14,
@@ -6483,22 +6328,7 @@
         {
           "x": -13,
           "y": -49,
-          "details": "river terr=344 -> dry(-13,-48) terr=338 gap=6"
-        },
-        {
-          "x": -13,
-          "y": -40,
-          "details": "river terr=239 -> dry(-13,-39) terr=237 gap=2"
-        },
-        {
-          "x": -12,
-          "y": -40,
-          "details": "river terr=235 -> dry(-12,-39) terr=234 gap=1"
-        },
-        {
-          "x": -11,
-          "y": -40,
-          "details": "river terr=230 -> dry(-11,-39) terr=229 gap=1"
+          "details": "river terr=341 -> dry(-13,-48) terr=338 gap=3"
         },
         {
           "x": -10,
@@ -6513,32 +6343,17 @@
         {
           "x": -2,
           "y": -36,
-          "details": "river terr=172 -> dry(-2,-35) terr=166 gap=6"
+          "details": "river terr=167 -> dry(-2,-35) terr=166 gap=1"
         },
         {
           "x": 3,
           "y": -57,
-          "details": "river terr=207 -> dry(3,-58) terr=201 gap=6"
-        },
-        {
-          "x": 3,
-          "y": -35,
-          "details": "river terr=144 -> dry(3,-34) terr=141 gap=3"
-        },
-        {
-          "x": 4,
-          "y": -57,
-          "details": "river terr=199 -> dry(4,-58) terr=198 gap=1"
+          "details": "river terr=206 -> dry(3,-58) terr=201 gap=5"
         },
         {
           "x": 4,
           "y": -56,
-          "details": "river terr=207 -> dry(5,-56) terr=200 gap=7"
-        },
-        {
-          "x": 4,
-          "y": -35,
-          "details": "river terr=156 -> dry(4,-34) terr=152 gap=4"
+          "details": "river terr=204 -> dry(5,-56) terr=200 gap=4"
         },
         {
           "x": 5,
@@ -6547,43 +6362,23 @@
         },
         {
           "x": 5,
-          "y": -42,
-          "details": "river terr=208 -> dry(5,-41) terr=204 gap=4"
-        },
-        {
-          "x": 5,
           "y": -37,
-          "details": "river terr=185 -> dry(4,-37) terr=181 gap=4"
+          "details": "river terr=182 -> dry(4,-37) terr=181 gap=1"
         },
         {
           "x": 5,
           "y": -35,
-          "details": "river terr=168 -> dry(5,-34) terr=162 gap=6"
-        },
-        {
-          "x": 6,
-          "y": -38,
-          "details": "river terr=192 -> dry(6,-37) terr=191 gap=1"
-        },
-        {
-          "x": 7,
-          "y": -11,
-          "details": "river terr=215 -> dry(7,-12) terr=214 gap=1"
+          "details": "river terr=164 -> dry(5,-34) terr=162 gap=2"
         },
         {
           "x": 9,
           "y": -60,
-          "details": "river terr=170 -> dry(9,-59) terr=159 gap=11"
-        },
-        {
-          "x": 10,
-          "y": -59,
-          "details": "river terr=155 -> dry(10,-58) terr=154 gap=1"
+          "details": "river terr=165 -> dry(9,-59) terr=159 gap=6"
         },
         {
           "x": 13,
           "y": -13,
-          "details": "river terr=172 -> dry(14,-13) terr=167 gap=5"
+          "details": "river terr=168 -> dry(14,-13) terr=167 gap=1"
         },
         {
           "x": 14,
@@ -6602,13 +6397,8 @@
         },
         {
           "x": 14,
-          "y": -4,
-          "details": "river terr=238 -> dry(14,-5) terr=237 gap=1"
-        },
-        {
-          "x": 14,
           "y": -3,
-          "details": "river terr=239 -> dry(14,-2) terr=237 gap=2"
+          "details": "river terr=238 -> dry(14,-2) terr=237 gap=1"
         },
         {
           "x": 14,
@@ -6617,73 +6407,48 @@
         },
         {
           "x": 14,
-          "y": 2,
-          "details": "river terr=250 -> dry(13,2) terr=248 gap=2"
-        },
-        {
-          "x": 14,
           "y": 10,
-          "details": "lake terr=247 -> dry(14,9) terr=219 gap=28"
+          "details": "lake terr=241 -> dry(14,9) terr=213 gap=28"
         },
         {
           "x": 15,
           "y": -15,
-          "details": "river terr=148 -> dry(15,-16) terr=145 gap=3"
+          "details": "river terr=146 -> dry(15,-16) terr=145 gap=1"
         },
         {
           "x": 15,
           "y": 10,
-          "details": "lake terr=219 -> dry(15,11) terr=215 gap=4"
+          "details": "lake terr=213 -> dry(15,11) terr=209 gap=4"
         },
         {
           "x": 15,
           "y": 13,
-          "details": "lake terr=175 -> dry(16,13) terr=147 gap=28"
+          "details": "lake terr=170 -> dry(16,13) terr=142 gap=28"
         },
         {
           "x": 15,
           "y": 20,
-          "details": "river terr=71 -> dry(15,21) terr=61 gap=10"
+          "details": "river terr=66 -> dry(15,21) terr=61 gap=5"
         },
         {
           "x": 16,
           "y": -15,
-          "details": "river terr=143 -> dry(16,-16) terr=139 gap=4"
-        },
-        {
-          "x": 16,
-          "y": -7,
-          "details": "river terr=193 -> dry(16,-8) terr=189 gap=4"
+          "details": "river terr=140 -> dry(16,-16) terr=139 gap=1"
         },
         {
           "x": 16,
           "y": 10,
-          "details": "river terr=191 -> dry(17,10) terr=171 gap=20"
-        },
-        {
-          "x": 17,
-          "y": -11,
-          "details": "river terr=157 -> dry(17,-12) terr=152 gap=5"
+          "details": "river terr=185 -> dry(17,10) terr=165 gap=20"
         },
         {
           "x": 17,
           "y": -3,
-          "details": "river terr=216 -> dry(18,-3) terr=209 gap=7"
+          "details": "river terr=215 -> dry(18,-3) terr=209 gap=6"
         },
         {
           "x": 17,
           "y": -2,
           "details": "river terr=222 -> dry(18,-2) terr=220 gap=2"
-        },
-        {
-          "x": 18,
-          "y": -11,
-          "details": "river terr=146 -> dry(18,-12) terr=144 gap=2"
-        },
-        {
-          "x": 20,
-          "y": 1,
-          "details": "river terr=235 -> dry(21,1) terr=234 gap=1"
         },
         {
           "x": 22,
@@ -6696,34 +6461,14 @@
           "details": "river terr=144 -> dry(23,-10) terr=143 gap=1"
         },
         {
-          "x": 27,
-          "y": -6,
-          "details": "river terr=151 -> dry(27,-7) terr=147 gap=4"
-        },
-        {
           "x": 35,
           "y": 14,
-          "details": "lake terr=123 -> dry(34,14) terr=120 gap=3"
-        },
-        {
-          "x": 39,
-          "y": 26,
-          "details": "river terr=52 -> dry(38,26) terr=51 gap=1"
-        },
-        {
-          "x": 40,
-          "y": 25,
-          "details": "river terr=57 -> dry(39,25) terr=56 gap=1"
+          "details": "lake terr=118 -> dry(34,14) terr=115 gap=3"
         },
         {
           "x": 40,
           "y": 29,
           "details": "river terr=48 -> dry(40,30) terr=47 gap=1"
-        },
-        {
-          "x": 41,
-          "y": 27,
-          "details": "river terr=56 -> dry(41,28) terr=55 gap=1"
         },
         {
           "x": 41,
@@ -6736,16 +6481,6 @@
           "details": "river terr=29 -> dry(41,39) terr=27 gap=2"
         },
         {
-          "x": 42,
-          "y": 25,
-          "details": "river terr=71 -> dry(42,26) terr=66 gap=5"
-        },
-        {
-          "x": 42,
-          "y": 37,
-          "details": "river terr=38 -> dry(42,38) terr=36 gap=2"
-        },
-        {
           "x": 43,
           "y": 42,
           "details": "river terr=43 -> dry(43,41) terr=40 gap=3"
@@ -6753,22 +6488,17 @@
         {
           "x": 44,
           "y": -61,
-          "details": "river terr=97 -> dry(45,-61) terr=89 gap=8"
+          "details": "river terr=91 -> dry(45,-61) terr=89 gap=2"
         },
         {
           "x": 44,
           "y": -60,
-          "details": "river terr=85 -> dry(45,-60) terr=61 gap=24"
+          "details": "river terr=79 -> dry(45,-60) terr=61 gap=18"
         },
         {
           "x": 44,
           "y": 16,
           "details": "river terr=158 -> dry(44,17) terr=155 gap=3"
-        },
-        {
-          "x": 44,
-          "y": 35,
-          "details": "river terr=57 -> dry(44,36) terr=56 gap=1"
         },
         {
           "x": 44,
@@ -6781,39 +6511,29 @@
           "details": "river terr=153 -> dry(45,17) terr=150 gap=3"
         },
         {
-          "x": 45,
-          "y": 35,
-          "details": "river terr=69 -> dry(45,36) terr=67 gap=2"
-        },
-        {
           "x": 46,
           "y": -62,
-          "details": "river terr=72 -> dry(46,-61) terr=61 gap=11"
+          "details": "river terr=66 -> dry(46,-61) terr=61 gap=5"
         },
         {
           "x": 46,
           "y": 16,
-          "details": "river terr=144 -> dry(46,17) terr=140 gap=4"
+          "details": "river terr=143 -> dry(46,17) terr=140 gap=3"
         },
         {
           "x": 46,
           "y": 35,
-          "details": "river terr=78 -> dry(46,36) terr=75 gap=3"
+          "details": "river terr=77 -> dry(46,36) terr=75 gap=2"
         },
         {
           "x": 47,
           "y": 16,
-          "details": "river terr=135 -> dry(47,17) terr=130 gap=5"
+          "details": "river terr=133 -> dry(47,17) terr=130 gap=3"
         },
         {
           "x": 47,
           "y": 35,
           "details": "river terr=85 -> dry(47,36) terr=83 gap=2"
-        },
-        {
-          "x": 48,
-          "y": 13,
-          "details": "river terr=136 -> dry(48,14) terr=132 gap=4"
         },
         {
           "x": 48,
@@ -6823,17 +6543,17 @@
         {
           "x": 49,
           "y": 13,
-          "details": "river terr=130 -> dry(49,14) terr=125 gap=5"
+          "details": "river terr=126 -> dry(49,14) terr=125 gap=1"
         },
         {
           "x": 50,
           "y": 12,
-          "details": "river terr=130 -> dry(51,12) terr=125 gap=5"
+          "details": "river terr=126 -> dry(51,12) terr=125 gap=1"
         },
         {
           "x": 51,
           "y": 10,
-          "details": "river terr=136 -> dry(51,11) terr=132 gap=4"
+          "details": "river terr=134 -> dry(51,11) terr=132 gap=2"
         },
         {
           "x": 52,
@@ -6843,22 +6563,22 @@
         {
           "x": 52,
           "y": 10,
-          "details": "river terr=131 -> dry(53,10) terr=127 gap=4"
+          "details": "river terr=129 -> dry(53,10) terr=127 gap=2"
         },
         {
           "x": 52,
           "y": 11,
-          "details": "river terr=125 -> dry(53,11) terr=121 gap=4"
+          "details": "river terr=123 -> dry(53,11) terr=121 gap=2"
         },
         {
           "x": 52,
           "y": 12,
-          "details": "river terr=118 -> dry(53,12) terr=113 gap=5"
+          "details": "river terr=115 -> dry(53,12) terr=113 gap=2"
         },
         {
           "x": 52,
           "y": 13,
-          "details": "river terr=110 -> dry(53,13) terr=106 gap=4"
+          "details": "river terr=107 -> dry(53,13) terr=106 gap=1"
         },
         {
           "x": 53,
@@ -6868,7 +6588,7 @@
         {
           "x": 54,
           "y": -14,
-          "details": "river terr=127 -> dry(55,-14) terr=123 gap=4"
+          "details": "river terr=125 -> dry(55,-14) terr=123 gap=2"
         },
         {
           "x": 54,
@@ -6893,17 +6613,12 @@
         {
           "x": 56,
           "y": -6,
-          "details": "river terr=114 -> dry(57,-6) terr=109 gap=5"
-        },
-        {
-          "x": 56,
-          "y": 9,
-          "details": "river terr=109 -> dry(56,10) terr=108 gap=1"
+          "details": "river terr=112 -> dry(57,-6) terr=109 gap=3"
         },
         {
           "x": 57,
           "y": -12,
-          "details": "river terr=103 -> dry(58,-12) terr=101 gap=2"
+          "details": "river terr=102 -> dry(58,-12) terr=101 gap=1"
         },
         {
           "x": 57,
@@ -6918,7 +6633,7 @@
         {
           "x": 58,
           "y": -26,
-          "details": "river terr=64 -> dry(58,-27) terr=58 gap=6"
+          "details": "river terr=60 -> dry(58,-27) terr=58 gap=2"
         },
         {
           "x": 59,
@@ -6928,7 +6643,7 @@
         {
           "x": 60,
           "y": -7,
-          "details": "river terr=76 -> dry(61,-7) terr=70 gap=6"
+          "details": "river terr=72 -> dry(61,-7) terr=70 gap=2"
         },
         {
           "x": 60,
@@ -6943,7 +6658,7 @@
         {
           "x": 60,
           "y": 5,
-          "details": "river terr=91 -> dry(61,5) terr=89 gap=2"
+          "details": "river terr=90 -> dry(61,5) terr=89 gap=1"
         },
         {
           "x": 61,
@@ -6964,11 +6679,6 @@
           "x": 62,
           "y": 3,
           "details": "river terr=94 -> dry(62,4) terr=92 gap=2"
-        },
-        {
-          "x": 63,
-          "y": -11,
-          "details": "river terr=68 -> dry(64,-11) terr=67 gap=1"
         },
         {
           "x": 63,
@@ -7011,39 +6721,9 @@
           "details": "river terr=63 -> dry(67,2) terr=62 gap=1"
         },
         {
-          "x": 68,
-          "y": -24,
-          "details": "river terr=58 -> dry(68,-25) terr=56 gap=2"
-        },
-        {
-          "x": 68,
-          "y": -21,
-          "details": "river terr=81 -> dry(69,-21) terr=80 gap=1"
-        },
-        {
           "x": 71,
           "y": -20,
-          "details": "river terr=77 -> dry(72,-20) terr=74 gap=3"
-        },
-        {
-          "x": 73,
-          "y": -51,
-          "details": "river terr=80 -> dry(73,-50) terr=77 gap=3"
-        },
-        {
-          "x": 74,
-          "y": -19,
-          "details": "river terr=60 -> dry(74,-20) terr=57 gap=3"
-        },
-        {
-          "x": 75,
-          "y": -19,
-          "details": "river terr=48 -> dry(76,-19) terr=46 gap=2"
-        },
-        {
-          "x": 79,
-          "y": -16,
-          "details": "river terr=40 -> dry(79,-17) terr=39 gap=1"
+          "details": "river terr=76 -> dry(72,-20) terr=74 gap=2"
         }
       ],
       "ISLAND_1TILE": [
@@ -7313,6 +6993,11 @@
         },
         {
           "x": -44,
+          "y": -17,
+          "details": "river surf=41 (terr=36) -> water nbr surf=38 (terr=37) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -44,
           "y": 39,
           "details": "river surf=4 (terr=-6) -> water nbr surf=0 (terr=-5) surf_diff=4 terr_diff=1"
         },
@@ -7337,14 +7022,179 @@
           "details": "lake surf=36 (terr=31) -> water nbr surf=31 (terr=29) surf_diff=5 terr_diff=2"
         },
         {
+          "x": -38,
+          "y": -26,
+          "details": "river surf=124 (terr=121) -> water nbr surf=122 (terr=121) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -36,
+          "y": -15,
+          "details": "river surf=41 (terr=35) -> water nbr surf=39 (terr=35) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -36,
+          "y": 29,
+          "details": "lake surf=34 (terr=30) -> water nbr surf=32 (terr=30) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -35,
+          "y": 28,
+          "details": "lake surf=36 (terr=32) -> water nbr surf=32 (terr=31) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -33,
+          "y": 19,
+          "details": "lake surf=37 (terr=30) -> water nbr surf=32 (terr=31) surf_diff=5 terr_diff=1"
+        },
+        {
           "x": -32,
-          "y": 22,
-          "details": "river surf=47 (terr=44) -> water nbr surf=44 (terr=43) surf_diff=3 terr_diff=1"
+          "y": 38,
+          "details": "river surf=6 (terr=1) -> water nbr surf=4 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -31,
+          "y": 39,
+          "details": "river surf=6 (terr=1) -> water nbr surf=4 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -31,
+          "y": 39,
+          "details": "river surf=6 (terr=1) -> water nbr surf=4 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -30,
+          "y": 21,
+          "details": "river surf=57 (terr=52) -> water nbr surf=53 (terr=50) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -28,
+          "y": -14,
+          "details": "river surf=71 (terr=64) -> water nbr surf=66 (terr=65) surf_diff=5 terr_diff=1"
         },
         {
           "x": -28,
           "y": -12,
-          "details": "lake surf=70 (terr=65) -> water nbr surf=66 (terr=67) surf_diff=4 terr_diff=2"
+          "details": "lake surf=70 (terr=65) -> water nbr surf=66 (terr=66) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -28,
+          "y": 14,
+          "details": "river surf=91 (terr=84) -> water nbr surf=88 (terr=83) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -28,
+          "y": 14,
+          "details": "river surf=91 (terr=84) -> water nbr surf=88 (terr=83) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -28,
+          "y": 29,
+          "details": "river surf=72 (terr=69) -> water nbr surf=69 (terr=68) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -27,
+          "y": -12,
+          "details": "lake surf=70 (terr=63) -> water nbr surf=66 (terr=64) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -26,
+          "y": -21,
+          "details": "river surf=131 (terr=127) -> water nbr surf=128 (terr=126) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -25,
+          "y": -22,
+          "details": "river surf=133 (terr=128) -> water nbr surf=128 (terr=126) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": 0,
+          "y": -34,
+          "details": "river surf=135 (terr=129) -> water nbr surf=130 (terr=129) surf_diff=5 terr_diff=0"
+        },
+        {
+          "x": 0,
+          "y": -33,
+          "details": "river surf=133 (terr=127) -> water nbr surf=130 (terr=128) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 1,
+          "y": -35,
+          "details": "river surf=138 (terr=131) -> water nbr surf=130 (terr=129) surf_diff=8 terr_diff=2"
+        },
+        {
+          "x": 3,
+          "y": -56,
+          "details": "river surf=211 (terr=206) -> water nbr surf=208 (terr=207) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 8,
+          "y": -10,
+          "details": "river surf=216 (terr=211) -> water nbr surf=212 (terr=209) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 11,
+          "y": -59,
+          "details": "river surf=153 (terr=148) -> water nbr surf=150 (terr=147) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 11,
+          "y": -59,
+          "details": "river surf=153 (terr=148) -> water nbr surf=151 (terr=148) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 12,
+          "y": -60,
+          "details": "river surf=153 (terr=149) -> water nbr surf=150 (terr=149) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 13,
+          "y": -14,
+          "details": "river surf=161 (terr=155) -> water nbr surf=158 (terr=156) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 17,
+          "y": 0,
+          "details": "river surf=228 (terr=224) -> water nbr surf=226 (terr=224) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 18,
+          "y": -15,
+          "details": "river surf=133 (terr=129) -> water nbr surf=131 (terr=129) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 18,
+          "y": 2,
+          "details": "river surf=250 (terr=243) -> water nbr surf=247 (terr=242) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 23,
+          "y": -8,
+          "details": "river surf=148 (terr=144) -> water nbr surf=145 (terr=145) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 23,
+          "y": -7,
+          "details": "river surf=151 (terr=145) -> water nbr surf=148 (terr=146) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 24,
+          "y": -7,
+          "details": "river surf=148 (terr=143) -> water nbr surf=145 (terr=144) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 25,
+          "y": -6,
+          "details": "lake surf=148 (terr=144) -> water nbr surf=145 (terr=143) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 37,
+          "y": 14,
+          "details": "lake surf=132 (terr=128) -> water nbr surf=130 (terr=128) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 39,
+          "y": 43,
+          "details": "river surf=6 (terr=1) -> water nbr surf=4 (terr=1) surf_diff=2 terr_diff=0"
         },
         {
           "x": 40,
@@ -7352,9 +7202,59 @@
           "details": "river surf=160 (terr=157) -> water nbr surf=156 (terr=155) surf_diff=4 terr_diff=2"
         },
         {
-          "x": 42,
-          "y": 47,
-          "details": "river surf=38 (terr=23) -> water nbr surf=22 (terr=21) surf_diff=16 terr_diff=2"
+          "x": 40,
+          "y": 27,
+          "details": "river surf=54 (terr=51) -> water nbr surf=52 (terr=51) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 41,
+          "y": 27,
+          "details": "river surf=57 (terr=52) -> water nbr surf=54 (terr=51) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 41,
+          "y": 35,
+          "details": "river surf=37 (terr=34) -> water nbr surf=35 (terr=34) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 50,
+          "y": -5,
+          "details": "river surf=150 (terr=147) -> water nbr surf=148 (terr=147) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 51,
+          "y": -7,
+          "details": "river surf=148 (terr=145) -> water nbr surf=146 (terr=145) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 51,
+          "y": 15,
+          "details": "river surf=109 (terr=106) -> water nbr surf=107 (terr=106) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 53,
+          "y": 14,
+          "details": "river surf=99 (terr=96) -> water nbr surf=95 (terr=94) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 55,
+          "y": -61,
+          "details": "river surf=98 (terr=94) -> water nbr surf=95 (terr=93) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 56,
+          "y": -61,
+          "details": "river surf=101 (terr=97) -> water nbr surf=98 (terr=96) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 57,
+          "y": -61,
+          "details": "river surf=101 (terr=96) -> water nbr surf=98 (terr=95) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 59,
+          "y": -60,
+          "details": "river surf=101 (terr=96) -> water nbr surf=98 (terr=95) surf_diff=3 terr_diff=1"
         },
         {
           "x": 60,
@@ -7362,9 +7262,49 @@
           "details": "river surf=112 (terr=109) -> water nbr surf=108 (terr=107) surf_diff=4 terr_diff=2"
         },
         {
+          "x": 60,
+          "y": 7,
+          "details": "river surf=77 (terr=74) -> water nbr surf=75 (terr=74) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 62,
+          "y": -10,
+          "details": "river surf=61 (terr=56) -> water nbr surf=59 (terr=56) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 65,
+          "y": -58,
+          "details": "river surf=101 (terr=96) -> water nbr surf=98 (terr=95) surf_diff=3 terr_diff=1"
+        },
+        {
           "x": 67,
           "y": 1,
           "details": "river surf=62 (terr=56) -> water nbr surf=59 (terr=57) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 75,
+          "y": -28,
+          "details": "river surf=49 (terr=45) -> water nbr surf=47 (terr=45) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 75,
+          "y": -22,
+          "details": "river surf=43 (terr=39) -> water nbr surf=41 (terr=39) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 76,
+          "y": -21,
+          "details": "river surf=42 (terr=39) -> water nbr surf=40 (terr=39) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 77,
+          "y": -63,
+          "details": "river surf=45 (terr=39) -> water nbr surf=42 (terr=38) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 77,
+          "y": -20,
+          "details": "river surf=41 (terr=38) -> water nbr surf=38 (terr=37) surf_diff=3 terr_diff=1"
         }
       ],
       "MULTI_ISLAND": [
@@ -7496,6 +7436,11 @@
           "details": "river surf=238 -> dry(14,-1) terr=234"
         },
         {
+          "x": 16,
+          "y": 15,
+          "details": "river surf=108 -> dry(16,16) terr=106"
+        },
+        {
           "x": 19,
           "y": 0,
           "details": "river surf=224 -> dry(19,-1) terr=223"
@@ -7509,6 +7454,11 @@
           "x": 27,
           "y": 47,
           "details": "river surf=2 -> dry(27,48) terr=1"
+        },
+        {
+          "x": 36,
+          "y": 15,
+          "details": "river surf=108 -> dry(36,16) terr=106"
         },
         {
           "x": 41,
@@ -7570,7 +7520,7 @@
         {
           "x": -47,
           "y": -17,
-          "details": "river surf=56 terr=55 -> land(-47,-16) terr=49 cliff=7"
+          "details": "river surf=56 terr=54 -> land(-47,-16) terr=49 cliff=7"
         },
         {
           "x": -40,
@@ -7585,17 +7535,17 @@
         {
           "x": -36,
           "y": 31,
-          "details": "river surf=41 terr=40 -> land(-37,31) terr=38 cliff=3"
+          "details": "river surf=41 terr=38 -> land(-37,31) terr=38 cliff=3"
         },
         {
           "x": -35,
           "y": -16,
-          "details": "river surf=54 terr=53 -> land(-35,-15) terr=48 cliff=6"
+          "details": "river surf=54 terr=47 -> land(-35,-15) terr=48 cliff=6"
         },
         {
           "x": -35,
           "y": 32,
-          "details": "river surf=42 terr=41 -> land(-36,32) terr=38 cliff=4"
+          "details": "river surf=42 terr=39 -> land(-36,32) terr=38 cliff=4"
         },
         {
           "x": -34,
@@ -7605,22 +7555,22 @@
         {
           "x": -33,
           "y": -18,
-          "details": "river surf=98 terr=97 -> land(-34,-18) terr=89 cliff=9"
+          "details": "river surf=98 terr=91 -> land(-34,-18) terr=89 cliff=9"
         },
         {
           "x": -33,
           "y": -17,
-          "details": "river surf=86 terr=85 -> land(-34,-17) terr=76 cliff=10"
+          "details": "river surf=86 terr=78 -> land(-34,-17) terr=76 cliff=10"
         },
         {
           "x": -33,
           "y": -16,
-          "details": "river surf=74 terr=73 -> land(-34,-16) terr=66 cliff=8"
+          "details": "river surf=74 terr=66 -> land(-34,-16) terr=66 cliff=8"
         },
         {
           "x": -33,
           "y": -15,
-          "details": "river surf=63 terr=62 -> land(-34,-15) terr=58 cliff=5"
+          "details": "river surf=63 terr=56 -> land(-34,-15) terr=58 cliff=5"
         },
         {
           "x": -33,
@@ -7645,7 +7595,7 @@
         {
           "x": -30,
           "y": -19,
-          "details": "river surf=129 terr=128 -> land(-31,-19) terr=127 cliff=2"
+          "details": "river surf=129 terr=123 -> land(-31,-19) terr=127 cliff=2"
         },
         {
           "x": -30,
@@ -7680,7 +7630,7 @@
         {
           "x": -28,
           "y": 18,
-          "details": "river surf=82 terr=81 -> land(-29,18) terr=70 cliff=12"
+          "details": "river surf=82 terr=78 -> land(-29,18) terr=70 cliff=12"
         },
         {
           "x": -28,
@@ -7690,32 +7640,32 @@
         {
           "x": -27,
           "y": -23,
-          "details": "river surf=154 terr=153 -> land(-27,-22) terr=147 cliff=7"
+          "details": "river surf=154 terr=151 -> land(-27,-22) terr=147 cliff=7"
         },
         {
           "x": -27,
           "y": -21,
-          "details": "river surf=140 terr=139 -> land(-27,-20) terr=136 cliff=4"
+          "details": "river surf=140 terr=137 -> land(-27,-20) terr=136 cliff=4"
         },
         {
           "x": -27,
           "y": -15,
-          "details": "river surf=86 terr=85 -> land(-28,-15) terr=83 cliff=3"
+          "details": "river surf=86 terr=79 -> land(-28,-15) terr=83 cliff=3"
         },
         {
           "x": -27,
           "y": 23,
-          "details": "river surf=73 terr=72 -> land(-28,23) terr=69 cliff=4"
+          "details": "river surf=73 terr=68 -> land(-28,23) terr=69 cliff=4"
         },
         {
           "x": -27,
           "y": 24,
-          "details": "river surf=79 terr=78 -> land(-28,24) terr=75 cliff=4"
+          "details": "river surf=79 terr=75 -> land(-28,24) terr=75 cliff=4"
         },
         {
           "x": -27,
           "y": 31,
-          "details": "river surf=82 terr=81 -> land(-28,31) terr=79 cliff=3"
+          "details": "river surf=82 terr=77 -> land(-28,31) terr=79 cliff=3"
         },
         {
           "x": -26,
@@ -7725,17 +7675,22 @@
         {
           "x": -26,
           "y": -14,
-          "details": "river surf=86 terr=85 -> land(-26,-13) terr=76 cliff=10"
+          "details": "river surf=86 terr=80 -> land(-26,-13) terr=76 cliff=10"
         },
         {
           "x": -25,
           "y": -13,
-          "details": "river surf=82 terr=81 -> land(-26,-13) terr=76 cliff=6"
+          "details": "river surf=82 terr=76 -> land(-26,-13) terr=76 cliff=6"
         },
         {
           "x": -25,
           "y": 24,
-          "details": "river surf=97 terr=96 -> land(-25,23) terr=91 cliff=6"
+          "details": "river surf=97 terr=93 -> land(-25,23) terr=91 cliff=6"
+        },
+        {
+          "x": -25,
+          "y": 30,
+          "details": "river surf=78 terr=72 -> land(-25,31) terr=76 cliff=2"
         },
         {
           "x": -24,
@@ -7745,72 +7700,82 @@
         {
           "x": -24,
           "y": -26,
-          "details": "river surf=176 terr=175 -> land(-25,-26) terr=174 cliff=2"
+          "details": "river surf=176 terr=173 -> land(-25,-26) terr=174 cliff=2"
         },
         {
           "x": -24,
           "y": -25,
-          "details": "river surf=167 terr=166 -> land(-25,-25) terr=165 cliff=2"
+          "details": "river surf=167 terr=163 -> land(-25,-25) terr=165 cliff=2"
         },
         {
           "x": -24,
           "y": -18,
-          "details": "river surf=128 terr=126 -> land(-25,-18) terr=124 cliff=4"
+          "details": "river surf=128 terr=122 -> land(-25,-18) terr=124 cliff=4"
         },
         {
           "x": -24,
           "y": -17,
-          "details": "river surf=124 terr=123 -> land(-25,-17) terr=119 cliff=5"
+          "details": "river surf=124 terr=119 -> land(-25,-17) terr=119 cliff=5"
         },
         {
           "x": -24,
           "y": -16,
-          "details": "river surf=117 terr=116 -> land(-25,-16) terr=111 cliff=6"
+          "details": "river surf=117 terr=111 -> land(-25,-16) terr=111 cliff=6"
+        },
+        {
+          "x": -23,
+          "y": 30,
+          "details": "river surf=78 terr=72 -> land(-23,31) terr=76 cliff=2"
         },
         {
           "x": -22,
           "y": -24,
-          "details": "river surf=169 terr=168 -> land(-23,-24) terr=163 cliff=6"
+          "details": "river surf=169 terr=165 -> land(-23,-24) terr=163 cliff=6"
         },
         {
           "x": -22,
           "y": -23,
-          "details": "river surf=161 terr=160 -> land(-22,-22) terr=153 cliff=8"
+          "details": "river surf=161 terr=156 -> land(-22,-22) terr=153 cliff=8"
         },
         {
           "x": -22,
           "y": 20,
-          "details": "river surf=130 terr=128 -> land(-23,20) terr=127 cliff=3"
+          "details": "river surf=130 terr=126 -> land(-23,20) terr=127 cliff=3"
+        },
+        {
+          "x": -22,
+          "y": 29,
+          "details": "river surf=102 terr=97 -> land(-22,30) terr=100 cliff=2"
         },
         {
           "x": -21,
           "y": -24,
-          "details": "river surf=177 terr=176 -> land(-21,-23) terr=170 cliff=7"
+          "details": "river surf=177 terr=174 -> land(-21,-23) terr=170 cliff=7"
         },
         {
           "x": -21,
           "y": -21,
-          "details": "river surf=161 terr=160 -> land(-21,-20) terr=158 cliff=3"
+          "details": "river surf=161 terr=157 -> land(-21,-20) terr=158 cliff=3"
         },
         {
           "x": -21,
           "y": 19,
-          "details": "river surf=149 terr=147 -> land(-22,19) terr=141 cliff=8"
+          "details": "river surf=149 terr=146 -> land(-22,19) terr=141 cliff=8"
         },
         {
           "x": -21,
           "y": 23,
-          "details": "river surf=133 terr=132 -> land(-22,23) terr=126 cliff=7"
+          "details": "river surf=133 terr=130 -> land(-22,23) terr=126 cliff=7"
         },
         {
           "x": -21,
           "y": 24,
-          "details": "river surf=141 terr=140 -> land(-22,24) terr=134 cliff=7"
+          "details": "river surf=141 terr=139 -> land(-22,24) terr=134 cliff=7"
         },
         {
           "x": -21,
           "y": 27,
-          "details": "river surf=138 terr=137 -> land(-21,28) terr=135 cliff=3"
+          "details": "river surf=138 terr=135 -> land(-21,28) terr=135 cliff=3"
         },
         {
           "x": -20,
@@ -7825,17 +7790,17 @@
         {
           "x": -20,
           "y": -38,
-          "details": "river surf=223 terr=222 -> land(-21,-38) terr=220 cliff=3"
+          "details": "river surf=223 terr=217 -> land(-21,-38) terr=220 cliff=3"
         },
         {
           "x": -20,
           "y": -37,
-          "details": "river surf=211 terr=210 -> land(-21,-37) terr=207 cliff=4"
+          "details": "river surf=211 terr=205 -> land(-21,-37) terr=207 cliff=4"
         },
         {
           "x": -20,
           "y": -36,
-          "details": "river surf=200 terr=199 -> land(-21,-36) terr=197 cliff=3"
+          "details": "river surf=200 terr=194 -> land(-21,-36) terr=197 cliff=3"
         },
         {
           "x": -20,
@@ -7845,12 +7810,12 @@
         {
           "x": -20,
           "y": -22,
-          "details": "river surf=172 terr=171 -> land(-21,-22) terr=168 cliff=4"
+          "details": "river surf=172 terr=169 -> land(-21,-22) terr=168 cliff=4"
         },
         {
           "x": -20,
           "y": -21,
-          "details": "river surf=168 terr=167 -> land(-20,-20) terr=166 cliff=2"
+          "details": "river surf=168 terr=166 -> land(-20,-20) terr=166 cliff=2"
         },
         {
           "x": -20,
@@ -7864,8 +7829,23 @@
         },
         {
           "x": -20,
+          "y": 34,
+          "details": "river surf=66 terr=60 -> land(-21,34) terr=64 cliff=2"
+        },
+        {
+          "x": -20,
+          "y": 36,
+          "details": "river surf=66 terr=59 -> land(-21,36) terr=64 cliff=2"
+        },
+        {
+          "x": -20,
           "y": 37,
-          "details": "river surf=54 terr=53 -> land(-21,37) terr=45 cliff=9"
+          "details": "river surf=54 terr=47 -> land(-21,37) terr=39 cliff=15"
+        },
+        {
+          "x": -20,
+          "y": 38,
+          "details": "river surf=42 terr=35 -> land(-21,38) terr=39 cliff=3"
         },
         {
           "x": -19,
@@ -7880,7 +7860,7 @@
         {
           "x": -19,
           "y": -22,
-          "details": "river surf=180 terr=179 -> land(-19,-21) terr=175 cliff=5"
+          "details": "river surf=180 terr=177 -> land(-19,-21) terr=175 cliff=5"
         },
         {
           "x": -19,
@@ -7905,27 +7885,27 @@
         {
           "x": -16,
           "y": -49,
-          "details": "river surf=316 terr=315 -> land(-17,-49) terr=310 cliff=6"
+          "details": "river surf=316 terr=310 -> land(-17,-49) terr=310 cliff=6"
         },
         {
           "x": -16,
           "y": -48,
-          "details": "river surf=308 terr=307 -> land(-17,-48) terr=302 cliff=6"
+          "details": "river surf=308 terr=301 -> land(-17,-48) terr=302 cliff=6"
         },
         {
           "x": -16,
           "y": -47,
-          "details": "river surf=300 terr=299 -> land(-17,-47) terr=296 cliff=4"
+          "details": "river surf=300 terr=293 -> land(-17,-47) terr=296 cliff=4"
         },
         {
           "x": -16,
           "y": -46,
-          "details": "river surf=293 terr=292 -> land(-17,-46) terr=289 cliff=4"
+          "details": "river surf=293 terr=287 -> land(-17,-46) terr=289 cliff=4"
         },
         {
           "x": -16,
           "y": -41,
-          "details": "river surf=257 terr=256 -> land(-15,-41) terr=255 cliff=2"
+          "details": "river surf=257 terr=254 -> land(-15,-41) terr=255 cliff=2"
         },
         {
           "x": -16,
@@ -7940,17 +7920,17 @@
         {
           "x": -15,
           "y": -51,
-          "details": "river surf=344 terr=343 -> land(-16,-51) terr=335 cliff=9"
+          "details": "river surf=344 terr=340 -> land(-16,-51) terr=335 cliff=9"
         },
         {
           "x": -15,
           "y": -50,
-          "details": "river surf=335 terr=334 -> land(-16,-50) terr=326 cliff=9"
+          "details": "river surf=335 terr=330 -> land(-16,-50) terr=326 cliff=9"
         },
         {
           "x": -15,
           "y": -49,
-          "details": "river surf=325 terr=324 -> land(-15,-48) terr=317 cliff=8"
+          "details": "river surf=325 terr=319 -> land(-15,-48) terr=317 cliff=8"
         },
         {
           "x": -15,
@@ -7960,17 +7940,17 @@
         {
           "x": -15,
           "y": -34,
-          "details": "river surf=216 terr=215 -> land(-15,-33) terr=214 cliff=2"
+          "details": "river surf=216 terr=214 -> land(-15,-33) terr=214 cliff=2"
         },
         {
           "x": -14,
           "y": -51,
-          "details": "river surf=352 terr=351 -> land(-14,-50) terr=345 cliff=7"
+          "details": "river surf=352 terr=349 -> land(-14,-50) terr=345 cliff=7"
         },
         {
           "x": -14,
           "y": -49,
-          "details": "river surf=336 terr=335 -> land(-14,-48) terr=328 cliff=8"
+          "details": "river surf=336 terr=331 -> land(-14,-48) terr=328 cliff=8"
         },
         {
           "x": -14,
@@ -7990,22 +7970,22 @@
         {
           "x": -13,
           "y": -49,
-          "details": "river surf=345 terr=344 -> land(-13,-48) terr=338 cliff=7"
+          "details": "river surf=345 terr=341 -> land(-13,-48) terr=338 cliff=7"
         },
         {
           "x": -13,
           "y": -40,
-          "details": "river surf=240 terr=239 -> land(-13,-39) terr=237 cliff=3"
+          "details": "river surf=240 terr=236 -> land(-13,-39) terr=237 cliff=3"
         },
         {
           "x": -12,
           "y": -40,
-          "details": "river surf=236 terr=235 -> land(-12,-39) terr=234 cliff=2"
+          "details": "river surf=236 terr=232 -> land(-12,-39) terr=234 cliff=2"
         },
         {
           "x": -11,
           "y": -40,
-          "details": "river surf=231 terr=230 -> land(-11,-39) terr=229 cliff=2"
+          "details": "river surf=231 terr=226 -> land(-11,-39) terr=229 cliff=2"
         },
         {
           "x": -10,
@@ -8018,34 +7998,59 @@
           "details": "lake surf=168 terr=167 -> land(-6,28) terr=161 cliff=7"
         },
         {
+          "x": -4,
+          "y": -29,
+          "details": "river surf=174 terr=167 -> land(-4,-28) terr=172 cliff=2"
+        },
+        {
+          "x": -3,
+          "y": -51,
+          "details": "river surf=300 terr=293 -> land(-3,-52) terr=297 cliff=3"
+        },
+        {
+          "x": -2,
+          "y": -51,
+          "details": "river surf=288 terr=281 -> land(-1,-51) terr=285 cliff=3"
+        },
+        {
+          "x": -2,
+          "y": -41,
+          "details": "river surf=234 terr=228 -> land(-2,-40) terr=231 cliff=3"
+        },
+        {
           "x": -2,
           "y": -36,
-          "details": "river surf=173 terr=172 -> land(-2,-35) terr=166 cliff=7"
+          "details": "river surf=173 terr=167 -> land(-2,-35) terr=166 cliff=7"
+        },
+        {
+          "x": -1,
+          "y": -52,
+          "details": "river surf=264 terr=257 -> land(-1,-53) terr=261 cliff=3"
         },
         {
           "x": 3,
           "y": -57,
-          "details": "river surf=208 terr=207 -> land(3,-58) terr=201 cliff=7"
+          "details": "river surf=208 terr=206 -> land(3,-58) terr=201 cliff=7"
         },
         {
           "x": 3,
           "y": -35,
-          "details": "river surf=145 terr=144 -> land(3,-34) terr=141 cliff=4"
+          "details": "river surf=145 terr=139 -> land(3,-34) terr=141 cliff=4"
         },
         {
           "x": 4,
           "y": -57,
-          "details": "river surf=200 terr=199 -> land(4,-58) terr=198 cliff=2"
+          "details": "river surf=200 terr=198 -> land(4,-58) terr=198 cliff=2"
         },
         {
           "x": 4,
           "y": -56,
-          "details": "river surf=208 terr=207 -> land(5,-56) terr=200 cliff=8"
+          "details": "river surf=208 terr=204 -> land(5,-56) terr=200 cliff=8"
         },
         {
           "x": 4,
           "y": -35,
-          "details": "river surf=157 terr=156 -> land(4,-34) terr=152 cliff=5"
+          "details": "river surf=157 terr=152 -> land(4,-34) terr=152 cliff=5"
         },
         {
           "x": 5,
@@ -8055,42 +8060,42 @@
         {
           "x": 5,
           "y": -42,
-          "details": "river surf=209 terr=208 -> land(5,-41) terr=204 cliff=5"
+          "details": "river surf=209 terr=203 -> land(5,-41) terr=204 cliff=5"
         },
         {
           "x": 5,
           "y": -37,
-          "details": "river surf=186 terr=185 -> land(4,-37) terr=181 cliff=5"
+          "details": "river surf=186 terr=182 -> land(4,-37) terr=181 cliff=5"
         },
         {
           "x": 5,
           "y": -35,
-          "details": "river surf=169 terr=168 -> land(5,-34) terr=162 cliff=7"
+          "details": "river surf=169 terr=164 -> land(5,-34) terr=162 cliff=7"
         },
         {
           "x": 6,
           "y": -38,
-          "details": "river surf=193 terr=192 -> land(6,-37) terr=191 cliff=2"
+          "details": "river surf=193 terr=190 -> land(6,-37) terr=191 cliff=2"
         },
         {
           "x": 7,
           "y": -11,
-          "details": "river surf=216 terr=215 -> land(7,-12) terr=214 cliff=2"
+          "details": "river surf=216 terr=210 -> land(7,-12) terr=214 cliff=2"
         },
         {
           "x": 9,
           "y": -60,
-          "details": "river surf=171 terr=170 -> land(9,-59) terr=159 cliff=12"
+          "details": "river surf=171 terr=165 -> land(9,-59) terr=159 cliff=12"
         },
         {
           "x": 10,
           "y": -59,
-          "details": "river surf=156 terr=155 -> land(10,-58) terr=154 cliff=2"
+          "details": "river surf=156 terr=150 -> land(10,-58) terr=154 cliff=2"
         },
         {
           "x": 13,
           "y": -13,
-          "details": "river surf=173 terr=172 -> land(14,-13) terr=167 cliff=6"
+          "details": "river surf=173 terr=168 -> land(14,-13) terr=167 cliff=6"
         },
         {
           "x": 14,
@@ -8110,12 +8115,12 @@
         {
           "x": 14,
           "y": -4,
-          "details": "river surf=239 terr=238 -> land(14,-5) terr=237 cliff=2"
+          "details": "river surf=239 terr=237 -> land(14,-5) terr=237 cliff=2"
         },
         {
           "x": 14,
           "y": -3,
-          "details": "river surf=240 terr=239 -> land(14,-2) terr=237 cliff=3"
+          "details": "river surf=240 terr=238 -> land(14,-2) terr=237 cliff=3"
         },
         {
           "x": 14,
@@ -8125,57 +8130,62 @@
         {
           "x": 14,
           "y": 2,
-          "details": "river surf=251 terr=250 -> land(13,2) terr=248 cliff=3"
+          "details": "river surf=251 terr=247 -> land(13,2) terr=248 cliff=3"
         },
         {
           "x": 14,
           "y": 10,
-          "details": "lake surf=266 terr=247 -> land(14,9) terr=219 cliff=47"
+          "details": "lake surf=266 terr=241 -> land(14,9) terr=213 cliff=53"
         },
         {
           "x": 15,
           "y": -15,
-          "details": "river surf=149 terr=148 -> land(15,-16) terr=145 cliff=4"
+          "details": "river surf=149 terr=146 -> land(15,-16) terr=145 cliff=4"
         },
         {
           "x": 15,
           "y": 10,
-          "details": "lake surf=266 terr=219 -> land(15,11) terr=215 cliff=51"
+          "details": "lake surf=266 terr=213 -> land(15,11) terr=209 cliff=57"
         },
         {
           "x": 15,
           "y": 13,
-          "details": "lake surf=274 terr=175 -> land(14,13) terr=203 cliff=71"
+          "details": "lake surf=274 terr=170 -> land(14,13) terr=198 cliff=76"
         },
         {
           "x": 15,
           "y": 20,
-          "details": "river surf=72 terr=71 -> land(15,21) terr=61 cliff=11"
+          "details": "river surf=72 terr=66 -> land(15,21) terr=61 cliff=11"
         },
         {
           "x": 16,
           "y": -15,
-          "details": "river surf=144 terr=143 -> land(16,-16) terr=139 cliff=5"
+          "details": "river surf=144 terr=140 -> land(16,-16) terr=139 cliff=5"
         },
         {
           "x": 16,
           "y": -7,
-          "details": "river surf=194 terr=193 -> land(16,-8) terr=189 cliff=5"
+          "details": "river surf=194 terr=188 -> land(16,-8) terr=189 cliff=5"
         },
         {
           "x": 16,
           "y": 10,
-          "details": "river surf=192 terr=191 -> land(17,10) terr=171 cliff=21"
+          "details": "river surf=192 terr=185 -> land(17,10) terr=165 cliff=27"
+        },
+        {
+          "x": 16,
+          "y": 15,
+          "details": "river surf=108 terr=102 -> land(16,16) terr=106 cliff=2"
         },
         {
           "x": 17,
           "y": -11,
-          "details": "river surf=158 terr=157 -> land(17,-12) terr=152 cliff=6"
+          "details": "river surf=158 terr=151 -> land(17,-12) terr=152 cliff=6"
         },
         {
           "x": 17,
           "y": -3,
-          "details": "river surf=217 terr=216 -> land(18,-3) terr=209 cliff=8"
+          "details": "river surf=217 terr=215 -> land(18,-3) terr=209 cliff=8"
         },
         {
           "x": 17,
@@ -8183,14 +8193,29 @@
           "details": "river surf=223 terr=222 -> land(18,-2) terr=220 cliff=3"
         },
         {
+          "x": 17,
+          "y": 9,
+          "details": "river surf=168 terr=161 -> land(17,10) terr=165 cliff=3"
+        },
+        {
+          "x": 17,
+          "y": 13,
+          "details": "river surf=120 terr=114 -> land(17,14) terr=118 cliff=2"
+        },
+        {
           "x": 18,
           "y": -11,
-          "details": "river surf=147 terr=146 -> land(18,-12) terr=144 cliff=3"
+          "details": "river surf=147 terr=141 -> land(18,-12) terr=144 cliff=3"
+        },
+        {
+          "x": 19,
+          "y": 9,
+          "details": "river surf=156 terr=149 -> land(20,9) terr=154 cliff=2"
         },
         {
           "x": 20,
           "y": 1,
-          "details": "river surf=236 terr=235 -> land(21,1) terr=234 cliff=2"
+          "details": "river surf=236 terr=229 -> land(21,1) terr=234 cliff=2"
         },
         {
           "x": 22,
@@ -8205,22 +8230,27 @@
         {
           "x": 27,
           "y": -6,
-          "details": "river surf=152 terr=151 -> land(27,-7) terr=147 cliff=5"
+          "details": "river surf=152 terr=147 -> land(27,-7) terr=147 cliff=5"
         },
         {
           "x": 35,
           "y": 14,
-          "details": "lake surf=130 terr=123 -> land(34,14) terr=120 cliff=10"
+          "details": "lake surf=130 terr=118 -> land(34,14) terr=115 cliff=15"
+        },
+        {
+          "x": 36,
+          "y": 15,
+          "details": "river surf=108 terr=103 -> land(36,16) terr=106 cliff=2"
         },
         {
           "x": 39,
           "y": 26,
-          "details": "river surf=53 terr=52 -> land(38,26) terr=51 cliff=2"
+          "details": "river surf=53 terr=50 -> land(38,26) terr=51 cliff=2"
         },
         {
           "x": 40,
           "y": 25,
-          "details": "river surf=58 terr=57 -> land(39,25) terr=56 cliff=2"
+          "details": "river surf=58 terr=53 -> land(39,25) terr=56 cliff=2"
         },
         {
           "x": 40,
@@ -8230,7 +8260,7 @@
         {
           "x": 41,
           "y": 27,
-          "details": "river surf=57 terr=56 -> land(41,28) terr=55 cliff=2"
+          "details": "river surf=57 terr=52 -> land(41,28) terr=55 cliff=2"
         },
         {
           "x": 41,
@@ -8245,12 +8275,12 @@
         {
           "x": 42,
           "y": 25,
-          "details": "river surf=72 terr=71 -> land(42,26) terr=66 cliff=6"
+          "details": "river surf=72 terr=66 -> land(42,26) terr=66 cliff=6"
         },
         {
           "x": 42,
           "y": 37,
-          "details": "river surf=39 terr=38 -> land(42,38) terr=36 cliff=3"
+          "details": "river surf=39 terr=36 -> land(42,38) terr=36 cliff=3"
         },
         {
           "x": 43,
@@ -8260,12 +8290,12 @@
         {
           "x": 44,
           "y": -61,
-          "details": "river surf=98 terr=97 -> land(45,-61) terr=89 cliff=9"
+          "details": "river surf=98 terr=91 -> land(45,-61) terr=89 cliff=9"
         },
         {
           "x": 44,
           "y": -60,
-          "details": "river surf=86 terr=85 -> land(45,-60) terr=61 cliff=25"
+          "details": "river surf=86 terr=79 -> land(45,-60) terr=61 cliff=25"
         },
         {
           "x": 44,
@@ -8275,7 +8305,7 @@
         {
           "x": 44,
           "y": 35,
-          "details": "river surf=58 terr=57 -> land(44,36) terr=56 cliff=2"
+          "details": "river surf=58 terr=54 -> land(44,36) terr=56 cliff=2"
         },
         {
           "x": 44,
@@ -8290,27 +8320,27 @@
         {
           "x": 45,
           "y": 35,
-          "details": "river surf=70 terr=69 -> land(45,36) terr=67 cliff=3"
+          "details": "river surf=70 terr=67 -> land(45,36) terr=67 cliff=3"
         },
         {
           "x": 46,
           "y": -62,
-          "details": "river surf=73 terr=72 -> land(46,-61) terr=61 cliff=12"
+          "details": "river surf=73 terr=66 -> land(46,-61) terr=61 cliff=12"
         },
         {
           "x": 46,
           "y": 16,
-          "details": "river surf=145 terr=144 -> land(46,17) terr=140 cliff=5"
+          "details": "river surf=145 terr=143 -> land(46,17) terr=140 cliff=5"
         },
         {
           "x": 46,
           "y": 35,
-          "details": "river surf=79 terr=78 -> land(46,36) terr=75 cliff=4"
+          "details": "river surf=79 terr=77 -> land(46,36) terr=75 cliff=4"
         },
         {
           "x": 47,
           "y": 16,
-          "details": "river surf=136 terr=135 -> land(47,17) terr=130 cliff=6"
+          "details": "river surf=136 terr=133 -> land(47,17) terr=130 cliff=6"
         },
         {
           "x": 47,
@@ -8320,7 +8350,7 @@
         {
           "x": 48,
           "y": 13,
-          "details": "river surf=137 terr=136 -> land(48,14) terr=132 cliff=5"
+          "details": "river surf=137 terr=131 -> land(48,14) terr=132 cliff=5"
         },
         {
           "x": 48,
@@ -8330,17 +8360,17 @@
         {
           "x": 49,
           "y": 13,
-          "details": "river surf=131 terr=130 -> land(49,14) terr=125 cliff=6"
+          "details": "river surf=131 terr=126 -> land(49,14) terr=125 cliff=6"
         },
         {
           "x": 50,
           "y": 12,
-          "details": "river surf=131 terr=130 -> land(51,12) terr=125 cliff=6"
+          "details": "river surf=131 terr=126 -> land(51,12) terr=125 cliff=6"
         },
         {
           "x": 51,
           "y": 10,
-          "details": "river surf=137 terr=136 -> land(51,11) terr=132 cliff=5"
+          "details": "river surf=137 terr=134 -> land(51,11) terr=132 cliff=5"
         },
         {
           "x": 52,
@@ -8350,22 +8380,22 @@
         {
           "x": 52,
           "y": 10,
-          "details": "river surf=132 terr=131 -> land(53,10) terr=127 cliff=5"
+          "details": "river surf=132 terr=129 -> land(53,10) terr=127 cliff=5"
         },
         {
           "x": 52,
           "y": 11,
-          "details": "river surf=126 terr=125 -> land(53,11) terr=121 cliff=5"
+          "details": "river surf=126 terr=123 -> land(53,11) terr=121 cliff=5"
         },
         {
           "x": 52,
           "y": 12,
-          "details": "river surf=119 terr=118 -> land(53,12) terr=113 cliff=6"
+          "details": "river surf=119 terr=115 -> land(53,12) terr=113 cliff=6"
         },
         {
           "x": 52,
           "y": 13,
-          "details": "river surf=111 terr=110 -> land(53,13) terr=106 cliff=5"
+          "details": "river surf=111 terr=107 -> land(53,13) terr=106 cliff=5"
         },
         {
           "x": 53,
@@ -8375,7 +8405,7 @@
         {
           "x": 54,
           "y": -14,
-          "details": "river surf=128 terr=127 -> land(55,-14) terr=123 cliff=5"
+          "details": "river surf=128 terr=125 -> land(55,-14) terr=123 cliff=5"
         },
         {
           "x": 54,
@@ -8400,17 +8430,17 @@
         {
           "x": 56,
           "y": -6,
-          "details": "river surf=115 terr=114 -> land(57,-6) terr=109 cliff=6"
+          "details": "river surf=115 terr=112 -> land(57,-6) terr=109 cliff=6"
         },
         {
           "x": 56,
           "y": 9,
-          "details": "river surf=110 terr=109 -> land(56,10) terr=108 cliff=2"
+          "details": "river surf=110 terr=108 -> land(56,10) terr=108 cliff=2"
         },
         {
           "x": 57,
           "y": -12,
-          "details": "river surf=104 terr=103 -> land(58,-12) terr=101 cliff=3"
+          "details": "river surf=104 terr=102 -> land(58,-12) terr=101 cliff=3"
         },
         {
           "x": 57,
@@ -8425,7 +8455,7 @@
         {
           "x": 58,
           "y": -26,
-          "details": "river surf=65 terr=64 -> land(58,-27) terr=58 cliff=7"
+          "details": "river surf=65 terr=60 -> land(58,-27) terr=58 cliff=7"
         },
         {
           "x": 59,
@@ -8435,7 +8465,7 @@
         {
           "x": 60,
           "y": -7,
-          "details": "river surf=77 terr=76 -> land(61,-7) terr=70 cliff=7"
+          "details": "river surf=77 terr=72 -> land(61,-7) terr=70 cliff=7"
         },
         {
           "x": 60,
@@ -8450,7 +8480,7 @@
         {
           "x": 60,
           "y": 5,
-          "details": "river surf=92 terr=91 -> land(61,5) terr=89 cliff=3"
+          "details": "river surf=92 terr=90 -> land(61,5) terr=89 cliff=3"
         },
         {
           "x": 61,
@@ -8475,7 +8505,7 @@
         {
           "x": 63,
           "y": -11,
-          "details": "river surf=69 terr=68 -> land(64,-11) terr=67 cliff=2"
+          "details": "river surf=69 terr=63 -> land(64,-11) terr=67 cliff=2"
         },
         {
           "x": 63,
@@ -8520,37 +8550,37 @@
         {
           "x": 68,
           "y": -24,
-          "details": "river surf=59 terr=58 -> land(68,-25) terr=56 cliff=3"
+          "details": "river surf=59 terr=55 -> land(68,-25) terr=56 cliff=3"
         },
         {
           "x": 68,
           "y": -21,
-          "details": "river surf=82 terr=81 -> land(69,-21) terr=80 cliff=2"
+          "details": "river surf=82 terr=80 -> land(69,-21) terr=80 cliff=2"
         },
         {
           "x": 71,
           "y": -20,
-          "details": "river surf=78 terr=77 -> land(72,-20) terr=74 cliff=4"
+          "details": "river surf=78 terr=76 -> land(72,-20) terr=74 cliff=4"
         },
         {
           "x": 73,
           "y": -51,
-          "details": "river surf=81 terr=80 -> land(73,-50) terr=77 cliff=4"
+          "details": "river surf=81 terr=77 -> land(73,-50) terr=77 cliff=4"
         },
         {
           "x": 74,
           "y": -19,
-          "details": "river surf=61 terr=60 -> land(74,-20) terr=57 cliff=4"
+          "details": "river surf=61 terr=56 -> land(74,-20) terr=57 cliff=4"
         },
         {
           "x": 75,
           "y": -19,
-          "details": "river surf=49 terr=48 -> land(76,-19) terr=46 cliff=3"
+          "details": "river surf=49 terr=43 -> land(76,-19) terr=46 cliff=3"
         },
         {
           "x": 79,
           "y": -16,
-          "details": "river surf=41 terr=40 -> land(79,-17) terr=39 cliff=2"
+          "details": "river surf=41 terr=36 -> land(79,-17) terr=39 cliff=2"
         }
       ],
       "WATER_CLIFF": [
@@ -8760,6 +8790,11 @@
           "details": "river surf=97 -> dry(-25,23) terr=91 cliff=6"
         },
         {
+          "x": -25,
+          "y": 30,
+          "details": "river surf=78 -> dry(-25,31) terr=76 cliff=2"
+        },
+        {
           "x": -24,
           "y": -27,
           "details": "river surf=182 -> dry(-25,-27) terr=179 cliff=3"
@@ -8790,6 +8825,11 @@
           "details": "river surf=117 -> dry(-25,-16) terr=111 cliff=6"
         },
         {
+          "x": -23,
+          "y": 30,
+          "details": "river surf=78 -> dry(-23,31) terr=76 cliff=2"
+        },
+        {
           "x": -22,
           "y": -24,
           "details": "river surf=169 -> dry(-23,-24) terr=163 cliff=6"
@@ -8803,6 +8843,11 @@
           "x": -22,
           "y": 20,
           "details": "river surf=130 -> dry(-23,20) terr=127 cliff=3"
+        },
+        {
+          "x": -22,
+          "y": 29,
+          "details": "river surf=102 -> dry(-22,30) terr=100 cliff=2"
         },
         {
           "x": -21,
@@ -8886,8 +8931,23 @@
         },
         {
           "x": -20,
+          "y": 34,
+          "details": "river surf=66 -> dry(-21,34) terr=64 cliff=2"
+        },
+        {
+          "x": -20,
+          "y": 36,
+          "details": "river surf=66 -> dry(-21,36) terr=64 cliff=2"
+        },
+        {
+          "x": -20,
           "y": 37,
-          "details": "river surf=54 -> dry(-21,37) terr=45 cliff=9"
+          "details": "river surf=54 -> dry(-21,37) terr=39 cliff=15"
+        },
+        {
+          "x": -20,
+          "y": 38,
+          "details": "river surf=42 -> dry(-21,38) terr=39 cliff=3"
         },
         {
           "x": -19,
@@ -9040,9 +9100,34 @@
           "details": "lake surf=168 -> dry(-6,28) terr=161 cliff=7"
         },
         {
+          "x": -4,
+          "y": -29,
+          "details": "river surf=174 -> dry(-4,-28) terr=172 cliff=2"
+        },
+        {
+          "x": -3,
+          "y": -51,
+          "details": "river surf=300 -> dry(-3,-52) terr=297 cliff=3"
+        },
+        {
+          "x": -2,
+          "y": -51,
+          "details": "river surf=288 -> dry(-1,-51) terr=285 cliff=3"
+        },
+        {
+          "x": -2,
+          "y": -41,
+          "details": "river surf=234 -> dry(-2,-40) terr=231 cliff=3"
+        },
+        {
           "x": -2,
           "y": -36,
           "details": "river surf=173 -> dry(-2,-35) terr=166 cliff=7"
+        },
+        {
+          "x": -1,
+          "y": -52,
+          "details": "river surf=264 -> dry(-1,-53) terr=261 cliff=3"
         },
         {
           "x": 3,
@@ -9152,7 +9237,7 @@
         {
           "x": 14,
           "y": 10,
-          "details": "lake surf=266 -> dry(14,9) terr=219 cliff=47"
+          "details": "lake surf=266 -> dry(14,9) terr=213 cliff=53"
         },
         {
           "x": 15,
@@ -9162,12 +9247,12 @@
         {
           "x": 15,
           "y": 10,
-          "details": "lake surf=266 -> dry(15,11) terr=215 cliff=51"
+          "details": "lake surf=266 -> dry(15,11) terr=209 cliff=57"
         },
         {
           "x": 15,
           "y": 13,
-          "details": "lake surf=274 -> dry(14,13) terr=203 cliff=71"
+          "details": "lake surf=274 -> dry(14,13) terr=198 cliff=76"
         },
         {
           "x": 15,
@@ -9187,7 +9272,12 @@
         {
           "x": 16,
           "y": 10,
-          "details": "river surf=192 -> dry(17,10) terr=171 cliff=21"
+          "details": "river surf=192 -> dry(17,10) terr=165 cliff=27"
+        },
+        {
+          "x": 16,
+          "y": 15,
+          "details": "river surf=108 -> dry(16,16) terr=106 cliff=2"
         },
         {
           "x": 17,
@@ -9205,9 +9295,24 @@
           "details": "river surf=223 -> dry(18,-2) terr=220 cliff=3"
         },
         {
+          "x": 17,
+          "y": 9,
+          "details": "river surf=168 -> dry(17,10) terr=165 cliff=3"
+        },
+        {
+          "x": 17,
+          "y": 13,
+          "details": "river surf=120 -> dry(17,14) terr=118 cliff=2"
+        },
+        {
           "x": 18,
           "y": -11,
           "details": "river surf=147 -> dry(18,-12) terr=144 cliff=3"
+        },
+        {
+          "x": 19,
+          "y": 9,
+          "details": "river surf=156 -> dry(20,9) terr=154 cliff=2"
         },
         {
           "x": 20,
@@ -9232,7 +9337,12 @@
         {
           "x": 35,
           "y": 14,
-          "details": "lake surf=130 -> dry(34,14) terr=120 cliff=10"
+          "details": "lake surf=130 -> dry(34,14) terr=115 cliff=15"
+        },
+        {
+          "x": 36,
+          "y": 15,
+          "details": "river surf=108 -> dry(36,16) terr=106 cliff=2"
         },
         {
           "x": 39,

--- a/tools/baselines/seed42_size32_region_-4_-4_4_4.json
+++ b/tools/baselines/seed42_size32_region_-4_-4_4_4.json
@@ -14,9 +14,9 @@
     "deterministic": true,
     "distinctHashes": 1,
     "hashes": [
-      "b9aafa1affd14ad0a5abd2cd7f7129e30867205d9573097f78eb98bbc2b03b38",
-      "b9aafa1affd14ad0a5abd2cd7f7129e30867205d9573097f78eb98bbc2b03b38",
-      "b9aafa1affd14ad0a5abd2cd7f7129e30867205d9573097f78eb98bbc2b03b38"
+      "12e7f64e7bda8e700dbd6f8bb232b8cdc3fd18e753ba085c8ee571da5307a8f7",
+      "12e7f64e7bda8e700dbd6f8bb232b8cdc3fd18e753ba085c8ee571da5307a8f7",
+      "12e7f64e7bda8e700dbd6f8bb232b8cdc3fd18e753ba085c8ee571da5307a8f7"
     ]
   },
   "tileCount": 20736,
@@ -76,13 +76,13 @@
   },
   "auditEnvelope": {
     "DESERT_SOIL_ON_SLOPE": {
-      "min": 46,
-      "max": 46,
-      "median": 46,
+      "min": 47,
+      "max": 47,
+      "median": 47,
       "all": [
-        46,
-        46,
-        46
+        47,
+        47,
+        47
       ]
     },
     "FLAT_ISOLATED_WATER": {
@@ -106,13 +106,13 @@
       ]
     },
     "FLOATING_WATER": {
-      "min": 174,
-      "max": 174,
-      "median": 174,
+      "min": 140,
+      "max": 140,
+      "median": 140,
       "all": [
-        174,
-        174,
-        174
+        140,
+        140,
+        140
       ]
     },
     "ISLAND_1TILE": {
@@ -136,13 +136,13 @@
       ]
     },
     "MID_RIVER_CLIFF": {
-      "min": 2,
-      "max": 2,
-      "median": 2,
+      "min": 30,
+      "max": 30,
+      "median": 30,
       "all": [
-        2,
-        2,
-        2
+        30,
+        30,
+        30
       ]
     },
     "MULTI_ISLAND": {
@@ -208,13 +208,13 @@
   },
   "representativeAudit": {
     "summary": {
-      "DESERT_SOIL_ON_SLOPE": 46,
+      "DESERT_SOIL_ON_SLOPE": 47,
       "FLAT_ISOLATED_WATER": 16,
       "FLOATING_LAKE": 2,
-      "FLOATING_WATER": 174,
+      "FLOATING_WATER": 140,
       "ISLAND_1TILE": 2,
       "ISOLATED_FLUID": 5,
-      "MID_RIVER_CLIFF": 2,
+      "MID_RIVER_CLIFF": 30,
       "MULTI_ISLAND": 16,
       "RIVER_CHUNK_GAP": 14,
       "RIVER_MOUTH_DROP": 3,
@@ -237,7 +237,7 @@
         {
           "x": -55,
           "y": 71,
-          "details": "sand maxNbrDelta=5"
+          "details": "sand maxNbrDelta=6"
         },
         {
           "x": -55,
@@ -252,12 +252,12 @@
         {
           "x": -54,
           "y": 70,
-          "details": "sand maxNbrDelta=4"
+          "details": "sand maxNbrDelta=5"
         },
         {
           "x": -53,
           "y": 69,
-          "details": "sand maxNbrDelta=4"
+          "details": "sand maxNbrDelta=3"
         },
         {
           "x": -48,
@@ -282,6 +282,11 @@
         {
           "x": -45,
           "y": 12,
+          "details": "sand maxNbrDelta=3"
+        },
+        {
+          "x": -45,
+          "y": 17,
           "details": "sand maxNbrDelta=3"
         },
         {
@@ -573,27 +578,17 @@
         {
           "x": -64,
           "y": 69,
-          "details": "river terr=75 -> dry(-63,69) terr=70 gap=5"
+          "details": "river terr=74 -> dry(-63,69) terr=70 gap=4"
         },
         {
           "x": -64,
           "y": 70,
-          "details": "river terr=67 -> dry(-63,70) terr=61 gap=6"
+          "details": "river terr=65 -> dry(-63,70) terr=61 gap=4"
         },
         {
           "x": -64,
           "y": 71,
-          "details": "river terr=58 -> dry(-63,71) terr=51 gap=7"
-        },
-        {
-          "x": -63,
-          "y": 15,
-          "details": "river terr=133 -> dry(-63,16) terr=132 gap=1"
-        },
-        {
-          "x": -63,
-          "y": 33,
-          "details": "river terr=130 -> dry(-64,33) terr=129 gap=1"
+          "details": "river terr=55 -> dry(-63,71) terr=51 gap=4"
         },
         {
           "x": -63,
@@ -607,11 +602,6 @@
         },
         {
           "x": -62,
-          "y": 13,
-          "details": "river terr=134 -> dry(-62,14) terr=130 gap=4"
-        },
-        {
-          "x": -62,
           "y": 24,
           "details": "river terr=155 -> dry(-62,25) terr=153 gap=2"
         },
@@ -619,11 +609,6 @@
           "x": -62,
           "y": 65,
           "details": "river terr=87 -> dry(-62,66) terr=84 gap=3"
-        },
-        {
-          "x": -62,
-          "y": 72,
-          "details": "river terr=33 -> dry(-61,72) terr=30 gap=3"
         },
         {
           "x": -61,
@@ -637,23 +622,13 @@
         },
         {
           "x": -61,
-          "y": 13,
-          "details": "river terr=122 -> dry(-61,14) terr=121 gap=1"
-        },
-        {
-          "x": -61,
           "y": 22,
-          "details": "river terr=145 -> dry(-61,21) terr=142 gap=3"
+          "details": "river terr=143 -> dry(-61,21) terr=142 gap=1"
         },
         {
           "x": -61,
           "y": 65,
           "details": "river terr=79 -> dry(-61,66) terr=76 gap=3"
-        },
-        {
-          "x": -61,
-          "y": 73,
-          "details": "river terr=21 -> dry(-60,73) terr=19 gap=2"
         },
         {
           "x": -60,
@@ -663,17 +638,17 @@
         {
           "x": -60,
           "y": 21,
-          "details": "river terr=132 -> dry(-60,20) terr=129 gap=3"
+          "details": "river terr=130 -> dry(-60,20) terr=129 gap=1"
         },
         {
           "x": -60,
           "y": 35,
-          "details": "river terr=132 -> dry(-61,35) terr=131 gap=1"
+          "details": "river terr=131 -> dry(-59,35) terr=128 gap=3"
         },
         {
           "x": -60,
           "y": 36,
-          "details": "river terr=121 -> dry(-59,36) terr=117 gap=4"
+          "details": "river terr=120 -> dry(-59,36) terr=117 gap=3"
         },
         {
           "x": -60,
@@ -683,7 +658,7 @@
         {
           "x": -60,
           "y": 65,
-          "details": "river terr=70 -> dry(-60,66) terr=65 gap=5"
+          "details": "river terr=68 -> dry(-60,66) terr=65 gap=3"
         },
         {
           "x": -60,
@@ -693,7 +668,7 @@
         {
           "x": -59,
           "y": 20,
-          "details": "river terr=119 -> dry(-59,19) terr=115 gap=4"
+          "details": "river terr=116 -> dry(-59,19) terr=115 gap=1"
         },
         {
           "x": -59,
@@ -703,12 +678,7 @@
         {
           "x": -59,
           "y": 60,
-          "details": "river terr=90 -> dry(-58,60) terr=86 gap=4"
-        },
-        {
-          "x": -59,
-          "y": 61,
-          "details": "river terr=83 -> dry(-58,61) terr=82 gap=1"
+          "details": "river terr=88 -> dry(-58,60) terr=86 gap=2"
         },
         {
           "x": -59,
@@ -732,18 +702,8 @@
         },
         {
           "x": -58,
-          "y": 19,
-          "details": "river terr=109 -> dry(-57,19) terr=108 gap=1"
-        },
-        {
-          "x": -58,
-          "y": 21,
-          "details": "river terr=118 -> dry(-57,21) terr=116 gap=2"
-        },
-        {
-          "x": -58,
           "y": 27,
-          "details": "river terr=124 -> dry(-57,27) terr=118 gap=6"
+          "details": "river terr=121 -> dry(-57,27) terr=118 gap=3"
         },
         {
           "x": -58,
@@ -763,12 +723,7 @@
         {
           "x": -57,
           "y": 1,
-          "details": "river terr=107 -> dry(-56,1) terr=103 gap=4"
-        },
-        {
-          "x": -57,
-          "y": 14,
-          "details": "river terr=83 -> dry(-56,14) terr=81 gap=2"
+          "details": "river terr=105 -> dry(-56,1) terr=103 gap=2"
         },
         {
           "x": -57,
@@ -788,12 +743,7 @@
         {
           "x": -57,
           "y": 65,
-          "details": "river terr=52 -> dry(-56,65) terr=48 gap=4"
-        },
-        {
-          "x": -57,
-          "y": 66,
-          "details": "river terr=43 -> dry(-56,66) terr=40 gap=3"
+          "details": "river terr=50 -> dry(-56,65) terr=48 gap=2"
         },
         {
           "x": -57,
@@ -813,7 +763,7 @@
         {
           "x": -56,
           "y": 18,
-          "details": "river terr=97 -> dry(-55,18) terr=94 gap=3"
+          "details": "river terr=96 -> dry(-55,18) terr=94 gap=2"
         },
         {
           "x": -56,
@@ -827,18 +777,13 @@
         },
         {
           "x": -56,
-          "y": 33,
-          "details": "river terr=88 -> dry(-56,34) terr=84 gap=4"
-        },
-        {
-          "x": -56,
           "y": 48,
           "details": "river terr=105 -> dry(-55,48) terr=101 gap=4"
         },
         {
           "x": -56,
           "y": 49,
-          "details": "river terr=98 -> dry(-55,49) terr=92 gap=6"
+          "details": "river terr=97 -> dry(-55,49) terr=92 gap=5"
         },
         {
           "x": -56,
@@ -848,7 +793,7 @@
         {
           "x": -56,
           "y": 69,
-          "details": "river terr=19 -> dry(-56,70) terr=15 gap=4"
+          "details": "river terr=18 -> dry(-56,70) terr=15 gap=3"
         },
         {
           "x": -55,
@@ -858,7 +803,7 @@
         {
           "x": -55,
           "y": -7,
-          "details": "river terr=83 -> dry(-54,-7) terr=77 gap=6"
+          "details": "river terr=82 -> dry(-54,-7) terr=77 gap=5"
         },
         {
           "x": -55,
@@ -868,7 +813,7 @@
         {
           "x": -55,
           "y": 37,
-          "details": "river terr=77 -> dry(-54,37) terr=70 gap=7"
+          "details": "river terr=74 -> dry(-54,37) terr=70 gap=4"
         },
         {
           "x": -55,
@@ -888,17 +833,17 @@
         {
           "x": -54,
           "y": 26,
-          "details": "river terr=92 -> dry(-53,26) terr=86 gap=6"
+          "details": "river terr=90 -> dry(-53,26) terr=86 gap=4"
         },
         {
           "x": -54,
           "y": 27,
-          "details": "river terr=80 -> dry(-53,27) terr=75 gap=5"
+          "details": "river terr=76 -> dry(-53,27) terr=75 gap=1"
         },
         {
           "x": -54,
           "y": 38,
-          "details": "river terr=76 -> dry(-54,37) terr=70 gap=6"
+          "details": "river terr=73 -> dry(-54,37) terr=70 gap=3"
         },
         {
           "x": -54,
@@ -928,17 +873,12 @@
         {
           "x": -53,
           "y": 38,
-          "details": "river terr=66 -> dry(-53,37) terr=60 gap=6"
-        },
-        {
-          "x": -53,
-          "y": 47,
-          "details": "river terr=89 -> dry(-53,48) terr=88 gap=1"
+          "details": "river terr=62 -> dry(-53,37) terr=60 gap=2"
         },
         {
           "x": -53,
           "y": 61,
-          "details": "river terr=47 -> dry(-53,62) terr=40 gap=7"
+          "details": "river terr=43 -> dry(-53,62) terr=40 gap=3"
         },
         {
           "x": -52,
@@ -948,27 +888,17 @@
         {
           "x": -52,
           "y": 9,
-          "details": "river terr=51 -> dry(-51,9) terr=47 gap=4"
-        },
-        {
-          "x": -52,
-          "y": 21,
-          "details": "river terr=79 -> dry(-52,20) terr=77 gap=2"
+          "details": "river terr=48 -> dry(-51,9) terr=47 gap=1"
         },
         {
           "x": -52,
           "y": 25,
-          "details": "river terr=83 -> dry(-52,26) terr=74 gap=9"
+          "details": "river terr=81 -> dry(-52,26) terr=74 gap=7"
         },
         {
           "x": -52,
           "y": 38,
-          "details": "river terr=55 -> dry(-52,37) terr=48 gap=7"
-        },
-        {
-          "x": -52,
-          "y": 64,
-          "details": "river terr=17 -> dry(-52,65) terr=14 gap=3"
+          "details": "river terr=50 -> dry(-52,37) terr=48 gap=2"
         },
         {
           "x": -51,
@@ -978,37 +908,17 @@
         {
           "x": -51,
           "y": -3,
-          "details": "river terr=76 -> dry(-51,-4) terr=72 gap=4"
-        },
-        {
-          "x": -51,
-          "y": 8,
-          "details": "river terr=49 -> dry(-51,9) terr=47 gap=2"
+          "details": "river terr=74 -> dry(-51,-4) terr=72 gap=2"
         },
         {
           "x": -51,
           "y": 16,
-          "details": "river terr=35 -> dry(-50,16) terr=28 gap=7"
-        },
-        {
-          "x": -51,
-          "y": 20,
-          "details": "river terr=55 -> dry(-50,20) terr=53 gap=2"
-        },
-        {
-          "x": -51,
-          "y": 21,
-          "details": "river terr=67 -> dry(-50,21) terr=64 gap=3"
+          "details": "river terr=31 -> dry(-50,16) terr=28 gap=3"
         },
         {
           "x": -51,
           "y": 25,
-          "details": "river terr=72 -> dry(-50,25) terr=64 gap=8"
-        },
-        {
-          "x": -51,
-          "y": 26,
-          "details": "river terr=60 -> dry(-50,26) terr=55 gap=5"
+          "details": "river terr=69 -> dry(-50,25) terr=64 gap=5"
         },
         {
           "x": -50,
@@ -1018,87 +928,57 @@
         {
           "x": -50,
           "y": -4,
-          "details": "river terr=61 -> dry(-50,-5) terr=56 gap=5"
-        },
-        {
-          "x": -50,
-          "y": 8,
-          "details": "river terr=43 -> dry(-50,9) terr=41 gap=2"
+          "details": "river terr=58 -> dry(-50,-5) terr=56 gap=2"
         },
         {
           "x": -50,
           "y": 17,
-          "details": "river terr=33 -> dry(-50,16) terr=28 gap=5"
+          "details": "river terr=30 -> dry(-50,16) terr=28 gap=2"
         },
         {
           "x": -50,
           "y": 22,
-          "details": "river terr=69 -> dry(-50,21) terr=64 gap=5"
+          "details": "river terr=67 -> dry(-50,21) terr=64 gap=3"
         },
         {
           "x": -50,
           "y": 24,
-          "details": "river terr=69 -> dry(-50,25) terr=64 gap=5"
-        },
-        {
-          "x": -50,
-          "y": 27,
-          "details": "river terr=46 -> dry(-49,27) terr=41 gap=5"
+          "details": "river terr=66 -> dry(-50,25) terr=64 gap=2"
         },
         {
           "x": -50,
           "y": 59,
-          "details": "river terr=34 -> dry(-49,59) terr=29 gap=5"
+          "details": "river terr=31 -> dry(-49,59) terr=29 gap=2"
         },
         {
           "x": -50,
           "y": 60,
-          "details": "river terr=27 -> dry(-49,60) terr=23 gap=4"
-        },
-        {
-          "x": -50,
-          "y": 61,
-          "details": "river terr=20 -> dry(-49,61) terr=17 gap=3"
-        },
-        {
-          "x": -50,
-          "y": 62,
-          "details": "river terr=14 -> dry(-49,62) terr=12 gap=2"
+          "details": "river terr=24 -> dry(-49,60) terr=23 gap=1"
         },
         {
           "x": -49,
           "y": -4,
-          "details": "river terr=50 -> dry(-49,-5) terr=47 gap=3"
-        },
-        {
-          "x": -49,
-          "y": 8,
-          "details": "river terr=37 -> dry(-49,9) terr=35 gap=2"
+          "details": "river terr=48 -> dry(-49,-5) terr=47 gap=1"
         },
         {
           "x": -49,
           "y": 17,
-          "details": "river terr=26 -> dry(-49,16) terr=22 gap=4"
+          "details": "river terr=24 -> dry(-49,16) terr=22 gap=2"
         },
         {
           "x": -49,
           "y": 22,
-          "details": "river terr=60 -> dry(-49,21) terr=56 gap=4"
+          "details": "river terr=58 -> dry(-49,21) terr=56 gap=2"
         },
         {
           "x": -49,
           "y": 24,
-          "details": "river terr=60 -> dry(-49,25) terr=56 gap=4"
-        },
-        {
-          "x": -49,
-          "y": 41,
-          "details": "river terr=46 -> dry(-48,41) terr=43 gap=3"
+          "details": "river terr=57 -> dry(-49,25) terr=56 gap=1"
         },
         {
           "x": -49,
           "y": 42,
-          "details": "river terr=52 -> dry(-48,42) terr=49 gap=3"
+          "details": "river terr=50 -> dry(-48,42) terr=49 gap=1"
         },
         {
           "x": -49,
@@ -1108,7 +988,7 @@
         {
           "x": -49,
           "y": 58,
-          "details": "river terr=33 -> dry(-49,59) terr=29 gap=4"
+          "details": "river terr=31 -> dry(-49,59) terr=29 gap=2"
         },
         {
           "x": -48,
@@ -1118,27 +998,12 @@
         {
           "x": -48,
           "y": -4,
-          "details": "river terr=40 -> dry(-48,-5) terr=37 gap=3"
-        },
-        {
-          "x": -48,
-          "y": 17,
-          "details": "river terr=19 -> dry(-48,16) terr=17 gap=2"
-        },
-        {
-          "x": -48,
-          "y": 22,
-          "details": "river terr=51 -> dry(-48,21) terr=48 gap=3"
-        },
-        {
-          "x": -48,
-          "y": 24,
-          "details": "river terr=50 -> dry(-48,25) terr=48 gap=2"
+          "details": "river terr=38 -> dry(-48,-5) terr=37 gap=1"
         },
         {
           "x": -48,
           "y": 40,
-          "details": "river terr=36 -> dry(-47,40) terr=33 gap=3"
+          "details": "river terr=35 -> dry(-47,40) terr=33 gap=2"
         },
         {
           "x": -48,
@@ -1153,57 +1018,32 @@
         {
           "x": -47,
           "y": -4,
-          "details": "river terr=30 -> dry(-47,-5) terr=27 gap=3"
-        },
-        {
-          "x": -47,
-          "y": 17,
-          "details": "river terr=12 -> dry(-47,16) terr=11 gap=1"
-        },
-        {
-          "x": -47,
-          "y": 22,
-          "details": "river terr=41 -> dry(-47,21) terr=39 gap=2"
-        },
-        {
-          "x": -47,
-          "y": 24,
-          "details": "river terr=41 -> dry(-47,25) terr=40 gap=1"
+          "details": "river terr=29 -> dry(-47,-5) terr=27 gap=2"
         },
         {
           "x": -47,
           "y": 39,
-          "details": "river terr=26 -> dry(-46,39) terr=22 gap=4"
+          "details": "river terr=25 -> dry(-46,39) terr=22 gap=3"
         },
         {
           "x": -47,
           "y": 47,
-          "details": "river terr=37 -> dry(-46,47) terr=33 gap=4"
-        },
-        {
-          "x": -47,
-          "y": 48,
-          "details": "river terr=31 -> dry(-46,48) terr=27 gap=4"
+          "details": "river terr=34 -> dry(-46,47) terr=33 gap=1"
         },
         {
           "x": -47,
           "y": 58,
-          "details": "river terr=20 -> dry(-47,59) terr=17 gap=3"
+          "details": "river terr=19 -> dry(-47,59) terr=17 gap=2"
         },
         {
           "x": -46,
           "y": 18,
-          "details": "river terr=9 -> dry(-45,18) terr=4 gap=5"
+          "details": "river terr=5 -> dry(-45,18) terr=4 gap=1"
         },
         {
           "x": -46,
           "y": 22,
-          "details": "river terr=32 -> dry(-46,21) terr=29 gap=3"
-        },
-        {
-          "x": -46,
-          "y": 25,
-          "details": "river terr=31 -> dry(-46,26) terr=29 gap=2"
+          "details": "river terr=30 -> dry(-46,21) terr=29 gap=1"
         },
         {
           "x": -46,
@@ -1217,18 +1057,13 @@
         },
         {
           "x": -45,
-          "y": 20,
-          "details": "river terr=13 -> dry(-44,20) terr=9 gap=4"
-        },
-        {
-          "x": -45,
           "y": 21,
-          "details": "river terr=20 -> dry(-44,21) terr=14 gap=6"
+          "details": "river terr=17 -> dry(-44,21) terr=14 gap=3"
         },
         {
           "x": -45,
           "y": 40,
-          "details": "river terr=22 -> dry(-44,40) terr=19 gap=3"
+          "details": "river terr=20 -> dry(-44,40) terr=19 gap=1"
         },
         {
           "x": -45,
@@ -1263,12 +1098,12 @@
         {
           "x": -44,
           "y": 47,
-          "details": "river terr=21 -> dry(-43,47) terr=18 gap=3"
+          "details": "river terr=19 -> dry(-43,47) terr=18 gap=1"
         },
         {
           "x": -44,
           "y": 48,
-          "details": "river terr=16 -> dry(-43,48) terr=13 gap=3"
+          "details": "river terr=14 -> dry(-43,48) terr=13 gap=1"
         },
         {
           "x": -43,
@@ -1462,14 +1297,154 @@
       ],
       "MID_RIVER_CLIFF": [
         {
+          "x": -64,
+          "y": 77,
+          "details": "river surf=18 (terr=15) -> water nbr surf=14 (terr=13) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -64,
+          "y": 77,
+          "details": "river surf=18 (terr=15) -> water nbr surf=16 (terr=15) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -63,
+          "y": 36,
+          "details": "river surf=122 (terr=119) -> water nbr surf=120 (terr=119) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -63,
+          "y": 76,
+          "details": "river surf=17 (terr=14) -> water nbr surf=14 (terr=13) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -61,
+          "y": 74,
+          "details": "river surf=18 (terr=15) -> water nbr surf=15 (terr=14) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -60,
+          "y": 63,
+          "details": "river surf=77 (terr=74) -> water nbr surf=74 (terr=73) surf_diff=3 terr_diff=1"
+        },
+        {
           "x": -58,
-          "y": 68,
-          "details": "river surf=41 (terr=35) -> water nbr surf=37 (terr=37) surf_diff=4 terr_diff=2"
+          "y": 14,
+          "details": "river surf=87 (terr=81) -> water nbr surf=84 (terr=80) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -58,
+          "y": 64,
+          "details": "river surf=64 (terr=61) -> water nbr surf=61 (terr=60) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -57,
+          "y": 13,
+          "details": "river surf=80 (terr=75) -> water nbr surf=78 (terr=75) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -56,
+          "y": 13,
+          "details": "river surf=78 (terr=75) -> water nbr surf=74 (terr=73) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -54,
+          "y": 69,
+          "details": "river surf=9 (terr=4) -> water nbr surf=6 (terr=3) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -54,
+          "y": 70,
+          "details": "river surf=6 (terr=3) -> water nbr surf=4 (terr=3) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -53,
+          "y": 3,
+          "details": "river surf=80 (terr=77) -> water nbr surf=77 (terr=76) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -53,
+          "y": 67,
+          "details": "river surf=8 (terr=1) -> water nbr surf=5 (terr=1) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -53,
+          "y": 69,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -53,
+          "y": 69,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -52,
+          "y": 4,
+          "details": "river surf=71 (terr=68) -> water nbr surf=67 (terr=66) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -52,
+          "y": 49,
+          "details": "river surf=78 (terr=75) -> water nbr surf=75 (terr=74) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -51,
+          "y": 28,
+          "details": "river surf=47 (terr=41) -> water nbr surf=44 (terr=40) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -51,
+          "y": 65,
+          "details": "river surf=6 (terr=2) -> water nbr surf=3 (terr=1) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -50,
+          "y": 37,
+          "details": "river surf=34 (terr=30) -> water nbr surf=30 (terr=28) surf_diff=4 terr_diff=2"
         },
         {
           "x": -49,
-          "y": -7,
-          "details": "river surf=35 (terr=32) -> water nbr surf=31 (terr=30) surf_diff=4 terr_diff=2"
+          "y": 15,
+          "details": "river surf=18 (terr=14) -> water nbr surf=15 (terr=14) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -49,
+          "y": 39,
+          "details": "river surf=37 (terr=31) -> water nbr surf=33 (terr=33) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -48,
+          "y": -8,
+          "details": "river surf=32 (terr=29) -> water nbr surf=28 (terr=27) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -47,
+          "y": 0,
+          "details": "river surf=20 (terr=16) -> water nbr surf=16 (terr=14) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -47,
+          "y": 11,
+          "details": "river surf=14 (terr=10) -> water nbr surf=11 (terr=10) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -47,
+          "y": 29,
+          "details": "river surf=24 (terr=21) -> water nbr surf=20 (terr=19) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -46,
+          "y": 10,
+          "details": "river surf=7 (terr=4) -> water nbr surf=5 (terr=4) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -46,
+          "y": 28,
+          "details": "river surf=20 (terr=17) -> water nbr surf=17 (terr=16) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -45,
+          "y": 50,
+          "details": "river surf=12 (terr=9) -> water nbr surf=8 (terr=7) surf_diff=4 terr_diff=2"
         }
       ],
       "MULTI_ISLAND": [
@@ -1667,27 +1642,27 @@
         {
           "x": -64,
           "y": 69,
-          "details": "river surf=76 terr=75 -> land(-63,69) terr=70 cliff=6"
+          "details": "river surf=76 terr=74 -> land(-63,69) terr=70 cliff=6"
         },
         {
           "x": -64,
           "y": 70,
-          "details": "river surf=68 terr=67 -> land(-63,70) terr=61 cliff=7"
+          "details": "river surf=68 terr=65 -> land(-63,70) terr=61 cliff=7"
         },
         {
           "x": -64,
           "y": 71,
-          "details": "river surf=59 terr=58 -> land(-63,71) terr=51 cliff=8"
+          "details": "river surf=59 terr=55 -> land(-63,71) terr=51 cliff=8"
         },
         {
           "x": -63,
           "y": 15,
-          "details": "river surf=134 terr=133 -> land(-63,16) terr=132 cliff=2"
+          "details": "river surf=134 terr=132 -> land(-63,16) terr=132 cliff=2"
         },
         {
           "x": -63,
           "y": 33,
-          "details": "river surf=131 terr=130 -> land(-64,33) terr=129 cliff=2"
+          "details": "river surf=131 terr=125 -> land(-64,33) terr=129 cliff=2"
         },
         {
           "x": -63,
@@ -1702,7 +1677,7 @@
         {
           "x": -62,
           "y": 13,
-          "details": "river surf=135 terr=134 -> land(-62,14) terr=130 cliff=5"
+          "details": "river surf=135 terr=130 -> land(-62,14) terr=130 cliff=5"
         },
         {
           "x": -62,
@@ -1717,7 +1692,7 @@
         {
           "x": -62,
           "y": 72,
-          "details": "river surf=34 terr=33 -> land(-61,72) terr=30 cliff=4"
+          "details": "river surf=34 terr=30 -> land(-61,72) terr=30 cliff=4"
         },
         {
           "x": -61,
@@ -1732,12 +1707,12 @@
         {
           "x": -61,
           "y": 13,
-          "details": "river surf=123 terr=122 -> land(-61,14) terr=121 cliff=2"
+          "details": "river surf=123 terr=118 -> land(-61,14) terr=121 cliff=2"
         },
         {
           "x": -61,
           "y": 22,
-          "details": "river surf=146 terr=145 -> land(-61,21) terr=142 cliff=4"
+          "details": "river surf=146 terr=143 -> land(-61,21) terr=142 cliff=4"
         },
         {
           "x": -61,
@@ -1747,7 +1722,7 @@
         {
           "x": -61,
           "y": 73,
-          "details": "river surf=22 terr=21 -> land(-60,73) terr=19 cliff=3"
+          "details": "river surf=22 terr=19 -> land(-60,73) terr=19 cliff=3"
         },
         {
           "x": -60,
@@ -1757,17 +1732,17 @@
         {
           "x": -60,
           "y": 21,
-          "details": "river surf=133 terr=132 -> land(-60,20) terr=129 cliff=4"
+          "details": "river surf=133 terr=130 -> land(-60,20) terr=129 cliff=4"
         },
         {
           "x": -60,
           "y": 35,
-          "details": "river surf=133 terr=132 -> land(-61,35) terr=131 cliff=2"
+          "details": "river surf=133 terr=131 -> land(-61,35) terr=131 cliff=2"
         },
         {
           "x": -60,
           "y": 36,
-          "details": "river surf=122 terr=121 -> land(-59,36) terr=117 cliff=5"
+          "details": "river surf=122 terr=120 -> land(-59,36) terr=117 cliff=5"
         },
         {
           "x": -60,
@@ -1777,7 +1752,7 @@
         {
           "x": -60,
           "y": 65,
-          "details": "river surf=71 terr=70 -> land(-60,66) terr=65 cliff=6"
+          "details": "river surf=71 terr=68 -> land(-60,66) terr=65 cliff=6"
         },
         {
           "x": -60,
@@ -1787,7 +1762,7 @@
         {
           "x": -59,
           "y": 20,
-          "details": "river surf=120 terr=119 -> land(-59,19) terr=115 cliff=5"
+          "details": "river surf=120 terr=116 -> land(-59,19) terr=115 cliff=5"
         },
         {
           "x": -59,
@@ -1797,12 +1772,12 @@
         {
           "x": -59,
           "y": 60,
-          "details": "river surf=91 terr=90 -> land(-58,60) terr=86 cliff=5"
+          "details": "river surf=91 terr=88 -> land(-58,60) terr=86 cliff=5"
         },
         {
           "x": -59,
           "y": 61,
-          "details": "river surf=84 terr=83 -> land(-58,61) terr=82 cliff=2"
+          "details": "river surf=84 terr=81 -> land(-58,61) terr=82 cliff=2"
         },
         {
           "x": -59,
@@ -1827,17 +1802,17 @@
         {
           "x": -58,
           "y": 19,
-          "details": "river surf=110 terr=109 -> land(-57,19) terr=108 cliff=2"
+          "details": "river surf=110 terr=107 -> land(-57,19) terr=108 cliff=2"
         },
         {
           "x": -58,
           "y": 21,
-          "details": "river surf=119 terr=118 -> land(-57,21) terr=116 cliff=3"
+          "details": "river surf=119 terr=116 -> land(-57,21) terr=116 cliff=3"
         },
         {
           "x": -58,
           "y": 27,
-          "details": "river surf=125 terr=124 -> land(-57,27) terr=118 cliff=7"
+          "details": "river surf=125 terr=121 -> land(-57,27) terr=118 cliff=7"
         },
         {
           "x": -58,
@@ -1857,12 +1832,12 @@
         {
           "x": -57,
           "y": 1,
-          "details": "river surf=108 terr=107 -> land(-56,1) terr=103 cliff=5"
+          "details": "river surf=108 terr=105 -> land(-56,1) terr=103 cliff=5"
         },
         {
           "x": -57,
           "y": 14,
-          "details": "river surf=84 terr=83 -> land(-56,14) terr=81 cliff=3"
+          "details": "river surf=84 terr=80 -> land(-56,14) terr=81 cliff=3"
         },
         {
           "x": -57,
@@ -1882,12 +1857,12 @@
         {
           "x": -57,
           "y": 65,
-          "details": "river surf=53 terr=52 -> land(-56,65) terr=48 cliff=5"
+          "details": "river surf=53 terr=50 -> land(-56,65) terr=48 cliff=5"
         },
         {
           "x": -57,
           "y": 66,
-          "details": "river surf=44 terr=43 -> land(-56,66) terr=40 cliff=4"
+          "details": "river surf=44 terr=40 -> land(-56,66) terr=40 cliff=4"
         },
         {
           "x": -57,
@@ -1907,7 +1882,7 @@
         {
           "x": -56,
           "y": 18,
-          "details": "river surf=98 terr=97 -> land(-55,18) terr=94 cliff=4"
+          "details": "river surf=98 terr=96 -> land(-55,18) terr=94 cliff=4"
         },
         {
           "x": -56,
@@ -1922,7 +1897,7 @@
         {
           "x": -56,
           "y": 33,
-          "details": "river surf=89 terr=88 -> land(-56,34) terr=84 cliff=5"
+          "details": "river surf=89 terr=84 -> land(-56,34) terr=84 cliff=5"
         },
         {
           "x": -56,
@@ -1932,7 +1907,7 @@
         {
           "x": -56,
           "y": 49,
-          "details": "river surf=99 terr=98 -> land(-55,49) terr=92 cliff=7"
+          "details": "river surf=99 terr=97 -> land(-55,49) terr=92 cliff=7"
         },
         {
           "x": -56,
@@ -1942,7 +1917,7 @@
         {
           "x": -56,
           "y": 69,
-          "details": "river surf=21 terr=19 -> land(-56,70) terr=15 cliff=6"
+          "details": "river surf=21 terr=18 -> land(-56,70) terr=15 cliff=6"
         },
         {
           "x": -55,
@@ -1952,7 +1927,7 @@
         {
           "x": -55,
           "y": -7,
-          "details": "river surf=84 terr=83 -> land(-54,-7) terr=77 cliff=7"
+          "details": "river surf=84 terr=82 -> land(-54,-7) terr=77 cliff=7"
         },
         {
           "x": -55,
@@ -1962,7 +1937,7 @@
         {
           "x": -55,
           "y": 37,
-          "details": "river surf=78 terr=77 -> land(-54,37) terr=70 cliff=8"
+          "details": "river surf=78 terr=74 -> land(-54,37) terr=70 cliff=8"
         },
         {
           "x": -55,
@@ -1982,17 +1957,17 @@
         {
           "x": -54,
           "y": 26,
-          "details": "river surf=93 terr=92 -> land(-53,26) terr=86 cliff=7"
+          "details": "river surf=93 terr=90 -> land(-53,26) terr=86 cliff=7"
         },
         {
           "x": -54,
           "y": 27,
-          "details": "river surf=81 terr=80 -> land(-53,27) terr=75 cliff=6"
+          "details": "river surf=81 terr=76 -> land(-53,27) terr=75 cliff=6"
         },
         {
           "x": -54,
           "y": 38,
-          "details": "river surf=77 terr=76 -> land(-54,37) terr=70 cliff=7"
+          "details": "river surf=77 terr=73 -> land(-54,37) terr=70 cliff=7"
         },
         {
           "x": -54,
@@ -2022,17 +1997,17 @@
         {
           "x": -53,
           "y": 38,
-          "details": "river surf=67 terr=66 -> land(-53,37) terr=60 cliff=7"
+          "details": "river surf=67 terr=62 -> land(-53,37) terr=60 cliff=7"
         },
         {
           "x": -53,
           "y": 47,
-          "details": "river surf=90 terr=89 -> land(-53,48) terr=88 cliff=2"
+          "details": "river surf=90 terr=87 -> land(-53,48) terr=88 cliff=2"
         },
         {
           "x": -53,
           "y": 61,
-          "details": "river surf=48 terr=47 -> land(-53,62) terr=40 cliff=8"
+          "details": "river surf=48 terr=43 -> land(-53,62) terr=40 cliff=8"
         },
         {
           "x": -52,
@@ -2042,27 +2017,27 @@
         {
           "x": -52,
           "y": 9,
-          "details": "river surf=52 terr=51 -> land(-51,9) terr=47 cliff=5"
+          "details": "river surf=52 terr=48 -> land(-51,9) terr=47 cliff=5"
         },
         {
           "x": -52,
           "y": 21,
-          "details": "river surf=80 terr=79 -> land(-52,20) terr=77 cliff=3"
+          "details": "river surf=80 terr=77 -> land(-52,20) terr=77 cliff=3"
         },
         {
           "x": -52,
           "y": 25,
-          "details": "river surf=84 terr=83 -> land(-52,26) terr=74 cliff=10"
+          "details": "river surf=84 terr=81 -> land(-52,26) terr=74 cliff=10"
         },
         {
           "x": -52,
           "y": 38,
-          "details": "river surf=56 terr=55 -> land(-52,37) terr=48 cliff=8"
+          "details": "river surf=56 terr=50 -> land(-52,37) terr=48 cliff=8"
         },
         {
           "x": -52,
           "y": 64,
-          "details": "river surf=18 terr=17 -> land(-52,65) terr=14 cliff=4"
+          "details": "river surf=18 terr=11 -> land(-52,65) terr=14 cliff=4"
         },
         {
           "x": -51,
@@ -2072,37 +2047,37 @@
         {
           "x": -51,
           "y": -3,
-          "details": "river surf=77 terr=76 -> land(-51,-4) terr=72 cliff=5"
+          "details": "river surf=77 terr=74 -> land(-51,-4) terr=72 cliff=5"
         },
         {
           "x": -51,
           "y": 8,
-          "details": "river surf=50 terr=49 -> land(-51,9) terr=47 cliff=3"
+          "details": "river surf=50 terr=47 -> land(-51,9) terr=47 cliff=3"
         },
         {
           "x": -51,
           "y": 16,
-          "details": "river surf=36 terr=35 -> land(-50,16) terr=28 cliff=8"
+          "details": "river surf=36 terr=31 -> land(-50,16) terr=28 cliff=8"
         },
         {
           "x": -51,
           "y": 20,
-          "details": "river surf=56 terr=55 -> land(-50,20) terr=53 cliff=3"
+          "details": "river surf=56 terr=51 -> land(-50,20) terr=53 cliff=3"
         },
         {
           "x": -51,
           "y": 21,
-          "details": "river surf=68 terr=67 -> land(-50,21) terr=64 cliff=4"
+          "details": "river surf=68 terr=63 -> land(-50,21) terr=64 cliff=4"
         },
         {
           "x": -51,
           "y": 25,
-          "details": "river surf=73 terr=72 -> land(-50,25) terr=64 cliff=9"
+          "details": "river surf=73 terr=69 -> land(-50,25) terr=64 cliff=9"
         },
         {
           "x": -51,
           "y": 26,
-          "details": "river surf=61 terr=60 -> land(-50,26) terr=55 cliff=6"
+          "details": "river surf=61 terr=55 -> land(-50,26) terr=55 cliff=6"
         },
         {
           "x": -50,
@@ -2112,87 +2087,87 @@
         {
           "x": -50,
           "y": -4,
-          "details": "river surf=62 terr=61 -> land(-50,-5) terr=56 cliff=6"
+          "details": "river surf=62 terr=58 -> land(-50,-5) terr=56 cliff=6"
         },
         {
           "x": -50,
           "y": 8,
-          "details": "river surf=44 terr=43 -> land(-50,9) terr=41 cliff=3"
+          "details": "river surf=44 terr=41 -> land(-50,9) terr=41 cliff=3"
         },
         {
           "x": -50,
           "y": 17,
-          "details": "river surf=34 terr=33 -> land(-50,16) terr=28 cliff=6"
+          "details": "river surf=34 terr=30 -> land(-50,16) terr=28 cliff=6"
         },
         {
           "x": -50,
           "y": 22,
-          "details": "river surf=70 terr=69 -> land(-50,21) terr=64 cliff=6"
+          "details": "river surf=70 terr=67 -> land(-50,21) terr=64 cliff=6"
         },
         {
           "x": -50,
           "y": 24,
-          "details": "river surf=70 terr=69 -> land(-50,25) terr=64 cliff=6"
+          "details": "river surf=70 terr=66 -> land(-50,25) terr=64 cliff=6"
         },
         {
           "x": -50,
           "y": 27,
-          "details": "river surf=47 terr=46 -> land(-49,27) terr=41 cliff=6"
+          "details": "river surf=47 terr=41 -> land(-49,27) terr=41 cliff=6"
         },
         {
           "x": -50,
           "y": 59,
-          "details": "river surf=35 terr=34 -> land(-49,59) terr=29 cliff=6"
+          "details": "river surf=35 terr=31 -> land(-49,59) terr=29 cliff=6"
         },
         {
           "x": -50,
           "y": 60,
-          "details": "river surf=28 terr=27 -> land(-49,60) terr=23 cliff=5"
+          "details": "river surf=28 terr=24 -> land(-49,60) terr=23 cliff=5"
         },
         {
           "x": -50,
           "y": 61,
-          "details": "river surf=21 terr=20 -> land(-49,61) terr=17 cliff=4"
+          "details": "river surf=21 terr=16 -> land(-49,61) terr=17 cliff=4"
         },
         {
           "x": -50,
           "y": 62,
-          "details": "river surf=15 terr=14 -> land(-49,62) terr=12 cliff=3"
+          "details": "river surf=15 terr=11 -> land(-49,62) terr=12 cliff=3"
         },
         {
           "x": -49,
           "y": -4,
-          "details": "river surf=51 terr=50 -> land(-49,-5) terr=47 cliff=4"
+          "details": "river surf=51 terr=48 -> land(-49,-5) terr=47 cliff=4"
         },
         {
           "x": -49,
           "y": 8,
-          "details": "river surf=38 terr=37 -> land(-49,9) terr=35 cliff=3"
+          "details": "river surf=38 terr=35 -> land(-49,9) terr=35 cliff=3"
         },
         {
           "x": -49,
           "y": 17,
-          "details": "river surf=27 terr=26 -> land(-49,16) terr=22 cliff=5"
+          "details": "river surf=27 terr=24 -> land(-49,16) terr=22 cliff=5"
         },
         {
           "x": -49,
           "y": 22,
-          "details": "river surf=61 terr=60 -> land(-49,21) terr=56 cliff=5"
+          "details": "river surf=61 terr=58 -> land(-49,21) terr=56 cliff=5"
         },
         {
           "x": -49,
           "y": 24,
-          "details": "river surf=61 terr=60 -> land(-49,25) terr=56 cliff=5"
+          "details": "river surf=61 terr=57 -> land(-49,25) terr=56 cliff=5"
         },
         {
           "x": -49,
           "y": 41,
-          "details": "river surf=47 terr=46 -> land(-48,41) terr=43 cliff=4"
+          "details": "river surf=47 terr=43 -> land(-48,41) terr=43 cliff=4"
         },
         {
           "x": -49,
           "y": 42,
-          "details": "river surf=53 terr=52 -> land(-48,42) terr=49 cliff=4"
+          "details": "river surf=53 terr=50 -> land(-48,42) terr=49 cliff=4"
         },
         {
           "x": -49,
@@ -2202,7 +2177,7 @@
         {
           "x": -49,
           "y": 58,
-          "details": "river surf=34 terr=33 -> land(-49,59) terr=29 cliff=5"
+          "details": "river surf=34 terr=31 -> land(-49,59) terr=29 cliff=5"
         },
         {
           "x": -48,
@@ -2212,27 +2187,27 @@
         {
           "x": -48,
           "y": -4,
-          "details": "river surf=41 terr=40 -> land(-48,-5) terr=37 cliff=4"
+          "details": "river surf=41 terr=38 -> land(-48,-5) terr=37 cliff=4"
         },
         {
           "x": -48,
           "y": 17,
-          "details": "river surf=20 terr=19 -> land(-48,16) terr=17 cliff=3"
+          "details": "river surf=20 terr=16 -> land(-48,16) terr=17 cliff=3"
         },
         {
           "x": -48,
           "y": 22,
-          "details": "river surf=52 terr=51 -> land(-48,21) terr=48 cliff=4"
+          "details": "river surf=52 terr=48 -> land(-48,21) terr=48 cliff=4"
         },
         {
           "x": -48,
           "y": 24,
-          "details": "river surf=51 terr=50 -> land(-48,25) terr=48 cliff=3"
+          "details": "river surf=51 terr=47 -> land(-48,25) terr=48 cliff=3"
         },
         {
           "x": -48,
           "y": 40,
-          "details": "river surf=37 terr=36 -> land(-47,40) terr=33 cliff=4"
+          "details": "river surf=37 terr=35 -> land(-47,40) terr=33 cliff=4"
         },
         {
           "x": -48,
@@ -2247,57 +2222,57 @@
         {
           "x": -47,
           "y": -4,
-          "details": "river surf=31 terr=30 -> land(-47,-5) terr=27 cliff=4"
+          "details": "river surf=31 terr=29 -> land(-47,-5) terr=27 cliff=4"
         },
         {
           "x": -47,
           "y": 17,
-          "details": "river surf=13 terr=12 -> land(-47,16) terr=11 cliff=2"
+          "details": "river surf=13 terr=9 -> land(-47,16) terr=11 cliff=2"
         },
         {
           "x": -47,
           "y": 22,
-          "details": "river surf=42 terr=41 -> land(-47,21) terr=39 cliff=3"
+          "details": "river surf=42 terr=38 -> land(-47,21) terr=39 cliff=3"
         },
         {
           "x": -47,
           "y": 24,
-          "details": "river surf=42 terr=41 -> land(-47,25) terr=40 cliff=2"
+          "details": "river surf=42 terr=38 -> land(-47,25) terr=40 cliff=2"
         },
         {
           "x": -47,
           "y": 39,
-          "details": "river surf=27 terr=26 -> land(-46,39) terr=22 cliff=5"
+          "details": "river surf=27 terr=25 -> land(-46,39) terr=22 cliff=5"
         },
         {
           "x": -47,
           "y": 47,
-          "details": "river surf=38 terr=37 -> land(-46,47) terr=33 cliff=5"
+          "details": "river surf=38 terr=34 -> land(-46,47) terr=33 cliff=5"
         },
         {
           "x": -47,
           "y": 48,
-          "details": "river surf=32 terr=31 -> land(-46,48) terr=27 cliff=5"
+          "details": "river surf=32 terr=27 -> land(-46,48) terr=27 cliff=5"
         },
         {
           "x": -47,
           "y": 58,
-          "details": "river surf=21 terr=20 -> land(-47,59) terr=17 cliff=4"
+          "details": "river surf=21 terr=19 -> land(-47,59) terr=17 cliff=4"
         },
         {
           "x": -46,
           "y": 18,
-          "details": "river surf=10 terr=9 -> land(-45,18) terr=4 cliff=6"
+          "details": "river surf=10 terr=5 -> land(-45,18) terr=4 cliff=6"
         },
         {
           "x": -46,
           "y": 22,
-          "details": "river surf=33 terr=32 -> land(-46,21) terr=29 cliff=4"
+          "details": "river surf=33 terr=30 -> land(-46,21) terr=29 cliff=4"
         },
         {
           "x": -46,
           "y": 25,
-          "details": "river surf=32 terr=31 -> land(-46,26) terr=29 cliff=3"
+          "details": "river surf=32 terr=28 -> land(-46,26) terr=29 cliff=3"
         },
         {
           "x": -46,
@@ -2312,17 +2287,17 @@
         {
           "x": -45,
           "y": 20,
-          "details": "river surf=14 terr=13 -> land(-44,20) terr=9 cliff=5"
+          "details": "river surf=14 terr=9 -> land(-44,20) terr=9 cliff=5"
         },
         {
           "x": -45,
           "y": 21,
-          "details": "river surf=21 terr=20 -> land(-44,21) terr=14 cliff=7"
+          "details": "river surf=21 terr=17 -> land(-44,21) terr=14 cliff=7"
         },
         {
           "x": -45,
           "y": 40,
-          "details": "river surf=23 terr=22 -> land(-44,40) terr=19 cliff=4"
+          "details": "river surf=23 terr=20 -> land(-44,40) terr=19 cliff=4"
         },
         {
           "x": -45,
@@ -2357,12 +2332,12 @@
         {
           "x": -44,
           "y": 47,
-          "details": "river surf=22 terr=21 -> land(-43,47) terr=18 cliff=4"
+          "details": "river surf=22 terr=19 -> land(-43,47) terr=18 cliff=4"
         },
         {
           "x": -44,
           "y": 48,
-          "details": "river surf=17 terr=16 -> land(-43,48) terr=13 cliff=4"
+          "details": "river surf=17 terr=14 -> land(-43,48) terr=13 cliff=4"
         },
         {
           "x": -43,

--- a/tools/baselines/seed4567_size32_region_-4_-4_4_4.json
+++ b/tools/baselines/seed4567_size32_region_-4_-4_4_4.json
@@ -14,16 +14,16 @@
     "deterministic": true,
     "distinctHashes": 1,
     "hashes": [
-      "b0f115694a855cd1a4eecf69f87b0df36f66a66b40ff3f20ba9959b5580b9dd1",
-      "b0f115694a855cd1a4eecf69f87b0df36f66a66b40ff3f20ba9959b5580b9dd1",
-      "b0f115694a855cd1a4eecf69f87b0df36f66a66b40ff3f20ba9959b5580b9dd1"
+      "0e3f94467771408b1ec3193759898cdca01fef6bdd4519f6657a3d17f3ac18b6",
+      "0e3f94467771408b1ec3193759898cdca01fef6bdd4519f6657a3d17f3ac18b6",
+      "0e3f94467771408b1ec3193759898cdca01fef6bdd4519f6657a3d17f3ac18b6"
     ]
   },
   "tileCount": 20736,
   "elevationStats": {
     "min": -61,
     "max": 457,
-    "median": 27,
+    "median": 26,
     "count": 20736
   },
   "fluidStats": {
@@ -127,13 +127,13 @@
       ]
     },
     "FLOATING_WATER": {
-      "min": 258,
-      "max": 258,
-      "median": 258,
+      "min": 188,
+      "max": 188,
+      "median": 188,
       "all": [
-        258,
-        258,
-        258
+        188,
+        188,
+        188
       ]
     },
     "ISLAND_1TILE": {
@@ -157,13 +157,13 @@
       ]
     },
     "MID_RIVER_CLIFF": {
-      "min": 8,
-      "max": 8,
-      "median": 8,
+      "min": 44,
+      "max": 44,
+      "median": 44,
       "all": [
-        8,
-        8,
-        8
+        44,
+        44,
+        44
       ]
     },
     "MULTI_ISLAND": {
@@ -177,13 +177,13 @@
       ]
     },
     "RIVER_CHUNK_GAP": {
-      "min": 10,
-      "max": 10,
-      "median": 10,
+      "min": 12,
+      "max": 12,
+      "median": 12,
       "all": [
-        10,
-        10,
-        10
+        12,
+        12,
+        12
       ]
     },
     "RIVER_MOUTH_DROP": {
@@ -207,23 +207,23 @@
       ]
     },
     "WATER_ABOVE_LAND": {
-      "min": 261,
-      "max": 261,
-      "median": 261,
+      "min": 286,
+      "max": 286,
+      "median": 286,
       "all": [
-        261,
-        261,
-        261
+        286,
+        286,
+        286
       ]
     },
     "WATER_CLIFF": {
-      "min": 261,
-      "max": 261,
-      "median": 261,
+      "min": 286,
+      "max": 286,
+      "median": 286,
       "all": [
-        261,
-        261,
-        261
+        286,
+        286,
+        286
       ]
     },
     "WATER_WATER_CLIFF": {
@@ -243,16 +243,16 @@
       "FLAT_ISOLATED_WATER": 11,
       "FLOATING_LAKE": 201,
       "FLOATING_RIVER": 2,
-      "FLOATING_WATER": 258,
+      "FLOATING_WATER": 188,
       "ISLAND_1TILE": 10,
       "ISOLATED_FLUID": 39,
-      "MID_RIVER_CLIFF": 8,
+      "MID_RIVER_CLIFF": 44,
       "MULTI_ISLAND": 9,
-      "RIVER_CHUNK_GAP": 10,
+      "RIVER_CHUNK_GAP": 12,
       "RIVER_MOUTH_DROP": 5,
       "SUBMERGED_BUMP": 1,
-      "WATER_ABOVE_LAND": 261,
-      "WATER_CLIFF": 261,
+      "WATER_ABOVE_LAND": 286,
+      "WATER_CLIFF": 286,
       "WATER_WATER_CLIFF": 2034
     },
     "issues": {
@@ -360,7 +360,7 @@
         {
           "x": 57,
           "y": -23,
-          "details": "sand maxNbrDelta=6"
+          "details": "sand maxNbrDelta=8"
         },
         {
           "x": 57,
@@ -370,12 +370,12 @@
         {
           "x": 60,
           "y": -26,
-          "details": "sand maxNbrDelta=5"
+          "details": "sand maxNbrDelta=4"
         },
         {
           "x": 60,
           "y": -25,
-          "details": "sand maxNbrDelta=8"
+          "details": "sand maxNbrDelta=6"
         },
         {
           "x": 63,
@@ -385,7 +385,7 @@
         {
           "x": 69,
           "y": -35,
-          "details": "sand maxNbrDelta=18"
+          "details": "sand maxNbrDelta=20"
         },
         {
           "x": 71,
@@ -1454,19 +1454,19 @@
         {
           "x": 74,
           "y": 52,
-          "details": "lake fluidSurf=133 terrainZ=109 depth=24"
+          "details": "lake fluidSurf=133 terrainZ=104 depth=29"
         }
       ],
       "FLOATING_RIVER": [
         {
           "x": -24,
           "y": -1,
-          "details": "river fluidSurf=174 terrainZ=133 depth=41"
+          "details": "river fluidSurf=174 terrainZ=126 depth=48"
         },
         {
           "x": -23,
           "y": -1,
-          "details": "river fluidSurf=162 terrainZ=121 depth=41"
+          "details": "river fluidSurf=162 terrainZ=114 depth=48"
         }
       ],
       "FLOATING_WATER": [
@@ -1478,32 +1478,22 @@
         {
           "x": -45,
           "y": -46,
-          "details": "river terr=98 -> dry(-45,-47) terr=95 gap=3"
+          "details": "river terr=96 -> dry(-45,-47) terr=95 gap=1"
         },
         {
           "x": -45,
           "y": -45,
-          "details": "river terr=102 -> dry(-44,-45) terr=99 gap=3"
-        },
-        {
-          "x": -44,
-          "y": -47,
-          "details": "river terr=88 -> dry(-44,-48) terr=87 gap=1"
+          "details": "river terr=100 -> dry(-44,-45) terr=99 gap=1"
         },
         {
           "x": -44,
           "y": -46,
-          "details": "river terr=93 -> dry(-43,-46) terr=90 gap=3"
-        },
-        {
-          "x": -43,
-          "y": -47,
-          "details": "river terr=84 -> dry(-43,-48) terr=83 gap=1"
+          "details": "river terr=91 -> dry(-43,-46) terr=90 gap=1"
         },
         {
           "x": -42,
           "y": -47,
-          "details": "river terr=81 -> dry(-42,-48) terr=78 gap=3"
+          "details": "river terr=79 -> dry(-42,-48) terr=78 gap=1"
         },
         {
           "x": -42,
@@ -1513,27 +1503,17 @@
         {
           "x": -42,
           "y": 56,
-          "details": "river terr=343 -> dry(-42,55) terr=336 gap=7"
+          "details": "river terr=338 -> dry(-42,55) terr=336 gap=2"
         },
         {
           "x": -41,
           "y": -47,
-          "details": "river terr=75 -> dry(-41,-48) terr=73 gap=2"
+          "details": "river terr=74 -> dry(-41,-48) terr=73 gap=1"
         },
         {
           "x": -41,
           "y": -42,
           "details": "river terr=98 -> dry(-41,-43) terr=96 gap=2"
-        },
-        {
-          "x": -41,
-          "y": 55,
-          "details": "river terr=324 -> dry(-40,55) terr=319 gap=5"
-        },
-        {
-          "x": -40,
-          "y": -47,
-          "details": "river terr=70 -> dry(-40,-48) terr=69 gap=1"
         },
         {
           "x": -40,
@@ -1553,17 +1533,12 @@
         {
           "x": -40,
           "y": 56,
-          "details": "river terr=321 -> dry(-39,56) terr=313 gap=8"
+          "details": "river terr=317 -> dry(-39,56) terr=313 gap=4"
         },
         {
           "x": -39,
           "y": -42,
-          "details": "river terr=85 -> dry(-39,-43) terr=81 gap=4"
-        },
-        {
-          "x": -39,
-          "y": -39,
-          "details": "river terr=88 -> dry(-39,-40) terr=87 gap=1"
+          "details": "river terr=83 -> dry(-39,-43) terr=81 gap=2"
         },
         {
           "x": -39,
@@ -1576,24 +1551,9 @@
           "details": "river terr=105 -> dry(-38,-37) terr=99 gap=6"
         },
         {
-          "x": -39,
-          "y": 48,
-          "details": "river terr=303 -> dry(-38,48) terr=301 gap=2"
-        },
-        {
           "x": -38,
           "y": -42,
-          "details": "river terr=78 -> dry(-38,-43) terr=75 gap=3"
-        },
-        {
-          "x": -38,
-          "y": -39,
-          "details": "river terr=85 -> dry(-38,-40) terr=82 gap=3"
-        },
-        {
-          "x": -38,
-          "y": 49,
-          "details": "river terr=282 -> dry(-37,49) terr=275 gap=7"
+          "details": "river terr=76 -> dry(-38,-43) terr=75 gap=1"
         },
         {
           "x": -38,
@@ -1603,17 +1563,12 @@
         {
           "x": -37,
           "y": -40,
-          "details": "river terr=75 -> dry(-36,-40) terr=72 gap=3"
+          "details": "river terr=73 -> dry(-36,-40) terr=72 gap=1"
         },
         {
           "x": -37,
           "y": -31,
-          "details": "river terr=135 -> dry(-37,-32) terr=127 gap=8"
-        },
-        {
-          "x": -37,
-          "y": 60,
-          "details": "river terr=294 -> dry(-36,60) terr=293 gap=1"
+          "details": "river terr=129 -> dry(-37,-32) terr=127 gap=2"
         },
         {
           "x": -37,
@@ -1633,52 +1588,22 @@
         {
           "x": -36,
           "y": -44,
-          "details": "river terr=56 -> dry(-36,-45) terr=53 gap=3"
+          "details": "river terr=55 -> dry(-36,-45) terr=53 gap=2"
         },
         {
           "x": -36,
           "y": -43,
-          "details": "river terr=60 -> dry(-35,-43) terr=58 gap=2"
+          "details": "river terr=59 -> dry(-35,-43) terr=58 gap=1"
         },
         {
           "x": -36,
           "y": -38,
-          "details": "river terr=85 -> dry(-36,-39) terr=81 gap=4"
-        },
-        {
-          "x": -36,
-          "y": -36,
-          "details": "river terr=91 -> dry(-35,-36) terr=90 gap=1"
-        },
-        {
-          "x": -36,
-          "y": -35,
-          "details": "river terr=95 -> dry(-35,-35) terr=93 gap=2"
-        },
-        {
-          "x": -36,
-          "y": -34,
-          "details": "river terr=100 -> dry(-35,-34) terr=98 gap=2"
-        },
-        {
-          "x": -36,
-          "y": -31,
-          "details": "river terr=123 -> dry(-36,-32) terr=117 gap=6"
-        },
-        {
-          "x": -36,
-          "y": 57,
-          "details": "river terr=278 -> dry(-35,57) terr=275 gap=3"
-        },
-        {
-          "x": -36,
-          "y": 58,
-          "details": "river terr=282 -> dry(-35,58) terr=280 gap=2"
+          "details": "river terr=82 -> dry(-36,-39) terr=81 gap=1"
         },
         {
           "x": -36,
           "y": 59,
-          "details": "river terr=288 -> dry(-35,59) terr=285 gap=3"
+          "details": "river terr=286 -> dry(-35,59) terr=285 gap=1"
         },
         {
           "x": -36,
@@ -1687,48 +1612,23 @@
         },
         {
           "x": -35,
-          "y": -44,
-          "details": "river terr=51 -> dry(-34,-44) terr=50 gap=1"
-        },
-        {
-          "x": -35,
           "y": -39,
-          "details": "river terr=73 -> dry(-35,-40) terr=69 gap=4"
+          "details": "river terr=70 -> dry(-35,-40) terr=69 gap=1"
         },
         {
           "x": -35,
           "y": -31,
-          "details": "river terr=115 -> dry(-35,-32) terr=109 gap=6"
-        },
-        {
-          "x": -35,
-          "y": 50,
-          "details": "river terr=248 -> dry(-34,50) terr=247 gap=1"
-        },
-        {
-          "x": -34,
-          "y": -31,
-          "details": "river terr=107 -> dry(-34,-32) terr=103 gap=4"
+          "details": "river terr=110 -> dry(-35,-32) terr=109 gap=1"
         },
         {
           "x": -34,
           "y": -28,
-          "details": "river terr=122 -> dry(-34,-29) terr=118 gap=4"
+          "details": "river terr=121 -> dry(-34,-29) terr=118 gap=3"
         },
         {
           "x": -34,
           "y": 56,
-          "details": "river terr=261 -> dry(-33,56) terr=255 gap=6"
-        },
-        {
-          "x": -33,
-          "y": -31,
-          "details": "river terr=101 -> dry(-33,-32) terr=99 gap=2"
-        },
-        {
-          "x": -33,
-          "y": -30,
-          "details": "river terr=105 -> dry(-32,-30) terr=103 gap=2"
+          "details": "river terr=258 -> dry(-33,56) terr=255 gap=3"
         },
         {
           "x": -33,
@@ -1752,38 +1652,13 @@
         },
         {
           "x": -32,
-          "y": -31,
-          "details": "river terr=97 -> dry(-32,-32) terr=96 gap=1"
-        },
-        {
-          "x": -32,
           "y": -29,
-          "details": "river terr=107 -> dry(-32,-30) terr=103 gap=4"
-        },
-        {
-          "x": -32,
-          "y": -28,
-          "details": "river terr=109 -> dry(-31,-28) terr=108 gap=1"
-        },
-        {
-          "x": -31,
-          "y": -41,
-          "details": "river terr=47 -> dry(-30,-41) terr=44 gap=3"
-        },
-        {
-          "x": -31,
-          "y": -40,
-          "details": "river terr=50 -> dry(-30,-40) terr=48 gap=2"
+          "details": "river terr=106 -> dry(-32,-30) terr=103 gap=3"
         },
         {
           "x": -31,
           "y": -29,
-          "details": "river terr=101 -> dry(-30,-29) terr=97 gap=4"
-        },
-        {
-          "x": -31,
-          "y": 51,
-          "details": "river terr=240 -> dry(-30,51) terr=239 gap=1"
+          "details": "river terr=100 -> dry(-30,-29) terr=97 gap=3"
         },
         {
           "x": -31,
@@ -1797,48 +1672,43 @@
         },
         {
           "x": -28,
-          "y": -41,
-          "details": "river terr=45 -> dry(-29,-41) terr=44 gap=1"
-        },
-        {
-          "x": -28,
           "y": -23,
-          "details": "river terr=129 -> dry(-29,-23) terr=124 gap=5"
+          "details": "river terr=125 -> dry(-29,-23) terr=124 gap=1"
         },
         {
           "x": -28,
           "y": -22,
-          "details": "river terr=136 -> dry(-29,-22) terr=130 gap=6"
+          "details": "river terr=132 -> dry(-29,-22) terr=130 gap=2"
         },
         {
           "x": -28,
           "y": -21,
-          "details": "river terr=144 -> dry(-29,-21) terr=137 gap=7"
+          "details": "river terr=141 -> dry(-29,-21) terr=137 gap=4"
         },
         {
           "x": -27,
           "y": -24,
-          "details": "river terr=130 -> dry(-27,-25) terr=124 gap=6"
+          "details": "river terr=127 -> dry(-27,-25) terr=124 gap=3"
         },
         {
           "x": -27,
           "y": -21,
-          "details": "river terr=151 -> dry(-27,-22) terr=146 gap=5"
+          "details": "river terr=148 -> dry(-27,-22) terr=146 gap=2"
         },
         {
           "x": -26,
           "y": -24,
-          "details": "river terr=138 -> dry(-26,-25) terr=134 gap=4"
+          "details": "river terr=136 -> dry(-26,-25) terr=134 gap=2"
         },
         {
           "x": -26,
           "y": -21,
-          "details": "river terr=160 -> dry(-26,-22) terr=155 gap=5"
+          "details": "river terr=158 -> dry(-26,-22) terr=155 gap=3"
         },
         {
           "x": -26,
           "y": -20,
-          "details": "river terr=168 -> dry(-27,-20) terr=162 gap=6"
+          "details": "river terr=167 -> dry(-27,-20) terr=162 gap=5"
         },
         {
           "x": -26,
@@ -1853,7 +1723,7 @@
         {
           "x": -25,
           "y": -24,
-          "details": "river terr=147 -> dry(-25,-25) terr=142 gap=5"
+          "details": "river terr=145 -> dry(-25,-25) terr=142 gap=3"
         },
         {
           "x": -24,
@@ -1863,12 +1733,12 @@
         {
           "x": -24,
           "y": -24,
-          "details": "river terr=156 -> dry(-24,-25) terr=149 gap=7"
+          "details": "river terr=155 -> dry(-24,-25) terr=149 gap=6"
         },
         {
           "x": -24,
           "y": -1,
-          "details": "river terr=133 -> dry(-24,0) terr=105 gap=28"
+          "details": "river terr=126 -> dry(-24,0) terr=98 gap=28"
         },
         {
           "x": -23,
@@ -1883,37 +1753,27 @@
         {
           "x": -23,
           "y": -30,
-          "details": "river terr=92 -> dry(-23,-31) terr=87 gap=5"
+          "details": "river terr=88 -> dry(-23,-31) terr=87 gap=1"
         },
         {
           "x": -23,
           "y": -29,
-          "details": "river terr=103 -> dry(-24,-29) terr=95 gap=8"
-        },
-        {
-          "x": -23,
-          "y": -28,
-          "details": "river terr=114 -> dry(-24,-28) terr=109 gap=5"
-        },
-        {
-          "x": -23,
-          "y": -25,
-          "details": "river terr=150 -> dry(-24,-25) terr=149 gap=1"
+          "details": "river terr=99 -> dry(-24,-29) terr=95 gap=4"
         },
         {
           "x": -23,
           "y": -1,
-          "details": "river terr=121 -> dry(-22,-1) terr=109 gap=12"
+          "details": "river terr=114 -> dry(-22,-1) terr=102 gap=12"
         },
         {
           "x": -22,
           "y": -31,
-          "details": "river terr=90 -> dry(-23,-31) terr=87 gap=3"
+          "details": "river terr=88 -> dry(-23,-31) terr=87 gap=1"
         },
         {
           "x": -22,
           "y": -2,
-          "details": "river terr=137 -> dry(-21,-2) terr=125 gap=12"
+          "details": "river terr=130 -> dry(-21,-2) terr=118 gap=12"
         },
         {
           "x": -21,
@@ -1923,12 +1783,12 @@
         {
           "x": -21,
           "y": -29,
-          "details": "river terr=114 -> dry(-22,-29) terr=111 gap=3"
+          "details": "river terr=112 -> dry(-22,-29) terr=111 gap=1"
         },
         {
           "x": -21,
           "y": -3,
-          "details": "river terr=113 -> dry(-20,-3) terr=109 gap=4"
+          "details": "river terr=107 -> dry(-20,-3) terr=104 gap=3"
         },
         {
           "x": -20,
@@ -1943,22 +1803,12 @@
         {
           "x": -20,
           "y": -32,
-          "details": "river terr=85 -> dry(-19,-32) terr=82 gap=3"
-        },
-        {
-          "x": -20,
-          "y": -31,
-          "details": "river terr=92 -> dry(-19,-31) terr=90 gap=2"
+          "details": "river terr=84 -> dry(-19,-32) terr=82 gap=2"
         },
         {
           "x": -20,
           "y": -30,
-          "details": "river terr=102 -> dry(-19,-30) terr=99 gap=3"
-        },
-        {
-          "x": -20,
-          "y": -11,
-          "details": "river terr=148 -> dry(-19,-11) terr=147 gap=1"
+          "details": "river terr=100 -> dry(-19,-30) terr=99 gap=1"
         },
         {
           "x": -19,
@@ -1973,27 +1823,12 @@
         {
           "x": -19,
           "y": -16,
-          "details": "river terr=156 -> dry(-18,-16) terr=149 gap=7"
-        },
-        {
-          "x": -19,
-          "y": -12,
-          "details": "river terr=135 -> dry(-18,-12) terr=132 gap=3"
+          "details": "river terr=155 -> dry(-18,-16) terr=149 gap=6"
         },
         {
           "x": -18,
           "y": -36,
           "details": "river terr=62 -> dry(-18,-37) terr=60 gap=2"
-        },
-        {
-          "x": -18,
-          "y": 59,
-          "details": "river terr=168 -> dry(-17,59) terr=166 gap=2"
-        },
-        {
-          "x": -18,
-          "y": 64,
-          "details": "river terr=181 -> dry(-18,65) terr=179 gap=2"
         },
         {
           "x": -17,
@@ -2003,27 +1838,12 @@
         {
           "x": -17,
           "y": -37,
-          "details": "river terr=52 -> dry(-17,-38) terr=50 gap=2"
-        },
-        {
-          "x": -17,
-          "y": -23,
-          "details": "river terr=115 -> dry(-17,-24) terr=114 gap=1"
-        },
-        {
-          "x": -17,
-          "y": 60,
-          "details": "river terr=167 -> dry(-17,59) terr=166 gap=1"
-        },
-        {
-          "x": -17,
-          "y": 64,
-          "details": "river terr=170 -> dry(-17,65) terr=169 gap=1"
+          "details": "river terr=51 -> dry(-17,-38) terr=50 gap=1"
         },
         {
           "x": -17,
           "y": 70,
-          "details": "river terr=154 -> dry(-17,71) terr=152 gap=2"
+          "details": "river terr=153 -> dry(-17,71) terr=152 gap=1"
         },
         {
           "x": -16,
@@ -2033,37 +1853,17 @@
         {
           "x": -16,
           "y": -39,
-          "details": "river terr=38 -> dry(-16,-40) terr=34 gap=4"
+          "details": "river terr=36 -> dry(-16,-40) terr=34 gap=2"
         },
         {
           "x": -16,
           "y": 52,
-          "details": "river terr=87 -> dry(-16,51) terr=85 gap=2"
-        },
-        {
-          "x": -16,
-          "y": 60,
-          "details": "river terr=163 -> dry(-16,59) terr=162 gap=1"
-        },
-        {
-          "x": -16,
-          "y": 66,
-          "details": "river terr=157 -> dry(-16,67) terr=156 gap=1"
-        },
-        {
-          "x": -16,
-          "y": 70,
-          "details": "river terr=148 -> dry(-16,71) terr=147 gap=1"
+          "details": "river terr=83 -> dry(-16,51) terr=79 gap=4"
         },
         {
           "x": -15,
           "y": -49,
           "details": "river terr=22 -> dry(-15,-50) terr=21 gap=1"
-        },
-        {
-          "x": -15,
-          "y": -41,
-          "details": "river terr=21 -> dry(-15,-42) terr=20 gap=1"
         },
         {
           "x": -15,
@@ -2073,22 +1873,12 @@
         {
           "x": -15,
           "y": -15,
-          "details": "river terr=120 -> dry(-14,-15) terr=118 gap=2"
+          "details": "river terr=119 -> dry(-14,-15) terr=118 gap=1"
         },
         {
           "x": -15,
-          "y": 67,
-          "details": "river terr=147 -> dry(-15,68) terr=146 gap=1"
-        },
-        {
-          "x": -15,
-          "y": 70,
-          "details": "river terr=141 -> dry(-15,71) terr=140 gap=1"
-        },
-        {
-          "x": -15,
-          "y": 72,
-          "details": "river terr=136 -> dry(-15,73) terr=135 gap=1"
+          "y": 52,
+          "details": "river terr=96 -> dry(-15,51) terr=95 gap=1"
         },
         {
           "x": -14,
@@ -2098,12 +1888,12 @@
         {
           "x": -14,
           "y": -35,
-          "details": "river terr=45 -> dry(-13,-35) terr=39 gap=6"
+          "details": "river terr=42 -> dry(-13,-35) terr=39 gap=3"
         },
         {
           "x": -14,
           "y": -34,
-          "details": "river terr=51 -> dry(-13,-34) terr=46 gap=5"
+          "details": "river terr=49 -> dry(-13,-34) terr=46 gap=3"
         },
         {
           "x": -14,
@@ -2112,8 +1902,8 @@
         },
         {
           "x": -14,
-          "y": -16,
-          "details": "river terr=109 -> dry(-13,-16) terr=108 gap=1"
+          "y": 55,
+          "details": "river terr=147 -> dry(-14,54) terr=146 gap=1"
         },
         {
           "x": -14,
@@ -2123,7 +1913,7 @@
         {
           "x": -14,
           "y": 70,
-          "details": "river terr=134 -> dry(-14,71) terr=131 gap=3"
+          "details": "river terr=133 -> dry(-14,71) terr=131 gap=2"
         },
         {
           "x": -13,
@@ -2132,33 +1922,28 @@
         },
         {
           "x": -13,
-          "y": -40,
-          "details": "river terr=10 -> dry(-12,-40) terr=8 gap=2"
-        },
-        {
-          "x": -13,
           "y": -39,
-          "details": "river terr=14 -> dry(-12,-39) terr=11 gap=3"
+          "details": "river terr=12 -> dry(-12,-39) terr=11 gap=1"
         },
         {
           "x": -13,
           "y": -38,
-          "details": "river terr=20 -> dry(-12,-38) terr=15 gap=5"
+          "details": "river terr=17 -> dry(-12,-38) terr=15 gap=2"
         },
         {
           "x": -13,
           "y": -33,
-          "details": "river terr=52 -> dry(-13,-34) terr=46 gap=6"
+          "details": "river terr=49 -> dry(-13,-34) terr=46 gap=3"
         },
         {
           "x": -13,
           "y": -32,
-          "details": "river terr=59 -> dry(-12,-32) terr=53 gap=6"
+          "details": "river terr=56 -> dry(-12,-32) terr=53 gap=3"
         },
         {
           "x": -13,
           "y": -31,
-          "details": "river terr=66 -> dry(-12,-31) terr=60 gap=6"
+          "details": "river terr=64 -> dry(-12,-31) terr=60 gap=4"
         },
         {
           "x": -13,
@@ -2173,17 +1958,17 @@
         {
           "x": -12,
           "y": -37,
-          "details": "river terr=19 -> dry(-12,-38) terr=15 gap=4"
+          "details": "river terr=16 -> dry(-12,-38) terr=15 gap=1"
         },
         {
           "x": -12,
           "y": -33,
-          "details": "river terr=44 -> dry(-12,-34) terr=38 gap=6"
+          "details": "river terr=40 -> dry(-12,-34) terr=38 gap=2"
         },
         {
           "x": -12,
           "y": -30,
-          "details": "river terr=66 -> dry(-12,-31) terr=60 gap=6"
+          "details": "river terr=64 -> dry(-12,-31) terr=60 gap=4"
         },
         {
           "x": -12,
@@ -2203,17 +1988,17 @@
         {
           "x": -12,
           "y": 73,
-          "details": "river terr=104 -> dry(-12,74) terr=99 gap=5"
+          "details": "river terr=102 -> dry(-12,74) terr=99 gap=3"
         },
         {
           "x": -11,
           "y": -33,
-          "details": "river terr=36 -> dry(-11,-34) terr=30 gap=6"
+          "details": "river terr=32 -> dry(-11,-34) terr=30 gap=2"
         },
         {
           "x": -11,
           "y": -30,
-          "details": "river terr=58 -> dry(-11,-31) terr=52 gap=6"
+          "details": "river terr=55 -> dry(-11,-31) terr=52 gap=3"
         },
         {
           "x": -11,
@@ -2221,14 +2006,9 @@
           "details": "river terr=152 -> dry(-11,56) terr=146 gap=6"
         },
         {
-          "x": -11,
-          "y": 73,
-          "details": "river terr=92 -> dry(-10,73) terr=89 gap=3"
-        },
-        {
           "x": -10,
           "y": -31,
-          "details": "river terr=42 -> dry(-10,-32) terr=35 gap=7"
+          "details": "river terr=38 -> dry(-10,-32) terr=35 gap=3"
         },
         {
           "x": -10,
@@ -2243,7 +2023,7 @@
         {
           "x": -10,
           "y": -3,
-          "details": "river terr=64 -> dry(-10,-2) terr=55 gap=9"
+          "details": "river terr=59 -> dry(-10,-2) terr=50 gap=9"
         },
         {
           "x": -10,
@@ -2263,12 +2043,12 @@
         {
           "x": -8,
           "y": -28,
-          "details": "river terr=54 -> dry(-7,-28) terr=47 gap=7"
+          "details": "river terr=49 -> dry(-7,-28) terr=47 gap=2"
         },
         {
           "x": -8,
           "y": -27,
-          "details": "river terr=64 -> dry(-7,-27) terr=58 gap=6"
+          "details": "river terr=60 -> dry(-7,-27) terr=58 gap=2"
         },
         {
           "x": -8,
@@ -2278,12 +2058,12 @@
         {
           "x": -8,
           "y": 55,
-          "details": "river terr=145 -> dry(-8,56) terr=139 gap=6"
+          "details": "river terr=144 -> dry(-8,56) terr=139 gap=5"
         },
         {
           "x": -8,
           "y": 57,
-          "details": "river terr=130 -> dry(-7,57) terr=128 gap=2"
+          "details": "river terr=129 -> dry(-7,57) terr=128 gap=1"
         },
         {
           "x": -7,
@@ -2293,7 +2073,7 @@
         {
           "x": -7,
           "y": 55,
-          "details": "river terr=140 -> dry(-7,56) terr=135 gap=5"
+          "details": "river terr=139 -> dry(-7,56) terr=135 gap=4"
         },
         {
           "x": -7,
@@ -2303,22 +2083,22 @@
         {
           "x": -6,
           "y": -29,
-          "details": "river terr=29 -> dry(-5,-29) terr=22 gap=7"
+          "details": "river terr=23 -> dry(-5,-29) terr=22 gap=1"
         },
         {
           "x": -6,
           "y": -23,
-          "details": "river terr=79 -> dry(-6,-24) terr=75 gap=4"
+          "details": "river terr=77 -> dry(-6,-24) terr=75 gap=2"
         },
         {
           "x": -6,
           "y": -2,
-          "details": "river terr=58 -> dry(-6,-1) terr=50 gap=8"
+          "details": "river terr=53 -> dry(-6,-1) terr=50 gap=3"
         },
         {
           "x": -6,
           "y": 55,
-          "details": "river terr=133 -> dry(-6,56) terr=129 gap=4"
+          "details": "river terr=131 -> dry(-6,56) terr=129 gap=2"
         },
         {
           "x": -6,
@@ -2333,17 +2113,12 @@
         {
           "x": -5,
           "y": -23,
-          "details": "river terr=68 -> dry(-5,-24) terr=65 gap=3"
+          "details": "river terr=66 -> dry(-5,-24) terr=65 gap=1"
         },
         {
           "x": -5,
           "y": -2,
-          "details": "river terr=46 -> dry(-5,-1) terr=40 gap=6"
-        },
-        {
-          "x": -5,
-          "y": 55,
-          "details": "river terr=126 -> dry(-5,56) terr=124 gap=2"
+          "details": "river terr=41 -> dry(-5,-1) terr=40 gap=1"
         },
         {
           "x": -5,
@@ -2352,13 +2127,8 @@
         },
         {
           "x": -4,
-          "y": -23,
-          "details": "river terr=56 -> dry(-4,-24) terr=54 gap=2"
-        },
-        {
-          "x": -4,
           "y": -2,
-          "details": "river terr=35 -> dry(-4,-1) terr=29 gap=6"
+          "details": "river terr=30 -> dry(-4,-1) terr=29 gap=1"
         },
         {
           "x": -4,
@@ -2377,16 +2147,6 @@
         },
         {
           "x": -3,
-          "y": -2,
-          "details": "river terr=23 -> dry(-3,-1) terr=19 gap=4"
-        },
-        {
-          "x": -3,
-          "y": 55,
-          "details": "river terr=111 -> dry(-3,54) terr=110 gap=1"
-        },
-        {
-          "x": -3,
           "y": 65,
           "details": "river terr=89 -> dry(-2,65) terr=88 gap=1"
         },
@@ -2401,29 +2161,9 @@
           "details": "river terr=82 -> dry(-2,67) terr=80 gap=2"
         },
         {
-          "x": -2,
-          "y": -2,
-          "details": "river terr=18 -> dry(-2,-1) terr=15 gap=3"
-        },
-        {
-          "x": -2,
-          "y": 55,
-          "details": "river terr=103 -> dry(-2,54) terr=102 gap=1"
-        },
-        {
           "x": -1,
           "y": -23,
           "details": "river terr=48 -> dry(-1,-24) terr=46 gap=2"
-        },
-        {
-          "x": -1,
-          "y": -2,
-          "details": "river terr=14 -> dry(-1,-1) terr=12 gap=2"
-        },
-        {
-          "x": -1,
-          "y": 55,
-          "details": "river terr=97 -> dry(-1,54) terr=95 gap=2"
         },
         {
           "x": 0,
@@ -2431,24 +2171,9 @@
           "details": "river terr=47 -> dry(0,-24) terr=46 gap=1"
         },
         {
-          "x": 0,
-          "y": -2,
-          "details": "river terr=12 -> dry(0,-1) terr=10 gap=2"
-        },
-        {
-          "x": 0,
-          "y": 55,
-          "details": "river terr=90 -> dry(0,54) terr=89 gap=1"
-        },
-        {
           "x": 1,
           "y": -27,
           "details": "river terr=30 -> dry(2,-27) terr=29 gap=1"
-        },
-        {
-          "x": 1,
-          "y": -2,
-          "details": "river terr=10 -> dry(1,-1) terr=8 gap=2"
         },
         {
           "x": 2,
@@ -2481,11 +2206,6 @@
           "details": "river terr=6 -> dry(3,-1) terr=5 gap=1"
         },
         {
-          "x": 3,
-          "y": 55,
-          "details": "river terr=65 -> dry(3,56) terr=64 gap=1"
-        },
-        {
           "x": 4,
           "y": -23,
           "details": "river terr=34 -> dry(4,-24) terr=33 gap=1"
@@ -2498,17 +2218,17 @@
         {
           "x": 4,
           "y": 55,
-          "details": "river terr=60 -> dry(4,56) terr=54 gap=6"
+          "details": "river terr=59 -> dry(4,56) terr=54 gap=5"
         },
         {
           "x": 5,
           "y": 55,
-          "details": "river terr=59 -> dry(5,56) terr=48 gap=11"
+          "details": "river terr=58 -> dry(5,56) terr=48 gap=10"
         },
         {
           "x": 6,
           "y": 55,
-          "details": "river terr=52 -> dry(7,55) terr=39 gap=13"
+          "details": "river terr=50 -> dry(7,55) terr=39 gap=11"
         },
         {
           "x": 7,
@@ -2523,7 +2243,7 @@
         {
           "x": 8,
           "y": 54,
-          "details": "river terr=33 -> dry(8,55) terr=31 gap=2"
+          "details": "river terr=32 -> dry(8,55) terr=31 gap=1"
         },
         {
           "x": 9,
@@ -2536,26 +2256,6 @@
           "details": "river terr=20 -> dry(13,55) terr=17 gap=3"
         },
         {
-          "x": 14,
-          "y": 54,
-          "details": "river terr=8 -> dry(14,55) terr=6 gap=2"
-        },
-        {
-          "x": 57,
-          "y": -23,
-          "details": "river terr=3 -> dry(56,-23) terr=2 gap=1"
-        },
-        {
-          "x": 60,
-          "y": -24,
-          "details": "river terr=9 -> dry(59,-24) terr=7 gap=2"
-        },
-        {
-          "x": 62,
-          "y": -28,
-          "details": "river terr=13 -> dry(61,-28) terr=12 gap=1"
-        },
-        {
           "x": 63,
           "y": -28,
           "details": "river terr=18 -> dry(63,-27) terr=16 gap=2"
@@ -2563,12 +2263,12 @@
         {
           "x": 65,
           "y": -25,
-          "details": "river terr=35 -> dry(65,-26) terr=29 gap=6"
+          "details": "river terr=30 -> dry(65,-26) terr=29 gap=1"
         },
         {
           "x": 66,
           "y": -25,
-          "details": "river terr=44 -> dry(66,-26) terr=37 gap=7"
+          "details": "river terr=39 -> dry(66,-26) terr=37 gap=2"
         },
         {
           "x": 67,
@@ -2582,23 +2282,13 @@
         },
         {
           "x": 67,
-          "y": -27,
-          "details": "river terr=35 -> dry(66,-27) terr=32 gap=3"
-        },
-        {
-          "x": 67,
           "y": -26,
-          "details": "river terr=41 -> dry(66,-26) terr=37 gap=4"
+          "details": "river terr=38 -> dry(66,-26) terr=37 gap=1"
         },
         {
           "x": 68,
           "y": -30,
           "details": "river terr=25 -> dry(69,-30) terr=23 gap=2"
-        },
-        {
-          "x": 68,
-          "y": -23,
-          "details": "river terr=77 -> dry(67,-23) terr=76 gap=1"
         },
         {
           "x": 69,
@@ -2612,53 +2302,33 @@
         },
         {
           "x": 69,
-          "y": -17,
-          "details": "river terr=149 -> dry(68,-17) terr=146 gap=3"
-        },
-        {
-          "x": 69,
           "y": -16,
-          "details": "river terr=161 -> dry(68,-16) terr=154 gap=7"
-        },
-        {
-          "x": 70,
-          "y": -29,
-          "details": "river terr=21 -> dry(70,-30) terr=19 gap=2"
-        },
-        {
-          "x": 71,
-          "y": -21,
-          "details": "river terr=89 -> dry(72,-21) terr=87 gap=2"
+          "details": "river terr=155 -> dry(68,-16) terr=154 gap=1"
         },
         {
           "x": 71,
           "y": 50,
-          "details": "river terr=17 -> dry(71,49) terr=6 gap=11"
+          "details": "river terr=12 -> dry(71,49) terr=6 gap=6"
         },
         {
           "x": 72,
           "y": -20,
-          "details": "river terr=96 -> dry(72,-21) terr=87 gap=9"
-        },
-        {
-          "x": 74,
-          "y": -21,
-          "details": "river terr=82 -> dry(74,-22) terr=79 gap=3"
+          "details": "river terr=91 -> dry(72,-21) terr=87 gap=4"
         },
         {
           "x": 74,
           "y": 52,
-          "details": "lake terr=109 -> dry(73,52) terr=97 gap=12"
+          "details": "lake terr=104 -> dry(73,52) terr=92 gap=12"
         },
         {
           "x": 75,
           "y": -20,
-          "details": "river terr=100 -> dry(75,-21) terr=93 gap=7"
+          "details": "river terr=95 -> dry(75,-21) terr=93 gap=2"
         },
         {
           "x": 76,
           "y": -19,
-          "details": "river terr=121 -> dry(76,-20) terr=112 gap=9"
+          "details": "river terr=117 -> dry(76,-20) terr=112 gap=5"
         },
         {
           "x": 77,
@@ -2683,27 +2353,17 @@
         {
           "x": 77,
           "y": -27,
-          "details": "river terr=42 -> dry(78,-27) terr=38 gap=4"
+          "details": "river terr=41 -> dry(78,-27) terr=38 gap=3"
         },
         {
           "x": 77,
           "y": -26,
-          "details": "river terr=50 -> dry(78,-26) terr=45 gap=5"
-        },
-        {
-          "x": 77,
-          "y": -22,
-          "details": "river terr=94 -> dry(76,-22) terr=93 gap=1"
-        },
-        {
-          "x": 77,
-          "y": -21,
-          "details": "river terr=105 -> dry(76,-21) terr=102 gap=3"
+          "details": "river terr=49 -> dry(78,-26) terr=45 gap=4"
         },
         {
           "x": 77,
           "y": -20,
-          "details": "river terr=117 -> dry(76,-20) terr=112 gap=5"
+          "details": "river terr=114 -> dry(76,-20) terr=112 gap=2"
         },
         {
           "x": 78,
@@ -2723,32 +2383,22 @@
         {
           "x": 78,
           "y": -25,
-          "details": "river terr=53 -> dry(78,-26) terr=45 gap=8"
-        },
-        {
-          "x": 79,
-          "y": -26,
-          "details": "river terr=36 -> dry(79,-27) terr=32 gap=4"
+          "details": "river terr=50 -> dry(78,-26) terr=45 gap=5"
         },
         {
           "x": 79,
           "y": 53,
-          "details": "river terr=149 -> dry(78,53) terr=144 gap=5"
-        },
-        {
-          "x": 79,
-          "y": 54,
-          "details": "river terr=154 -> dry(78,54) terr=151 gap=3"
+          "details": "river terr=145 -> dry(78,53) terr=144 gap=1"
         },
         {
           "x": 79,
           "y": 55,
-          "details": "river terr=161 -> dry(78,55) terr=155 gap=6"
+          "details": "river terr=159 -> dry(78,55) terr=155 gap=4"
         },
         {
           "x": 79,
           "y": 58,
-          "details": "river terr=188 -> dry(78,58) terr=184 gap=4"
+          "details": "river terr=187 -> dry(78,58) terr=184 gap=3"
         },
         {
           "x": 79,
@@ -3012,14 +2662,34 @@
       ],
       "MID_RIVER_CLIFF": [
         {
-          "x": -32,
-          "y": -51,
-          "details": "river surf=33 (terr=25) -> water nbr surf=29 (terr=26) surf_diff=4 terr_diff=1"
+          "x": -39,
+          "y": 50,
+          "details": "river surf=286 (terr=278) -> water nbr surf=283 (terr=277) surf_diff=3 terr_diff=1"
         },
         {
           "x": -32,
           "y": -51,
-          "details": "river surf=33 (terr=24) -> water nbr surf=27 (terr=25) surf_diff=6 terr_diff=1"
+          "details": "river surf=33 (terr=25) -> water nbr surf=29 (terr=24) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -31,
+          "y": -43,
+          "details": "river surf=41 (terr=37) -> water nbr surf=38 (terr=38) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -31,
+          "y": -43,
+          "details": "river surf=41 (terr=38) -> water nbr surf=38 (terr=37) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -31,
+          "y": -42,
+          "details": "river surf=44 (terr=41) -> water nbr surf=41 (terr=40) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -28,
+          "y": -41,
+          "details": "river surf=46 (terr=42) -> water nbr surf=43 (terr=43) surf_diff=3 terr_diff=1"
         },
         {
           "x": -25,
@@ -3030,6 +2700,11 @@
           "x": -24,
           "y": -31,
           "details": "river surf=86 (terr=81) -> water nbr surf=82 (terr=81) surf_diff=4 terr_diff=0"
+        },
+        {
+          "x": -21,
+          "y": -63,
+          "details": "river surf=36 (terr=32) -> water nbr surf=32 (terr=30) surf_diff=4 terr_diff=2"
         },
         {
           "x": -18,
@@ -3047,9 +2722,164 @@
           "details": "river surf=21 (terr=16) -> water nbr surf=18 (terr=15) surf_diff=3 terr_diff=1"
         },
         {
-          "x": 72,
+          "x": -16,
+          "y": -23,
+          "details": "river surf=104 (terr=98) -> water nbr surf=100 (terr=96) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -15,
+          "y": -23,
+          "details": "river surf=100 (terr=96) -> water nbr surf=96 (terr=95) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -14,
+          "y": 1,
+          "details": "river surf=5 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -13,
+          "y": 1,
+          "details": "river surf=5 (terr=1) -> water nbr surf=1 (terr=0) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -12,
+          "y": 1,
+          "details": "river surf=5 (terr=1) -> water nbr surf=1 (terr=0) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -11,
+          "y": 1,
+          "details": "river surf=5 (terr=1) -> water nbr surf=1 (terr=0) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -10,
+          "y": 1,
+          "details": "river surf=4 (terr=1) -> water nbr surf=1 (terr=0) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -8,
+          "y": 2,
+          "details": "river surf=5 (terr=1) -> water nbr surf=1 (terr=0) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -8,
+          "y": 2,
+          "details": "river surf=5 (terr=1) -> water nbr surf=1 (terr=0) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -7,
+          "y": -32,
+          "details": "river surf=16 (terr=8) -> water nbr surf=12 (terr=10) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -7,
+          "y": 2,
+          "details": "river surf=4 (terr=1) -> water nbr surf=1 (terr=0) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -6,
+          "y": -33,
+          "details": "river surf=9 (terr=5) -> water nbr surf=6 (terr=6) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -6,
+          "y": -33,
+          "details": "river surf=9 (terr=6) -> water nbr surf=7 (terr=6) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -6,
+          "y": -32,
+          "details": "river surf=13 (terr=6) -> water nbr surf=9 (terr=8) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -5,
+          "y": -32,
+          "details": "river surf=10 (terr=6) -> water nbr surf=7 (terr=6) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -5,
+          "y": -32,
+          "details": "river surf=10 (terr=6) -> water nbr surf=7 (terr=6) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -4,
+          "y": -31,
+          "details": "river surf=10 (terr=6) -> water nbr surf=7 (terr=6) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -4,
+          "y": -31,
+          "details": "river surf=10 (terr=6) -> water nbr surf=7 (terr=6) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -4,
+          "y": -30,
+          "details": "river surf=13 (terr=8) -> water nbr surf=10 (terr=7) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -3,
+          "y": -30,
+          "details": "river surf=10 (terr=6) -> water nbr surf=7 (terr=7) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -2,
+          "y": -30,
+          "details": "river surf=11 (terr=7) -> water nbr surf=8 (terr=8) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 1,
+          "y": -2,
+          "details": "river surf=11 (terr=8) -> water nbr surf=9 (terr=8) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 57,
+          "y": -23,
+          "details": "river surf=4 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 58,
           "y": -24,
-          "details": "river surf=64 (terr=61) -> water nbr surf=60 (terr=59) surf_diff=4 terr_diff=2"
+          "details": "river surf=4 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 58,
+          "y": -23,
+          "details": "river surf=7 (terr=1) -> water nbr surf=4 (terr=2) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 58,
+          "y": -23,
+          "details": "river surf=7 (terr=2) -> water nbr surf=4 (terr=1) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 62,
+          "y": -26,
+          "details": "river surf=12 (terr=7) -> water nbr surf=8 (terr=5) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 67,
+          "y": -27,
+          "details": "river surf=36 (terr=30) -> water nbr surf=31 (terr=32) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": 68,
+          "y": -27,
+          "details": "river surf=38 (terr=32) -> water nbr surf=33 (terr=34) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": 71,
+          "y": -30,
+          "details": "river surf=13 (terr=10) -> water nbr surf=11 (terr=10) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 71,
+          "y": -22,
+          "details": "river surf=78 (terr=71) -> water nbr surf=74 (terr=69) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 72,
+          "y": -30,
+          "details": "river surf=13 (terr=10) -> water nbr surf=11 (terr=10) surf_diff=2 terr_diff=0"
         }
       ],
       "MULTI_ISLAND": [
@@ -3131,19 +2961,29 @@
           "details": "river surf=91 -> dry(-33,-35) terr=88"
         },
         {
+          "x": -25,
+          "y": 48,
+          "details": "river surf=126 -> dry(-25,47) terr=125"
+        },
+        {
           "x": -24,
           "y": -1,
-          "details": "river surf=174 -> dry(-24,0) terr=105"
+          "details": "river surf=174 -> dry(-24,0) terr=98"
         },
         {
           "x": -23,
           "y": -1,
-          "details": "river surf=162 -> dry(-23,0) terr=93"
+          "details": "river surf=162 -> dry(-23,0) terr=86"
         },
         {
           "x": -19,
           "y": 63,
           "details": "river surf=196 -> dry(-19,64) terr=195"
+        },
+        {
+          "x": -17,
+          "y": 50,
+          "details": "river surf=54 -> dry(-16,50) terr=51"
         },
         {
           "x": 64,
@@ -3194,32 +3034,32 @@
         {
           "x": -45,
           "y": -46,
-          "details": "river surf=99 terr=98 -> land(-45,-47) terr=95 cliff=4"
+          "details": "river surf=99 terr=96 -> land(-45,-47) terr=95 cliff=4"
         },
         {
           "x": -45,
           "y": -45,
-          "details": "river surf=103 terr=102 -> land(-44,-45) terr=99 cliff=4"
+          "details": "river surf=103 terr=100 -> land(-44,-45) terr=99 cliff=4"
         },
         {
           "x": -44,
           "y": -47,
-          "details": "river surf=89 terr=88 -> land(-44,-48) terr=87 cliff=2"
+          "details": "river surf=89 terr=86 -> land(-44,-48) terr=87 cliff=2"
         },
         {
           "x": -44,
           "y": -46,
-          "details": "river surf=94 terr=93 -> land(-43,-46) terr=90 cliff=4"
+          "details": "river surf=94 terr=91 -> land(-43,-46) terr=90 cliff=4"
         },
         {
           "x": -43,
           "y": -47,
-          "details": "river surf=85 terr=84 -> land(-43,-48) terr=83 cliff=2"
+          "details": "river surf=85 terr=82 -> land(-43,-48) terr=83 cliff=2"
         },
         {
           "x": -42,
           "y": -47,
-          "details": "river surf=82 terr=81 -> land(-42,-48) terr=78 cliff=4"
+          "details": "river surf=82 terr=79 -> land(-42,-48) terr=78 cliff=4"
         },
         {
           "x": -42,
@@ -3229,12 +3069,12 @@
         {
           "x": -42,
           "y": 56,
-          "details": "river surf=344 terr=343 -> land(-42,55) terr=336 cliff=8"
+          "details": "river surf=344 terr=338 -> land(-42,55) terr=336 cliff=8"
         },
         {
           "x": -41,
           "y": -47,
-          "details": "river surf=76 terr=75 -> land(-41,-48) terr=73 cliff=3"
+          "details": "river surf=76 terr=74 -> land(-41,-48) terr=73 cliff=3"
         },
         {
           "x": -41,
@@ -3244,12 +3084,12 @@
         {
           "x": -41,
           "y": 55,
-          "details": "river surf=325 terr=324 -> land(-40,55) terr=319 cliff=6"
+          "details": "river surf=325 terr=319 -> land(-40,55) terr=319 cliff=6"
         },
         {
           "x": -40,
           "y": -47,
-          "details": "river surf=71 terr=70 -> land(-40,-48) terr=69 cliff=2"
+          "details": "river surf=71 terr=69 -> land(-40,-48) terr=69 cliff=2"
         },
         {
           "x": -40,
@@ -3269,17 +3109,17 @@
         {
           "x": -40,
           "y": 56,
-          "details": "river surf=322 terr=321 -> land(-39,56) terr=313 cliff=9"
+          "details": "river surf=322 terr=317 -> land(-39,56) terr=313 cliff=9"
         },
         {
           "x": -39,
           "y": -42,
-          "details": "river surf=86 terr=85 -> land(-39,-43) terr=81 cliff=5"
+          "details": "river surf=86 terr=83 -> land(-39,-43) terr=81 cliff=5"
         },
         {
           "x": -39,
           "y": -39,
-          "details": "river surf=89 terr=88 -> land(-39,-40) terr=87 cliff=2"
+          "details": "river surf=89 terr=86 -> land(-39,-40) terr=87 cliff=2"
         },
         {
           "x": -39,
@@ -3294,22 +3134,22 @@
         {
           "x": -39,
           "y": 48,
-          "details": "river surf=304 terr=303 -> land(-38,48) terr=301 cliff=3"
+          "details": "river surf=304 terr=296 -> land(-38,48) terr=301 cliff=3"
         },
         {
           "x": -38,
           "y": -42,
-          "details": "river surf=79 terr=78 -> land(-38,-43) terr=75 cliff=4"
+          "details": "river surf=79 terr=76 -> land(-38,-43) terr=75 cliff=4"
         },
         {
           "x": -38,
           "y": -39,
-          "details": "river surf=86 terr=85 -> land(-38,-40) terr=82 cliff=4"
+          "details": "river surf=86 terr=82 -> land(-38,-40) terr=82 cliff=4"
         },
         {
           "x": -38,
           "y": 49,
-          "details": "river surf=283 terr=282 -> land(-37,49) terr=275 cliff=8"
+          "details": "river surf=283 terr=275 -> land(-37,49) terr=275 cliff=8"
         },
         {
           "x": -38,
@@ -3319,17 +3159,17 @@
         {
           "x": -37,
           "y": -40,
-          "details": "river surf=76 terr=75 -> land(-36,-40) terr=72 cliff=4"
+          "details": "river surf=76 terr=73 -> land(-36,-40) terr=72 cliff=4"
         },
         {
           "x": -37,
           "y": -31,
-          "details": "river surf=136 terr=135 -> land(-37,-32) terr=127 cliff=9"
+          "details": "river surf=136 terr=129 -> land(-37,-32) terr=127 cliff=9"
         },
         {
           "x": -37,
           "y": 60,
-          "details": "river surf=295 terr=294 -> land(-36,60) terr=293 cliff=2"
+          "details": "river surf=295 terr=292 -> land(-36,60) terr=293 cliff=2"
         },
         {
           "x": -37,
@@ -3349,52 +3189,52 @@
         {
           "x": -36,
           "y": -44,
-          "details": "river surf=57 terr=56 -> land(-36,-45) terr=53 cliff=4"
+          "details": "river surf=57 terr=55 -> land(-36,-45) terr=53 cliff=4"
         },
         {
           "x": -36,
           "y": -43,
-          "details": "river surf=61 terr=60 -> land(-35,-43) terr=58 cliff=3"
+          "details": "river surf=61 terr=59 -> land(-35,-43) terr=58 cliff=3"
         },
         {
           "x": -36,
           "y": -38,
-          "details": "river surf=86 terr=85 -> land(-36,-39) terr=81 cliff=5"
+          "details": "river surf=86 terr=82 -> land(-36,-39) terr=81 cliff=5"
         },
         {
           "x": -36,
           "y": -36,
-          "details": "river surf=92 terr=91 -> land(-35,-36) terr=90 cliff=2"
+          "details": "river surf=92 terr=87 -> land(-35,-36) terr=90 cliff=2"
         },
         {
           "x": -36,
           "y": -35,
-          "details": "river surf=96 terr=95 -> land(-35,-35) terr=93 cliff=3"
+          "details": "river surf=96 terr=90 -> land(-35,-35) terr=93 cliff=3"
         },
         {
           "x": -36,
           "y": -34,
-          "details": "river surf=101 terr=100 -> land(-35,-34) terr=98 cliff=3"
+          "details": "river surf=101 terr=95 -> land(-35,-34) terr=98 cliff=3"
         },
         {
           "x": -36,
           "y": -31,
-          "details": "river surf=124 terr=123 -> land(-36,-32) terr=117 cliff=7"
+          "details": "river surf=124 terr=117 -> land(-36,-32) terr=117 cliff=7"
         },
         {
           "x": -36,
           "y": 57,
-          "details": "river surf=279 terr=278 -> land(-35,57) terr=275 cliff=4"
+          "details": "river surf=279 terr=274 -> land(-35,57) terr=275 cliff=4"
         },
         {
           "x": -36,
           "y": 58,
-          "details": "river surf=283 terr=282 -> land(-35,58) terr=280 cliff=3"
+          "details": "river surf=283 terr=279 -> land(-35,58) terr=280 cliff=3"
         },
         {
           "x": -36,
           "y": 59,
-          "details": "river surf=289 terr=288 -> land(-35,59) terr=285 cliff=4"
+          "details": "river surf=289 terr=286 -> land(-35,59) terr=285 cliff=4"
         },
         {
           "x": -36,
@@ -3404,47 +3244,47 @@
         {
           "x": -35,
           "y": -44,
-          "details": "river surf=52 terr=51 -> land(-34,-44) terr=50 cliff=2"
+          "details": "river surf=52 terr=50 -> land(-34,-44) terr=50 cliff=2"
         },
         {
           "x": -35,
           "y": -39,
-          "details": "river surf=74 terr=73 -> land(-35,-40) terr=69 cliff=5"
+          "details": "river surf=74 terr=70 -> land(-35,-40) terr=69 cliff=5"
         },
         {
           "x": -35,
           "y": -31,
-          "details": "river surf=116 terr=115 -> land(-35,-32) terr=109 cliff=7"
+          "details": "river surf=116 terr=110 -> land(-35,-32) terr=109 cliff=7"
         },
         {
           "x": -35,
           "y": 50,
-          "details": "river surf=249 terr=248 -> land(-34,50) terr=247 cliff=2"
+          "details": "river surf=249 terr=242 -> land(-34,50) terr=247 cliff=2"
         },
         {
           "x": -34,
           "y": -31,
-          "details": "river surf=108 terr=107 -> land(-34,-32) terr=103 cliff=5"
+          "details": "river surf=108 terr=103 -> land(-34,-32) terr=103 cliff=5"
         },
         {
           "x": -34,
           "y": -28,
-          "details": "river surf=123 terr=122 -> land(-34,-29) terr=118 cliff=5"
+          "details": "river surf=123 terr=121 -> land(-34,-29) terr=118 cliff=5"
         },
         {
           "x": -34,
           "y": 56,
-          "details": "river surf=262 terr=261 -> land(-33,56) terr=255 cliff=7"
+          "details": "river surf=262 terr=258 -> land(-33,56) terr=255 cliff=7"
         },
         {
           "x": -33,
           "y": -31,
-          "details": "river surf=102 terr=101 -> land(-33,-32) terr=99 cliff=3"
+          "details": "river surf=102 terr=98 -> land(-33,-32) terr=99 cliff=3"
         },
         {
           "x": -33,
           "y": -30,
-          "details": "river surf=106 terr=105 -> land(-32,-30) terr=103 cliff=3"
+          "details": "river surf=106 terr=102 -> land(-32,-30) terr=103 cliff=3"
         },
         {
           "x": -33,
@@ -3469,37 +3309,37 @@
         {
           "x": -32,
           "y": -31,
-          "details": "river surf=98 terr=97 -> land(-32,-32) terr=96 cliff=2"
+          "details": "river surf=98 terr=95 -> land(-32,-32) terr=96 cliff=2"
         },
         {
           "x": -32,
           "y": -29,
-          "details": "river surf=108 terr=107 -> land(-32,-30) terr=103 cliff=5"
+          "details": "river surf=108 terr=106 -> land(-32,-30) terr=103 cliff=5"
         },
         {
           "x": -32,
           "y": -28,
-          "details": "river surf=110 terr=109 -> land(-31,-28) terr=108 cliff=2"
+          "details": "river surf=110 terr=108 -> land(-31,-28) terr=108 cliff=2"
         },
         {
           "x": -31,
           "y": -41,
-          "details": "river surf=48 terr=47 -> land(-30,-41) terr=44 cliff=4"
+          "details": "river surf=48 terr=44 -> land(-30,-41) terr=44 cliff=4"
         },
         {
           "x": -31,
           "y": -40,
-          "details": "river surf=51 terr=50 -> land(-30,-40) terr=48 cliff=3"
+          "details": "river surf=51 terr=47 -> land(-30,-40) terr=48 cliff=3"
         },
         {
           "x": -31,
           "y": -29,
-          "details": "river surf=102 terr=101 -> land(-30,-29) terr=97 cliff=5"
+          "details": "river surf=102 terr=100 -> land(-30,-29) terr=97 cliff=5"
         },
         {
           "x": -31,
           "y": 51,
-          "details": "river surf=241 terr=240 -> land(-30,51) terr=239 cliff=2"
+          "details": "river surf=241 terr=237 -> land(-30,51) terr=239 cliff=2"
         },
         {
           "x": -31,
@@ -3512,54 +3352,64 @@
           "details": "river surf=126 terr=125 -> land(-29,-23) terr=124 cliff=2"
         },
         {
+          "x": -29,
+          "y": 52,
+          "details": "river surf=222 terr=216 -> land(-29,51) terr=220 cliff=2"
+        },
+        {
           "x": -28,
           "y": -41,
-          "details": "river surf=46 terr=45 -> land(-29,-41) terr=44 cliff=2"
+          "details": "river surf=46 terr=43 -> land(-29,-41) terr=44 cliff=2"
         },
         {
           "x": -28,
           "y": -23,
-          "details": "river surf=130 terr=129 -> land(-29,-23) terr=124 cliff=6"
+          "details": "river surf=130 terr=125 -> land(-29,-23) terr=124 cliff=6"
         },
         {
           "x": -28,
           "y": -22,
-          "details": "river surf=137 terr=136 -> land(-29,-22) terr=130 cliff=7"
+          "details": "river surf=137 terr=132 -> land(-29,-22) terr=130 cliff=7"
         },
         {
           "x": -28,
           "y": -21,
-          "details": "river surf=145 terr=144 -> land(-29,-21) terr=137 cliff=8"
+          "details": "river surf=145 terr=141 -> land(-29,-21) terr=137 cliff=8"
         },
         {
           "x": -27,
           "y": -24,
-          "details": "river surf=131 terr=130 -> land(-27,-25) terr=124 cliff=7"
+          "details": "river surf=131 terr=127 -> land(-27,-25) terr=124 cliff=7"
         },
         {
           "x": -27,
           "y": -21,
-          "details": "river surf=152 terr=151 -> land(-27,-22) terr=146 cliff=6"
+          "details": "river surf=152 terr=148 -> land(-27,-22) terr=146 cliff=6"
         },
         {
           "x": -26,
           "y": -24,
-          "details": "river surf=139 terr=138 -> land(-26,-25) terr=134 cliff=5"
+          "details": "river surf=139 terr=136 -> land(-26,-25) terr=134 cliff=5"
         },
         {
           "x": -26,
           "y": -21,
-          "details": "river surf=161 terr=160 -> land(-26,-22) terr=155 cliff=6"
+          "details": "river surf=161 terr=158 -> land(-26,-22) terr=155 cliff=6"
         },
         {
           "x": -26,
           "y": -20,
-          "details": "river surf=169 terr=168 -> land(-27,-20) terr=162 cliff=7"
+          "details": "river surf=169 terr=167 -> land(-27,-20) terr=162 cliff=7"
         },
         {
           "x": -26,
           "y": -19,
           "details": "river surf=176 terr=175 -> land(-27,-19) terr=171 cliff=5"
+        },
+        {
+          "x": -26,
+          "y": 50,
+          "details": "river surf=162 terr=157 -> land(-26,49) terr=160 cliff=2"
         },
         {
           "x": -25,
@@ -3569,7 +3419,12 @@
         {
           "x": -25,
           "y": -24,
-          "details": "river surf=148 terr=147 -> land(-25,-25) terr=142 cliff=6"
+          "details": "river surf=148 terr=145 -> land(-25,-25) terr=142 cliff=6"
+        },
+        {
+          "x": -25,
+          "y": 55,
+          "details": "river surf=210 terr=204 -> land(-24,55) terr=207 cliff=3"
         },
         {
           "x": -24,
@@ -3579,12 +3434,17 @@
         {
           "x": -24,
           "y": -24,
-          "details": "river surf=157 terr=156 -> land(-24,-25) terr=149 cliff=8"
+          "details": "river surf=157 terr=155 -> land(-24,-25) terr=149 cliff=8"
         },
         {
           "x": -24,
           "y": -1,
-          "details": "river surf=174 terr=133 -> land(-25,-1) terr=145 cliff=29"
+          "details": "river surf=174 terr=126 -> land(-25,-1) terr=138 cliff=36"
+        },
+        {
+          "x": -24,
+          "y": 54,
+          "details": "river surf=186 terr=179 -> land(-23,54) terr=184 cliff=2"
         },
         {
           "x": -23,
@@ -3599,37 +3459,57 @@
         {
           "x": -23,
           "y": -30,
-          "details": "river surf=93 terr=92 -> land(-23,-31) terr=87 cliff=6"
+          "details": "river surf=93 terr=88 -> land(-23,-31) terr=87 cliff=6"
         },
         {
           "x": -23,
           "y": -29,
-          "details": "river surf=104 terr=103 -> land(-24,-29) terr=95 cliff=9"
+          "details": "river surf=104 terr=99 -> land(-24,-29) terr=95 cliff=9"
         },
         {
           "x": -23,
           "y": -28,
-          "details": "river surf=115 terr=114 -> land(-24,-28) terr=109 cliff=6"
+          "details": "river surf=115 terr=109 -> land(-24,-28) terr=109 cliff=6"
         },
         {
           "x": -23,
           "y": -25,
-          "details": "river surf=151 terr=150 -> land(-24,-25) terr=149 cliff=2"
+          "details": "river surf=151 terr=148 -> land(-24,-25) terr=149 cliff=2"
+        },
+        {
+          "x": -23,
+          "y": -2,
+          "details": "river surf=150 terr=142 -> land(-23,-3) terr=147 cliff=3"
         },
         {
           "x": -23,
           "y": -1,
-          "details": "river surf=162 terr=121 -> land(-22,-1) terr=109 cliff=53"
+          "details": "river surf=162 terr=114 -> land(-22,-1) terr=102 cliff=60"
         },
         {
           "x": -22,
           "y": -31,
-          "details": "river surf=91 terr=90 -> land(-23,-31) terr=87 cliff=4"
+          "details": "river surf=91 terr=88 -> land(-23,-31) terr=87 cliff=4"
+        },
+        {
+          "x": -22,
+          "y": -5,
+          "details": "river surf=126 terr=119 -> land(-22,-4) terr=123 cliff=3"
+        },
+        {
+          "x": -22,
+          "y": -3,
+          "details": "river surf=126 terr=119 -> land(-22,-4) terr=123 cliff=3"
         },
         {
           "x": -22,
           "y": -2,
-          "details": "river surf=138 terr=137 -> land(-21,-2) terr=125 cliff=13"
+          "details": "river surf=138 terr=130 -> land(-21,-2) terr=118 cliff=20"
+        },
+        {
+          "x": -22,
+          "y": 42,
+          "details": "river surf=102 terr=96 -> land(-21,42) terr=100 cliff=2"
         },
         {
           "x": -21,
@@ -3639,12 +3519,17 @@
         {
           "x": -21,
           "y": -29,
-          "details": "river surf=115 terr=114 -> land(-22,-29) terr=111 cliff=4"
+          "details": "river surf=115 terr=112 -> land(-22,-29) terr=111 cliff=4"
         },
         {
           "x": -21,
           "y": -3,
-          "details": "river surf=114 terr=113 -> land(-20,-3) terr=109 cliff=5"
+          "details": "river surf=114 terr=107 -> land(-20,-3) terr=104 cliff=10"
+        },
+        {
+          "x": -21,
+          "y": 49,
+          "details": "river surf=90 terr=82 -> land(-21,48) terr=88 cliff=2"
         },
         {
           "x": -20,
@@ -3664,22 +3549,27 @@
         {
           "x": -20,
           "y": -32,
-          "details": "river surf=86 terr=85 -> land(-19,-32) terr=82 cliff=4"
+          "details": "river surf=86 terr=84 -> land(-19,-32) terr=82 cliff=4"
         },
         {
           "x": -20,
           "y": -31,
-          "details": "river surf=93 terr=92 -> land(-19,-31) terr=90 cliff=3"
+          "details": "river surf=93 terr=90 -> land(-19,-31) terr=90 cliff=3"
         },
         {
           "x": -20,
           "y": -30,
-          "details": "river surf=103 terr=102 -> land(-19,-30) terr=99 cliff=4"
+          "details": "river surf=103 terr=100 -> land(-19,-30) terr=99 cliff=4"
         },
         {
           "x": -20,
           "y": -11,
-          "details": "river surf=149 terr=148 -> land(-19,-11) terr=147 cliff=2"
+          "details": "river surf=149 terr=146 -> land(-19,-11) terr=147 cliff=2"
+        },
+        {
+          "x": -20,
+          "y": 49,
+          "details": "river surf=78 terr=70 -> land(-20,48) terr=76 cliff=2"
         },
         {
           "x": -19,
@@ -3699,12 +3589,32 @@
         {
           "x": -19,
           "y": -16,
-          "details": "river surf=157 terr=156 -> land(-18,-16) terr=149 cliff=8"
+          "details": "river surf=157 terr=155 -> land(-18,-16) terr=149 cliff=8"
         },
         {
           "x": -19,
           "y": -12,
-          "details": "river surf=136 terr=135 -> land(-18,-12) terr=132 cliff=4"
+          "details": "river surf=136 terr=132 -> land(-18,-12) terr=132 cliff=4"
+        },
+        {
+          "x": -19,
+          "y": -8,
+          "details": "river surf=126 terr=121 -> land(-18,-8) terr=124 cliff=2"
+        },
+        {
+          "x": -19,
+          "y": -7,
+          "details": "river surf=114 terr=109 -> land(-19,-6) terr=112 cliff=2"
+        },
+        {
+          "x": -19,
+          "y": -4,
+          "details": "river surf=78 terr=72 -> land(-19,-3) terr=76 cliff=2"
+        },
+        {
+          "x": -19,
+          "y": 57,
+          "details": "river surf=162 terr=155 -> land(-19,56) terr=158 cliff=4"
         },
         {
           "x": -18,
@@ -3719,12 +3629,12 @@
         {
           "x": -18,
           "y": 59,
-          "details": "river surf=169 terr=168 -> land(-17,59) terr=166 cliff=3"
+          "details": "river surf=169 terr=163 -> land(-17,59) terr=166 cliff=3"
         },
         {
           "x": -18,
           "y": 64,
-          "details": "river surf=182 terr=181 -> land(-18,65) terr=179 cliff=3"
+          "details": "river surf=182 terr=177 -> land(-18,65) terr=179 cliff=3"
         },
         {
           "x": -17,
@@ -3734,27 +3644,37 @@
         {
           "x": -17,
           "y": -37,
-          "details": "river surf=53 terr=52 -> land(-17,-38) terr=50 cliff=3"
+          "details": "river surf=53 terr=51 -> land(-17,-38) terr=50 cliff=3"
         },
         {
           "x": -17,
           "y": -23,
-          "details": "river surf=116 terr=115 -> land(-17,-24) terr=114 cliff=2"
+          "details": "river surf=116 terr=110 -> land(-17,-24) terr=114 cliff=2"
+        },
+        {
+          "x": -17,
+          "y": -5,
+          "details": "river surf=78 terr=72 -> land(-17,-4) terr=76 cliff=2"
+        },
+        {
+          "x": -17,
+          "y": 50,
+          "details": "river surf=54 terr=47 -> land(-16,50) terr=51 cliff=3"
         },
         {
           "x": -17,
           "y": 60,
-          "details": "river surf=168 terr=167 -> land(-17,59) terr=166 cliff=2"
+          "details": "river surf=168 terr=164 -> land(-17,59) terr=166 cliff=2"
         },
         {
           "x": -17,
           "y": 64,
-          "details": "river surf=171 terr=170 -> land(-17,65) terr=169 cliff=2"
+          "details": "river surf=171 terr=167 -> land(-17,65) terr=169 cliff=2"
         },
         {
           "x": -17,
           "y": 70,
-          "details": "river surf=155 terr=154 -> land(-17,71) terr=152 cliff=3"
+          "details": "river surf=155 terr=153 -> land(-17,71) terr=152 cliff=3"
         },
         {
           "x": -16,
@@ -3764,27 +3684,27 @@
         {
           "x": -16,
           "y": -39,
-          "details": "river surf=39 terr=38 -> land(-16,-40) terr=34 cliff=5"
+          "details": "river surf=39 terr=36 -> land(-16,-40) terr=34 cliff=5"
         },
         {
           "x": -16,
           "y": 52,
-          "details": "river surf=90 terr=87 -> land(-16,51) terr=85 cliff=5"
+          "details": "river surf=90 terr=83 -> land(-16,51) terr=79 cliff=11"
         },
         {
           "x": -16,
           "y": 60,
-          "details": "river surf=164 terr=163 -> land(-16,59) terr=162 cliff=2"
+          "details": "river surf=164 terr=161 -> land(-16,59) terr=162 cliff=2"
         },
         {
           "x": -16,
           "y": 66,
-          "details": "river surf=158 terr=157 -> land(-16,67) terr=156 cliff=2"
+          "details": "river surf=158 terr=155 -> land(-16,67) terr=156 cliff=2"
         },
         {
           "x": -16,
           "y": 70,
-          "details": "river surf=149 terr=148 -> land(-16,71) terr=147 cliff=2"
+          "details": "river surf=149 terr=147 -> land(-16,71) terr=147 cliff=2"
         },
         {
           "x": -15,
@@ -3794,7 +3714,7 @@
         {
           "x": -15,
           "y": -41,
-          "details": "river surf=22 terr=21 -> land(-15,-42) terr=20 cliff=2"
+          "details": "river surf=22 terr=19 -> land(-15,-42) terr=20 cliff=2"
         },
         {
           "x": -15,
@@ -3804,22 +3724,32 @@
         {
           "x": -15,
           "y": -15,
-          "details": "river surf=122 terr=120 -> land(-14,-15) terr=118 cliff=4"
+          "details": "river surf=122 terr=119 -> land(-14,-15) terr=118 cliff=4"
+        },
+        {
+          "x": -15,
+          "y": -6,
+          "details": "river surf=90 terr=85 -> land(-15,-5) terr=88 cliff=2"
+        },
+        {
+          "x": -15,
+          "y": 52,
+          "details": "river surf=102 terr=96 -> land(-15,51) terr=95 cliff=7"
         },
         {
           "x": -15,
           "y": 67,
-          "details": "river surf=148 terr=147 -> land(-15,68) terr=146 cliff=2"
+          "details": "river surf=148 terr=146 -> land(-15,68) terr=146 cliff=2"
         },
         {
           "x": -15,
           "y": 70,
-          "details": "river surf=142 terr=141 -> land(-15,71) terr=140 cliff=2"
+          "details": "river surf=142 terr=140 -> land(-15,71) terr=140 cliff=2"
         },
         {
           "x": -15,
           "y": 72,
-          "details": "river surf=137 terr=136 -> land(-15,73) terr=135 cliff=2"
+          "details": "river surf=137 terr=135 -> land(-15,73) terr=135 cliff=2"
         },
         {
           "x": -14,
@@ -3829,12 +3759,12 @@
         {
           "x": -14,
           "y": -35,
-          "details": "river surf=46 terr=45 -> land(-13,-35) terr=39 cliff=7"
+          "details": "river surf=46 terr=42 -> land(-13,-35) terr=39 cliff=7"
         },
         {
           "x": -14,
           "y": -34,
-          "details": "river surf=52 terr=51 -> land(-13,-34) terr=46 cliff=6"
+          "details": "river surf=52 terr=49 -> land(-13,-34) terr=46 cliff=6"
         },
         {
           "x": -14,
@@ -3844,7 +3774,12 @@
         {
           "x": -14,
           "y": -16,
-          "details": "river surf=110 terr=109 -> land(-13,-16) terr=108 cliff=2"
+          "details": "river surf=110 terr=108 -> land(-13,-16) terr=108 cliff=2"
+        },
+        {
+          "x": -14,
+          "y": 55,
+          "details": "river surf=150 terr=147 -> land(-14,54) terr=146 cliff=4"
         },
         {
           "x": -14,
@@ -3854,7 +3789,7 @@
         {
           "x": -14,
           "y": 70,
-          "details": "river surf=135 terr=134 -> land(-14,71) terr=131 cliff=4"
+          "details": "river surf=135 terr=133 -> land(-14,71) terr=131 cliff=4"
         },
         {
           "x": -13,
@@ -3864,32 +3799,37 @@
         {
           "x": -13,
           "y": -40,
-          "details": "river surf=11 terr=10 -> land(-12,-40) terr=8 cliff=3"
+          "details": "river surf=11 terr=8 -> land(-12,-40) terr=8 cliff=3"
         },
         {
           "x": -13,
           "y": -39,
-          "details": "river surf=15 terr=14 -> land(-12,-39) terr=11 cliff=4"
+          "details": "river surf=15 terr=12 -> land(-12,-39) terr=11 cliff=4"
         },
         {
           "x": -13,
           "y": -38,
-          "details": "river surf=21 terr=20 -> land(-12,-38) terr=15 cliff=6"
+          "details": "river surf=21 terr=17 -> land(-12,-38) terr=15 cliff=6"
         },
         {
           "x": -13,
           "y": -33,
-          "details": "river surf=53 terr=52 -> land(-13,-34) terr=46 cliff=7"
+          "details": "river surf=53 terr=49 -> land(-13,-34) terr=46 cliff=7"
         },
         {
           "x": -13,
           "y": -32,
-          "details": "river surf=60 terr=59 -> land(-12,-32) terr=53 cliff=7"
+          "details": "river surf=60 terr=56 -> land(-12,-32) terr=53 cliff=7"
         },
         {
           "x": -13,
           "y": -31,
-          "details": "river surf=67 terr=66 -> land(-12,-31) terr=60 cliff=7"
+          "details": "river surf=67 terr=64 -> land(-12,-31) terr=60 cliff=7"
+        },
+        {
+          "x": -13,
+          "y": -6,
+          "details": "river surf=101 terr=96 -> land(-13,-5) terr=99 cliff=2"
         },
         {
           "x": -13,
@@ -3904,22 +3844,32 @@
         {
           "x": -12,
           "y": -37,
-          "details": "river surf=20 terr=19 -> land(-12,-38) terr=15 cliff=5"
+          "details": "river surf=20 terr=16 -> land(-12,-38) terr=15 cliff=5"
         },
         {
           "x": -12,
           "y": -33,
-          "details": "river surf=45 terr=44 -> land(-12,-34) terr=38 cliff=7"
+          "details": "river surf=45 terr=40 -> land(-12,-34) terr=38 cliff=7"
         },
         {
           "x": -12,
           "y": -30,
-          "details": "river surf=67 terr=66 -> land(-12,-31) terr=60 cliff=7"
+          "details": "river surf=67 terr=64 -> land(-12,-31) terr=60 cliff=7"
         },
         {
           "x": -12,
           "y": -16,
           "details": "river surf=110 terr=109 -> land(-13,-16) terr=108 cliff=2"
+        },
+        {
+          "x": -12,
+          "y": -6,
+          "details": "river surf=101 terr=96 -> land(-11,-6) terr=99 cliff=2"
+        },
+        {
+          "x": -12,
+          "y": -5,
+          "details": "river surf=89 terr=83 -> land(-12,-4) terr=87 cliff=2"
         },
         {
           "x": -12,
@@ -3934,17 +3884,17 @@
         {
           "x": -12,
           "y": 73,
-          "details": "river surf=105 terr=104 -> land(-12,74) terr=99 cliff=6"
+          "details": "river surf=105 terr=102 -> land(-12,74) terr=99 cliff=6"
         },
         {
           "x": -11,
           "y": -33,
-          "details": "river surf=37 terr=36 -> land(-11,-34) terr=30 cliff=7"
+          "details": "river surf=37 terr=32 -> land(-11,-34) terr=30 cliff=7"
         },
         {
           "x": -11,
           "y": -30,
-          "details": "river surf=59 terr=58 -> land(-11,-31) terr=52 cliff=7"
+          "details": "river surf=59 terr=55 -> land(-11,-31) terr=52 cliff=7"
         },
         {
           "x": -11,
@@ -3954,12 +3904,12 @@
         {
           "x": -11,
           "y": 73,
-          "details": "river surf=93 terr=92 -> land(-10,73) terr=89 cliff=4"
+          "details": "river surf=93 terr=89 -> land(-10,73) terr=89 cliff=4"
         },
         {
           "x": -10,
           "y": -31,
-          "details": "river surf=43 terr=42 -> land(-10,-32) terr=35 cliff=8"
+          "details": "river surf=43 terr=38 -> land(-10,-32) terr=35 cliff=8"
         },
         {
           "x": -10,
@@ -3974,7 +3924,7 @@
         {
           "x": -10,
           "y": -3,
-          "details": "river surf=65 terr=64 -> land(-10,-2) terr=55 cliff=10"
+          "details": "river surf=65 terr=59 -> land(-10,-2) terr=50 cliff=15"
         },
         {
           "x": -10,
@@ -3994,12 +3944,12 @@
         {
           "x": -8,
           "y": -28,
-          "details": "river surf=55 terr=54 -> land(-7,-28) terr=47 cliff=8"
+          "details": "river surf=55 terr=49 -> land(-7,-28) terr=47 cliff=8"
         },
         {
           "x": -8,
           "y": -27,
-          "details": "river surf=65 terr=64 -> land(-7,-27) terr=58 cliff=7"
+          "details": "river surf=65 terr=60 -> land(-7,-27) terr=58 cliff=7"
         },
         {
           "x": -8,
@@ -4009,12 +3959,12 @@
         {
           "x": -8,
           "y": 55,
-          "details": "river surf=146 terr=145 -> land(-8,56) terr=139 cliff=7"
+          "details": "river surf=146 terr=144 -> land(-8,56) terr=139 cliff=7"
         },
         {
           "x": -8,
           "y": 57,
-          "details": "river surf=131 terr=130 -> land(-7,57) terr=128 cliff=3"
+          "details": "river surf=131 terr=129 -> land(-7,57) terr=128 cliff=3"
         },
         {
           "x": -7,
@@ -4024,7 +3974,7 @@
         {
           "x": -7,
           "y": 55,
-          "details": "river surf=141 terr=140 -> land(-7,56) terr=135 cliff=6"
+          "details": "river surf=141 terr=139 -> land(-7,56) terr=135 cliff=6"
         },
         {
           "x": -7,
@@ -4034,22 +3984,22 @@
         {
           "x": -6,
           "y": -29,
-          "details": "river surf=30 terr=29 -> land(-5,-29) terr=22 cliff=8"
+          "details": "river surf=30 terr=23 -> land(-5,-29) terr=22 cliff=8"
         },
         {
           "x": -6,
           "y": -23,
-          "details": "river surf=80 terr=79 -> land(-6,-24) terr=75 cliff=5"
+          "details": "river surf=80 terr=77 -> land(-6,-24) terr=75 cliff=5"
         },
         {
           "x": -6,
           "y": -2,
-          "details": "river surf=59 terr=58 -> land(-6,-1) terr=50 cliff=9"
+          "details": "river surf=59 terr=53 -> land(-6,-1) terr=50 cliff=9"
         },
         {
           "x": -6,
           "y": 55,
-          "details": "river surf=134 terr=133 -> land(-6,56) terr=129 cliff=5"
+          "details": "river surf=134 terr=131 -> land(-6,56) terr=129 cliff=5"
         },
         {
           "x": -6,
@@ -4064,17 +4014,17 @@
         {
           "x": -5,
           "y": -23,
-          "details": "river surf=69 terr=68 -> land(-5,-24) terr=65 cliff=4"
+          "details": "river surf=69 terr=66 -> land(-5,-24) terr=65 cliff=4"
         },
         {
           "x": -5,
           "y": -2,
-          "details": "river surf=47 terr=46 -> land(-5,-1) terr=40 cliff=7"
+          "details": "river surf=47 terr=41 -> land(-5,-1) terr=40 cliff=7"
         },
         {
           "x": -5,
           "y": 55,
-          "details": "river surf=127 terr=126 -> land(-5,56) terr=124 cliff=3"
+          "details": "river surf=127 terr=124 -> land(-5,56) terr=124 cliff=3"
         },
         {
           "x": -5,
@@ -4084,12 +4034,12 @@
         {
           "x": -4,
           "y": -23,
-          "details": "river surf=57 terr=56 -> land(-4,-24) terr=54 cliff=3"
+          "details": "river surf=57 terr=54 -> land(-4,-24) terr=54 cliff=3"
         },
         {
           "x": -4,
           "y": -2,
-          "details": "river surf=36 terr=35 -> land(-4,-1) terr=29 cliff=7"
+          "details": "river surf=36 terr=30 -> land(-4,-1) terr=29 cliff=7"
         },
         {
           "x": -4,
@@ -4109,12 +4059,12 @@
         {
           "x": -3,
           "y": -2,
-          "details": "river surf=24 terr=23 -> land(-3,-1) terr=19 cliff=5"
+          "details": "river surf=24 terr=19 -> land(-3,-1) terr=19 cliff=5"
         },
         {
           "x": -3,
           "y": 55,
-          "details": "river surf=112 terr=111 -> land(-3,54) terr=110 cliff=2"
+          "details": "river surf=112 terr=110 -> land(-3,54) terr=110 cliff=2"
         },
         {
           "x": -3,
@@ -4134,12 +4084,12 @@
         {
           "x": -2,
           "y": -2,
-          "details": "river surf=19 terr=18 -> land(-2,-1) terr=15 cliff=4"
+          "details": "river surf=19 terr=13 -> land(-2,-1) terr=15 cliff=4"
         },
         {
           "x": -2,
           "y": 55,
-          "details": "river surf=104 terr=103 -> land(-2,54) terr=102 cliff=2"
+          "details": "river surf=104 terr=102 -> land(-2,54) terr=102 cliff=2"
         },
         {
           "x": -1,
@@ -4149,12 +4099,12 @@
         {
           "x": -1,
           "y": -2,
-          "details": "river surf=15 terr=14 -> land(-1,-1) terr=12 cliff=3"
+          "details": "river surf=15 terr=10 -> land(-1,-1) terr=12 cliff=3"
         },
         {
           "x": -1,
           "y": 55,
-          "details": "river surf=98 terr=97 -> land(-1,54) terr=95 cliff=3"
+          "details": "river surf=98 terr=95 -> land(-1,54) terr=95 cliff=3"
         },
         {
           "x": 0,
@@ -4164,12 +4114,12 @@
         {
           "x": 0,
           "y": -2,
-          "details": "river surf=13 terr=12 -> land(0,-1) terr=10 cliff=3"
+          "details": "river surf=13 terr=9 -> land(0,-1) terr=10 cliff=3"
         },
         {
           "x": 0,
           "y": 55,
-          "details": "river surf=91 terr=90 -> land(0,54) terr=89 cliff=2"
+          "details": "river surf=91 terr=88 -> land(0,54) terr=89 cliff=2"
         },
         {
           "x": 1,
@@ -4179,7 +4129,7 @@
         {
           "x": 1,
           "y": -2,
-          "details": "river surf=11 terr=10 -> land(1,-1) terr=8 cliff=3"
+          "details": "river surf=11 terr=8 -> land(1,-1) terr=8 cliff=3"
         },
         {
           "x": 2,
@@ -4214,7 +4164,7 @@
         {
           "x": 3,
           "y": 55,
-          "details": "river surf=66 terr=65 -> land(3,56) terr=64 cliff=2"
+          "details": "river surf=66 terr=64 -> land(3,56) terr=64 cliff=2"
         },
         {
           "x": 4,
@@ -4229,17 +4179,17 @@
         {
           "x": 4,
           "y": 55,
-          "details": "river surf=61 terr=60 -> land(4,56) terr=54 cliff=7"
+          "details": "river surf=61 terr=59 -> land(4,56) terr=54 cliff=7"
         },
         {
           "x": 5,
           "y": 55,
-          "details": "river surf=60 terr=59 -> land(5,56) terr=48 cliff=12"
+          "details": "river surf=60 terr=58 -> land(5,56) terr=48 cliff=12"
         },
         {
           "x": 6,
           "y": 55,
-          "details": "river surf=53 terr=52 -> land(7,55) terr=39 cliff=14"
+          "details": "river surf=53 terr=50 -> land(7,55) terr=39 cliff=14"
         },
         {
           "x": 7,
@@ -4254,7 +4204,7 @@
         {
           "x": 8,
           "y": 54,
-          "details": "river surf=34 terr=33 -> land(8,55) terr=31 cliff=3"
+          "details": "river surf=34 terr=32 -> land(8,55) terr=31 cliff=3"
         },
         {
           "x": 9,
@@ -4269,22 +4219,22 @@
         {
           "x": 14,
           "y": 54,
-          "details": "river surf=9 terr=8 -> land(14,55) terr=6 cliff=3"
+          "details": "river surf=9 terr=6 -> land(14,55) terr=6 cliff=3"
         },
         {
           "x": 57,
           "y": -23,
-          "details": "river surf=4 terr=3 -> land(56,-23) terr=2 cliff=2"
+          "details": "river surf=4 terr=1 -> land(56,-23) terr=2 cliff=2"
         },
         {
           "x": 60,
           "y": -24,
-          "details": "river surf=10 terr=9 -> land(59,-24) terr=7 cliff=3"
+          "details": "river surf=10 terr=5 -> land(59,-24) terr=7 cliff=3"
         },
         {
           "x": 62,
           "y": -28,
-          "details": "river surf=14 terr=13 -> land(61,-28) terr=12 cliff=2"
+          "details": "river surf=14 terr=11 -> land(61,-28) terr=12 cliff=2"
         },
         {
           "x": 63,
@@ -4294,12 +4244,12 @@
         {
           "x": 65,
           "y": -25,
-          "details": "river surf=36 terr=35 -> land(65,-26) terr=29 cliff=7"
+          "details": "river surf=36 terr=30 -> land(65,-26) terr=29 cliff=7"
         },
         {
           "x": 66,
           "y": -25,
-          "details": "river surf=45 terr=44 -> land(66,-26) terr=37 cliff=8"
+          "details": "river surf=45 terr=39 -> land(66,-26) terr=37 cliff=8"
         },
         {
           "x": 67,
@@ -4314,12 +4264,12 @@
         {
           "x": 67,
           "y": -27,
-          "details": "river surf=36 terr=35 -> land(66,-27) terr=32 cliff=4"
+          "details": "river surf=36 terr=32 -> land(66,-27) terr=32 cliff=4"
         },
         {
           "x": 67,
           "y": -26,
-          "details": "river surf=42 terr=41 -> land(66,-26) terr=37 cliff=5"
+          "details": "river surf=42 terr=38 -> land(66,-26) terr=37 cliff=5"
         },
         {
           "x": 68,
@@ -4329,7 +4279,7 @@
         {
           "x": 68,
           "y": -23,
-          "details": "river surf=78 terr=77 -> land(67,-23) terr=76 cliff=2"
+          "details": "river surf=78 terr=72 -> land(67,-23) terr=76 cliff=2"
         },
         {
           "x": 69,
@@ -4344,52 +4294,67 @@
         {
           "x": 69,
           "y": -17,
-          "details": "river surf=150 terr=149 -> land(68,-17) terr=146 cliff=4"
+          "details": "river surf=150 terr=143 -> land(68,-17) terr=146 cliff=4"
         },
         {
           "x": 69,
           "y": -16,
-          "details": "river surf=162 terr=161 -> land(68,-16) terr=154 cliff=8"
+          "details": "river surf=162 terr=155 -> land(68,-16) terr=154 cliff=8"
         },
         {
           "x": 70,
           "y": -29,
-          "details": "river surf=22 terr=21 -> land(70,-30) terr=19 cliff=3"
+          "details": "river surf=22 terr=19 -> land(70,-30) terr=19 cliff=3"
         },
         {
           "x": 71,
           "y": -21,
-          "details": "river surf=90 terr=89 -> land(72,-21) terr=87 cliff=3"
+          "details": "river surf=90 terr=84 -> land(72,-21) terr=87 cliff=3"
         },
         {
           "x": 71,
           "y": 50,
-          "details": "river surf=18 terr=17 -> land(71,49) terr=6 cliff=12"
+          "details": "river surf=18 terr=12 -> land(71,49) terr=6 cliff=12"
         },
         {
           "x": 72,
           "y": -20,
-          "details": "river surf=97 terr=96 -> land(72,-21) terr=87 cliff=10"
+          "details": "river surf=97 terr=91 -> land(72,-21) terr=87 cliff=10"
         },
         {
           "x": 74,
           "y": -21,
-          "details": "river surf=83 terr=82 -> land(74,-22) terr=79 cliff=4"
+          "details": "river surf=83 terr=77 -> land(74,-22) terr=79 cliff=4"
         },
         {
           "x": 74,
           "y": 52,
-          "details": "lake surf=133 terr=109 -> land(73,52) terr=97 cliff=36"
+          "details": "lake surf=133 terr=104 -> land(73,52) terr=92 cliff=41"
         },
         {
           "x": 75,
           "y": -20,
-          "details": "river surf=101 terr=100 -> land(75,-21) terr=93 cliff=8"
+          "details": "river surf=101 terr=95 -> land(75,-21) terr=93 cliff=8"
+        },
+        {
+          "x": 75,
+          "y": 51,
+          "details": "river surf=78 terr=72 -> land(74,51) terr=76 cliff=2"
         },
         {
           "x": 76,
           "y": -19,
-          "details": "river surf=122 terr=121 -> land(76,-20) terr=112 cliff=10"
+          "details": "river surf=122 terr=117 -> land(76,-20) terr=112 cliff=10"
+        },
+        {
+          "x": 76,
+          "y": -15,
+          "details": "river surf=170 terr=164 -> land(75,-15) terr=168 cliff=2"
+        },
+        {
+          "x": 76,
+          "y": 52,
+          "details": "river surf=102 terr=97 -> land(75,52) terr=100 cliff=2"
         },
         {
           "x": 77,
@@ -4414,27 +4379,27 @@
         {
           "x": 77,
           "y": -27,
-          "details": "river surf=43 terr=42 -> land(78,-27) terr=38 cliff=5"
+          "details": "river surf=43 terr=41 -> land(78,-27) terr=38 cliff=5"
         },
         {
           "x": 77,
           "y": -26,
-          "details": "river surf=51 terr=50 -> land(78,-26) terr=45 cliff=6"
+          "details": "river surf=51 terr=49 -> land(78,-26) terr=45 cliff=6"
         },
         {
           "x": 77,
           "y": -22,
-          "details": "river surf=95 terr=94 -> land(76,-22) terr=93 cliff=2"
+          "details": "river surf=95 terr=91 -> land(76,-22) terr=93 cliff=2"
         },
         {
           "x": 77,
           "y": -21,
-          "details": "river surf=106 terr=105 -> land(76,-21) terr=102 cliff=4"
+          "details": "river surf=106 terr=102 -> land(76,-21) terr=102 cliff=4"
         },
         {
           "x": 77,
           "y": -20,
-          "details": "river surf=118 terr=117 -> land(76,-20) terr=112 cliff=6"
+          "details": "river surf=118 terr=114 -> land(76,-20) terr=112 cliff=6"
         },
         {
           "x": 78,
@@ -4454,32 +4419,32 @@
         {
           "x": 78,
           "y": -25,
-          "details": "river surf=54 terr=53 -> land(78,-26) terr=45 cliff=9"
+          "details": "river surf=54 terr=50 -> land(78,-26) terr=45 cliff=9"
         },
         {
           "x": 79,
           "y": -26,
-          "details": "river surf=37 terr=36 -> land(79,-27) terr=32 cliff=5"
+          "details": "river surf=37 terr=32 -> land(79,-27) terr=32 cliff=5"
         },
         {
           "x": 79,
           "y": 53,
-          "details": "river surf=150 terr=149 -> land(78,53) terr=144 cliff=6"
+          "details": "river surf=150 terr=145 -> land(78,53) terr=144 cliff=6"
         },
         {
           "x": 79,
           "y": 54,
-          "details": "river surf=155 terr=154 -> land(78,54) terr=151 cliff=4"
+          "details": "river surf=155 terr=151 -> land(78,54) terr=151 cliff=4"
         },
         {
           "x": 79,
           "y": 55,
-          "details": "river surf=162 terr=161 -> land(78,55) terr=155 cliff=7"
+          "details": "river surf=162 terr=159 -> land(78,55) terr=155 cliff=7"
         },
         {
           "x": 79,
           "y": 58,
-          "details": "river surf=189 terr=188 -> land(78,58) terr=184 cliff=5"
+          "details": "river surf=189 terr=187 -> land(78,58) terr=184 cliff=5"
         },
         {
           "x": 79,
@@ -4819,6 +4784,11 @@
           "details": "river surf=126 -> dry(-29,-23) terr=124 cliff=2"
         },
         {
+          "x": -29,
+          "y": 52,
+          "details": "river surf=222 -> dry(-29,51) terr=220 cliff=2"
+        },
+        {
           "x": -28,
           "y": -41,
           "details": "river surf=46 -> dry(-29,-41) terr=44 cliff=2"
@@ -4869,6 +4839,11 @@
           "details": "river surf=176 -> dry(-27,-19) terr=171 cliff=5"
         },
         {
+          "x": -26,
+          "y": 50,
+          "details": "river surf=162 -> dry(-26,49) terr=160 cliff=2"
+        },
+        {
           "x": -25,
           "y": -49,
           "details": "river surf=38 -> dry(-25,-50) terr=36 cliff=2"
@@ -4877,6 +4852,11 @@
           "x": -25,
           "y": -24,
           "details": "river surf=148 -> dry(-25,-25) terr=142 cliff=6"
+        },
+        {
+          "x": -25,
+          "y": 55,
+          "details": "river surf=210 -> dry(-24,55) terr=207 cliff=3"
         },
         {
           "x": -24,
@@ -4891,7 +4871,12 @@
         {
           "x": -24,
           "y": -1,
-          "details": "river surf=174 -> dry(-25,-1) terr=145 cliff=29"
+          "details": "river surf=174 -> dry(-25,-1) terr=138 cliff=36"
+        },
+        {
+          "x": -24,
+          "y": 54,
+          "details": "river surf=186 -> dry(-23,54) terr=184 cliff=2"
         },
         {
           "x": -23,
@@ -4925,8 +4910,13 @@
         },
         {
           "x": -23,
+          "y": -2,
+          "details": "river surf=150 -> dry(-23,-3) terr=147 cliff=3"
+        },
+        {
+          "x": -23,
           "y": -1,
-          "details": "river surf=162 -> dry(-22,-1) terr=109 cliff=53"
+          "details": "river surf=162 -> dry(-22,-1) terr=102 cliff=60"
         },
         {
           "x": -22,
@@ -4935,8 +4925,23 @@
         },
         {
           "x": -22,
+          "y": -5,
+          "details": "river surf=126 -> dry(-22,-4) terr=123 cliff=3"
+        },
+        {
+          "x": -22,
+          "y": -3,
+          "details": "river surf=126 -> dry(-22,-4) terr=123 cliff=3"
+        },
+        {
+          "x": -22,
           "y": -2,
-          "details": "river surf=138 -> dry(-21,-2) terr=125 cliff=13"
+          "details": "river surf=138 -> dry(-21,-2) terr=118 cliff=20"
+        },
+        {
+          "x": -22,
+          "y": 42,
+          "details": "river surf=102 -> dry(-21,42) terr=100 cliff=2"
         },
         {
           "x": -21,
@@ -4951,7 +4956,12 @@
         {
           "x": -21,
           "y": -3,
-          "details": "river surf=114 -> dry(-20,-3) terr=109 cliff=5"
+          "details": "river surf=114 -> dry(-20,-3) terr=104 cliff=10"
+        },
+        {
+          "x": -21,
+          "y": 49,
+          "details": "river surf=90 -> dry(-21,48) terr=88 cliff=2"
         },
         {
           "x": -20,
@@ -4989,6 +4999,11 @@
           "details": "river surf=149 -> dry(-19,-11) terr=147 cliff=2"
         },
         {
+          "x": -20,
+          "y": 49,
+          "details": "river surf=78 -> dry(-20,48) terr=76 cliff=2"
+        },
+        {
           "x": -19,
           "y": -63,
           "details": "river surf=27 -> dry(-19,-62) terr=25 cliff=2"
@@ -5012,6 +5027,26 @@
           "x": -19,
           "y": -12,
           "details": "river surf=136 -> dry(-18,-12) terr=132 cliff=4"
+        },
+        {
+          "x": -19,
+          "y": -8,
+          "details": "river surf=126 -> dry(-18,-8) terr=124 cliff=2"
+        },
+        {
+          "x": -19,
+          "y": -7,
+          "details": "river surf=114 -> dry(-19,-6) terr=112 cliff=2"
+        },
+        {
+          "x": -19,
+          "y": -4,
+          "details": "river surf=78 -> dry(-19,-3) terr=76 cliff=2"
+        },
+        {
+          "x": -19,
+          "y": 57,
+          "details": "river surf=162 -> dry(-19,56) terr=158 cliff=4"
         },
         {
           "x": -18,
@@ -5050,6 +5085,16 @@
         },
         {
           "x": -17,
+          "y": -5,
+          "details": "river surf=78 -> dry(-17,-4) terr=76 cliff=2"
+        },
+        {
+          "x": -17,
+          "y": 50,
+          "details": "river surf=54 -> dry(-16,50) terr=51 cliff=3"
+        },
+        {
+          "x": -17,
           "y": 60,
           "details": "river surf=168 -> dry(-17,59) terr=166 cliff=2"
         },
@@ -5076,7 +5121,7 @@
         {
           "x": -16,
           "y": 52,
-          "details": "river surf=90 -> dry(-16,51) terr=85 cliff=5"
+          "details": "river surf=90 -> dry(-16,51) terr=79 cliff=11"
         },
         {
           "x": -16,
@@ -5112,6 +5157,16 @@
           "x": -15,
           "y": -15,
           "details": "river surf=122 -> dry(-14,-15) terr=118 cliff=4"
+        },
+        {
+          "x": -15,
+          "y": -6,
+          "details": "river surf=90 -> dry(-15,-5) terr=88 cliff=2"
+        },
+        {
+          "x": -15,
+          "y": 52,
+          "details": "river surf=102 -> dry(-15,51) terr=95 cliff=7"
         },
         {
           "x": -15,
@@ -5152,6 +5207,11 @@
           "x": -14,
           "y": -16,
           "details": "river surf=110 -> dry(-13,-16) terr=108 cliff=2"
+        },
+        {
+          "x": -14,
+          "y": 55,
+          "details": "river surf=150 -> dry(-14,54) terr=146 cliff=4"
         },
         {
           "x": -14,
@@ -5200,6 +5260,11 @@
         },
         {
           "x": -13,
+          "y": -6,
+          "details": "river surf=101 -> dry(-13,-5) terr=99 cliff=2"
+        },
+        {
+          "x": -13,
           "y": 56,
           "details": "river surf=153 -> dry(-12,56) terr=149 cliff=4"
         },
@@ -5227,6 +5292,16 @@
           "x": -12,
           "y": -16,
           "details": "river surf=110 -> dry(-13,-16) terr=108 cliff=2"
+        },
+        {
+          "x": -12,
+          "y": -6,
+          "details": "river surf=101 -> dry(-11,-6) terr=99 cliff=2"
+        },
+        {
+          "x": -12,
+          "y": -5,
+          "details": "river surf=89 -> dry(-12,-4) terr=87 cliff=2"
         },
         {
           "x": -12,
@@ -5281,7 +5356,7 @@
         {
           "x": -10,
           "y": -3,
-          "details": "river surf=65 -> dry(-10,-2) terr=55 cliff=10"
+          "details": "river surf=65 -> dry(-10,-2) terr=50 cliff=15"
         },
         {
           "x": -10,
@@ -5686,7 +5761,7 @@
         {
           "x": 74,
           "y": 52,
-          "details": "lake surf=133 -> dry(73,52) terr=97 cliff=36"
+          "details": "lake surf=133 -> dry(73,52) terr=92 cliff=41"
         },
         {
           "x": 75,
@@ -5694,9 +5769,24 @@
           "details": "river surf=101 -> dry(75,-21) terr=93 cliff=8"
         },
         {
+          "x": 75,
+          "y": 51,
+          "details": "river surf=78 -> dry(74,51) terr=76 cliff=2"
+        },
+        {
           "x": 76,
           "y": -19,
           "details": "river surf=122 -> dry(76,-20) terr=112 cliff=10"
+        },
+        {
+          "x": 76,
+          "y": -15,
+          "details": "river surf=170 -> dry(75,-15) terr=168 cliff=2"
+        },
+        {
+          "x": 76,
+          "y": 52,
+          "details": "river surf=102 -> dry(75,52) terr=100 cliff=2"
         },
         {
           "x": 77,

--- a/tools/baselines/seed5050_size32_region_-4_-4_4_4.json
+++ b/tools/baselines/seed5050_size32_region_-4_-4_4_4.json
@@ -14,9 +14,9 @@
     "deterministic": true,
     "distinctHashes": 1,
     "hashes": [
-      "419b707bef2ec5ed3082ce1beb3990e5516e6a9b9c478d96ddb192366149f737",
-      "419b707bef2ec5ed3082ce1beb3990e5516e6a9b9c478d96ddb192366149f737",
-      "419b707bef2ec5ed3082ce1beb3990e5516e6a9b9c478d96ddb192366149f737"
+      "a9f608dab774d564bedccfb8860a06af4f3de5a274d8a57bacfd003e09d24183",
+      "a9f608dab774d564bedccfb8860a06af4f3de5a274d8a57bacfd003e09d24183",
+      "a9f608dab774d564bedccfb8860a06af4f3de5a274d8a57bacfd003e09d24183"
     ]
   },
   "tileCount": 20736,
@@ -87,13 +87,13 @@
   },
   "auditEnvelope": {
     "DESERT_SOIL_ON_SLOPE": {
-      "min": 36,
-      "max": 36,
-      "median": 36,
+      "min": 35,
+      "max": 35,
+      "median": 35,
       "all": [
-        36,
-        36,
-        36
+        35,
+        35,
+        35
       ]
     },
     "FLAT_ISOLATED_WATER": {
@@ -127,13 +127,13 @@
       ]
     },
     "FLOATING_WATER": {
-      "min": 198,
-      "max": 198,
-      "median": 198,
+      "min": 151,
+      "max": 151,
+      "median": 151,
       "all": [
-        198,
-        198,
-        198
+        151,
+        151,
+        151
       ]
     },
     "ISOLATED_FLUID": {
@@ -147,13 +147,13 @@
       ]
     },
     "MID_RIVER_CLIFF": {
-      "min": 1,
-      "max": 1,
-      "median": 1,
+      "min": 42,
+      "max": 42,
+      "median": 42,
       "all": [
-        1,
-        1,
-        1
+        42,
+        42,
+        42
       ]
     },
     "MULTI_ISLAND": {
@@ -177,23 +177,23 @@
       ]
     },
     "WATER_ABOVE_LAND": {
-      "min": 198,
-      "max": 198,
-      "median": 198,
+      "min": 199,
+      "max": 199,
+      "median": 199,
       "all": [
-        198,
-        198,
-        198
+        199,
+        199,
+        199
       ]
     },
     "WATER_CLIFF": {
-      "min": 198,
-      "max": 198,
-      "median": 198,
+      "min": 199,
+      "max": 199,
+      "median": 199,
       "all": [
-        198,
-        198,
-        198
+        199,
+        199,
+        199
       ]
     },
     "WATER_WATER_CLIFF": {
@@ -209,17 +209,17 @@
   },
   "representativeAudit": {
     "summary": {
-      "DESERT_SOIL_ON_SLOPE": 36,
+      "DESERT_SOIL_ON_SLOPE": 35,
       "FLAT_ISOLATED_WATER": 52,
       "FLOATING_LAKE": 471,
       "FLOATING_LAVA": 1,
-      "FLOATING_WATER": 198,
+      "FLOATING_WATER": 151,
       "ISOLATED_FLUID": 27,
-      "MID_RIVER_CLIFF": 1,
+      "MID_RIVER_CLIFF": 42,
       "MULTI_ISLAND": 2,
       "RIVER_CHUNK_GAP": 18,
-      "WATER_ABOVE_LAND": 198,
-      "WATER_CLIFF": 198,
+      "WATER_ABOVE_LAND": 199,
+      "WATER_CLIFF": 199,
       "WATER_WATER_CLIFF": 2123
     },
     "issues": {
@@ -292,7 +292,7 @@
         {
           "x": 54,
           "y": -5,
-          "details": "sand maxNbrDelta=5"
+          "details": "sand maxNbrDelta=8"
         },
         {
           "x": 61,
@@ -342,7 +342,7 @@
         {
           "x": 64,
           "y": -27,
-          "details": "sand maxNbrDelta=4"
+          "details": "sand maxNbrDelta=3"
         },
         {
           "x": 64,
@@ -368,11 +368,6 @@
           "x": 65,
           "y": -46,
           "details": "sand maxNbrDelta=4"
-        },
-        {
-          "x": 65,
-          "y": -38,
-          "details": "sand maxNbrDelta=3"
         },
         {
           "x": 65,
@@ -3055,52 +3050,32 @@
         {
           "x": -63,
           "y": 73,
-          "details": "river terr=125 -> dry(-62,73) terr=117 gap=8"
-        },
-        {
-          "x": -61,
-          "y": 70,
-          "details": "river terr=127 -> dry(-62,70) terr=121 gap=6"
-        },
-        {
-          "x": -59,
-          "y": 73,
-          "details": "river terr=110 -> dry(-59,74) terr=106 gap=4"
-        },
-        {
-          "x": -55,
-          "y": 75,
-          "details": "river terr=102 -> dry(-55,76) terr=98 gap=4"
+          "details": "river terr=118 -> dry(-62,73) terr=117 gap=1"
         },
         {
           "x": -54,
           "y": 73,
-          "details": "river terr=125 -> dry(-54,74) terr=118 gap=7"
+          "details": "river terr=120 -> dry(-54,74) terr=118 gap=2"
         },
         {
           "x": -53,
           "y": 73,
-          "details": "river terr=136 -> dry(-53,74) terr=129 gap=7"
+          "details": "river terr=130 -> dry(-53,74) terr=129 gap=1"
         },
         {
           "x": -52,
           "y": 72,
-          "details": "river terr=156 -> dry(-52,73) terr=148 gap=8"
+          "details": "river terr=151 -> dry(-52,73) terr=148 gap=3"
         },
         {
           "x": -51,
           "y": 72,
-          "details": "river terr=168 -> dry(-51,73) terr=160 gap=8"
-        },
-        {
-          "x": -50,
-          "y": 71,
-          "details": "river terr=185 -> dry(-50,72) terr=182 gap=3"
+          "details": "river terr=163 -> dry(-51,73) terr=160 gap=3"
         },
         {
           "x": -49,
           "y": 68,
-          "details": "river terr=186 -> dry(-49,67) terr=178 gap=8"
+          "details": "river terr=181 -> dry(-49,67) terr=178 gap=3"
         },
         {
           "x": -38,
@@ -3134,11 +3109,6 @@
         },
         {
           "x": -19,
-          "y": -5,
-          "details": "river terr=94 -> dry(-19,-6) terr=88 gap=6"
-        },
-        {
-          "x": -19,
           "y": 27,
           "details": "lake terr=261 -> dry(-20,27) terr=233 gap=28"
         },
@@ -3159,11 +3129,6 @@
         },
         {
           "x": -18,
-          "y": -6,
-          "details": "river terr=76 -> dry(-18,-7) terr=74 gap=2"
-        },
-        {
-          "x": -18,
           "y": 28,
           "details": "lake terr=318 -> dry(-19,28) terr=261 gap=57"
         },
@@ -3175,72 +3140,57 @@
         {
           "x": -12,
           "y": -8,
-          "details": "river terr=66 -> dry(-12,-9) terr=61 gap=5"
+          "details": "river terr=64 -> dry(-12,-9) terr=61 gap=3"
         },
         {
           "x": -11,
           "y": -8,
-          "details": "river terr=59 -> dry(-11,-9) terr=53 gap=6"
+          "details": "river terr=56 -> dry(-11,-9) terr=53 gap=3"
         },
         {
           "x": -11,
           "y": -7,
-          "details": "river terr=68 -> dry(-10,-7) terr=60 gap=8"
-        },
-        {
-          "x": -10,
-          "y": -8,
-          "details": "river terr=50 -> dry(-10,-9) terr=47 gap=3"
+          "details": "river terr=65 -> dry(-10,-7) terr=60 gap=5"
         },
         {
           "x": -10,
           "y": -5,
-          "details": "river terr=80 -> dry(-10,-6) terr=71 gap=9"
-        },
-        {
-          "x": -10,
-          "y": -4,
-          "details": "river terr=92 -> dry(-9,-4) terr=87 gap=5"
+          "details": "river terr=74 -> dry(-10,-6) terr=71 gap=3"
         },
         {
           "x": -9,
           "y": -10,
-          "details": "river terr=39 -> dry(-9,-9) terr=37 gap=2"
-        },
-        {
-          "x": -9,
-          "y": -8,
-          "details": "river terr=39 -> dry(-9,-9) terr=37 gap=2"
+          "details": "river terr=38 -> dry(-9,-9) terr=37 gap=1"
         },
         {
           "x": -9,
           "y": -6,
-          "details": "river terr=56 -> dry(-9,-7) terr=48 gap=8"
+          "details": "river terr=50 -> dry(-9,-7) terr=48 gap=2"
         },
         {
           "x": -9,
           "y": -5,
-          "details": "river terr=68 -> dry(-8,-5) terr=59 gap=9"
+          "details": "river terr=62 -> dry(-8,-5) terr=59 gap=3"
         },
         {
           "x": -8,
           "y": -10,
-          "details": "river terr=33 -> dry(-8,-9) terr=31 gap=2"
+          "details": "river terr=32 -> dry(-8,-9) terr=31 gap=1"
         },
         {
           "x": -8,
           "y": -6,
-          "details": "river terr=44 -> dry(-7,-6) terr=37 gap=7"
+          "details": "river terr=39 -> dry(-7,-6) terr=37 gap=2"
         },
         {
           "x": -7,
           "y": -10,
-          "details": "river terr=28 -> dry(-7,-9) terr=26 gap=2"
+          "details": "river terr=27 -> dry(-7,-9) terr=26 gap=1"
         },
         {
           "x": -5,
           "y": -14,
-          "details": "river terr=14 -> dry(-5,-15) terr=12 gap=2"
+          "details": "river terr=13 -> dry(-5,-15) terr=12 gap=1"
         },
         {
           "x": -4,
@@ -3248,44 +3198,9 @@
           "details": "river terr=9 -> dry(-3,-12) terr=6 gap=3"
         },
         {
-          "x": -4,
-          "y": -3,
-          "details": "river terr=22 -> dry(-4,-4) terr=20 gap=2"
-        },
-        {
-          "x": -3,
-          "y": -3,
-          "details": "river terr=18 -> dry(-3,-4) terr=17 gap=1"
-        },
-        {
-          "x": -3,
-          "y": -2,
-          "details": "river terr=22 -> dry(-2,-2) terr=19 gap=3"
-        },
-        {
-          "x": -3,
-          "y": -1,
-          "details": "river terr=27 -> dry(-2,-1) terr=23 gap=4"
-        },
-        {
-          "x": -3,
-          "y": 0,
-          "details": "river terr=33 -> dry(-2,0) terr=28 gap=5"
-        },
-        {
           "x": -2,
           "y": -7,
           "details": "river terr=8 -> dry(-1,-7) terr=7 gap=1"
-        },
-        {
-          "x": -2,
-          "y": -3,
-          "details": "river terr=15 -> dry(-2,-4) terr=14 gap=1"
-        },
-        {
-          "x": -2,
-          "y": 7,
-          "details": "river terr=72 -> dry(-2,6) terr=68 gap=4"
         },
         {
           "x": -1,
@@ -3294,63 +3209,38 @@
         },
         {
           "x": -1,
-          "y": 2,
-          "details": "river terr=30 -> dry(-1,1) terr=27 gap=3"
-        },
-        {
-          "x": -1,
           "y": 6,
-          "details": "river terr=57 -> dry(0,6) terr=50 gap=7"
+          "details": "river terr=52 -> dry(0,6) terr=50 gap=2"
         },
         {
           "x": -1,
           "y": 7,
-          "details": "river terr=64 -> dry(0,7) terr=58 gap=6"
-        },
-        {
-          "x": -1,
-          "y": 8,
-          "details": "river terr=70 -> dry(0,8) terr=66 gap=4"
-        },
-        {
-          "x": -1,
-          "y": 9,
-          "details": "river terr=78 -> dry(0,9) terr=74 gap=4"
-        },
-        {
-          "x": -1,
-          "y": 10,
-          "details": "river terr=86 -> dry(0,10) terr=82 gap=4"
-        },
-        {
-          "x": -1,
-          "y": 11,
-          "details": "river terr=96 -> dry(0,11) terr=90 gap=6"
+          "details": "river terr=59 -> dry(0,7) terr=58 gap=1"
         },
         {
           "x": 7,
           "y": 6,
-          "details": "river terr=23 -> dry(8,6) terr=20 gap=3"
+          "details": "river terr=22 -> dry(8,6) terr=20 gap=2"
         },
         {
           "x": 8,
           "y": 15,
-          "details": "river terr=100 -> dry(8,14) terr=95 gap=5"
+          "details": "river terr=97 -> dry(8,14) terr=95 gap=2"
         },
         {
           "x": 8,
           "y": 16,
-          "details": "river terr=107 -> dry(9,16) terr=103 gap=4"
+          "details": "river terr=105 -> dry(9,16) terr=103 gap=2"
         },
         {
           "x": 9,
           "y": 14,
-          "details": "river terr=81 -> dry(9,13) terr=75 gap=6"
+          "details": "river terr=76 -> dry(9,13) terr=75 gap=1"
         },
         {
           "x": 9,
           "y": 15,
-          "details": "river terr=91 -> dry(10,15) terr=86 gap=5"
+          "details": "river terr=87 -> dry(10,15) terr=86 gap=1"
         },
         {
           "x": 9,
@@ -3360,7 +3250,7 @@
         {
           "x": 10,
           "y": 14,
-          "details": "river terr=71 -> dry(11,14) terr=65 gap=6"
+          "details": "river terr=66 -> dry(11,14) terr=65 gap=1"
         },
         {
           "x": 10,
@@ -3369,73 +3259,28 @@
         },
         {
           "x": 11,
-          "y": 13,
-          "details": "river terr=55 -> dry(12,13) terr=49 gap=6"
-        },
-        {
-          "x": 11,
           "y": 17,
           "details": "river terr=107 -> dry(12,17) terr=106 gap=1"
         },
         {
           "x": 15,
-          "y": 5,
-          "details": "river terr=9 -> dry(15,4) terr=8 gap=1"
-        },
-        {
-          "x": 15,
           "y": 9,
-          "details": "river terr=27 -> dry(15,8) terr=21 gap=6"
-        },
-        {
-          "x": 15,
-          "y": 14,
-          "details": "river terr=58 -> dry(14,14) terr=55 gap=3"
+          "details": "river terr=23 -> dry(15,8) terr=21 gap=2"
         },
         {
           "x": 16,
           "y": 5,
-          "details": "river terr=19 -> dry(16,4) terr=15 gap=4"
-        },
-        {
-          "x": 16,
-          "y": 13,
-          "details": "river terr=64 -> dry(16,12) terr=60 gap=4"
-        },
-        {
-          "x": 16,
-          "y": 15,
-          "details": "river terr=82 -> dry(15,15) terr=78 gap=4"
-        },
-        {
-          "x": 17,
-          "y": 15,
-          "details": "river terr=94 -> dry(17,14) terr=90 gap=4"
-        },
-        {
-          "x": 18,
-          "y": 16,
-          "details": "river terr=118 -> dry(17,16) terr=116 gap=2"
-        },
-        {
-          "x": 18,
-          "y": 17,
-          "details": "river terr=130 -> dry(17,17) terr=128 gap=2"
+          "details": "river terr=16 -> dry(16,4) terr=15 gap=1"
         },
         {
           "x": 18,
           "y": 18,
-          "details": "river terr=142 -> dry(17,18) terr=138 gap=4"
-        },
-        {
-          "x": 19,
-          "y": 16,
-          "details": "river terr=130 -> dry(19,15) terr=128 gap=2"
+          "details": "river terr=140 -> dry(17,18) terr=138 gap=2"
         },
         {
           "x": 20,
           "y": 17,
-          "details": "river terr=152 -> dry(20,16) terr=146 gap=6"
+          "details": "river terr=151 -> dry(20,16) terr=146 gap=5"
         },
         {
           "x": 21,
@@ -3445,17 +3290,17 @@
         {
           "x": 22,
           "y": 70,
-          "details": "river terr=14 -> dry(21,70) terr=6 gap=8"
+          "details": "river terr=10 -> dry(21,70) terr=6 gap=4"
         },
         {
           "x": 23,
           "y": 70,
-          "details": "river terr=22 -> dry(23,71) terr=16 gap=6"
+          "details": "river terr=18 -> dry(23,71) terr=16 gap=2"
         },
         {
           "x": 24,
           "y": 71,
-          "details": "river terr=21 -> dry(23,71) terr=16 gap=5"
+          "details": "river terr=19 -> dry(23,71) terr=16 gap=3"
         },
         {
           "x": 24,
@@ -3475,17 +3320,12 @@
         {
           "x": 25,
           "y": 2,
-          "details": "river terr=29 -> dry(25,1) terr=24 gap=5"
+          "details": "river terr=25 -> dry(25,1) terr=24 gap=1"
         },
         {
           "x": 25,
           "y": 14,
           "details": "river terr=162 -> dry(24,14) terr=160 gap=2"
-        },
-        {
-          "x": 25,
-          "y": 69,
-          "details": "river terr=39 -> dry(24,69) terr=38 gap=1"
         },
         {
           "x": 27,
@@ -3494,73 +3334,38 @@
         },
         {
           "x": 27,
-          "y": 61,
-          "details": "river terr=136 -> dry(26,61) terr=135 gap=1"
-        },
-        {
-          "x": 27,
-          "y": 62,
-          "details": "river terr=128 -> dry(26,62) terr=126 gap=2"
-        },
-        {
-          "x": 27,
-          "y": 67,
-          "details": "river terr=68 -> dry(26,67) terr=66 gap=2"
-        },
-        {
-          "x": 27,
           "y": 68,
-          "details": "river terr=56 -> dry(26,68) terr=50 gap=6"
+          "details": "river terr=52 -> dry(26,68) terr=50 gap=2"
         },
         {
           "x": 29,
           "y": 2,
-          "details": "river terr=32 -> dry(29,1) terr=22 gap=10"
+          "details": "river terr=26 -> dry(29,1) terr=22 gap=4"
         },
         {
           "x": 30,
           "y": 0,
-          "details": "river terr=18 -> dry(30,-1) terr=11 gap=7"
+          "details": "river terr=12 -> dry(30,-1) terr=11 gap=1"
         },
         {
           "x": 30,
           "y": 1,
-          "details": "river terr=30 -> dry(29,1) terr=22 gap=8"
-        },
-        {
-          "x": 31,
-          "y": -1,
-          "details": "river terr=13 -> dry(30,-1) terr=11 gap=2"
-        },
-        {
-          "x": 33,
-          "y": 77,
-          "details": "river terr=20 -> dry(33,78) terr=18 gap=2"
-        },
-        {
-          "x": 34,
-          "y": 6,
-          "details": "river terr=102 -> dry(35,6) terr=101 gap=1"
-        },
-        {
-          "x": 34,
-          "y": 7,
-          "details": "river terr=109 -> dry(35,7) terr=107 gap=2"
+          "details": "river terr=25 -> dry(29,1) terr=22 gap=3"
         },
         {
           "x": 34,
           "y": 8,
-          "details": "river terr=115 -> dry(35,8) terr=112 gap=3"
+          "details": "river terr=113 -> dry(35,8) terr=112 gap=1"
         },
         {
           "x": 34,
           "y": 9,
-          "details": "river terr=120 -> dry(35,9) terr=117 gap=3"
+          "details": "river terr=119 -> dry(35,9) terr=117 gap=2"
         },
         {
           "x": 34,
           "y": 15,
-          "details": "river terr=156 -> dry(35,15) terr=152 gap=4"
+          "details": "river terr=155 -> dry(35,15) terr=152 gap=3"
         },
         {
           "x": 34,
@@ -3570,27 +3375,27 @@
         {
           "x": 34,
           "y": 77,
-          "details": "river terr=27 -> dry(34,78) terr=23 gap=4"
+          "details": "river terr=24 -> dry(34,78) terr=23 gap=1"
         },
         {
           "x": 35,
           "y": 10,
-          "details": "river terr=120 -> dry(35,9) terr=117 gap=3"
+          "details": "river terr=119 -> dry(35,9) terr=117 gap=2"
         },
         {
           "x": 35,
           "y": 77,
-          "details": "river terr=33 -> dry(35,78) terr=29 gap=4"
+          "details": "river terr=30 -> dry(35,78) terr=29 gap=1"
         },
         {
           "x": 36,
           "y": 78,
-          "details": "river terr=33 -> dry(35,78) terr=29 gap=4"
+          "details": "river terr=31 -> dry(35,78) terr=29 gap=2"
         },
         {
           "x": 36,
           "y": 79,
-          "details": "river terr=28 -> dry(35,79) terr=24 gap=4"
+          "details": "river terr=26 -> dry(35,79) terr=24 gap=2"
         },
         {
           "x": 37,
@@ -3614,18 +3419,13 @@
         },
         {
           "x": 39,
-          "y": 17,
-          "details": "river terr=167 -> dry(40,17) terr=166 gap=1"
-        },
-        {
-          "x": 39,
           "y": 73,
           "details": "river terr=79 -> dry(38,73) terr=76 gap=3"
         },
         {
           "x": 40,
           "y": 11,
-          "details": "river terr=119 -> dry(40,10) terr=117 gap=2"
+          "details": "river terr=118 -> dry(40,10) terr=117 gap=1"
         },
         {
           "x": 40,
@@ -3655,7 +3455,7 @@
         {
           "x": 41,
           "y": 12,
-          "details": "river terr=128 -> dry(41,11) terr=125 gap=3"
+          "details": "river terr=127 -> dry(41,11) terr=125 gap=2"
         },
         {
           "x": 42,
@@ -3700,7 +3500,7 @@
         {
           "x": 51,
           "y": 8,
-          "details": "river terr=111 -> dry(52,8) terr=108 gap=3"
+          "details": "river terr=110 -> dry(52,8) terr=108 gap=2"
         },
         {
           "x": 51,
@@ -3725,17 +3525,12 @@
         {
           "x": 53,
           "y": 7,
-          "details": "river terr=95 -> dry(54,7) terr=90 gap=5"
+          "details": "river terr=93 -> dry(54,7) terr=90 gap=3"
         },
         {
           "x": 55,
           "y": 6,
-          "details": "river terr=78 -> dry(56,6) terr=74 gap=4"
-        },
-        {
-          "x": 56,
-          "y": 5,
-          "details": "river terr=69 -> dry(57,5) terr=68 gap=1"
+          "details": "river terr=76 -> dry(56,6) terr=74 gap=2"
         },
         {
           "x": 57,
@@ -3820,7 +3615,7 @@
         {
           "x": 66,
           "y": -35,
-          "details": "river terr=12 -> dry(66,-36) terr=10 gap=2"
+          "details": "river terr=11 -> dry(66,-36) terr=10 gap=1"
         },
         {
           "x": 66,
@@ -3830,7 +3625,7 @@
         {
           "x": 66,
           "y": -28,
-          "details": "river terr=21 -> dry(66,-27) terr=18 gap=3"
+          "details": "river terr=20 -> dry(66,-27) terr=18 gap=2"
         },
         {
           "x": 66,
@@ -3849,13 +3644,8 @@
         },
         {
           "x": 67,
-          "y": -35,
-          "details": "river terr=18 -> dry(67,-36) terr=16 gap=2"
-        },
-        {
-          "x": 67,
           "y": -33,
-          "details": "river terr=26 -> dry(66,-33) terr=21 gap=5"
+          "details": "river terr=25 -> dry(66,-33) terr=21 gap=4"
         },
         {
           "x": 67,
@@ -3870,22 +3660,17 @@
         {
           "x": 68,
           "y": -40,
-          "details": "river terr=26 -> dry(67,-40) terr=20 gap=6"
+          "details": "river terr=24 -> dry(67,-40) terr=20 gap=4"
         },
         {
           "x": 68,
           "y": -35,
-          "details": "river terr=26 -> dry(68,-36) terr=23 gap=3"
+          "details": "river terr=24 -> dry(68,-36) terr=23 gap=1"
         },
         {
           "x": 68,
           "y": -29,
           "details": "river terr=40 -> dry(68,-28) terr=37 gap=3"
-        },
-        {
-          "x": 69,
-          "y": -48,
-          "details": "river terr=9 -> dry(68,-48) terr=7 gap=2"
         },
         {
           "x": 69,
@@ -3895,132 +3680,107 @@
         {
           "x": 69,
           "y": -40,
-          "details": "river terr=35 -> dry(69,-39) terr=28 gap=7"
+          "details": "river terr=33 -> dry(69,-39) terr=28 gap=5"
         },
         {
           "x": 69,
           "y": -35,
-          "details": "river terr=35 -> dry(69,-36) terr=30 gap=5"
+          "details": "river terr=32 -> dry(69,-36) terr=30 gap=2"
         },
         {
           "x": 70,
           "y": -43,
-          "details": "river terr=46 -> dry(70,-44) terr=41 gap=5"
+          "details": "river terr=45 -> dry(70,-44) terr=41 gap=4"
         },
         {
           "x": 70,
           "y": -39,
-          "details": "river terr=37 -> dry(69,-39) terr=28 gap=9"
+          "details": "river terr=35 -> dry(69,-39) terr=28 gap=7"
         },
         {
           "x": 70,
           "y": -35,
-          "details": "river terr=45 -> dry(70,-36) terr=38 gap=7"
+          "details": "river terr=41 -> dry(70,-36) terr=38 gap=3"
         },
         {
           "x": 71,
           "y": -43,
-          "details": "river terr=52 -> dry(71,-44) terr=48 gap=4"
+          "details": "river terr=51 -> dry(71,-44) terr=48 gap=3"
         },
         {
           "x": 71,
           "y": -34,
-          "details": "river terr=63 -> dry(71,-35) terr=58 gap=5"
+          "details": "river terr=59 -> dry(71,-35) terr=58 gap=1"
         },
         {
           "x": 72,
           "y": -47,
-          "details": "river terr=31 -> dry(71,-47) terr=26 gap=5"
+          "details": "river terr=29 -> dry(71,-47) terr=26 gap=3"
         },
         {
           "x": 72,
           "y": -46,
-          "details": "river terr=39 -> dry(71,-46) terr=34 gap=5"
+          "details": "river terr=37 -> dry(71,-46) terr=34 gap=3"
         },
         {
           "x": 72,
           "y": -45,
-          "details": "river terr=47 -> dry(71,-45) terr=41 gap=6"
+          "details": "river terr=46 -> dry(71,-45) terr=41 gap=5"
         },
         {
           "x": 72,
           "y": -44,
-          "details": "river terr=53 -> dry(71,-44) terr=48 gap=5"
+          "details": "river terr=51 -> dry(71,-44) terr=48 gap=3"
         },
         {
           "x": 73,
           "y": -45,
-          "details": "river terr=55 -> dry(73,-46) terr=49 gap=6"
-        },
-        {
-          "x": 73,
-          "y": -42,
-          "details": "river terr=66 -> dry(72,-42) terr=62 gap=4"
-        },
-        {
-          "x": 73,
-          "y": -40,
-          "details": "river terr=73 -> dry(73,-41) terr=72 gap=1"
+          "details": "river terr=53 -> dry(73,-46) terr=49 gap=4"
         },
         {
           "x": 74,
           "y": -45,
-          "details": "river terr=66 -> dry(74,-46) terr=59 gap=7"
+          "details": "river terr=63 -> dry(74,-46) terr=59 gap=4"
         },
         {
           "x": 74,
           "y": -41,
-          "details": "river terr=79 -> dry(73,-41) terr=72 gap=7"
-        },
-        {
-          "x": 74,
-          "y": -33,
-          "details": "river terr=101 -> dry(74,-34) terr=100 gap=1"
-        },
-        {
-          "x": 75,
-          "y": -49,
-          "details": "river terr=18 -> dry(74,-49) terr=15 gap=3"
+          "details": "river terr=76 -> dry(73,-41) terr=72 gap=4"
         },
         {
           "x": 75,
           "y": -45,
-          "details": "river terr=78 -> dry(75,-46) terr=71 gap=7"
+          "details": "river terr=75 -> dry(75,-46) terr=71 gap=4"
         },
         {
           "x": 75,
           "y": -36,
-          "details": "river terr=91 -> dry(74,-36) terr=84 gap=7"
+          "details": "river terr=87 -> dry(74,-36) terr=84 gap=3"
         },
         {
           "x": 75,
           "y": -35,
-          "details": "river terr=100 -> dry(74,-35) terr=92 gap=8"
+          "details": "river terr=96 -> dry(74,-35) terr=92 gap=4"
         },
         {
           "x": 76,
           "y": -49,
-          "details": "river terr=30 -> dry(76,-50) terr=20 gap=10"
+          "details": "river terr=26 -> dry(76,-50) terr=20 gap=6"
         },
         {
           "x": 77,
           "y": -39,
-          "details": "river terr=112 -> dry(77,-38) terr=104 gap=8"
+          "details": "river terr=109 -> dry(77,-38) terr=104 gap=5"
         },
         {
           "x": 77,
           "y": -36,
-          "details": "river terr=111 -> dry(77,-37) terr=104 gap=7"
+          "details": "river terr=108 -> dry(77,-37) terr=104 gap=4"
         },
         {
           "x": 78,
           "y": -36,
-          "details": "river terr=121 -> dry(78,-37) terr=115 gap=6"
-        },
-        {
-          "x": 79,
-          "y": -36,
-          "details": "river terr=129 -> dry(79,-37) terr=128 gap=1"
+          "details": "river terr=119 -> dry(78,-37) terr=115 gap=4"
         }
       ],
       "ISOLATED_FLUID": [
@@ -4162,9 +3922,214 @@
       ],
       "MID_RIVER_CLIFF": [
         {
+          "x": -63,
+          "y": 72,
+          "details": "river surf=117 (terr=110) -> water nbr surf=112 (terr=111) surf_diff=5 terr_diff=1"
+        },
+        {
+          "x": -61,
+          "y": 71,
+          "details": "river surf=116 (terr=109) -> water nbr surf=112 (terr=109) surf_diff=4 terr_diff=0"
+        },
+        {
+          "x": -56,
+          "y": 78,
+          "details": "river surf=85 (terr=81) -> water nbr surf=82 (terr=81) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -17,
+          "y": -7,
+          "details": "river surf=69 (terr=62) -> water nbr surf=66 (terr=63) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -16,
+          "y": -8,
+          "details": "river surf=67 (terr=62) -> water nbr surf=63 (terr=63) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -16,
+          "y": -6,
+          "details": "river surf=74 (terr=65) -> water nbr surf=70 (terr=67) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -15,
+          "y": -8,
+          "details": "river surf=69 (terr=63) -> water nbr surf=64 (terr=65) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -3,
+          "y": -3,
+          "details": "river surf=19 (terr=15) -> water nbr surf=16 (terr=14) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -1,
+          "y": 3,
+          "details": "river surf=37 (terr=31) -> water nbr surf=35 (terr=31) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 2,
+          "y": 6,
+          "details": "river surf=36 (terr=31) -> water nbr surf=32 (terr=29) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 9,
+          "y": 6,
+          "details": "river surf=11 (terr=5) -> water nbr surf=8 (terr=6) surf_diff=3 terr_diff=1"
+        },
+        {
           "x": 11,
           "y": 7,
+          "details": "river surf=12 (terr=7) -> water nbr surf=9 (terr=6) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 11,
+          "y": 8,
+          "details": "river surf=17 (terr=11) -> water nbr surf=12 (terr=9) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": 11,
+          "y": 9,
+          "details": "river surf=23 (terr=16) -> water nbr surf=18 (terr=14) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": 25,
+          "y": 72,
+          "details": "river surf=19 (terr=16) -> water nbr surf=16 (terr=15) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 25,
+          "y": 72,
+          "details": "river surf=19 (terr=16) -> water nbr surf=15 (terr=14) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 27,
+          "y": 73,
+          "details": "river surf=18 (terr=15) -> water nbr surf=16 (terr=15) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 27,
+          "y": 73,
+          "details": "river surf=18 (terr=15) -> water nbr surf=14 (terr=13) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 28,
+          "y": 0,
+          "details": "river surf=9 (terr=3) -> water nbr surf=6 (terr=4) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 30,
+          "y": 10,
+          "details": "river surf=139 (terr=136) -> water nbr surf=137 (terr=136) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 31,
+          "y": -2,
+          "details": "river surf=6 (terr=1) -> water nbr surf=4 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 32,
+          "y": -3,
+          "details": "river surf=6 (terr=1) -> water nbr surf=4 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 32,
+          "y": -3,
+          "details": "river surf=6 (terr=1) -> water nbr surf=4 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 33,
+          "y": -5,
+          "details": "river surf=4 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 34,
+          "y": -6,
+          "details": "river surf=4 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 34,
+          "y": -6,
+          "details": "river surf=4 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 35,
+          "y": -6,
+          "details": "river surf=6 (terr=2) -> water nbr surf=3 (terr=3) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 36,
+          "y": -1,
+          "details": "river surf=40 (terr=35) -> water nbr surf=36 (terr=37) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 37,
+          "y": 0,
+          "details": "river surf=44 (terr=40) -> water nbr surf=41 (terr=41) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 38,
+          "y": 0,
+          "details": "river surf=48 (terr=43) -> water nbr surf=44 (terr=45) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 47,
+          "y": 0,
+          "details": "river surf=36 (terr=33) -> water nbr surf=34 (terr=33) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 54,
+          "y": -6,
+          "details": "river surf=11 (terr=7) -> water nbr surf=8 (terr=7) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 54,
+          "y": -5,
+          "details": "river surf=15 (terr=11) -> water nbr surf=12 (terr=11) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 55,
+          "y": -4,
+          "details": "river surf=24 (terr=21) -> water nbr surf=20 (terr=19) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 65,
+          "y": -27,
+          "details": "river surf=12 (terr=9) -> water nbr surf=8 (terr=7) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 65,
+          "y": -27,
           "details": "river surf=12 (terr=9) -> water nbr surf=9 (terr=8) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 66,
+          "y": -39,
+          "details": "river surf=10 (terr=6) -> water nbr surf=7 (terr=6) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 66,
+          "y": -38,
+          "details": "river surf=9 (terr=6) -> water nbr surf=6 (terr=5) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 66,
+          "y": -37,
+          "details": "river surf=9 (terr=6) -> water nbr surf=6 (terr=5) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 71,
+          "y": -49,
+          "details": "river surf=10 (terr=6) -> water nbr surf=7 (terr=7) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 75,
+          "y": -51,
+          "details": "river surf=10 (terr=5) -> water nbr surf=8 (terr=5) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 75,
+          "y": -50,
+          "details": "river surf=12 (terr=7) -> water nbr surf=10 (terr=7) surf_diff=2 terr_diff=0"
         }
       ],
       "MULTI_ISLAND": [
@@ -4295,57 +4260,62 @@
         {
           "x": -63,
           "y": 73,
-          "details": "river surf=126 terr=125 -> land(-62,73) terr=117 cliff=9"
+          "details": "river surf=126 terr=118 -> land(-62,73) terr=117 cliff=9"
         },
         {
           "x": -61,
           "y": 70,
-          "details": "river surf=128 terr=127 -> land(-62,70) terr=121 cliff=7"
+          "details": "river surf=128 terr=121 -> land(-62,70) terr=121 cliff=7"
         },
         {
           "x": -59,
           "y": 73,
-          "details": "river surf=111 terr=110 -> land(-59,74) terr=106 cliff=5"
+          "details": "river surf=111 terr=105 -> land(-59,74) terr=106 cliff=5"
         },
         {
           "x": -55,
           "y": 75,
-          "details": "river surf=103 terr=102 -> land(-55,76) terr=98 cliff=5"
+          "details": "river surf=103 terr=98 -> land(-55,76) terr=98 cliff=5"
         },
         {
           "x": -54,
           "y": 73,
-          "details": "river surf=126 terr=125 -> land(-54,74) terr=118 cliff=8"
+          "details": "river surf=126 terr=120 -> land(-54,74) terr=118 cliff=8"
         },
         {
           "x": -53,
           "y": 73,
-          "details": "river surf=137 terr=136 -> land(-53,74) terr=129 cliff=8"
+          "details": "river surf=137 terr=130 -> land(-53,74) terr=129 cliff=8"
         },
         {
           "x": -52,
           "y": 72,
-          "details": "river surf=157 terr=156 -> land(-52,73) terr=148 cliff=9"
+          "details": "river surf=157 terr=151 -> land(-52,73) terr=148 cliff=9"
         },
         {
           "x": -51,
           "y": 72,
-          "details": "river surf=169 terr=168 -> land(-51,73) terr=160 cliff=9"
+          "details": "river surf=169 terr=163 -> land(-51,73) terr=160 cliff=9"
         },
         {
           "x": -50,
           "y": 71,
-          "details": "river surf=186 terr=185 -> land(-50,72) terr=182 cliff=4"
+          "details": "river surf=186 terr=180 -> land(-50,72) terr=182 cliff=4"
         },
         {
           "x": -49,
           "y": 68,
-          "details": "river surf=187 terr=186 -> land(-49,67) terr=178 cliff=9"
+          "details": "river surf=187 terr=181 -> land(-49,67) terr=178 cliff=9"
         },
         {
           "x": -38,
           "y": 70,
           "details": "lake surf=242 terr=233 -> land(-39,70) terr=233 cliff=9"
+        },
+        {
+          "x": -29,
+          "y": 79,
+          "details": "river surf=78 terr=72 -> land(-28,79) terr=76 cliff=2"
         },
         {
           "x": -21,
@@ -4375,7 +4345,7 @@
         {
           "x": -19,
           "y": -5,
-          "details": "river surf=95 terr=94 -> land(-19,-6) terr=88 cliff=7"
+          "details": "river surf=95 terr=87 -> land(-19,-6) terr=88 cliff=7"
         },
         {
           "x": -19,
@@ -4400,7 +4370,7 @@
         {
           "x": -18,
           "y": -6,
-          "details": "river surf=77 terr=76 -> land(-18,-7) terr=74 cliff=3"
+          "details": "river surf=77 terr=70 -> land(-18,-7) terr=74 cliff=3"
         },
         {
           "x": -18,
@@ -4415,72 +4385,72 @@
         {
           "x": -12,
           "y": -8,
-          "details": "river surf=67 terr=66 -> land(-12,-9) terr=61 cliff=6"
+          "details": "river surf=67 terr=64 -> land(-12,-9) terr=61 cliff=6"
         },
         {
           "x": -11,
           "y": -8,
-          "details": "river surf=60 terr=59 -> land(-11,-9) terr=53 cliff=7"
+          "details": "river surf=60 terr=56 -> land(-11,-9) terr=53 cliff=7"
         },
         {
           "x": -11,
           "y": -7,
-          "details": "river surf=69 terr=68 -> land(-10,-7) terr=60 cliff=9"
+          "details": "river surf=69 terr=65 -> land(-10,-7) terr=60 cliff=9"
         },
         {
           "x": -10,
           "y": -8,
-          "details": "river surf=51 terr=50 -> land(-10,-9) terr=47 cliff=4"
+          "details": "river surf=51 terr=46 -> land(-10,-9) terr=47 cliff=4"
         },
         {
           "x": -10,
           "y": -5,
-          "details": "river surf=81 terr=80 -> land(-10,-6) terr=71 cliff=10"
+          "details": "river surf=81 terr=74 -> land(-10,-6) terr=71 cliff=10"
         },
         {
           "x": -10,
           "y": -4,
-          "details": "river surf=93 terr=92 -> land(-9,-4) terr=87 cliff=6"
+          "details": "river surf=93 terr=86 -> land(-9,-4) terr=87 cliff=6"
         },
         {
           "x": -9,
           "y": -10,
-          "details": "river surf=40 terr=39 -> land(-9,-9) terr=37 cliff=3"
+          "details": "river surf=40 terr=38 -> land(-9,-9) terr=37 cliff=3"
         },
         {
           "x": -9,
           "y": -8,
-          "details": "river surf=40 terr=39 -> land(-9,-9) terr=37 cliff=3"
+          "details": "river surf=40 terr=35 -> land(-9,-9) terr=37 cliff=3"
         },
         {
           "x": -9,
           "y": -6,
-          "details": "river surf=57 terr=56 -> land(-9,-7) terr=48 cliff=9"
+          "details": "river surf=57 terr=50 -> land(-9,-7) terr=48 cliff=9"
         },
         {
           "x": -9,
           "y": -5,
-          "details": "river surf=69 terr=68 -> land(-8,-5) terr=59 cliff=10"
+          "details": "river surf=69 terr=62 -> land(-8,-5) terr=59 cliff=10"
         },
         {
           "x": -8,
           "y": -10,
-          "details": "river surf=34 terr=33 -> land(-8,-9) terr=31 cliff=3"
+          "details": "river surf=34 terr=32 -> land(-8,-9) terr=31 cliff=3"
         },
         {
           "x": -8,
           "y": -6,
-          "details": "river surf=45 terr=44 -> land(-7,-6) terr=37 cliff=8"
+          "details": "river surf=45 terr=39 -> land(-7,-6) terr=37 cliff=8"
         },
         {
           "x": -7,
           "y": -10,
-          "details": "river surf=29 terr=28 -> land(-7,-9) terr=26 cliff=3"
+          "details": "river surf=29 terr=27 -> land(-7,-9) terr=26 cliff=3"
         },
         {
           "x": -5,
           "y": -14,
-          "details": "river surf=15 terr=14 -> land(-5,-15) terr=12 cliff=3"
+          "details": "river surf=15 terr=13 -> land(-5,-15) terr=12 cliff=3"
         },
         {
           "x": -4,
@@ -4490,27 +4460,27 @@
         {
           "x": -4,
           "y": -3,
-          "details": "river surf=23 terr=22 -> land(-4,-4) terr=20 cliff=3"
+          "details": "river surf=23 terr=18 -> land(-4,-4) terr=20 cliff=3"
         },
         {
           "x": -3,
           "y": -3,
-          "details": "river surf=19 terr=18 -> land(-3,-4) terr=17 cliff=2"
+          "details": "river surf=19 terr=15 -> land(-3,-4) terr=17 cliff=2"
         },
         {
           "x": -3,
           "y": -2,
-          "details": "river surf=23 terr=22 -> land(-2,-2) terr=19 cliff=4"
+          "details": "river surf=23 terr=18 -> land(-2,-2) terr=19 cliff=4"
         },
         {
           "x": -3,
           "y": -1,
-          "details": "river surf=28 terr=27 -> land(-2,-1) terr=23 cliff=5"
+          "details": "river surf=28 terr=22 -> land(-2,-1) terr=23 cliff=5"
         },
         {
           "x": -3,
           "y": 0,
-          "details": "river surf=34 terr=33 -> land(-2,0) terr=28 cliff=6"
+          "details": "river surf=34 terr=27 -> land(-2,0) terr=28 cliff=6"
         },
         {
           "x": -2,
@@ -4520,12 +4490,12 @@
         {
           "x": -2,
           "y": -3,
-          "details": "river surf=16 terr=15 -> land(-2,-4) terr=14 cliff=2"
+          "details": "river surf=16 terr=14 -> land(-2,-4) terr=14 cliff=2"
         },
         {
           "x": -2,
           "y": 7,
-          "details": "river surf=73 terr=72 -> land(-2,6) terr=68 cliff=5"
+          "details": "river surf=73 terr=66 -> land(-2,6) terr=68 cliff=5"
         },
         {
           "x": -1,
@@ -4535,62 +4505,62 @@
         {
           "x": -1,
           "y": 2,
-          "details": "river surf=31 terr=30 -> land(-1,1) terr=27 cliff=4"
+          "details": "river surf=31 terr=26 -> land(-1,1) terr=27 cliff=4"
         },
         {
           "x": -1,
           "y": 6,
-          "details": "river surf=58 terr=57 -> land(0,6) terr=50 cliff=8"
+          "details": "river surf=58 terr=52 -> land(0,6) terr=50 cliff=8"
         },
         {
           "x": -1,
           "y": 7,
-          "details": "river surf=65 terr=64 -> land(0,7) terr=58 cliff=7"
+          "details": "river surf=65 terr=59 -> land(0,7) terr=58 cliff=7"
         },
         {
           "x": -1,
           "y": 8,
-          "details": "river surf=71 terr=70 -> land(0,8) terr=66 cliff=5"
+          "details": "river surf=71 terr=65 -> land(0,8) terr=66 cliff=5"
         },
         {
           "x": -1,
           "y": 9,
-          "details": "river surf=79 terr=78 -> land(0,9) terr=74 cliff=5"
+          "details": "river surf=79 terr=72 -> land(0,9) terr=74 cliff=5"
         },
         {
           "x": -1,
           "y": 10,
-          "details": "river surf=87 terr=86 -> land(0,10) terr=82 cliff=5"
+          "details": "river surf=87 terr=79 -> land(0,10) terr=82 cliff=5"
         },
         {
           "x": -1,
           "y": 11,
-          "details": "river surf=97 terr=96 -> land(0,11) terr=90 cliff=7"
+          "details": "river surf=97 terr=89 -> land(0,11) terr=90 cliff=7"
         },
         {
           "x": 7,
           "y": 6,
-          "details": "river surf=24 terr=23 -> land(8,6) terr=20 cliff=4"
+          "details": "river surf=24 terr=22 -> land(8,6) terr=20 cliff=4"
         },
         {
           "x": 8,
           "y": 15,
-          "details": "river surf=103 terr=100 -> land(8,14) terr=95 cliff=8"
+          "details": "river surf=103 terr=97 -> land(8,14) terr=95 cliff=8"
         },
         {
           "x": 8,
           "y": 16,
-          "details": "river surf=110 terr=107 -> land(9,16) terr=103 cliff=7"
+          "details": "river surf=110 terr=105 -> land(9,16) terr=103 cliff=7"
         },
         {
           "x": 9,
           "y": 14,
-          "details": "river surf=84 terr=81 -> land(9,13) terr=75 cliff=9"
+          "details": "river surf=84 terr=76 -> land(9,13) terr=75 cliff=9"
         },
         {
           "x": 9,
           "y": 15,
-          "details": "river surf=94 terr=91 -> land(10,15) terr=86 cliff=8"
+          "details": "river surf=94 terr=87 -> land(10,15) terr=86 cliff=8"
         },
         {
           "x": 9,
@@ -4600,7 +4570,7 @@
         {
           "x": 10,
           "y": 14,
-          "details": "river surf=74 terr=71 -> land(11,14) terr=65 cliff=9"
+          "details": "river surf=74 terr=66 -> land(11,14) terr=65 cliff=9"
         },
         {
           "x": 10,
@@ -4610,7 +4580,7 @@
         {
           "x": 11,
           "y": 13,
-          "details": "river surf=56 terr=55 -> land(12,13) terr=49 cliff=7"
+          "details": "river surf=56 terr=49 -> land(12,13) terr=49 cliff=7"
         },
         {
           "x": 11,
@@ -4620,62 +4590,62 @@
         {
           "x": 15,
           "y": 5,
-          "details": "river surf=10 terr=9 -> land(15,4) terr=8 cliff=2"
+          "details": "river surf=10 terr=6 -> land(15,4) terr=8 cliff=2"
         },
         {
           "x": 15,
           "y": 9,
-          "details": "river surf=28 terr=27 -> land(15,8) terr=21 cliff=7"
+          "details": "river surf=28 terr=23 -> land(15,8) terr=21 cliff=7"
         },
         {
           "x": 15,
           "y": 14,
-          "details": "river surf=59 terr=58 -> land(14,14) terr=55 cliff=4"
+          "details": "river surf=59 terr=53 -> land(14,14) terr=55 cliff=4"
         },
         {
           "x": 16,
           "y": 5,
-          "details": "river surf=20 terr=19 -> land(16,4) terr=15 cliff=5"
+          "details": "river surf=20 terr=16 -> land(16,4) terr=15 cliff=5"
         },
         {
           "x": 16,
           "y": 13,
-          "details": "river surf=65 terr=64 -> land(16,12) terr=60 cliff=5"
+          "details": "river surf=65 terr=59 -> land(16,12) terr=60 cliff=5"
         },
         {
           "x": 16,
           "y": 15,
-          "details": "river surf=83 terr=82 -> land(15,15) terr=78 cliff=5"
+          "details": "river surf=83 terr=77 -> land(15,15) terr=78 cliff=5"
         },
         {
           "x": 17,
           "y": 15,
-          "details": "river surf=95 terr=94 -> land(17,14) terr=90 cliff=5"
+          "details": "river surf=95 terr=89 -> land(17,14) terr=90 cliff=5"
         },
         {
           "x": 18,
           "y": 16,
-          "details": "river surf=119 terr=118 -> land(17,16) terr=116 cliff=3"
+          "details": "river surf=119 terr=114 -> land(17,16) terr=116 cliff=3"
         },
         {
           "x": 18,
           "y": 17,
-          "details": "river surf=131 terr=130 -> land(17,17) terr=128 cliff=3"
+          "details": "river surf=131 terr=128 -> land(17,17) terr=128 cliff=3"
         },
         {
           "x": 18,
           "y": 18,
-          "details": "river surf=143 terr=142 -> land(17,18) terr=138 cliff=5"
+          "details": "river surf=143 terr=140 -> land(17,18) terr=138 cliff=5"
         },
         {
           "x": 19,
           "y": 16,
-          "details": "river surf=131 terr=130 -> land(19,15) terr=128 cliff=3"
+          "details": "river surf=131 terr=126 -> land(19,15) terr=128 cliff=3"
         },
         {
           "x": 20,
           "y": 17,
-          "details": "river surf=153 terr=152 -> land(20,16) terr=146 cliff=7"
+          "details": "river surf=153 terr=151 -> land(20,16) terr=146 cliff=7"
         },
         {
           "x": 21,
@@ -4685,17 +4655,17 @@
         {
           "x": 22,
           "y": 70,
-          "details": "river surf=15 terr=14 -> land(21,70) terr=6 cliff=9"
+          "details": "river surf=15 terr=10 -> land(21,70) terr=6 cliff=9"
         },
         {
           "x": 23,
           "y": 70,
-          "details": "river surf=23 terr=22 -> land(23,71) terr=16 cliff=7"
+          "details": "river surf=23 terr=18 -> land(23,71) terr=16 cliff=7"
         },
         {
           "x": 24,
           "y": 71,
-          "details": "river surf=22 terr=21 -> land(23,71) terr=16 cliff=6"
+          "details": "river surf=22 terr=19 -> land(23,71) terr=16 cliff=6"
         },
         {
           "x": 24,
@@ -4715,7 +4685,7 @@
         {
           "x": 25,
           "y": 2,
-          "details": "river surf=30 terr=29 -> land(25,1) terr=24 cliff=6"
+          "details": "river surf=30 terr=25 -> land(25,1) terr=24 cliff=6"
         },
         {
           "x": 25,
@@ -4725,7 +4695,7 @@
         {
           "x": 25,
           "y": 69,
-          "details": "river surf=40 terr=39 -> land(24,69) terr=38 cliff=2"
+          "details": "river surf=40 terr=36 -> land(24,69) terr=38 cliff=2"
         },
         {
           "x": 27,
@@ -4735,72 +4705,72 @@
         {
           "x": 27,
           "y": 61,
-          "details": "river surf=137 terr=136 -> land(26,61) terr=135 cliff=2"
+          "details": "river surf=137 terr=135 -> land(26,61) terr=135 cliff=2"
         },
         {
           "x": 27,
           "y": 62,
-          "details": "river surf=129 terr=128 -> land(26,62) terr=126 cliff=3"
+          "details": "river surf=129 terr=126 -> land(26,62) terr=126 cliff=3"
         },
         {
           "x": 27,
           "y": 67,
-          "details": "river surf=69 terr=68 -> land(26,67) terr=66 cliff=3"
+          "details": "river surf=69 terr=63 -> land(26,67) terr=66 cliff=3"
         },
         {
           "x": 27,
           "y": 68,
-          "details": "river surf=57 terr=56 -> land(26,68) terr=50 cliff=7"
+          "details": "river surf=57 terr=52 -> land(26,68) terr=50 cliff=7"
         },
         {
           "x": 29,
           "y": 2,
-          "details": "river surf=33 terr=32 -> land(29,1) terr=22 cliff=11"
+          "details": "river surf=33 terr=26 -> land(29,1) terr=22 cliff=11"
         },
         {
           "x": 30,
           "y": 0,
-          "details": "river surf=19 terr=18 -> land(30,-1) terr=11 cliff=8"
+          "details": "river surf=19 terr=12 -> land(30,-1) terr=11 cliff=8"
         },
         {
           "x": 30,
           "y": 1,
-          "details": "river surf=31 terr=30 -> land(29,1) terr=22 cliff=9"
+          "details": "river surf=31 terr=25 -> land(29,1) terr=22 cliff=9"
         },
         {
           "x": 31,
           "y": -1,
-          "details": "river surf=14 terr=13 -> land(30,-1) terr=11 cliff=3"
+          "details": "river surf=14 terr=8 -> land(30,-1) terr=11 cliff=3"
         },
         {
           "x": 33,
           "y": 77,
-          "details": "river surf=21 terr=20 -> land(33,78) terr=18 cliff=3"
+          "details": "river surf=21 terr=18 -> land(33,78) terr=18 cliff=3"
         },
         {
           "x": 34,
           "y": 6,
-          "details": "river surf=103 terr=102 -> land(35,6) terr=101 cliff=2"
+          "details": "river surf=103 terr=100 -> land(35,6) terr=101 cliff=2"
         },
         {
           "x": 34,
           "y": 7,
-          "details": "river surf=110 terr=109 -> land(35,7) terr=107 cliff=3"
+          "details": "river surf=110 terr=107 -> land(35,7) terr=107 cliff=3"
         },
         {
           "x": 34,
           "y": 8,
-          "details": "river surf=116 terr=115 -> land(35,8) terr=112 cliff=4"
+          "details": "river surf=116 terr=113 -> land(35,8) terr=112 cliff=4"
         },
         {
           "x": 34,
           "y": 9,
-          "details": "river surf=121 terr=120 -> land(35,9) terr=117 cliff=4"
+          "details": "river surf=121 terr=119 -> land(35,9) terr=117 cliff=4"
         },
         {
           "x": 34,
           "y": 15,
-          "details": "river surf=157 terr=156 -> land(35,15) terr=152 cliff=5"
+          "details": "river surf=157 terr=155 -> land(35,15) terr=152 cliff=5"
         },
         {
           "x": 34,
@@ -4810,27 +4780,27 @@
         {
           "x": 34,
           "y": 77,
-          "details": "river surf=28 terr=27 -> land(34,78) terr=23 cliff=5"
+          "details": "river surf=28 terr=24 -> land(34,78) terr=23 cliff=5"
         },
         {
           "x": 35,
           "y": 10,
-          "details": "river surf=121 terr=120 -> land(35,9) terr=117 cliff=4"
+          "details": "river surf=121 terr=119 -> land(35,9) terr=117 cliff=4"
         },
         {
           "x": 35,
           "y": 77,
-          "details": "river surf=34 terr=33 -> land(35,78) terr=29 cliff=5"
+          "details": "river surf=34 terr=30 -> land(35,78) terr=29 cliff=5"
         },
         {
           "x": 36,
           "y": 78,
-          "details": "river surf=34 terr=33 -> land(35,78) terr=29 cliff=5"
+          "details": "river surf=34 terr=31 -> land(35,78) terr=29 cliff=5"
         },
         {
           "x": 36,
           "y": 79,
-          "details": "river surf=29 terr=28 -> land(35,79) terr=24 cliff=5"
+          "details": "river surf=29 terr=26 -> land(35,79) terr=24 cliff=5"
         },
         {
           "x": 37,
@@ -4855,7 +4825,7 @@
         {
           "x": 39,
           "y": 17,
-          "details": "river surf=168 terr=167 -> land(40,17) terr=166 cliff=2"
+          "details": "river surf=168 terr=165 -> land(40,17) terr=166 cliff=2"
         },
         {
           "x": 39,
@@ -4865,7 +4835,7 @@
         {
           "x": 40,
           "y": 11,
-          "details": "river surf=120 terr=119 -> land(40,10) terr=117 cliff=3"
+          "details": "river surf=120 terr=118 -> land(40,10) terr=117 cliff=3"
         },
         {
           "x": 40,
@@ -4895,7 +4865,7 @@
         {
           "x": 41,
           "y": 12,
-          "details": "river surf=129 terr=128 -> land(41,11) terr=125 cliff=4"
+          "details": "river surf=129 terr=127 -> land(41,11) terr=125 cliff=4"
         },
         {
           "x": 42,
@@ -4940,7 +4910,7 @@
         {
           "x": 51,
           "y": 8,
-          "details": "river surf=112 terr=111 -> land(52,8) terr=108 cliff=4"
+          "details": "river surf=112 terr=110 -> land(52,8) terr=108 cliff=4"
         },
         {
           "x": 51,
@@ -4965,17 +4935,17 @@
         {
           "x": 53,
           "y": 7,
-          "details": "river surf=96 terr=95 -> land(54,7) terr=90 cliff=6"
+          "details": "river surf=96 terr=93 -> land(54,7) terr=90 cliff=6"
         },
         {
           "x": 55,
           "y": 6,
-          "details": "river surf=79 terr=78 -> land(56,6) terr=74 cliff=5"
+          "details": "river surf=79 terr=76 -> land(56,6) terr=74 cliff=5"
         },
         {
           "x": 56,
           "y": 5,
-          "details": "river surf=70 terr=69 -> land(57,5) terr=68 cliff=2"
+          "details": "river surf=70 terr=68 -> land(57,5) terr=68 cliff=2"
         },
         {
           "x": 57,
@@ -5060,7 +5030,7 @@
         {
           "x": 66,
           "y": -35,
-          "details": "river surf=13 terr=12 -> land(66,-36) terr=10 cliff=3"
+          "details": "river surf=13 terr=11 -> land(66,-36) terr=10 cliff=3"
         },
         {
           "x": 66,
@@ -5070,7 +5040,7 @@
         {
           "x": 66,
           "y": -28,
-          "details": "river surf=22 terr=21 -> land(66,-27) terr=18 cliff=4"
+          "details": "river surf=22 terr=20 -> land(66,-27) terr=18 cliff=4"
         },
         {
           "x": 66,
@@ -5090,12 +5060,12 @@
         {
           "x": 67,
           "y": -35,
-          "details": "river surf=19 terr=18 -> land(67,-36) terr=16 cliff=3"
+          "details": "river surf=19 terr=16 -> land(67,-36) terr=16 cliff=3"
         },
         {
           "x": 67,
           "y": -33,
-          "details": "river surf=27 terr=26 -> land(66,-33) terr=21 cliff=6"
+          "details": "river surf=27 terr=25 -> land(66,-33) terr=21 cliff=6"
         },
         {
           "x": 67,
@@ -5110,12 +5080,12 @@
         {
           "x": 68,
           "y": -40,
-          "details": "river surf=27 terr=26 -> land(67,-40) terr=20 cliff=7"
+          "details": "river surf=27 terr=24 -> land(67,-40) terr=20 cliff=7"
         },
         {
           "x": 68,
           "y": -35,
-          "details": "river surf=27 terr=26 -> land(68,-36) terr=23 cliff=4"
+          "details": "river surf=27 terr=24 -> land(68,-36) terr=23 cliff=4"
         },
         {
           "x": 68,
@@ -5125,7 +5095,7 @@
         {
           "x": 69,
           "y": -48,
-          "details": "river surf=10 terr=9 -> land(68,-48) terr=7 cliff=3"
+          "details": "river surf=10 terr=7 -> land(68,-48) terr=7 cliff=3"
         },
         {
           "x": 69,
@@ -5135,132 +5105,132 @@
         {
           "x": 69,
           "y": -40,
-          "details": "river surf=36 terr=35 -> land(69,-39) terr=28 cliff=8"
+          "details": "river surf=36 terr=33 -> land(69,-39) terr=28 cliff=8"
         },
         {
           "x": 69,
           "y": -35,
-          "details": "river surf=36 terr=35 -> land(69,-36) terr=30 cliff=6"
+          "details": "river surf=36 terr=32 -> land(69,-36) terr=30 cliff=6"
         },
         {
           "x": 70,
           "y": -43,
-          "details": "river surf=47 terr=46 -> land(70,-44) terr=41 cliff=6"
+          "details": "river surf=47 terr=45 -> land(70,-44) terr=41 cliff=6"
         },
         {
           "x": 70,
           "y": -39,
-          "details": "river surf=38 terr=37 -> land(69,-39) terr=28 cliff=10"
+          "details": "river surf=38 terr=35 -> land(69,-39) terr=28 cliff=10"
         },
         {
           "x": 70,
           "y": -35,
-          "details": "river surf=46 terr=45 -> land(70,-36) terr=38 cliff=8"
+          "details": "river surf=46 terr=41 -> land(70,-36) terr=38 cliff=8"
         },
         {
           "x": 71,
           "y": -43,
-          "details": "river surf=53 terr=52 -> land(71,-44) terr=48 cliff=5"
+          "details": "river surf=53 terr=51 -> land(71,-44) terr=48 cliff=5"
         },
         {
           "x": 71,
           "y": -34,
-          "details": "river surf=64 terr=63 -> land(71,-35) terr=58 cliff=6"
+          "details": "river surf=64 terr=59 -> land(71,-35) terr=58 cliff=6"
         },
         {
           "x": 72,
           "y": -47,
-          "details": "river surf=32 terr=31 -> land(71,-47) terr=26 cliff=6"
+          "details": "river surf=32 terr=29 -> land(71,-47) terr=26 cliff=6"
         },
         {
           "x": 72,
           "y": -46,
-          "details": "river surf=40 terr=39 -> land(71,-46) terr=34 cliff=6"
+          "details": "river surf=40 terr=37 -> land(71,-46) terr=34 cliff=6"
         },
         {
           "x": 72,
           "y": -45,
-          "details": "river surf=48 terr=47 -> land(71,-45) terr=41 cliff=7"
+          "details": "river surf=48 terr=46 -> land(71,-45) terr=41 cliff=7"
         },
         {
           "x": 72,
           "y": -44,
-          "details": "river surf=54 terr=53 -> land(71,-44) terr=48 cliff=6"
+          "details": "river surf=54 terr=51 -> land(71,-44) terr=48 cliff=6"
         },
         {
           "x": 73,
           "y": -45,
-          "details": "river surf=56 terr=55 -> land(73,-46) terr=49 cliff=7"
+          "details": "river surf=56 terr=53 -> land(73,-46) terr=49 cliff=7"
         },
         {
           "x": 73,
           "y": -42,
-          "details": "river surf=67 terr=66 -> land(72,-42) terr=62 cliff=5"
+          "details": "river surf=67 terr=62 -> land(72,-42) terr=62 cliff=5"
         },
         {
           "x": 73,
           "y": -40,
-          "details": "river surf=74 terr=73 -> land(73,-41) terr=72 cliff=2"
+          "details": "river surf=74 terr=71 -> land(73,-41) terr=72 cliff=2"
         },
         {
           "x": 74,
           "y": -45,
-          "details": "river surf=67 terr=66 -> land(74,-46) terr=59 cliff=8"
+          "details": "river surf=67 terr=63 -> land(74,-46) terr=59 cliff=8"
         },
         {
           "x": 74,
           "y": -41,
-          "details": "river surf=80 terr=79 -> land(73,-41) terr=72 cliff=8"
+          "details": "river surf=80 terr=76 -> land(73,-41) terr=72 cliff=8"
         },
         {
           "x": 74,
           "y": -33,
-          "details": "river surf=102 terr=101 -> land(74,-34) terr=100 cliff=2"
+          "details": "river surf=102 terr=99 -> land(74,-34) terr=100 cliff=2"
         },
         {
           "x": 75,
           "y": -49,
-          "details": "river surf=19 terr=18 -> land(74,-49) terr=15 cliff=4"
+          "details": "river surf=19 terr=14 -> land(74,-49) terr=15 cliff=4"
         },
         {
           "x": 75,
           "y": -45,
-          "details": "river surf=79 terr=78 -> land(75,-46) terr=71 cliff=8"
+          "details": "river surf=79 terr=75 -> land(75,-46) terr=71 cliff=8"
         },
         {
           "x": 75,
           "y": -36,
-          "details": "river surf=92 terr=91 -> land(74,-36) terr=84 cliff=8"
+          "details": "river surf=92 terr=87 -> land(74,-36) terr=84 cliff=8"
         },
         {
           "x": 75,
           "y": -35,
-          "details": "river surf=101 terr=100 -> land(74,-35) terr=92 cliff=9"
+          "details": "river surf=101 terr=96 -> land(74,-35) terr=92 cliff=9"
         },
         {
           "x": 76,
           "y": -49,
-          "details": "river surf=31 terr=30 -> land(76,-50) terr=20 cliff=11"
+          "details": "river surf=31 terr=26 -> land(76,-50) terr=20 cliff=11"
         },
         {
           "x": 77,
           "y": -39,
-          "details": "river surf=113 terr=112 -> land(77,-38) terr=104 cliff=9"
+          "details": "river surf=113 terr=109 -> land(77,-38) terr=104 cliff=9"
         },
         {
           "x": 77,
           "y": -36,
-          "details": "river surf=112 terr=111 -> land(77,-37) terr=104 cliff=8"
+          "details": "river surf=112 terr=108 -> land(77,-37) terr=104 cliff=8"
         },
         {
           "x": 78,
           "y": -36,
-          "details": "river surf=122 terr=121 -> land(78,-37) terr=115 cliff=7"
+          "details": "river surf=122 terr=119 -> land(78,-37) terr=115 cliff=7"
         },
         {
           "x": 79,
           "y": -36,
-          "details": "river surf=130 terr=129 -> land(79,-37) terr=128 cliff=2"
+          "details": "river surf=130 terr=128 -> land(79,-37) terr=128 cliff=2"
         }
       ],
       "WATER_CLIFF": [
@@ -5338,6 +5308,11 @@
           "x": -38,
           "y": 70,
           "details": "lake surf=242 -> dry(-39,70) terr=233 cliff=9"
+        },
+        {
+          "x": -29,
+          "y": 79,
+          "details": "river surf=78 -> dry(-28,79) terr=76 cliff=2"
         },
         {
           "x": -21,

--- a/tools/baselines/seed666_size32_region_-4_-4_4_4.json
+++ b/tools/baselines/seed666_size32_region_-4_-4_4_4.json
@@ -14,9 +14,9 @@
     "deterministic": true,
     "distinctHashes": 1,
     "hashes": [
-      "065bf7639c1a08317692871bdfdecfd4ebc5ffda77b3661722a6d3e9cfdd109b",
-      "065bf7639c1a08317692871bdfdecfd4ebc5ffda77b3661722a6d3e9cfdd109b",
-      "065bf7639c1a08317692871bdfdecfd4ebc5ffda77b3661722a6d3e9cfdd109b"
+      "ac06262b1331babd0016c47e3d61a85be60ecd9d061c94a33621b30b10f2152b",
+      "ac06262b1331babd0016c47e3d61a85be60ecd9d061c94a33621b30b10f2152b",
+      "ac06262b1331babd0016c47e3d61a85be60ecd9d061c94a33621b30b10f2152b"
     ]
   },
   "tileCount": 20736,
@@ -117,13 +117,13 @@
       ]
     },
     "FLOATING_WATER": {
-      "min": 124,
-      "max": 124,
-      "median": 124,
+      "min": 75,
+      "max": 75,
+      "median": 75,
       "all": [
-        124,
-        124,
-        124
+        75,
+        75,
+        75
       ]
     },
     "ISLAND_1TILE": {
@@ -147,13 +147,13 @@
       ]
     },
     "MID_RIVER_CLIFF": {
-      "min": 2,
-      "max": 2,
-      "median": 2,
+      "min": 56,
+      "max": 56,
+      "median": 56,
       "all": [
-        2,
-        2,
-        2
+        56,
+        56,
+        56
       ]
     },
     "MULTI_ISLAND": {
@@ -187,23 +187,23 @@
       ]
     },
     "WATER_ABOVE_LAND": {
-      "min": 127,
-      "max": 127,
-      "median": 127,
+      "min": 131,
+      "max": 131,
+      "median": 131,
       "all": [
-        127,
-        127,
-        127
+        131,
+        131,
+        131
       ]
     },
     "WATER_CLIFF": {
-      "min": 127,
-      "max": 127,
-      "median": 127,
+      "min": 131,
+      "max": 131,
+      "median": 131,
       "all": [
-        127,
-        127,
-        127
+        131,
+        131,
+        131
       ]
     },
     "WATER_WATER_CLIFF": {
@@ -222,15 +222,15 @@
       "DESERT_SOIL_ON_SLOPE": 7,
       "FLAT_ISOLATED_WATER": 18,
       "FLOATING_LAKE": 8,
-      "FLOATING_WATER": 124,
+      "FLOATING_WATER": 75,
       "ISLAND_1TILE": 4,
       "ISOLATED_FLUID": 15,
-      "MID_RIVER_CLIFF": 2,
+      "MID_RIVER_CLIFF": 56,
       "MULTI_ISLAND": 6,
       "RIVER_CHUNK_GAP": 7,
       "RIVER_MOUTH_DROP": 4,
-      "WATER_ABOVE_LAND": 127,
-      "WATER_CLIFF": 127,
+      "WATER_ABOVE_LAND": 131,
+      "WATER_CLIFF": 131,
       "WATER_WATER_CLIFF": 2401
     },
     "issues": {
@@ -238,7 +238,7 @@
         {
           "x": -53,
           "y": 40,
-          "details": "sand maxNbrDelta=10"
+          "details": "sand maxNbrDelta=8"
         },
         {
           "x": -2,
@@ -367,7 +367,7 @@
         {
           "x": -62,
           "y": -54,
-          "details": "lake fluidSurf=207 terrainZ=153 depth=54"
+          "details": "lake fluidSurf=207 terrainZ=148 depth=59"
         },
         {
           "x": -38,
@@ -407,26 +407,6 @@
       ],
       "FLOATING_WATER": [
         {
-          "x": -64,
-          "y": -29,
-          "details": "river terr=137 -> dry(-64,-28) terr=134 gap=3"
-        },
-        {
-          "x": -64,
-          "y": 74,
-          "details": "river terr=105 -> dry(-63,74) terr=104 gap=1"
-        },
-        {
-          "x": -63,
-          "y": -29,
-          "details": "river terr=125 -> dry(-63,-28) terr=121 gap=4"
-        },
-        {
-          "x": -63,
-          "y": 75,
-          "details": "river terr=101 -> dry(-62,75) terr=98 gap=3"
-        },
-        {
           "x": -60,
           "y": -42,
           "details": "river terr=230 -> dry(-60,-43) terr=229 gap=1"
@@ -439,112 +419,32 @@
         {
           "x": -58,
           "y": -29,
-          "details": "river terr=129 -> dry(-58,-28) terr=120 gap=9"
-        },
-        {
-          "x": -58,
-          "y": 37,
-          "details": "river terr=8 -> dry(-57,37) terr=7 gap=1"
-        },
-        {
-          "x": -58,
-          "y": 38,
-          "details": "river terr=12 -> dry(-57,38) terr=10 gap=2"
+          "details": "river terr=124 -> dry(-58,-28) terr=120 gap=4"
         },
         {
           "x": -57,
           "y": -29,
-          "details": "river terr=141 -> dry(-57,-28) terr=131 gap=10"
-        },
-        {
-          "x": -57,
-          "y": 39,
-          "details": "river terr=12 -> dry(-57,38) terr=10 gap=2"
-        },
-        {
-          "x": -56,
-          "y": -25,
-          "details": "river terr=90 -> dry(-57,-25) terr=89 gap=1"
-        },
-        {
-          "x": -56,
-          "y": -24,
-          "details": "river terr=78 -> dry(-57,-24) terr=77 gap=1"
-        },
-        {
-          "x": -56,
-          "y": -23,
-          "details": "river terr=66 -> dry(-57,-23) terr=63 gap=3"
+          "details": "river terr=136 -> dry(-57,-28) terr=131 gap=5"
         },
         {
           "x": -55,
           "y": -64,
-          "details": "river terr=235 -> dry(-56,-64) terr=232 gap=3"
-        },
-        {
-          "x": -50,
-          "y": 42,
-          "details": "river terr=17 -> dry(-51,42) terr=15 gap=2"
-        },
-        {
-          "x": -44,
-          "y": -17,
-          "details": "river terr=7 -> dry(-44,-16) terr=5 gap=2"
-        },
-        {
-          "x": -43,
-          "y": -23,
-          "details": "river terr=59 -> dry(-42,-23) terr=54 gap=5"
+          "details": "river terr=234 -> dry(-56,-64) terr=232 gap=2"
         },
         {
           "x": -43,
           "y": -22,
-          "details": "river terr=47 -> dry(-42,-22) terr=41 gap=6"
+          "details": "river terr=42 -> dry(-42,-22) terr=41 gap=1"
         },
         {
           "x": -43,
           "y": -21,
-          "details": "river terr=35 -> dry(-42,-21) terr=29 gap=6"
-        },
-        {
-          "x": -43,
-          "y": -20,
-          "details": "river terr=24 -> dry(-42,-20) terr=20 gap=4"
-        },
-        {
-          "x": -43,
-          "y": -18,
-          "details": "river terr=9 -> dry(-42,-18) terr=8 gap=1"
+          "details": "river terr=30 -> dry(-42,-21) terr=29 gap=1"
         },
         {
           "x": -42,
           "y": -24,
-          "details": "river terr=65 -> dry(-42,-23) terr=54 gap=11"
-        },
-        {
-          "x": -42,
-          "y": -19,
-          "details": "river terr=12 -> dry(-42,-18) terr=8 gap=4"
-        },
-        {
-          "x": -41,
-          "y": -21,
-          "details": "river terr=21 -> dry(-40,-21) terr=17 gap=4"
-        },
-        {
-          "x": -41,
-          "y": -20,
-          "details": "river terr=13 -> dry(-40,-20) terr=11 gap=2"
-        },
-        {
-          "x": -41,
-          "y": -19,
-          "details": "river terr=7 -> dry(-40,-19) terr=6 gap=1"
-        },
-        {
-          "x": -41,
-          "y": -18,
-          "details": "river terr=4 -> dry(-41,-17) terr=3 gap=1"
+          "details": "river terr=60 -> dry(-42,-23) terr=54 gap=6"
         },
         {
           "x": -40,
@@ -554,7 +454,7 @@
         {
           "x": -40,
           "y": -22,
-          "details": "river terr=23 -> dry(-40,-21) terr=17 gap=6"
+          "details": "river terr=19 -> dry(-40,-21) terr=17 gap=2"
         },
         {
           "x": -39,
@@ -579,52 +479,42 @@
         {
           "x": -34,
           "y": -41,
-          "details": "river terr=226 -> dry(-33,-41) terr=219 gap=7"
+          "details": "river terr=223 -> dry(-33,-41) terr=219 gap=4"
         },
         {
           "x": -34,
           "y": -40,
-          "details": "river terr=214 -> dry(-33,-40) terr=207 gap=7"
-        },
-        {
-          "x": -33,
-          "y": -35,
-          "details": "river terr=155 -> dry(-33,-34) terr=151 gap=4"
+          "details": "river terr=210 -> dry(-33,-40) terr=207 gap=3"
         },
         {
           "x": -32,
           "y": -34,
-          "details": "river terr=136 -> dry(-32,-33) terr=127 gap=9"
-        },
-        {
-          "x": -31,
-          "y": -39,
-          "details": "river terr=166 -> dry(-30,-39) terr=160 gap=6"
+          "details": "river terr=130 -> dry(-32,-33) terr=127 gap=3"
         },
         {
           "x": -31,
           "y": -34,
-          "details": "river terr=124 -> dry(-31,-33) terr=116 gap=8"
+          "details": "river terr=119 -> dry(-31,-33) terr=116 gap=3"
         },
         {
           "x": -30,
           "y": -34,
-          "details": "river terr=112 -> dry(-30,-33) terr=104 gap=8"
+          "details": "river terr=107 -> dry(-30,-33) terr=104 gap=3"
         },
         {
           "x": -29,
           "y": -34,
-          "details": "river terr=101 -> dry(-29,-33) terr=94 gap=7"
+          "details": "river terr=97 -> dry(-29,-33) terr=94 gap=3"
         },
         {
           "x": -28,
           "y": -38,
-          "details": "river terr=124 -> dry(-27,-38) terr=119 gap=5"
+          "details": "river terr=120 -> dry(-27,-38) terr=119 gap=1"
         },
         {
           "x": -28,
           "y": -34,
-          "details": "river terr=92 -> dry(-28,-33) terr=85 gap=7"
+          "details": "river terr=88 -> dry(-28,-33) terr=85 gap=3"
         },
         {
           "x": -27,
@@ -634,47 +524,32 @@
         {
           "x": -27,
           "y": -36,
-          "details": "river terr=98 -> dry(-26,-36) terr=93 gap=5"
+          "details": "river terr=94 -> dry(-26,-36) terr=93 gap=1"
         },
         {
           "x": -27,
           "y": -33,
-          "details": "river terr=76 -> dry(-27,-32) terr=70 gap=6"
-        },
-        {
-          "x": -26,
-          "y": -63,
-          "details": "river terr=216 -> dry(-26,-62) terr=214 gap=2"
+          "details": "river terr=72 -> dry(-27,-32) terr=70 gap=2"
         },
         {
           "x": -26,
           "y": -35,
-          "details": "river terr=83 -> dry(-25,-35) terr=78 gap=5"
+          "details": "river terr=81 -> dry(-25,-35) terr=78 gap=3"
         },
         {
           "x": -26,
           "y": -33,
-          "details": "river terr=68 -> dry(-26,-32) terr=62 gap=6"
+          "details": "river terr=64 -> dry(-26,-32) terr=62 gap=2"
         },
         {
           "x": -25,
           "y": -63,
-          "details": "river terr=208 -> dry(-25,-62) terr=205 gap=3"
-        },
-        {
-          "x": -25,
-          "y": -42,
-          "details": "river terr=126 -> dry(-25,-41) terr=123 gap=3"
+          "details": "river terr=207 -> dry(-25,-62) terr=205 gap=2"
         },
         {
           "x": -24,
           "y": -63,
-          "details": "river terr=201 -> dry(-24,-62) terr=195 gap=6"
-        },
-        {
-          "x": -24,
-          "y": -41,
-          "details": "river terr=111 -> dry(-24,-40) terr=107 gap=4"
+          "details": "river terr=200 -> dry(-24,-62) terr=195 gap=5"
         },
         {
           "x": -24,
@@ -682,44 +557,14 @@
           "details": "river terr=63 -> dry(-23,-34) terr=59 gap=4"
         },
         {
-          "x": -24,
-          "y": -33,
-          "details": "river terr=54 -> dry(-23,-33) terr=51 gap=3"
-        },
-        {
-          "x": -23,
-          "y": -51,
-          "details": "river terr=149 -> dry(-22,-51) terr=148 gap=1"
-        },
-        {
-          "x": -23,
-          "y": -50,
-          "details": "river terr=145 -> dry(-22,-50) terr=143 gap=2"
-        },
-        {
-          "x": -23,
-          "y": -49,
-          "details": "river terr=139 -> dry(-22,-49) terr=134 gap=5"
-        },
-        {
-          "x": -23,
-          "y": -48,
-          "details": "river terr=131 -> dry(-22,-48) terr=127 gap=4"
-        },
-        {
           "x": -23,
           "y": -40,
-          "details": "river terr=98 -> dry(-23,-39) terr=93 gap=5"
-        },
-        {
-          "x": -23,
-          "y": -32,
-          "details": "river terr=42 -> dry(-22,-32) terr=40 gap=2"
+          "details": "river terr=96 -> dry(-23,-39) terr=93 gap=3"
         },
         {
           "x": -22,
           "y": -58,
-          "details": "river terr=160 -> dry(-21,-58) terr=157 gap=3"
+          "details": "river terr=158 -> dry(-21,-58) terr=157 gap=1"
         },
         {
           "x": -22,
@@ -729,17 +574,12 @@
         {
           "x": -22,
           "y": -39,
-          "details": "river terr=85 -> dry(-22,-38) terr=80 gap=5"
-        },
-        {
-          "x": -22,
-          "y": -31,
-          "details": "river terr=33 -> dry(-21,-31) terr=32 gap=1"
+          "details": "river terr=83 -> dry(-22,-38) terr=80 gap=3"
         },
         {
           "x": -21,
           "y": -59,
-          "details": "river terr=160 -> dry(-21,-58) terr=157 gap=3"
+          "details": "river terr=159 -> dry(-21,-58) terr=157 gap=2"
         },
         {
           "x": -21,
@@ -749,12 +589,12 @@
         {
           "x": -21,
           "y": -38,
-          "details": "river terr=71 -> dry(-21,-37) terr=66 gap=5"
+          "details": "river terr=69 -> dry(-21,-37) terr=66 gap=3"
         },
         {
           "x": -20,
           "y": -59,
-          "details": "river terr=155 -> dry(-20,-58) terr=153 gap=2"
+          "details": "river terr=154 -> dry(-20,-58) terr=153 gap=1"
         },
         {
           "x": -20,
@@ -764,22 +604,22 @@
         {
           "x": -20,
           "y": -48,
-          "details": "river terr=115 -> dry(-19,-48) terr=110 gap=5"
+          "details": "river terr=111 -> dry(-19,-48) terr=110 gap=1"
         },
         {
           "x": -20,
           "y": -47,
-          "details": "river terr=107 -> dry(-19,-47) terr=102 gap=5"
+          "details": "river terr=104 -> dry(-19,-47) terr=102 gap=2"
         },
         {
           "x": -20,
           "y": -38,
-          "details": "river terr=62 -> dry(-20,-37) terr=57 gap=5"
+          "details": "river terr=58 -> dry(-20,-37) terr=57 gap=1"
         },
         {
           "x": -19,
           "y": -59,
-          "details": "river terr=150 -> dry(-19,-58) terr=148 gap=2"
+          "details": "river terr=149 -> dry(-19,-58) terr=148 gap=1"
         },
         {
           "x": -19,
@@ -787,74 +627,24 @@
           "details": "river terr=134 -> dry(-19,-51) terr=131 gap=3"
         },
         {
-          "x": -19,
-          "y": -37,
-          "details": "river terr=46 -> dry(-19,-36) terr=43 gap=3"
-        },
-        {
-          "x": -18,
-          "y": -59,
-          "details": "river terr=144 -> dry(-18,-58) terr=142 gap=2"
-        },
-        {
           "x": -18,
           "y": -52,
           "details": "river terr=128 -> dry(-18,-51) terr=125 gap=3"
         },
         {
-          "x": -18,
-          "y": -36,
-          "details": "river terr=32 -> dry(-18,-35) terr=31 gap=1"
-        },
-        {
-          "x": -17,
-          "y": -59,
-          "details": "river terr=135 -> dry(-17,-58) terr=134 gap=1"
-        },
-        {
-          "x": -17,
-          "y": -52,
-          "details": "river terr=119 -> dry(-17,-51) terr=118 gap=1"
-        },
-        {
           "x": -15,
           "y": -64,
-          "details": "river terr=83 -> dry(-14,-64) terr=73 gap=10"
-        },
-        {
-          "x": -15,
-          "y": -39,
-          "details": "river terr=24 -> dry(-14,-39) terr=21 gap=3"
+          "details": "river terr=76 -> dry(-14,-64) terr=73 gap=3"
         },
         {
           "x": -14,
           "y": -63,
-          "details": "river terr=81 -> dry(-14,-64) terr=73 gap=8"
-        },
-        {
-          "x": -14,
-          "y": -50,
-          "details": "river terr=78 -> dry(-14,-49) terr=74 gap=4"
-        },
-        {
-          "x": -14,
-          "y": -40,
-          "details": "river terr=24 -> dry(-14,-39) terr=21 gap=3"
+          "details": "river terr=75 -> dry(-14,-64) terr=73 gap=2"
         },
         {
           "x": -13,
           "y": -63,
-          "details": "river terr=70 -> dry(-13,-64) terr=62 gap=8"
-        },
-        {
-          "x": -13,
-          "y": -40,
-          "details": "river terr=19 -> dry(-13,-39) terr=17 gap=2"
-        },
-        {
-          "x": -12,
-          "y": -63,
-          "details": "river terr=59 -> dry(-12,-64) terr=53 gap=6"
+          "details": "river terr=64 -> dry(-13,-64) terr=62 gap=2"
         },
         {
           "x": -12,
@@ -863,18 +653,8 @@
         },
         {
           "x": -11,
-          "y": -63,
-          "details": "river terr=49 -> dry(-11,-64) terr=44 gap=5"
-        },
-        {
-          "x": -11,
           "y": -40,
           "details": "river terr=12 -> dry(-11,-39) terr=10 gap=2"
-        },
-        {
-          "x": -10,
-          "y": -63,
-          "details": "river terr=40 -> dry(-10,-64) terr=35 gap=5"
         },
         {
           "x": -8,
@@ -902,16 +682,6 @@
           "details": "river terr=39 -> dry(-9,54) terr=36 gap=3"
         },
         {
-          "x": -7,
-          "y": 56,
-          "details": "river terr=58 -> dry(-6,56) terr=56 gap=2"
-        },
-        {
-          "x": -6,
-          "y": -64,
-          "details": "river terr=9 -> dry(-5,-64) terr=7 gap=2"
-        },
-        {
           "x": -6,
           "y": 55,
           "details": "river terr=44 -> dry(-5,55) terr=38 gap=6"
@@ -927,24 +697,9 @@
           "details": "river terr=28 -> dry(-4,54) terr=25 gap=3"
         },
         {
-          "x": -5,
-          "y": 65,
-          "details": "river terr=44 -> dry(-5,66) terr=41 gap=3"
-        },
-        {
           "x": -4,
           "y": 53,
           "details": "river terr=19 -> dry(-3,53) terr=17 gap=2"
-        },
-        {
-          "x": -4,
-          "y": 65,
-          "details": "river terr=39 -> dry(-4,66) terr=37 gap=2"
-        },
-        {
-          "x": -1,
-          "y": 59,
-          "details": "river terr=31 -> dry(-1,58) terr=30 gap=1"
         },
         {
           "x": 1,
@@ -1128,6 +883,271 @@
       ],
       "MID_RIVER_CLIFF": [
         {
+          "x": -64,
+          "y": 36,
+          "details": "river surf=8 (terr=4) -> water nbr surf=5 (terr=5) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -64,
+          "y": 36,
+          "details": "river surf=8 (terr=5) -> water nbr surf=6 (terr=5) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -63,
+          "y": 37,
+          "details": "river surf=10 (terr=5) -> water nbr surf=6 (terr=6) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -60,
+          "y": 37,
+          "details": "river surf=13 (terr=7) -> water nbr surf=8 (terr=9) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -59,
+          "y": 37,
+          "details": "river surf=11 (terr=6) -> water nbr surf=7 (terr=7) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -58,
+          "y": -18,
+          "details": "river surf=9 (terr=6) -> water nbr surf=5 (terr=4) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -58,
+          "y": 37,
+          "details": "river surf=9 (terr=5) -> water nbr surf=6 (terr=5) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -56,
+          "y": 39,
+          "details": "river surf=9 (terr=3) -> water nbr surf=7 (terr=3) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -55,
+          "y": 38,
+          "details": "river surf=5 (terr=2) -> water nbr surf=3 (terr=2) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -55,
+          "y": 39,
+          "details": "river surf=8 (terr=2) -> water nbr surf=5 (terr=3) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -54,
+          "y": 39,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -54,
+          "y": 39,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -54,
+          "y": 40,
+          "details": "river surf=9 (terr=1) -> water nbr surf=5 (terr=3) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -54,
+          "y": 40,
+          "details": "river surf=9 (terr=3) -> water nbr surf=5 (terr=1) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -53,
+          "y": 40,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -53,
+          "y": 40,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -52,
+          "y": 41,
+          "details": "river surf=6 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -49,
+          "y": 41,
+          "details": "river surf=5 (terr=1) -> water nbr surf=2 (terr=2) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -48,
+          "y": 41,
+          "details": "river surf=4 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -46,
+          "y": -17,
+          "details": "river surf=13 (terr=9) -> water nbr surf=8 (terr=7) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -45,
+          "y": -16,
+          "details": "river surf=6 (terr=3) -> water nbr surf=4 (terr=3) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -34,
+          "y": -23,
+          "details": "river surf=7 (terr=4) -> water nbr surf=4 (terr=3) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -27,
+          "y": -25,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -25,
+          "y": -45,
+          "details": "river surf=132 (terr=124) -> water nbr surf=129 (terr=123) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -24,
+          "y": -29,
+          "details": "river surf=26 (terr=21) -> water nbr surf=23 (terr=20) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -24,
+          "y": -28,
+          "details": "river surf=19 (terr=15) -> water nbr surf=16 (terr=14) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -23,
+          "y": -54,
+          "details": "river surf=155 (terr=151) -> water nbr surf=151 (terr=149) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -23,
+          "y": -53,
+          "details": "river surf=154 (terr=150) -> water nbr surf=150 (terr=148) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -23,
+          "y": -41,
+          "details": "river surf=102 (terr=97) -> water nbr surf=99 (terr=96) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -22,
+          "y": -55,
+          "details": "river surf=151 (terr=148) -> water nbr surf=148 (terr=147) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -21,
+          "y": -62,
+          "details": "river surf=171 (terr=167) -> water nbr surf=168 (terr=166) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -16,
+          "y": -35,
+          "details": "river surf=19 (terr=16) -> water nbr surf=15 (terr=14) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -15,
+          "y": -37,
+          "details": "river surf=17 (terr=14) -> water nbr surf=14 (terr=13) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -15,
+          "y": -36,
+          "details": "river surf=15 (terr=12) -> water nbr surf=12 (terr=11) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -14,
+          "y": -38,
+          "details": "river surf=17 (terr=14) -> water nbr surf=14 (terr=13) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -14,
+          "y": -38,
+          "details": "river surf=17 (terr=14) -> water nbr surf=14 (terr=13) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -13,
+          "y": -40,
+          "details": "river surf=20 (terr=17) -> water nbr surf=17 (terr=16) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -12,
+          "y": -42,
+          "details": "river surf=23 (terr=19) -> water nbr surf=18 (terr=17) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -12,
+          "y": -41,
+          "details": "river surf=19 (terr=16) -> water nbr surf=15 (terr=14) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -12,
+          "y": -41,
+          "details": "river surf=19 (terr=16) -> water nbr surf=17 (terr=16) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -11,
+          "y": -43,
+          "details": "river surf=21 (terr=17) -> water nbr surf=17 (terr=16) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -11,
+          "y": -43,
+          "details": "river surf=21 (terr=17) -> water nbr surf=18 (terr=17) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -10,
+          "y": -46,
+          "details": "river surf=22 (terr=17) -> water nbr surf=18 (terr=17) surf_diff=4 terr_diff=0"
+        },
+        {
+          "x": -10,
+          "y": -45,
+          "details": "river surf=22 (terr=18) -> water nbr surf=18 (terr=17) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -10,
+          "y": -44,
+          "details": "river surf=19 (terr=15) -> water nbr surf=16 (terr=15) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -9,
+          "y": -52,
+          "details": "river surf=29 (terr=25) -> water nbr surf=25 (terr=24) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -9,
+          "y": -49,
+          "details": "river surf=26 (terr=23) -> water nbr surf=22 (terr=21) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -9,
+          "y": -48,
+          "details": "river surf=25 (terr=22) -> water nbr surf=21 (terr=20) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -9,
+          "y": -47,
+          "details": "river surf=23 (terr=19) -> water nbr surf=18 (terr=17) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": -7,
+          "y": 55,
+          "details": "river surf=49 (terr=46) -> water nbr surf=45 (terr=44) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -6,
+          "y": -63,
+          "details": "river surf=13 (terr=10) -> water nbr surf=9 (terr=8) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -5,
+          "y": 53,
+          "details": "river surf=24 (terr=19) -> water nbr surf=20 (terr=20) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -5,
+          "y": 53,
+          "details": "river surf=24 (terr=20) -> water nbr surf=20 (terr=19) surf_diff=4 terr_diff=1"
+        },
+        {
           "x": -4,
           "y": 74,
           "details": "river surf=30 (terr=25) -> water nbr surf=28 (terr=25) surf_diff=2 terr_diff=0"
@@ -1136,6 +1156,11 @@
           "x": -4,
           "y": 74,
           "details": "lake surf=30 (terr=25) -> water nbr surf=28 (terr=25) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -3,
+          "y": 65,
+          "details": "river surf=36 (terr=32) -> water nbr surf=34 (terr=32) surf_diff=2 terr_diff=0"
         }
       ],
       "MULTI_ISLAND": [
@@ -1233,27 +1258,47 @@
         {
           "x": -64,
           "y": -29,
-          "details": "river surf=138 terr=137 -> land(-64,-28) terr=134 cliff=4"
+          "details": "river surf=138 terr=133 -> land(-64,-28) terr=134 cliff=4"
         },
         {
           "x": -64,
           "y": 74,
-          "details": "river surf=106 terr=105 -> land(-63,74) terr=104 cliff=2"
+          "details": "river surf=106 terr=98 -> land(-63,74) terr=104 cliff=2"
         },
         {
           "x": -63,
           "y": -29,
-          "details": "river surf=126 terr=125 -> land(-63,-28) terr=121 cliff=5"
+          "details": "river surf=126 terr=120 -> land(-63,-28) terr=121 cliff=5"
         },
         {
           "x": -63,
           "y": 75,
-          "details": "river surf=103 terr=101 -> land(-62,75) terr=98 cliff=5"
+          "details": "river surf=103 terr=97 -> land(-62,75) terr=98 cliff=5"
         },
         {
           "x": -62,
           "y": -54,
-          "details": "lake surf=207 terr=153 -> land(-61,-54) terr=181 cliff=26"
+          "details": "lake surf=207 terr=148 -> land(-61,-54) terr=176 cliff=31"
+        },
+        {
+          "x": -62,
+          "y": -46,
+          "details": "river surf=162 terr=156 -> land(-62,-47) terr=160 cliff=2"
+        },
+        {
+          "x": -62,
+          "y": -42,
+          "details": "river surf=210 terr=206 -> land(-62,-43) terr=208 cliff=2"
+        },
+        {
+          "x": -61,
+          "y": -44,
+          "details": "river surf=198 terr=192 -> land(-61,-45) terr=196 cliff=2"
+        },
+        {
+          "x": -61,
+          "y": -42,
+          "details": "river surf=222 terr=220 -> land(-61,-43) terr=220 cliff=2"
         },
         {
           "x": -60,
@@ -1268,112 +1313,112 @@
         {
           "x": -58,
           "y": -29,
-          "details": "river surf=130 terr=129 -> land(-58,-28) terr=120 cliff=10"
+          "details": "river surf=130 terr=124 -> land(-58,-28) terr=120 cliff=10"
         },
         {
           "x": -58,
           "y": 37,
-          "details": "river surf=9 terr=8 -> land(-57,37) terr=7 cliff=2"
+          "details": "river surf=9 terr=5 -> land(-57,37) terr=7 cliff=2"
         },
         {
           "x": -58,
           "y": 38,
-          "details": "river surf=13 terr=12 -> land(-57,38) terr=10 cliff=3"
+          "details": "river surf=13 terr=8 -> land(-57,38) terr=10 cliff=3"
         },
         {
           "x": -57,
           "y": -29,
-          "details": "river surf=142 terr=141 -> land(-57,-28) terr=131 cliff=11"
+          "details": "river surf=142 terr=136 -> land(-57,-28) terr=131 cliff=11"
         },
         {
           "x": -57,
           "y": 39,
-          "details": "river surf=13 terr=12 -> land(-57,38) terr=10 cliff=3"
+          "details": "river surf=13 terr=7 -> land(-57,38) terr=10 cliff=3"
         },
         {
           "x": -56,
           "y": -25,
-          "details": "river surf=91 terr=90 -> land(-57,-25) terr=89 cliff=2"
+          "details": "river surf=91 terr=85 -> land(-57,-25) terr=89 cliff=2"
         },
         {
           "x": -56,
           "y": -24,
-          "details": "river surf=79 terr=78 -> land(-57,-24) terr=77 cliff=2"
+          "details": "river surf=79 terr=73 -> land(-57,-24) terr=77 cliff=2"
         },
         {
           "x": -56,
           "y": -23,
-          "details": "river surf=67 terr=66 -> land(-57,-23) terr=63 cliff=4"
+          "details": "river surf=67 terr=61 -> land(-57,-23) terr=63 cliff=4"
         },
         {
           "x": -55,
           "y": -64,
-          "details": "river surf=236 terr=235 -> land(-56,-64) terr=232 cliff=4"
+          "details": "river surf=236 terr=234 -> land(-56,-64) terr=232 cliff=4"
         },
         {
           "x": -50,
           "y": 42,
-          "details": "river surf=18 terr=17 -> land(-51,42) terr=15 cliff=3"
+          "details": "river surf=18 terr=13 -> land(-51,42) terr=15 cliff=3"
         },
         {
           "x": -44,
           "y": -17,
-          "details": "river surf=8 terr=7 -> land(-44,-16) terr=5 cliff=3"
+          "details": "river surf=8 terr=5 -> land(-44,-16) terr=5 cliff=3"
         },
         {
           "x": -43,
           "y": -23,
-          "details": "river surf=60 terr=59 -> land(-42,-23) terr=54 cliff=6"
+          "details": "river surf=60 terr=54 -> land(-42,-23) terr=54 cliff=6"
         },
         {
           "x": -43,
           "y": -22,
-          "details": "river surf=48 terr=47 -> land(-42,-22) terr=41 cliff=7"
+          "details": "river surf=48 terr=42 -> land(-42,-22) terr=41 cliff=7"
         },
         {
           "x": -43,
           "y": -21,
-          "details": "river surf=36 terr=35 -> land(-42,-21) terr=29 cliff=7"
+          "details": "river surf=36 terr=30 -> land(-42,-21) terr=29 cliff=7"
         },
         {
           "x": -43,
           "y": -20,
-          "details": "river surf=25 terr=24 -> land(-42,-20) terr=20 cliff=5"
+          "details": "river surf=25 terr=20 -> land(-42,-20) terr=20 cliff=5"
         },
         {
           "x": -43,
           "y": -18,
-          "details": "river surf=10 terr=9 -> land(-42,-18) terr=8 cliff=2"
+          "details": "river surf=10 terr=6 -> land(-42,-18) terr=8 cliff=2"
         },
         {
           "x": -42,
           "y": -24,
-          "details": "river surf=66 terr=65 -> land(-42,-23) terr=54 cliff=12"
+          "details": "river surf=66 terr=60 -> land(-42,-23) terr=54 cliff=12"
         },
         {
           "x": -42,
           "y": -19,
-          "details": "river surf=13 terr=12 -> land(-42,-18) terr=8 cliff=5"
+          "details": "river surf=13 terr=8 -> land(-42,-18) terr=8 cliff=5"
         },
         {
           "x": -41,
           "y": -21,
-          "details": "river surf=22 terr=21 -> land(-40,-21) terr=17 cliff=5"
+          "details": "river surf=22 terr=17 -> land(-40,-21) terr=17 cliff=5"
         },
         {
           "x": -41,
           "y": -20,
-          "details": "river surf=14 terr=13 -> land(-40,-20) terr=11 cliff=3"
+          "details": "river surf=14 terr=9 -> land(-40,-20) terr=11 cliff=3"
         },
         {
           "x": -41,
           "y": -19,
-          "details": "river surf=8 terr=7 -> land(-40,-19) terr=6 cliff=2"
+          "details": "river surf=8 terr=4 -> land(-40,-19) terr=6 cliff=2"
         },
         {
           "x": -41,
           "y": -18,
-          "details": "river surf=5 terr=4 -> land(-41,-17) terr=3 cliff=2"
+          "details": "river surf=5 terr=2 -> land(-41,-17) terr=3 cliff=2"
         },
         {
           "x": -40,
@@ -1383,7 +1428,7 @@
         {
           "x": -40,
           "y": -22,
-          "details": "river surf=24 terr=23 -> land(-40,-21) terr=17 cliff=7"
+          "details": "river surf=24 terr=19 -> land(-40,-21) terr=17 cliff=7"
         },
         {
           "x": -39,
@@ -1408,52 +1453,52 @@
         {
           "x": -34,
           "y": -41,
-          "details": "river surf=227 terr=226 -> land(-33,-41) terr=219 cliff=8"
+          "details": "river surf=227 terr=223 -> land(-33,-41) terr=219 cliff=8"
         },
         {
           "x": -34,
           "y": -40,
-          "details": "river surf=215 terr=214 -> land(-33,-40) terr=207 cliff=8"
+          "details": "river surf=215 terr=210 -> land(-33,-40) terr=207 cliff=8"
         },
         {
           "x": -33,
           "y": -35,
-          "details": "river surf=156 terr=155 -> land(-33,-34) terr=151 cliff=5"
+          "details": "river surf=156 terr=149 -> land(-33,-34) terr=151 cliff=5"
         },
         {
           "x": -32,
           "y": -34,
-          "details": "river surf=137 terr=136 -> land(-32,-33) terr=127 cliff=10"
+          "details": "river surf=137 terr=130 -> land(-32,-33) terr=127 cliff=10"
         },
         {
           "x": -31,
           "y": -39,
-          "details": "river surf=167 terr=166 -> land(-30,-39) terr=160 cliff=7"
+          "details": "river surf=167 terr=160 -> land(-30,-39) terr=160 cliff=7"
         },
         {
           "x": -31,
           "y": -34,
-          "details": "river surf=125 terr=124 -> land(-31,-33) terr=116 cliff=9"
+          "details": "river surf=125 terr=119 -> land(-31,-33) terr=116 cliff=9"
         },
         {
           "x": -30,
           "y": -34,
-          "details": "river surf=113 terr=112 -> land(-30,-33) terr=104 cliff=9"
+          "details": "river surf=113 terr=107 -> land(-30,-33) terr=104 cliff=9"
         },
         {
           "x": -29,
           "y": -34,
-          "details": "river surf=102 terr=101 -> land(-29,-33) terr=94 cliff=8"
+          "details": "river surf=102 terr=97 -> land(-29,-33) terr=94 cliff=8"
         },
         {
           "x": -28,
           "y": -38,
-          "details": "river surf=125 terr=124 -> land(-27,-38) terr=119 cliff=6"
+          "details": "river surf=125 terr=120 -> land(-27,-38) terr=119 cliff=6"
         },
         {
           "x": -28,
           "y": -34,
-          "details": "river surf=93 terr=92 -> land(-28,-33) terr=85 cliff=8"
+          "details": "river surf=93 terr=88 -> land(-28,-33) terr=85 cliff=8"
         },
         {
           "x": -27,
@@ -1463,47 +1508,47 @@
         {
           "x": -27,
           "y": -36,
-          "details": "river surf=100 terr=98 -> land(-26,-36) terr=93 cliff=7"
+          "details": "river surf=100 terr=94 -> land(-26,-36) terr=93 cliff=7"
         },
         {
           "x": -27,
           "y": -33,
-          "details": "river surf=77 terr=76 -> land(-27,-32) terr=70 cliff=7"
+          "details": "river surf=77 terr=72 -> land(-27,-32) terr=70 cliff=7"
         },
         {
           "x": -26,
           "y": -63,
-          "details": "river surf=217 terr=216 -> land(-26,-62) terr=214 cliff=3"
+          "details": "river surf=217 terr=214 -> land(-26,-62) terr=214 cliff=3"
         },
         {
           "x": -26,
           "y": -35,
-          "details": "river surf=85 terr=83 -> land(-25,-35) terr=78 cliff=7"
+          "details": "river surf=85 terr=81 -> land(-25,-35) terr=78 cliff=7"
         },
         {
           "x": -26,
           "y": -33,
-          "details": "river surf=69 terr=68 -> land(-26,-32) terr=62 cliff=7"
+          "details": "river surf=69 terr=64 -> land(-26,-32) terr=62 cliff=7"
         },
         {
           "x": -25,
           "y": -63,
-          "details": "river surf=209 terr=208 -> land(-25,-62) terr=205 cliff=4"
+          "details": "river surf=209 terr=207 -> land(-25,-62) terr=205 cliff=4"
         },
         {
           "x": -25,
           "y": -42,
-          "details": "river surf=127 terr=126 -> land(-25,-41) terr=123 cliff=4"
+          "details": "river surf=127 terr=121 -> land(-25,-41) terr=123 cliff=4"
         },
         {
           "x": -24,
           "y": -63,
-          "details": "river surf=202 terr=201 -> land(-24,-62) terr=195 cliff=7"
+          "details": "river surf=202 terr=200 -> land(-24,-62) terr=195 cliff=7"
         },
         {
           "x": -24,
           "y": -41,
-          "details": "river surf=112 terr=111 -> land(-24,-40) terr=107 cliff=5"
+          "details": "river surf=112 terr=107 -> land(-24,-40) terr=107 cliff=5"
         },
         {
           "x": -24,
@@ -1513,42 +1558,42 @@
         {
           "x": -24,
           "y": -33,
-          "details": "river surf=56 terr=54 -> land(-23,-33) terr=51 cliff=5"
+          "details": "river surf=56 terr=51 -> land(-23,-33) terr=51 cliff=5"
         },
         {
           "x": -23,
           "y": -51,
-          "details": "river surf=150 terr=149 -> land(-22,-51) terr=148 cliff=2"
+          "details": "river surf=150 terr=145 -> land(-22,-51) terr=148 cliff=2"
         },
         {
           "x": -23,
           "y": -50,
-          "details": "river surf=146 terr=145 -> land(-22,-50) terr=143 cliff=3"
+          "details": "river surf=146 terr=141 -> land(-22,-50) terr=143 cliff=3"
         },
         {
           "x": -23,
           "y": -49,
-          "details": "river surf=140 terr=139 -> land(-22,-49) terr=134 cliff=6"
+          "details": "river surf=140 terr=134 -> land(-22,-49) terr=134 cliff=6"
         },
         {
           "x": -23,
           "y": -48,
-          "details": "river surf=132 terr=131 -> land(-22,-48) terr=127 cliff=5"
+          "details": "river surf=132 terr=125 -> land(-22,-48) terr=127 cliff=5"
         },
         {
           "x": -23,
           "y": -40,
-          "details": "river surf=99 terr=98 -> land(-23,-39) terr=93 cliff=6"
+          "details": "river surf=99 terr=96 -> land(-23,-39) terr=93 cliff=6"
         },
         {
           "x": -23,
           "y": -32,
-          "details": "river surf=43 terr=42 -> land(-22,-32) terr=40 cliff=3"
+          "details": "river surf=43 terr=39 -> land(-22,-32) terr=40 cliff=3"
         },
         {
           "x": -22,
           "y": -58,
-          "details": "river surf=161 terr=160 -> land(-21,-58) terr=157 cliff=4"
+          "details": "river surf=161 terr=158 -> land(-21,-58) terr=157 cliff=4"
         },
         {
           "x": -22,
@@ -1558,17 +1603,17 @@
         {
           "x": -22,
           "y": -39,
-          "details": "river surf=86 terr=85 -> land(-22,-38) terr=80 cliff=6"
+          "details": "river surf=86 terr=83 -> land(-22,-38) terr=80 cliff=6"
         },
         {
           "x": -22,
           "y": -31,
-          "details": "river surf=34 terr=33 -> land(-21,-31) terr=32 cliff=2"
+          "details": "river surf=34 terr=31 -> land(-21,-31) terr=32 cliff=2"
         },
         {
           "x": -21,
           "y": -59,
-          "details": "river surf=161 terr=160 -> land(-21,-58) terr=157 cliff=4"
+          "details": "river surf=161 terr=159 -> land(-21,-58) terr=157 cliff=4"
         },
         {
           "x": -21,
@@ -1578,12 +1623,12 @@
         {
           "x": -21,
           "y": -38,
-          "details": "river surf=72 terr=71 -> land(-21,-37) terr=66 cliff=6"
+          "details": "river surf=72 terr=69 -> land(-21,-37) terr=66 cliff=6"
         },
         {
           "x": -20,
           "y": -59,
-          "details": "river surf=156 terr=155 -> land(-20,-58) terr=153 cliff=3"
+          "details": "river surf=156 terr=154 -> land(-20,-58) terr=153 cliff=3"
         },
         {
           "x": -20,
@@ -1593,22 +1638,22 @@
         {
           "x": -20,
           "y": -48,
-          "details": "river surf=116 terr=115 -> land(-19,-48) terr=110 cliff=6"
+          "details": "river surf=116 terr=111 -> land(-19,-48) terr=110 cliff=6"
         },
         {
           "x": -20,
           "y": -47,
-          "details": "river surf=108 terr=107 -> land(-19,-47) terr=102 cliff=6"
+          "details": "river surf=108 terr=104 -> land(-19,-47) terr=102 cliff=6"
         },
         {
           "x": -20,
           "y": -38,
-          "details": "river surf=63 terr=62 -> land(-20,-37) terr=57 cliff=6"
+          "details": "river surf=63 terr=58 -> land(-20,-37) terr=57 cliff=6"
         },
         {
           "x": -19,
           "y": -59,
-          "details": "river surf=151 terr=150 -> land(-19,-58) terr=148 cliff=3"
+          "details": "river surf=151 terr=149 -> land(-19,-58) terr=148 cliff=3"
         },
         {
           "x": -19,
@@ -1618,12 +1663,12 @@
         {
           "x": -19,
           "y": -37,
-          "details": "river surf=47 terr=46 -> land(-19,-36) terr=43 cliff=4"
+          "details": "river surf=47 terr=42 -> land(-19,-36) terr=43 cliff=4"
         },
         {
           "x": -18,
           "y": -59,
-          "details": "river surf=145 terr=144 -> land(-18,-58) terr=142 cliff=3"
+          "details": "river surf=145 terr=142 -> land(-18,-58) terr=142 cliff=3"
         },
         {
           "x": -18,
@@ -1633,57 +1678,57 @@
         {
           "x": -18,
           "y": -36,
-          "details": "river surf=33 terr=32 -> land(-18,-35) terr=31 cliff=2"
+          "details": "river surf=33 terr=28 -> land(-18,-35) terr=31 cliff=2"
         },
         {
           "x": -17,
           "y": -59,
-          "details": "river surf=136 terr=135 -> land(-17,-58) terr=134 cliff=2"
+          "details": "river surf=136 terr=133 -> land(-17,-58) terr=134 cliff=2"
         },
         {
           "x": -17,
           "y": -52,
-          "details": "river surf=120 terr=119 -> land(-17,-51) terr=118 cliff=2"
+          "details": "river surf=120 terr=118 -> land(-17,-51) terr=118 cliff=2"
         },
         {
           "x": -15,
           "y": -64,
-          "details": "river surf=84 terr=83 -> land(-14,-64) terr=73 cliff=11"
+          "details": "river surf=84 terr=76 -> land(-14,-64) terr=73 cliff=11"
         },
         {
           "x": -15,
           "y": -39,
-          "details": "river surf=25 terr=24 -> land(-14,-39) terr=21 cliff=4"
+          "details": "river surf=25 terr=20 -> land(-14,-39) terr=21 cliff=4"
         },
         {
           "x": -14,
           "y": -63,
-          "details": "river surf=82 terr=81 -> land(-14,-64) terr=73 cliff=9"
+          "details": "river surf=82 terr=75 -> land(-14,-64) terr=73 cliff=9"
         },
         {
           "x": -14,
           "y": -50,
-          "details": "river surf=79 terr=78 -> land(-14,-49) terr=74 cliff=5"
+          "details": "river surf=79 terr=72 -> land(-14,-49) terr=74 cliff=5"
         },
         {
           "x": -14,
           "y": -40,
-          "details": "river surf=25 terr=24 -> land(-14,-39) terr=21 cliff=4"
+          "details": "river surf=25 terr=21 -> land(-14,-39) terr=21 cliff=4"
         },
         {
           "x": -13,
           "y": -63,
-          "details": "river surf=71 terr=70 -> land(-13,-64) terr=62 cliff=9"
+          "details": "river surf=71 terr=64 -> land(-13,-64) terr=62 cliff=9"
         },
         {
           "x": -13,
           "y": -40,
-          "details": "river surf=20 terr=19 -> land(-13,-39) terr=17 cliff=3"
+          "details": "river surf=20 terr=17 -> land(-13,-39) terr=17 cliff=3"
         },
         {
           "x": -12,
           "y": -63,
-          "details": "river surf=60 terr=59 -> land(-12,-64) terr=53 cliff=7"
+          "details": "river surf=60 terr=53 -> land(-12,-64) terr=53 cliff=7"
         },
         {
           "x": -12,
@@ -1693,7 +1738,7 @@
         {
           "x": -11,
           "y": -63,
-          "details": "river surf=50 terr=49 -> land(-11,-64) terr=44 cliff=6"
+          "details": "river surf=50 terr=43 -> land(-11,-64) terr=44 cliff=6"
         },
         {
           "x": -11,
@@ -1703,7 +1748,7 @@
         {
           "x": -10,
           "y": -63,
-          "details": "river surf=41 terr=40 -> land(-10,-64) terr=35 cliff=6"
+          "details": "river surf=41 terr=35 -> land(-10,-64) terr=35 cliff=6"
         },
         {
           "x": -8,
@@ -1733,12 +1778,12 @@
         {
           "x": -7,
           "y": 56,
-          "details": "river surf=59 terr=58 -> land(-6,56) terr=56 cliff=3"
+          "details": "river surf=59 terr=56 -> land(-6,56) terr=56 cliff=3"
         },
         {
           "x": -6,
           "y": -64,
-          "details": "river surf=10 terr=9 -> land(-5,-64) terr=7 cliff=3"
+          "details": "river surf=10 terr=7 -> land(-5,-64) terr=7 cliff=3"
         },
         {
           "x": -6,
@@ -1758,7 +1803,7 @@
         {
           "x": -5,
           "y": 65,
-          "details": "river surf=45 terr=44 -> land(-5,66) terr=41 cliff=4"
+          "details": "river surf=45 terr=41 -> land(-5,66) terr=41 cliff=4"
         },
         {
           "x": -4,
@@ -1768,12 +1813,12 @@
         {
           "x": -4,
           "y": 65,
-          "details": "river surf=40 terr=39 -> land(-4,66) terr=37 cliff=3"
+          "details": "river surf=40 terr=35 -> land(-4,66) terr=37 cliff=3"
         },
         {
           "x": -1,
           "y": 59,
-          "details": "river surf=32 terr=31 -> land(-1,58) terr=30 cliff=2"
+          "details": "river surf=32 terr=29 -> land(-1,58) terr=30 cliff=2"
         },
         {
           "x": 0,
@@ -1890,7 +1935,27 @@
         {
           "x": -62,
           "y": -54,
-          "details": "lake surf=207 -> dry(-61,-54) terr=181 cliff=26"
+          "details": "lake surf=207 -> dry(-61,-54) terr=176 cliff=31"
+        },
+        {
+          "x": -62,
+          "y": -46,
+          "details": "river surf=162 -> dry(-62,-47) terr=160 cliff=2"
+        },
+        {
+          "x": -62,
+          "y": -42,
+          "details": "river surf=210 -> dry(-62,-43) terr=208 cliff=2"
+        },
+        {
+          "x": -61,
+          "y": -44,
+          "details": "river surf=198 -> dry(-61,-45) terr=196 cliff=2"
+        },
+        {
+          "x": -61,
+          "y": -42,
+          "details": "river surf=222 -> dry(-61,-43) terr=220 cliff=2"
         },
         {
           "x": -60,

--- a/tools/baselines/seed7_size32_region_-4_-4_4_4.json
+++ b/tools/baselines/seed7_size32_region_-4_-4_4_4.json
@@ -14,9 +14,9 @@
     "deterministic": true,
     "distinctHashes": 1,
     "hashes": [
-      "019cd62957601d866cf990b9e5295c1e36af4a063bae9e499273d8cad89fa03c",
-      "019cd62957601d866cf990b9e5295c1e36af4a063bae9e499273d8cad89fa03c",
-      "019cd62957601d866cf990b9e5295c1e36af4a063bae9e499273d8cad89fa03c"
+      "618e11860dffcb8bda4c8d0e8074697962bfaf6920975d0c7283c6afe9fb1d23",
+      "618e11860dffcb8bda4c8d0e8074697962bfaf6920975d0c7283c6afe9fb1d23",
+      "618e11860dffcb8bda4c8d0e8074697962bfaf6920975d0c7283c6afe9fb1d23"
     ]
   },
   "tileCount": 20736,
@@ -117,13 +117,13 @@
       ]
     },
     "FLOATING_WATER": {
-      "min": 101,
-      "max": 101,
-      "median": 101,
+      "min": 36,
+      "max": 36,
+      "median": 36,
       "all": [
-        101,
-        101,
-        101
+        36,
+        36,
+        36
       ]
     },
     "ISLAND_1TILE": {
@@ -147,13 +147,13 @@
       ]
     },
     "MID_RIVER_CLIFF": {
-      "min": 1,
-      "max": 1,
-      "median": 1,
+      "min": 45,
+      "max": 45,
+      "median": 45,
       "all": [
-        1,
-        1,
-        1
+        45,
+        45,
+        45
       ]
     },
     "MULTI_ISLAND": {
@@ -167,33 +167,33 @@
       ]
     },
     "RIVER_CHUNK_GAP": {
-      "min": 12,
-      "max": 12,
-      "median": 12,
+      "min": 14,
+      "max": 14,
+      "median": 14,
       "all": [
-        12,
-        12,
-        12
+        14,
+        14,
+        14
       ]
     },
     "WATER_ABOVE_LAND": {
-      "min": 102,
-      "max": 102,
-      "median": 102,
+      "min": 132,
+      "max": 132,
+      "median": 132,
       "all": [
-        102,
-        102,
-        102
+        132,
+        132,
+        132
       ]
     },
     "WATER_CLIFF": {
-      "min": 102,
-      "max": 102,
-      "median": 102,
+      "min": 132,
+      "max": 132,
+      "median": 132,
       "all": [
-        102,
-        102,
-        102
+        132,
+        132,
+        132
       ]
     },
     "WATER_WATER_CLIFF": {
@@ -212,14 +212,14 @@
       "DESERT_SOIL_ON_SLOPE": 9,
       "FLAT_ISOLATED_WATER": 3,
       "FLOATING_LAKE": 177,
-      "FLOATING_WATER": 101,
+      "FLOATING_WATER": 36,
       "ISLAND_1TILE": 1,
       "ISOLATED_FLUID": 6,
-      "MID_RIVER_CLIFF": 1,
+      "MID_RIVER_CLIFF": 45,
       "MULTI_ISLAND": 7,
-      "RIVER_CHUNK_GAP": 12,
-      "WATER_ABOVE_LAND": 102,
-      "WATER_CLIFF": 102,
+      "RIVER_CHUNK_GAP": 14,
+      "WATER_ABOVE_LAND": 132,
+      "WATER_CLIFF": 132,
       "WATER_WATER_CLIFF": 1555
     },
     "issues": {
@@ -1176,269 +1176,79 @@
       ],
       "FLOATING_WATER": [
         {
-          "x": -3,
-          "y": 14,
-          "details": "river terr=6 -> dry(-4,14) terr=4 gap=2"
-        },
-        {
-          "x": -3,
-          "y": 17,
-          "details": "river terr=15 -> dry(-3,16) terr=13 gap=2"
-        },
-        {
-          "x": -3,
-          "y": 23,
-          "details": "river terr=6 -> dry(-3,24) terr=5 gap=1"
-        },
-        {
           "x": -2,
           "y": 16,
-          "details": "river terr=20 -> dry(-3,16) terr=13 gap=7"
-        },
-        {
-          "x": -2,
-          "y": 23,
-          "details": "river terr=10 -> dry(-2,24) terr=8 gap=2"
-        },
-        {
-          "x": -1,
-          "y": 23,
-          "details": "river terr=16 -> dry(-1,24) terr=13 gap=3"
-        },
-        {
-          "x": 0,
-          "y": 9,
-          "details": "river terr=12 -> dry(-1,9) terr=10 gap=2"
-        },
-        {
-          "x": 0,
-          "y": 24,
-          "details": "river terr=17 -> dry(-1,24) terr=13 gap=4"
-        },
-        {
-          "x": 0,
-          "y": 25,
-          "details": "river terr=12 -> dry(-1,25) terr=9 gap=3"
+          "details": "river terr=16 -> dry(-3,16) terr=13 gap=3"
         },
         {
           "x": 0,
           "y": 26,
-          "details": "river terr=8 -> dry(-1,26) terr=5 gap=3"
-        },
-        {
-          "x": 0,
-          "y": 27,
-          "details": "river terr=4 -> dry(-1,27) terr=3 gap=1"
+          "details": "river terr=6 -> dry(-1,26) terr=5 gap=1"
         },
         {
           "x": 1,
           "y": 12,
-          "details": "river terr=23 -> dry(0,12) terr=12 gap=11"
-        },
-        {
-          "x": 1,
-          "y": 24,
-          "details": "river terr=23 -> dry(1,25) terr=19 gap=4"
-        },
-        {
-          "x": 2,
-          "y": 24,
-          "details": "river terr=31 -> dry(2,25) terr=26 gap=5"
+          "details": "river terr=18 -> dry(0,12) terr=12 gap=6"
         },
         {
           "x": 3,
           "y": -40,
-          "details": "river terr=56 -> dry(2,-40) terr=50 gap=6"
+          "details": "river terr=53 -> dry(2,-40) terr=50 gap=3"
         },
         {
           "x": 3,
           "y": 24,
-          "details": "river terr=39 -> dry(3,25) terr=33 gap=6"
-        },
-        {
-          "x": 3,
-          "y": 27,
-          "details": "river terr=16 -> dry(2,27) terr=13 gap=3"
-        },
-        {
-          "x": 4,
-          "y": 23,
-          "details": "river terr=56 -> dry(4,24) terr=51 gap=5"
-        },
-        {
-          "x": 5,
-          "y": -49,
-          "details": "river terr=11 -> dry(5,-50) terr=10 gap=1"
-        },
-        {
-          "x": 5,
-          "y": 23,
-          "details": "river terr=68 -> dry(5,24) terr=64 gap=4"
-        },
-        {
-          "x": 6,
-          "y": -50,
-          "details": "river terr=11 -> dry(5,-50) terr=10 gap=1"
-        },
-        {
-          "x": 6,
-          "y": -48,
-          "details": "river terr=18 -> dry(5,-48) terr=15 gap=3"
+          "details": "river terr=34 -> dry(3,25) terr=33 gap=1"
         },
         {
           "x": 6,
           "y": -47,
-          "details": "river terr=30 -> dry(5,-47) terr=19 gap=11"
+          "details": "river terr=24 -> dry(5,-47) terr=19 gap=5"
         },
         {
           "x": 6,
           "y": -46,
-          "details": "river terr=42 -> dry(5,-46) terr=33 gap=9"
+          "details": "river terr=37 -> dry(5,-46) terr=33 gap=4"
         },
         {
           "x": 6,
           "y": -45,
-          "details": "river terr=54 -> dry(5,-45) terr=48 gap=6"
-        },
-        {
-          "x": 6,
-          "y": -44,
-          "details": "river terr=63 -> dry(5,-44) terr=59 gap=4"
-        },
-        {
-          "x": 6,
-          "y": -43,
-          "details": "river terr=68 -> dry(5,-43) terr=66 gap=2"
-        },
-        {
-          "x": 6,
-          "y": -42,
-          "details": "river terr=73 -> dry(5,-42) terr=71 gap=2"
-        },
-        {
-          "x": 6,
-          "y": -35,
-          "details": "river terr=108 -> dry(5,-35) terr=107 gap=1"
+          "details": "river terr=49 -> dry(5,-45) terr=48 gap=1"
         },
         {
           "x": 6,
           "y": 29,
-          "details": "river terr=15 -> dry(5,29) terr=6 gap=9"
-        },
-        {
-          "x": 10,
-          "y": 27,
-          "details": "river terr=75 -> dry(9,27) terr=70 gap=5"
-        },
-        {
-          "x": 11,
-          "y": -51,
-          "details": "river terr=21 -> dry(10,-51) terr=19 gap=2"
-        },
-        {
-          "x": 11,
-          "y": -50,
-          "details": "river terr=24 -> dry(10,-50) terr=22 gap=2"
-        },
-        {
-          "x": 11,
-          "y": 10,
-          "details": "river terr=143 -> dry(10,10) terr=139 gap=4"
-        },
-        {
-          "x": 11,
-          "y": 11,
-          "details": "river terr=155 -> dry(10,11) terr=154 gap=1"
-        },
-        {
-          "x": 11,
-          "y": 13,
-          "details": "river terr=179 -> dry(10,13) terr=178 gap=1"
-        },
-        {
-          "x": 12,
-          "y": -51,
-          "details": "river terr=27 -> dry(12,-52) terr=23 gap=4"
-        },
-        {
-          "x": 12,
-          "y": -39,
-          "details": "river terr=102 -> dry(11,-39) terr=100 gap=2"
+          "details": "river terr=10 -> dry(5,29) terr=6 gap=4"
         },
         {
           "x": 12,
           "y": -31,
-          "details": "river terr=166 -> dry(11,-31) terr=159 gap=7"
-        },
-        {
-          "x": 12,
-          "y": -30,
-          "details": "river terr=178 -> dry(11,-30) terr=177 gap=1"
-        },
-        {
-          "x": 13,
-          "y": -40,
-          "details": "river terr=127 -> dry(12,-40) terr=122 gap=5"
+          "details": "river terr=160 -> dry(11,-31) terr=159 gap=1"
         },
         {
           "x": 13,
           "y": -35,
-          "details": "river terr=139 -> dry(13,-36) terr=130 gap=9"
-        },
-        {
-          "x": 13,
-          "y": -31,
-          "details": "river terr=178 -> dry(13,-32) terr=172 gap=6"
-        },
-        {
-          "x": 13,
-          "y": -26,
-          "details": "river terr=238 -> dry(13,-27) terr=236 gap=2"
-        },
-        {
-          "x": 14,
-          "y": -40,
-          "details": "river terr=139 -> dry(14,-39) terr=138 gap=1"
+          "details": "river terr=134 -> dry(13,-36) terr=130 gap=4"
         },
         {
           "x": 14,
           "y": -36,
-          "details": "river terr=151 -> dry(13,-36) terr=130 gap=21"
-        },
-        {
-          "x": 15,
-          "y": -55,
-          "details": "river terr=39 -> dry(14,-55) terr=37 gap=2"
-        },
-        {
-          "x": 15,
-          "y": -54,
-          "details": "river terr=45 -> dry(14,-54) terr=44 gap=1"
-        },
-        {
-          "x": 15,
-          "y": -53,
-          "details": "river terr=54 -> dry(14,-53) terr=53 gap=1"
-        },
-        {
-          "x": 15,
-          "y": -52,
-          "details": "river terr=63 -> dry(14,-52) terr=61 gap=2"
+          "details": "river terr=147 -> dry(13,-36) terr=130 gap=17"
         },
         {
           "x": 15,
           "y": 38,
-          "details": "river terr=17 -> dry(14,38) terr=6 gap=11"
+          "details": "river terr=11 -> dry(14,38) terr=6 gap=5"
         },
         {
           "x": 16,
           "y": 40,
-          "details": "river terr=17 -> dry(15,40) terr=6 gap=11"
+          "details": "river terr=11 -> dry(15,40) terr=6 gap=5"
         },
         {
           "x": 17,
           "y": 19,
-          "details": "river terr=255 -> dry(16,19) terr=251 gap=4"
+          "details": "river terr=252 -> dry(16,19) terr=251 gap=1"
         },
         {
           "x": 18,
@@ -1448,7 +1258,7 @@
         {
           "x": 19,
           "y": -49,
-          "details": "river terr=107 -> dry(19,-50) terr=100 gap=7"
+          "details": "river terr=103 -> dry(19,-50) terr=100 gap=3"
         },
         {
           "x": 20,
@@ -1458,147 +1268,72 @@
         {
           "x": 20,
           "y": -49,
-          "details": "river terr=119 -> dry(20,-50) terr=113 gap=6"
+          "details": "river terr=116 -> dry(20,-50) terr=113 gap=3"
         },
         {
           "x": 20,
           "y": -48,
-          "details": "river terr=131 -> dry(19,-48) terr=122 gap=9"
-        },
-        {
-          "x": 21,
-          "y": -58,
-          "details": "river terr=31 -> dry(20,-58) terr=29 gap=2"
+          "details": "river terr=128 -> dry(19,-48) terr=122 gap=6"
         },
         {
           "x": 21,
           "y": -57,
-          "details": "river terr=40 -> dry(20,-57) terr=34 gap=6"
+          "details": "river terr=36 -> dry(20,-57) terr=34 gap=2"
         },
         {
           "x": 21,
           "y": -56,
-          "details": "river terr=51 -> dry(20,-56) terr=46 gap=5"
+          "details": "river terr=47 -> dry(20,-56) terr=46 gap=1"
         },
         {
           "x": 21,
           "y": -55,
-          "details": "river terr=63 -> dry(20,-55) terr=58 gap=5"
-        },
-        {
-          "x": 21,
-          "y": -53,
-          "details": "river terr=87 -> dry(20,-53) terr=85 gap=2"
-        },
-        {
-          "x": 21,
-          "y": -52,
-          "details": "river terr=99 -> dry(20,-52) terr=96 gap=3"
+          "details": "river terr=59 -> dry(20,-55) terr=58 gap=1"
         },
         {
           "x": 21,
           "y": -51,
-          "details": "river terr=111 -> dry(20,-51) terr=105 gap=6"
+          "details": "river terr=110 -> dry(20,-51) terr=105 gap=5"
         },
         {
           "x": 21,
           "y": -50,
-          "details": "river terr=123 -> dry(20,-50) terr=113 gap=10"
-        },
-        {
-          "x": 21,
-          "y": -33,
-          "details": "river terr=244 -> dry(20,-33) terr=241 gap=3"
-        },
-        {
-          "x": 22,
-          "y": -32,
-          "details": "river terr=260 -> dry(21,-32) terr=257 gap=3"
+          "details": "river terr=122 -> dry(20,-50) terr=113 gap=9"
         },
         {
           "x": 23,
           "y": -31,
-          "details": "river terr=276 -> dry(22,-31) terr=272 gap=4"
+          "details": "river terr=274 -> dry(22,-31) terr=272 gap=2"
         },
         {
           "x": 23,
           "y": -30,
-          "details": "river terr=284 -> dry(22,-30) terr=280 gap=4"
-        },
-        {
-          "x": 23,
-          "y": -29,
-          "details": "river terr=289 -> dry(22,-29) terr=287 gap=2"
-        },
-        {
-          "x": 23,
-          "y": -28,
-          "details": "river terr=293 -> dry(22,-28) terr=290 gap=3"
-        },
-        {
-          "x": 24,
-          "y": -28,
-          "details": "river terr=297 -> dry(24,-29) terr=295 gap=2"
-        },
-        {
-          "x": 27,
-          "y": -34,
-          "details": "river terr=257 -> dry(26,-34) terr=256 gap=1"
-        },
-        {
-          "x": 28,
-          "y": -33,
-          "details": "river terr=268 -> dry(27,-33) terr=267 gap=1"
-        },
-        {
-          "x": 29,
-          "y": -32,
-          "details": "river terr=281 -> dry(28,-32) terr=279 gap=2"
-        },
-        {
-          "x": 31,
-          "y": -58,
-          "details": "river terr=18 -> dry(32,-58) terr=15 gap=3"
+          "details": "river terr=282 -> dry(22,-30) terr=280 gap=2"
         },
         {
           "x": 31,
           "y": -57,
-          "details": "river terr=29 -> dry(32,-57) terr=22 gap=7"
+          "details": "river terr=24 -> dry(32,-57) terr=22 gap=2"
         },
         {
           "x": 31,
           "y": -56,
-          "details": "river terr=41 -> dry(32,-56) terr=32 gap=9"
-        },
-        {
-          "x": 32,
-          "y": -55,
-          "details": "river terr=36 -> dry(32,-56) terr=32 gap=4"
+          "details": "river terr=35 -> dry(32,-56) terr=32 gap=3"
         },
         {
           "x": 33,
           "y": -36,
-          "details": "river terr=234 -> dry(33,-37) terr=228 gap=6"
-        },
-        {
-          "x": 34,
-          "y": -43,
-          "details": "river terr=156 -> dry(34,-44) terr=154 gap=2"
-        },
-        {
-          "x": 34,
-          "y": -38,
-          "details": "river terr=200 -> dry(34,-39) terr=195 gap=5"
+          "details": "river terr=231 -> dry(33,-37) terr=228 gap=3"
         },
         {
           "x": 36,
           "y": -47,
-          "details": "river terr=118 -> dry(36,-48) terr=113 gap=5"
+          "details": "river terr=114 -> dry(36,-48) terr=113 gap=1"
         },
         {
           "x": 37,
           "y": -47,
-          "details": "river terr=105 -> dry(37,-48) terr=100 gap=5"
+          "details": "river terr=101 -> dry(37,-48) terr=100 gap=1"
         },
         {
           "x": 40,
@@ -1606,14 +1341,9 @@
           "details": "river terr=43 -> dry(39,-53) terr=42 gap=1"
         },
         {
-          "x": 43,
-          "y": -49,
-          "details": "river terr=58 -> dry(43,-50) terr=55 gap=3"
-        },
-        {
           "x": 44,
           "y": -50,
-          "details": "river terr=59 -> dry(43,-50) terr=55 gap=4"
+          "details": "river terr=56 -> dry(43,-50) terr=55 gap=1"
         },
         {
           "x": 46,
@@ -1624,61 +1354,6 @@
           "x": 47,
           "y": 40,
           "details": "lake terr=174 -> dry(47,41) terr=146 gap=28"
-        },
-        {
-          "x": 48,
-          "y": -56,
-          "details": "river terr=9 -> dry(49,-56) terr=7 gap=2"
-        },
-        {
-          "x": 48,
-          "y": -49,
-          "details": "river terr=62 -> dry(49,-49) terr=61 gap=1"
-        },
-        {
-          "x": 49,
-          "y": -55,
-          "details": "river terr=9 -> dry(49,-56) terr=7 gap=2"
-        },
-        {
-          "x": 49,
-          "y": -51,
-          "details": "river terr=32 -> dry(50,-51) terr=30 gap=2"
-        },
-        {
-          "x": 49,
-          "y": -50,
-          "details": "river terr=44 -> dry(50,-50) terr=41 gap=3"
-        },
-        {
-          "x": 50,
-          "y": -53,
-          "details": "river terr=16 -> dry(51,-53) terr=13 gap=3"
-        },
-        {
-          "x": 50,
-          "y": -52,
-          "details": "river terr=22 -> dry(51,-52) terr=18 gap=4"
-        },
-        {
-          "x": 52,
-          "y": -53,
-          "details": "river terr=8 -> dry(53,-53) terr=6 gap=2"
-        },
-        {
-          "x": 52,
-          "y": -52,
-          "details": "river terr=12 -> dry(53,-52) terr=10 gap=2"
-        },
-        {
-          "x": 52,
-          "y": -51,
-          "details": "river terr=17 -> dry(53,-51) terr=14 gap=3"
-        },
-        {
-          "x": 52,
-          "y": -50,
-          "details": "river terr=22 -> dry(53,-50) terr=18 gap=4"
         }
       ],
       "ISLAND_1TILE": [
@@ -1722,9 +1397,229 @@
       ],
       "MID_RIVER_CLIFF": [
         {
-          "x": 20,
+          "x": -3,
+          "y": 23,
+          "details": "river surf=7 (terr=4) -> water nbr surf=4 (terr=3) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -1,
+          "y": 11,
+          "details": "river surf=7 (terr=2) -> water nbr surf=5 (terr=2) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 0,
+          "y": 27,
+          "details": "river surf=5 (terr=2) -> water nbr surf=3 (terr=2) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 3,
+          "y": 28,
+          "details": "river surf=6 (terr=1) -> water nbr surf=4 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 5,
+          "y": 30,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 6,
+          "y": 30,
+          "details": "river surf=6 (terr=1) -> water nbr surf=4 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 7,
+          "y": 29,
+          "details": "river surf=18 (terr=10) -> water nbr surf=16 (terr=10) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 8,
+          "y": 31,
+          "details": "river surf=6 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 9,
+          "y": -52,
+          "details": "river surf=14 (terr=11) -> water nbr surf=12 (terr=11) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 9,
+          "y": 32,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 11,
+          "y": -52,
+          "details": "river surf=19 (terr=13) -> water nbr surf=16 (terr=12) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 11,
+          "y": 9,
+          "details": "lake surf=132 (terr=125) -> water nbr surf=126 (terr=125) surf_diff=6 terr_diff=0"
+        },
+        {
+          "x": 11,
+          "y": 34,
+          "details": "river surf=6 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 12,
+          "y": 36,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 13,
+          "y": 37,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 13,
+          "y": 37,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 15,
+          "y": 41,
+          "details": "river surf=5 (terr=1) -> water nbr surf=3 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 15,
+          "y": 42,
+          "details": "river surf=4 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 16,
+          "y": -56,
+          "details": "river surf=31 (terr=27) -> water nbr surf=28 (terr=27) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 17,
+          "y": -57,
+          "details": "river surf=29 (terr=25) -> water nbr surf=26 (terr=26) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 18,
+          "y": -58,
+          "details": "river surf=26 (terr=22) -> water nbr surf=23 (terr=23) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 18,
+          "y": -56,
+          "details": "river surf=34 (terr=26) -> water nbr surf=30 (terr=28) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 18,
+          "y": -56,
+          "details": "river surf=34 (terr=28) -> water nbr surf=31 (terr=27) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 19,
+          "y": -58,
+          "details": "river surf=27 (terr=22) -> water nbr surf=23 (terr=23) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": 22,
+          "y": -60,
+          "details": "river surf=19 (terr=14) -> water nbr surf=16 (terr=14) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 22,
+          "y": -51,
+          "details": "river surf=117 (terr=112) -> water nbr surf=113 (terr=110) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 22,
+          "y": -50,
+          "details": "river surf=129 (terr=124) -> water nbr surf=125 (terr=122) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 23,
+          "y": -60,
+          "details": "river surf=18 (terr=12) -> water nbr surf=14 (terr=13) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": 24,
+          "y": -60,
+          "details": "river surf=16 (terr=10) -> water nbr surf=12 (terr=11) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": 25,
+          "y": -60,
+          "details": "river surf=14 (terr=10) -> water nbr surf=11 (terr=10) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 25,
+          "y": -59,
+          "details": "river surf=18 (terr=10) -> water nbr surf=14 (terr=12) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 26,
+          "y": -60,
+          "details": "river surf=13 (terr=9) -> water nbr surf=10 (terr=9) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 31,
+          "y": -59,
+          "details": "river surf=9 (terr=3) -> water nbr surf=5 (terr=5) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 33,
+          "y": -57,
+          "details": "river surf=16 (terr=11) -> water nbr surf=13 (terr=10) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 34,
+          "y": -58,
+          "details": "river surf=9 (terr=5) -> water nbr surf=6 (terr=6) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 34,
+          "y": -56,
+          "details": "river surf=16 (terr=10) -> water nbr surf=13 (terr=11) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 34,
+          "y": -56,
+          "details": "river surf=16 (terr=11) -> water nbr surf=13 (terr=10) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 36,
           "y": -54,
-          "details": "river surf=81 (terr=76) -> water nbr surf=77 (terr=75) surf_diff=4 terr_diff=1"
+          "details": "river surf=26 (terr=18) -> water nbr surf=21 (terr=20) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": 44,
+          "y": -58,
+          "details": "river surf=7 (terr=3) -> water nbr surf=4 (terr=4) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 45,
+          "y": -57,
+          "details": "river surf=9 (terr=5) -> water nbr surf=6 (terr=6) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 46,
+          "y": -57,
+          "details": "river surf=8 (terr=4) -> water nbr surf=5 (terr=5) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 47,
+          "y": -57,
+          "details": "river surf=6 (terr=3) -> water nbr surf=4 (terr=3) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 50,
+          "y": -54,
+          "details": "river surf=11 (terr=8) -> water nbr surf=8 (terr=7) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 52,
+          "y": -53,
+          "details": "river surf=9 (terr=3) -> water nbr surf=4 (terr=5) surf_diff=5 terr_diff=2"
+        },
+        {
+          "x": 52,
+          "y": -52,
+          "details": "river surf=13 (terr=5) -> water nbr surf=9 (terr=7) surf_diff=4 terr_diff=2"
         }
       ],
       "MULTI_ISLAND": [
@@ -1796,6 +1691,11 @@
           "details": "river surf=3 -> dry(-1,28) terr=2"
         },
         {
+          "x": 13,
+          "y": 16,
+          "details": "river surf=199 -> dry(13,15) terr=195"
+        },
+        {
           "x": 16,
           "y": 40,
           "details": "river surf=18 -> dry(15,40) terr=6"
@@ -1824,273 +1724,358 @@
           "x": 31,
           "y": -56,
           "details": "river surf=42 -> dry(32,-56) terr=32"
+        },
+        {
+          "x": 31,
+          "y": -51,
+          "details": "river surf=97 -> dry(32,-51) terr=94"
         }
       ],
       "WATER_ABOVE_LAND": [
         {
           "x": -3,
           "y": 14,
-          "details": "river surf=7 terr=6 -> land(-4,14) terr=4 cliff=3"
+          "details": "river surf=7 terr=4 -> land(-4,14) terr=4 cliff=3"
         },
         {
           "x": -3,
           "y": 17,
-          "details": "river surf=16 terr=15 -> land(-3,16) terr=13 cliff=3"
+          "details": "river surf=16 terr=13 -> land(-3,16) terr=13 cliff=3"
         },
         {
           "x": -3,
           "y": 23,
-          "details": "river surf=7 terr=6 -> land(-3,24) terr=5 cliff=2"
+          "details": "river surf=7 terr=4 -> land(-3,24) terr=5 cliff=2"
         },
         {
           "x": -2,
           "y": 16,
-          "details": "river surf=21 terr=20 -> land(-3,16) terr=13 cliff=8"
+          "details": "river surf=21 terr=16 -> land(-3,16) terr=13 cliff=8"
         },
         {
           "x": -2,
           "y": 23,
-          "details": "river surf=11 terr=10 -> land(-2,24) terr=8 cliff=3"
+          "details": "river surf=11 terr=8 -> land(-2,24) terr=8 cliff=3"
         },
         {
           "x": -1,
           "y": 23,
-          "details": "river surf=17 terr=16 -> land(-1,24) terr=13 cliff=4"
+          "details": "river surf=17 terr=13 -> land(-1,24) terr=13 cliff=4"
         },
         {
           "x": 0,
           "y": 9,
-          "details": "river surf=13 terr=12 -> land(-1,9) terr=10 cliff=3"
+          "details": "river surf=13 terr=7 -> land(-1,9) terr=10 cliff=3"
         },
         {
           "x": 0,
           "y": 24,
-          "details": "river surf=18 terr=17 -> land(-1,24) terr=13 cliff=5"
+          "details": "river surf=18 terr=13 -> land(-1,24) terr=13 cliff=5"
         },
         {
           "x": 0,
           "y": 25,
-          "details": "river surf=13 terr=12 -> land(-1,25) terr=9 cliff=4"
+          "details": "river surf=13 terr=9 -> land(-1,25) terr=9 cliff=4"
         },
         {
           "x": 0,
           "y": 26,
-          "details": "river surf=9 terr=8 -> land(-1,26) terr=5 cliff=4"
+          "details": "river surf=9 terr=6 -> land(-1,26) terr=5 cliff=4"
         },
         {
           "x": 0,
           "y": 27,
-          "details": "river surf=5 terr=4 -> land(-1,27) terr=3 cliff=2"
+          "details": "river surf=5 terr=2 -> land(-1,27) terr=3 cliff=2"
         },
         {
           "x": 1,
           "y": 12,
-          "details": "river surf=24 terr=23 -> land(0,12) terr=12 cliff=12"
+          "details": "river surf=24 terr=18 -> land(0,12) terr=12 cliff=12"
         },
         {
           "x": 1,
           "y": 24,
-          "details": "river surf=24 terr=23 -> land(1,25) terr=19 cliff=5"
+          "details": "river surf=24 terr=19 -> land(1,25) terr=19 cliff=5"
         },
         {
           "x": 2,
           "y": 24,
-          "details": "river surf=32 terr=31 -> land(2,25) terr=26 cliff=6"
+          "details": "river surf=32 terr=26 -> land(2,25) terr=26 cliff=6"
         },
         {
           "x": 3,
           "y": -40,
-          "details": "river surf=57 terr=56 -> land(2,-40) terr=50 cliff=7"
+          "details": "river surf=57 terr=53 -> land(2,-40) terr=50 cliff=7"
         },
         {
           "x": 3,
           "y": 24,
-          "details": "river surf=40 terr=39 -> land(3,25) terr=33 cliff=7"
+          "details": "river surf=40 terr=34 -> land(3,25) terr=33 cliff=7"
         },
         {
           "x": 3,
           "y": 27,
-          "details": "river surf=17 terr=16 -> land(2,27) terr=13 cliff=4"
+          "details": "river surf=17 terr=11 -> land(2,27) terr=13 cliff=4"
         },
         {
           "x": 4,
           "y": 23,
-          "details": "river surf=57 terr=56 -> land(4,24) terr=51 cliff=6"
+          "details": "river surf=57 terr=50 -> land(4,24) terr=51 cliff=6"
         },
         {
           "x": 5,
           "y": -49,
-          "details": "river surf=12 terr=11 -> land(5,-50) terr=10 cliff=2"
+          "details": "river surf=12 terr=6 -> land(5,-50) terr=10 cliff=2"
+        },
+        {
+          "x": 5,
+          "y": 15,
+          "details": "river surf=91 terr=84 -> land(5,14) terr=88 cliff=3"
         },
         {
           "x": 5,
           "y": 23,
-          "details": "river surf=69 terr=68 -> land(5,24) terr=64 cliff=5"
+          "details": "river surf=69 terr=62 -> land(5,24) terr=64 cliff=5"
         },
         {
           "x": 6,
           "y": -50,
-          "details": "river surf=12 terr=11 -> land(5,-50) terr=10 cliff=2"
+          "details": "river surf=12 terr=7 -> land(5,-50) terr=10 cliff=2"
         },
         {
           "x": 6,
           "y": -48,
-          "details": "river surf=19 terr=18 -> land(5,-48) terr=15 cliff=4"
+          "details": "river surf=19 terr=13 -> land(5,-48) terr=15 cliff=4"
         },
         {
           "x": 6,
           "y": -47,
-          "details": "river surf=31 terr=30 -> land(5,-47) terr=19 cliff=12"
+          "details": "river surf=31 terr=24 -> land(5,-47) terr=19 cliff=12"
         },
         {
           "x": 6,
           "y": -46,
-          "details": "river surf=43 terr=42 -> land(5,-46) terr=33 cliff=10"
+          "details": "river surf=43 terr=37 -> land(5,-46) terr=33 cliff=10"
         },
         {
           "x": 6,
           "y": -45,
-          "details": "river surf=55 terr=54 -> land(5,-45) terr=48 cliff=7"
+          "details": "river surf=55 terr=49 -> land(5,-45) terr=48 cliff=7"
         },
         {
           "x": 6,
           "y": -44,
-          "details": "river surf=64 terr=63 -> land(5,-44) terr=59 cliff=5"
+          "details": "river surf=64 terr=58 -> land(5,-44) terr=59 cliff=5"
         },
         {
           "x": 6,
           "y": -43,
-          "details": "river surf=69 terr=68 -> land(5,-43) terr=66 cliff=3"
+          "details": "river surf=69 terr=63 -> land(5,-43) terr=66 cliff=3"
         },
         {
           "x": 6,
           "y": -42,
-          "details": "river surf=74 terr=73 -> land(5,-42) terr=71 cliff=3"
+          "details": "river surf=74 terr=69 -> land(5,-42) terr=71 cliff=3"
         },
         {
           "x": 6,
           "y": -35,
-          "details": "river surf=109 terr=108 -> land(5,-35) terr=107 cliff=2"
+          "details": "river surf=109 terr=102 -> land(5,-35) terr=107 cliff=2"
         },
         {
           "x": 6,
           "y": 29,
-          "details": "river surf=16 terr=15 -> land(5,29) terr=6 cliff=10"
+          "details": "river surf=16 terr=10 -> land(5,29) terr=6 cliff=10"
         },
         {
           "x": 10,
           "y": 27,
-          "details": "river surf=76 terr=75 -> land(9,27) terr=70 cliff=6"
+          "details": "river surf=76 terr=70 -> land(9,27) terr=70 cliff=6"
         },
         {
           "x": 11,
           "y": -51,
-          "details": "river surf=22 terr=21 -> land(10,-51) terr=19 cliff=3"
+          "details": "river surf=22 terr=15 -> land(10,-51) terr=19 cliff=3"
         },
         {
           "x": 11,
           "y": -50,
-          "details": "river surf=25 terr=24 -> land(10,-50) terr=22 cliff=3"
+          "details": "river surf=25 terr=18 -> land(10,-50) terr=22 cliff=3"
         },
         {
           "x": 11,
           "y": 10,
-          "details": "river surf=144 terr=143 -> land(10,10) terr=139 cliff=5"
+          "details": "river surf=144 terr=136 -> land(10,10) terr=139 cliff=5"
         },
         {
           "x": 11,
           "y": 11,
-          "details": "river surf=156 terr=155 -> land(10,11) terr=154 cliff=2"
+          "details": "river surf=156 terr=148 -> land(10,11) terr=154 cliff=2"
         },
         {
           "x": 11,
           "y": 13,
-          "details": "river surf=180 terr=179 -> land(10,13) terr=178 cliff=2"
+          "details": "river surf=180 terr=172 -> land(10,13) terr=178 cliff=2"
+        },
+        {
+          "x": 11,
+          "y": 14,
+          "details": "river surf=175 terr=167 -> land(10,14) terr=171 cliff=4"
+        },
+        {
+          "x": 11,
+          "y": 26,
+          "details": "river surf=100 terr=94 -> land(10,26) terr=98 cliff=2"
         },
         {
           "x": 12,
           "y": -51,
-          "details": "river surf=28 terr=27 -> land(12,-52) terr=23 cliff=5"
+          "details": "river surf=28 terr=21 -> land(12,-52) terr=23 cliff=5"
         },
         {
           "x": 12,
           "y": -39,
-          "details": "river surf=104 terr=102 -> land(11,-39) terr=100 cliff=4"
+          "details": "river surf=104 terr=97 -> land(11,-39) terr=100 cliff=4"
         },
         {
           "x": 12,
           "y": -31,
-          "details": "river surf=167 terr=166 -> land(11,-31) terr=159 cliff=8"
+          "details": "river surf=167 terr=160 -> land(11,-31) terr=159 cliff=8"
         },
         {
           "x": 12,
           "y": -30,
-          "details": "river surf=179 terr=178 -> land(11,-30) terr=177 cliff=2"
+          "details": "river surf=179 terr=172 -> land(11,-30) terr=177 cliff=2"
+        },
+        {
+          "x": 13,
+          "y": -49,
+          "details": "river surf=61 terr=54 -> land(12,-49) terr=58 cliff=3"
         },
         {
           "x": 13,
           "y": -40,
-          "details": "river surf=128 terr=127 -> land(12,-40) terr=122 cliff=6"
+          "details": "river surf=128 terr=122 -> land(12,-40) terr=122 cliff=6"
         },
         {
           "x": 13,
           "y": -35,
-          "details": "river surf=140 terr=139 -> land(13,-36) terr=130 cliff=10"
+          "details": "river surf=140 terr=134 -> land(13,-36) terr=130 cliff=10"
         },
         {
           "x": 13,
           "y": -31,
-          "details": "river surf=179 terr=178 -> land(13,-32) terr=172 cliff=7"
+          "details": "river surf=179 terr=172 -> land(13,-32) terr=172 cliff=7"
         },
         {
           "x": 13,
           "y": -26,
-          "details": "river surf=239 terr=238 -> land(13,-27) terr=236 cliff=3"
+          "details": "river surf=239 terr=234 -> land(13,-27) terr=236 cliff=3"
+        },
+        {
+          "x": 13,
+          "y": 16,
+          "details": "river surf=199 terr=191 -> land(13,15) terr=195 cliff=4"
+        },
+        {
+          "x": 13,
+          "y": 25,
+          "details": "river surf=136 terr=130 -> land(12,25) terr=134 cliff=2"
         },
         {
           "x": 14,
           "y": -40,
-          "details": "river surf=140 terr=139 -> land(14,-39) terr=138 cliff=2"
+          "details": "river surf=140 terr=134 -> land(14,-39) terr=138 cliff=2"
         },
         {
           "x": 14,
           "y": -36,
-          "details": "river surf=152 terr=151 -> land(13,-36) terr=130 cliff=22"
+          "details": "river surf=152 terr=147 -> land(13,-36) terr=130 cliff=22"
+        },
+        {
+          "x": 14,
+          "y": -33,
+          "details": "river surf=176 terr=170 -> land(14,-34) terr=174 cliff=2"
+        },
+        {
+          "x": 14,
+          "y": 24,
+          "details": "river surf=160 terr=154 -> land(13,24) terr=158 cliff=2"
         },
         {
           "x": 15,
           "y": -55,
-          "details": "river surf=40 terr=39 -> land(14,-55) terr=37 cliff=3"
+          "details": "river surf=40 terr=36 -> land(14,-55) terr=37 cliff=3"
         },
         {
           "x": 15,
           "y": -54,
-          "details": "river surf=46 terr=45 -> land(14,-54) terr=44 cliff=2"
+          "details": "river surf=46 terr=42 -> land(14,-54) terr=44 cliff=2"
         },
         {
           "x": 15,
           "y": -53,
-          "details": "river surf=55 terr=54 -> land(14,-53) terr=53 cliff=2"
+          "details": "river surf=55 terr=51 -> land(14,-53) terr=53 cliff=2"
         },
         {
           "x": 15,
           "y": -52,
-          "details": "river surf=64 terr=63 -> land(14,-52) terr=61 cliff=3"
+          "details": "river surf=64 terr=60 -> land(14,-52) terr=61 cliff=3"
+        },
+        {
+          "x": 15,
+          "y": -33,
+          "details": "river surf=188 terr=182 -> land(15,-34) terr=186 cliff=2"
+        },
+        {
+          "x": 15,
+          "y": 23,
+          "details": "river surf=184 terr=178 -> land(14,23) terr=182 cliff=2"
+        },
+        {
+          "x": 15,
+          "y": 35,
+          "details": "river surf=42 terr=35 -> land(15,36) terr=39 cliff=3"
         },
         {
           "x": 15,
           "y": 38,
-          "details": "river surf=18 terr=17 -> land(14,38) terr=6 cliff=12"
+          "details": "river surf=18 terr=11 -> land(14,38) terr=6 cliff=12"
+        },
+        {
+          "x": 16,
+          "y": -33,
+          "details": "river surf=200 terr=194 -> land(16,-34) terr=198 cliff=2"
+        },
+        {
+          "x": 16,
+          "y": 35,
+          "details": "river surf=54 terr=47 -> land(16,36) terr=51 cliff=3"
         },
         {
           "x": 16,
           "y": 40,
-          "details": "river surf=18 terr=17 -> land(15,40) terr=6 cliff=12"
+          "details": "river surf=18 terr=11 -> land(15,40) terr=6 cliff=12"
+        },
+        {
+          "x": 17,
+          "y": -33,
+          "details": "river surf=212 terr=206 -> land(17,-34) terr=210 cliff=2"
         },
         {
           "x": 17,
           "y": 19,
-          "details": "river surf=256 terr=255 -> land(16,19) terr=251 cliff=5"
+          "details": "river surf=256 terr=252 -> land(16,19) terr=251 cliff=5"
+        },
+        {
+          "x": 17,
+          "y": 22,
+          "details": "river surf=220 terr=214 -> land(16,22) terr=218 cliff=2"
+        },
+        {
+          "x": 17,
+          "y": 35,
+          "details": "river surf=66 terr=59 -> land(17,36) terr=63 cliff=3"
         },
         {
           "x": 18,
@@ -2098,9 +2083,29 @@
           "details": "river surf=262 terr=261 -> land(18,20) terr=257 cliff=5"
         },
         {
+          "x": 18,
+          "y": 29,
+          "details": "river surf=148 terr=141 -> land(18,30) terr=145 cliff=3"
+        },
+        {
+          "x": 18,
+          "y": 36,
+          "details": "river surf=66 terr=59 -> land(17,36) terr=63 cliff=3"
+        },
+        {
           "x": 19,
           "y": -49,
-          "details": "river surf=108 terr=107 -> land(19,-50) terr=100 cliff=8"
+          "details": "river surf=108 terr=103 -> land(19,-50) terr=100 cliff=8"
+        },
+        {
+          "x": 19,
+          "y": -33,
+          "details": "river surf=236 terr=229 -> land(19,-34) terr=234 cliff=2"
+        },
+        {
+          "x": 19,
+          "y": 24,
+          "details": "river surf=220 terr=214 -> land(19,25) terr=218 cliff=2"
         },
         {
           "x": 20,
@@ -2110,152 +2115,202 @@
         {
           "x": 20,
           "y": -49,
-          "details": "river surf=120 terr=119 -> land(20,-50) terr=113 cliff=7"
+          "details": "river surf=120 terr=116 -> land(20,-50) terr=113 cliff=7"
         },
         {
           "x": 20,
           "y": -48,
-          "details": "river surf=132 terr=131 -> land(19,-48) terr=122 cliff=10"
+          "details": "river surf=132 terr=128 -> land(19,-48) terr=122 cliff=10"
+        },
+        {
+          "x": 20,
+          "y": -34,
+          "details": "river surf=236 terr=231 -> land(19,-34) terr=234 cliff=2"
+        },
+        {
+          "x": 20,
+          "y": 38,
+          "details": "river surf=78 terr=71 -> land(20,39) terr=75 cliff=3"
         },
         {
           "x": 21,
           "y": -58,
-          "details": "river surf=33 terr=31 -> land(20,-58) terr=29 cliff=4"
+          "details": "river surf=33 terr=28 -> land(20,-58) terr=29 cliff=4"
         },
         {
           "x": 21,
           "y": -57,
-          "details": "river surf=42 terr=40 -> land(20,-57) terr=34 cliff=8"
+          "details": "river surf=42 terr=36 -> land(20,-57) terr=34 cliff=8"
         },
         {
           "x": 21,
           "y": -56,
-          "details": "river surf=53 terr=51 -> land(20,-56) terr=46 cliff=7"
+          "details": "river surf=53 terr=47 -> land(20,-56) terr=46 cliff=7"
         },
         {
           "x": 21,
           "y": -55,
-          "details": "river surf=65 terr=63 -> land(20,-55) terr=58 cliff=7"
+          "details": "river surf=65 terr=59 -> land(20,-55) terr=58 cliff=7"
         },
         {
           "x": 21,
           "y": -53,
-          "details": "river surf=89 terr=87 -> land(20,-53) terr=85 cliff=4"
+          "details": "river surf=89 terr=84 -> land(20,-53) terr=85 cliff=4"
         },
         {
           "x": 21,
           "y": -52,
-          "details": "river surf=101 terr=99 -> land(20,-52) terr=96 cliff=5"
+          "details": "river surf=101 terr=96 -> land(20,-52) terr=96 cliff=5"
         },
         {
           "x": 21,
           "y": -51,
-          "details": "river surf=113 terr=111 -> land(20,-51) terr=105 cliff=8"
+          "details": "river surf=113 terr=110 -> land(20,-51) terr=105 cliff=8"
         },
         {
           "x": 21,
           "y": -50,
-          "details": "river surf=125 terr=123 -> land(20,-50) terr=113 cliff=12"
+          "details": "river surf=125 terr=122 -> land(20,-50) terr=113 cliff=12"
         },
         {
           "x": 21,
           "y": -33,
-          "details": "river surf=245 terr=244 -> land(20,-33) terr=241 cliff=4"
+          "details": "river surf=245 terr=240 -> land(20,-33) terr=241 cliff=4"
+        },
+        {
+          "x": 21,
+          "y": 36,
+          "details": "river surf=102 terr=95 -> land(21,37) terr=99 cliff=3"
         },
         {
           "x": 22,
           "y": -32,
-          "details": "river surf=261 terr=260 -> land(21,-32) terr=257 cliff=4"
+          "details": "river surf=261 terr=256 -> land(21,-32) terr=257 cliff=4"
+        },
+        {
+          "x": 22,
+          "y": 34,
+          "details": "river surf=138 terr=131 -> land(22,35) terr=135 cliff=3"
         },
         {
           "x": 23,
           "y": -31,
-          "details": "river surf=277 terr=276 -> land(22,-31) terr=272 cliff=5"
+          "details": "river surf=277 terr=274 -> land(22,-31) terr=272 cliff=5"
         },
         {
           "x": 23,
           "y": -30,
-          "details": "river surf=285 terr=284 -> land(22,-30) terr=280 cliff=5"
+          "details": "river surf=285 terr=282 -> land(22,-30) terr=280 cliff=5"
         },
         {
           "x": 23,
           "y": -29,
-          "details": "river surf=290 terr=289 -> land(22,-29) terr=287 cliff=3"
+          "details": "river surf=290 terr=286 -> land(22,-29) terr=287 cliff=3"
         },
         {
           "x": 23,
           "y": -28,
-          "details": "river surf=294 terr=293 -> land(22,-28) terr=290 cliff=4"
+          "details": "river surf=294 terr=289 -> land(22,-28) terr=290 cliff=4"
+        },
+        {
+          "x": 23,
+          "y": 31,
+          "details": "river surf=184 terr=177 -> land(22,31) terr=181 cliff=3"
         },
         {
           "x": 24,
           "y": -28,
-          "details": "river surf=298 terr=297 -> land(24,-29) terr=295 cliff=3"
+          "details": "river surf=298 terr=293 -> land(24,-29) terr=295 cliff=3"
+        },
+        {
+          "x": 24,
+          "y": 27,
+          "details": "river surf=244 terr=239 -> land(24,28) terr=242 cliff=2"
+        },
+        {
+          "x": 24,
+          "y": 29,
+          "details": "river surf=220 terr=214 -> land(24,30) terr=218 cliff=2"
         },
         {
           "x": 27,
           "y": -34,
-          "details": "river surf=258 terr=257 -> land(26,-34) terr=256 cliff=2"
+          "details": "river surf=258 terr=255 -> land(26,-34) terr=256 cliff=2"
         },
         {
           "x": 28,
           "y": -33,
-          "details": "river surf=269 terr=268 -> land(27,-33) terr=267 cliff=2"
+          "details": "river surf=269 terr=265 -> land(27,-33) terr=267 cliff=2"
         },
         {
           "x": 29,
           "y": -32,
-          "details": "river surf=282 terr=281 -> land(28,-32) terr=279 cliff=3"
+          "details": "river surf=282 terr=277 -> land(28,-32) terr=279 cliff=3"
         },
         {
           "x": 31,
           "y": -58,
-          "details": "river surf=19 terr=18 -> land(32,-58) terr=15 cliff=4"
+          "details": "river surf=19 terr=14 -> land(32,-58) terr=15 cliff=4"
         },
         {
           "x": 31,
           "y": -57,
-          "details": "river surf=30 terr=29 -> land(32,-57) terr=22 cliff=8"
+          "details": "river surf=30 terr=24 -> land(32,-57) terr=22 cliff=8"
         },
         {
           "x": 31,
           "y": -56,
-          "details": "river surf=42 terr=41 -> land(32,-56) terr=32 cliff=10"
+          "details": "river surf=42 terr=35 -> land(32,-56) terr=32 cliff=10"
+        },
+        {
+          "x": 31,
+          "y": -51,
+          "details": "river surf=97 terr=90 -> land(32,-51) terr=94 cliff=3"
         },
         {
           "x": 32,
           "y": -55,
-          "details": "river surf=37 terr=36 -> land(32,-56) terr=32 cliff=5"
+          "details": "river surf=37 terr=30 -> land(32,-56) terr=32 cliff=5"
+        },
+        {
+          "x": 33,
+          "y": -52,
+          "details": "river surf=61 terr=54 -> land(34,-52) terr=59 cliff=2"
         },
         {
           "x": 33,
           "y": -36,
-          "details": "river surf=235 terr=234 -> land(33,-37) terr=228 cliff=7"
+          "details": "river surf=235 terr=231 -> land(33,-37) terr=228 cliff=7"
         },
         {
           "x": 34,
           "y": -43,
-          "details": "river surf=157 terr=156 -> land(34,-44) terr=154 cliff=3"
+          "details": "river surf=157 terr=151 -> land(34,-44) terr=154 cliff=3"
         },
         {
           "x": 34,
           "y": -38,
-          "details": "river surf=201 terr=200 -> land(34,-39) terr=195 cliff=6"
+          "details": "river surf=201 terr=195 -> land(34,-39) terr=195 cliff=6"
         },
         {
           "x": 36,
           "y": -47,
-          "details": "river surf=119 terr=118 -> land(36,-48) terr=113 cliff=6"
+          "details": "river surf=119 terr=114 -> land(36,-48) terr=113 cliff=6"
         },
         {
           "x": 37,
           "y": -47,
-          "details": "river surf=107 terr=105 -> land(37,-48) terr=100 cliff=7"
+          "details": "river surf=107 terr=101 -> land(37,-48) terr=100 cliff=7"
         },
         {
           "x": 38,
           "y": -49,
-          "details": "river surf=71 terr=69 -> land(38,-50) terr=69 cliff=2"
+          "details": "river surf=71 terr=65 -> land(38,-50) terr=69 cliff=2"
+        },
+        {
+          "x": 39,
+          "y": -38,
+          "details": "river surf=191 terr=185 -> land(40,-38) terr=188 cliff=3"
         },
         {
           "x": 40,
@@ -2265,12 +2320,12 @@
         {
           "x": 43,
           "y": -49,
-          "details": "river surf=59 terr=58 -> land(43,-50) terr=55 cliff=4"
+          "details": "river surf=59 terr=53 -> land(43,-50) terr=55 cliff=4"
         },
         {
           "x": 44,
           "y": -50,
-          "details": "river surf=60 terr=59 -> land(43,-50) terr=55 cliff=5"
+          "details": "river surf=60 terr=56 -> land(43,-50) terr=55 cliff=5"
         },
         {
           "x": 46,
@@ -2285,57 +2340,57 @@
         {
           "x": 48,
           "y": -56,
-          "details": "river surf=10 terr=9 -> land(49,-56) terr=7 cliff=3"
+          "details": "river surf=10 terr=7 -> land(49,-56) terr=7 cliff=3"
         },
         {
           "x": 48,
           "y": -49,
-          "details": "river surf=63 terr=62 -> land(49,-49) terr=61 cliff=2"
+          "details": "river surf=63 terr=58 -> land(49,-49) terr=61 cliff=2"
         },
         {
           "x": 49,
           "y": -55,
-          "details": "river surf=10 terr=9 -> land(49,-56) terr=7 cliff=3"
+          "details": "river surf=10 terr=7 -> land(49,-56) terr=7 cliff=3"
         },
         {
           "x": 49,
           "y": -51,
-          "details": "river surf=33 terr=32 -> land(50,-51) terr=30 cliff=3"
+          "details": "river surf=33 terr=27 -> land(50,-51) terr=30 cliff=3"
         },
         {
           "x": 49,
           "y": -50,
-          "details": "river surf=45 terr=44 -> land(50,-50) terr=41 cliff=4"
+          "details": "river surf=45 terr=39 -> land(50,-50) terr=41 cliff=4"
         },
         {
           "x": 50,
           "y": -53,
-          "details": "river surf=17 terr=16 -> land(51,-53) terr=13 cliff=4"
+          "details": "river surf=17 terr=13 -> land(51,-53) terr=13 cliff=4"
         },
         {
           "x": 50,
           "y": -52,
-          "details": "river surf=23 terr=22 -> land(51,-52) terr=18 cliff=5"
+          "details": "river surf=23 terr=18 -> land(51,-52) terr=18 cliff=5"
         },
         {
           "x": 52,
           "y": -53,
-          "details": "river surf=9 terr=8 -> land(53,-53) terr=6 cliff=3"
+          "details": "river surf=9 terr=5 -> land(53,-53) terr=6 cliff=3"
         },
         {
           "x": 52,
           "y": -52,
-          "details": "river surf=13 terr=12 -> land(53,-52) terr=10 cliff=3"
+          "details": "river surf=13 terr=7 -> land(53,-52) terr=10 cliff=3"
         },
         {
           "x": 52,
           "y": -51,
-          "details": "river surf=18 terr=17 -> land(53,-51) terr=14 cliff=4"
+          "details": "river surf=18 terr=12 -> land(53,-51) terr=14 cliff=4"
         },
         {
           "x": 52,
           "y": -50,
-          "details": "river surf=23 terr=22 -> land(53,-50) terr=18 cliff=5"
+          "details": "river surf=23 terr=17 -> land(53,-50) terr=18 cliff=5"
         }
       ],
       "WATER_CLIFF": [
@@ -2436,6 +2491,11 @@
         },
         {
           "x": 5,
+          "y": 15,
+          "details": "river surf=91 -> dry(5,14) terr=88 cliff=3"
+        },
+        {
+          "x": 5,
           "y": 23,
           "details": "river surf=69 -> dry(5,24) terr=64 cliff=5"
         },
@@ -2520,6 +2580,16 @@
           "details": "river surf=180 -> dry(10,13) terr=178 cliff=2"
         },
         {
+          "x": 11,
+          "y": 14,
+          "details": "river surf=175 -> dry(10,14) terr=171 cliff=4"
+        },
+        {
+          "x": 11,
+          "y": 26,
+          "details": "river surf=100 -> dry(10,26) terr=98 cliff=2"
+        },
+        {
           "x": 12,
           "y": -51,
           "details": "river surf=28 -> dry(12,-52) terr=23 cliff=5"
@@ -2538,6 +2608,11 @@
           "x": 12,
           "y": -30,
           "details": "river surf=179 -> dry(11,-30) terr=177 cliff=2"
+        },
+        {
+          "x": 13,
+          "y": -49,
+          "details": "river surf=61 -> dry(12,-49) terr=58 cliff=3"
         },
         {
           "x": 13,
@@ -2560,6 +2635,16 @@
           "details": "river surf=239 -> dry(13,-27) terr=236 cliff=3"
         },
         {
+          "x": 13,
+          "y": 16,
+          "details": "river surf=199 -> dry(13,15) terr=195 cliff=4"
+        },
+        {
+          "x": 13,
+          "y": 25,
+          "details": "river surf=136 -> dry(12,25) terr=134 cliff=2"
+        },
+        {
           "x": 14,
           "y": -40,
           "details": "river surf=140 -> dry(14,-39) terr=138 cliff=2"
@@ -2568,6 +2653,16 @@
           "x": 14,
           "y": -36,
           "details": "river surf=152 -> dry(13,-36) terr=130 cliff=22"
+        },
+        {
+          "x": 14,
+          "y": -33,
+          "details": "river surf=176 -> dry(14,-34) terr=174 cliff=2"
+        },
+        {
+          "x": 14,
+          "y": 24,
+          "details": "river surf=160 -> dry(13,24) terr=158 cliff=2"
         },
         {
           "x": 15,
@@ -2591,8 +2686,33 @@
         },
         {
           "x": 15,
+          "y": -33,
+          "details": "river surf=188 -> dry(15,-34) terr=186 cliff=2"
+        },
+        {
+          "x": 15,
+          "y": 23,
+          "details": "river surf=184 -> dry(14,23) terr=182 cliff=2"
+        },
+        {
+          "x": 15,
+          "y": 35,
+          "details": "river surf=42 -> dry(15,36) terr=39 cliff=3"
+        },
+        {
+          "x": 15,
           "y": 38,
           "details": "river surf=18 -> dry(14,38) terr=6 cliff=12"
+        },
+        {
+          "x": 16,
+          "y": -33,
+          "details": "river surf=200 -> dry(16,-34) terr=198 cliff=2"
+        },
+        {
+          "x": 16,
+          "y": 35,
+          "details": "river surf=54 -> dry(16,36) terr=51 cliff=3"
         },
         {
           "x": 16,
@@ -2601,8 +2721,23 @@
         },
         {
           "x": 17,
+          "y": -33,
+          "details": "river surf=212 -> dry(17,-34) terr=210 cliff=2"
+        },
+        {
+          "x": 17,
           "y": 19,
           "details": "river surf=256 -> dry(16,19) terr=251 cliff=5"
+        },
+        {
+          "x": 17,
+          "y": 22,
+          "details": "river surf=220 -> dry(16,22) terr=218 cliff=2"
+        },
+        {
+          "x": 17,
+          "y": 35,
+          "details": "river surf=66 -> dry(17,36) terr=63 cliff=3"
         },
         {
           "x": 18,
@@ -2610,9 +2745,29 @@
           "details": "river surf=262 -> dry(18,20) terr=257 cliff=5"
         },
         {
+          "x": 18,
+          "y": 29,
+          "details": "river surf=148 -> dry(18,30) terr=145 cliff=3"
+        },
+        {
+          "x": 18,
+          "y": 36,
+          "details": "river surf=66 -> dry(17,36) terr=63 cliff=3"
+        },
+        {
           "x": 19,
           "y": -49,
           "details": "river surf=108 -> dry(19,-50) terr=100 cliff=8"
+        },
+        {
+          "x": 19,
+          "y": -33,
+          "details": "river surf=236 -> dry(19,-34) terr=234 cliff=2"
+        },
+        {
+          "x": 19,
+          "y": 24,
+          "details": "river surf=220 -> dry(19,25) terr=218 cliff=2"
         },
         {
           "x": 20,
@@ -2628,6 +2783,16 @@
           "x": 20,
           "y": -48,
           "details": "river surf=132 -> dry(19,-48) terr=122 cliff=10"
+        },
+        {
+          "x": 20,
+          "y": -34,
+          "details": "river surf=236 -> dry(19,-34) terr=234 cliff=2"
+        },
+        {
+          "x": 20,
+          "y": 38,
+          "details": "river surf=78 -> dry(20,39) terr=75 cliff=3"
         },
         {
           "x": 21,
@@ -2675,9 +2840,19 @@
           "details": "river surf=245 -> dry(20,-33) terr=241 cliff=4"
         },
         {
+          "x": 21,
+          "y": 36,
+          "details": "river surf=102 -> dry(21,37) terr=99 cliff=3"
+        },
+        {
           "x": 22,
           "y": -32,
           "details": "river surf=261 -> dry(21,-32) terr=257 cliff=4"
+        },
+        {
+          "x": 22,
+          "y": 34,
+          "details": "river surf=138 -> dry(22,35) terr=135 cliff=3"
         },
         {
           "x": 23,
@@ -2700,9 +2875,24 @@
           "details": "river surf=294 -> dry(22,-28) terr=290 cliff=4"
         },
         {
+          "x": 23,
+          "y": 31,
+          "details": "river surf=184 -> dry(22,31) terr=181 cliff=3"
+        },
+        {
           "x": 24,
           "y": -28,
           "details": "river surf=298 -> dry(24,-29) terr=295 cliff=3"
+        },
+        {
+          "x": 24,
+          "y": 27,
+          "details": "river surf=244 -> dry(24,28) terr=242 cliff=2"
+        },
+        {
+          "x": 24,
+          "y": 29,
+          "details": "river surf=220 -> dry(24,30) terr=218 cliff=2"
         },
         {
           "x": 27,
@@ -2735,9 +2925,19 @@
           "details": "river surf=42 -> dry(32,-56) terr=32 cliff=10"
         },
         {
+          "x": 31,
+          "y": -51,
+          "details": "river surf=97 -> dry(32,-51) terr=94 cliff=3"
+        },
+        {
           "x": 32,
           "y": -55,
           "details": "river surf=37 -> dry(32,-56) terr=32 cliff=5"
+        },
+        {
+          "x": 33,
+          "y": -52,
+          "details": "river surf=61 -> dry(34,-52) terr=59 cliff=2"
         },
         {
           "x": 33,
@@ -2768,6 +2968,11 @@
           "x": 38,
           "y": -49,
           "details": "river surf=71 -> dry(38,-50) terr=69 cliff=2"
+        },
+        {
+          "x": 39,
+          "y": -38,
+          "details": "river surf=191 -> dry(40,-38) terr=188 cliff=3"
         },
         {
           "x": 40,

--- a/tools/baselines/seed8080_size32_region_-4_-4_4_4.json
+++ b/tools/baselines/seed8080_size32_region_-4_-4_4_4.json
@@ -14,9 +14,9 @@
     "deterministic": true,
     "distinctHashes": 1,
     "hashes": [
-      "dbdcfa46f367650bd7910d56b02f119d034062d94af0855b4e938558b122f891",
-      "dbdcfa46f367650bd7910d56b02f119d034062d94af0855b4e938558b122f891",
-      "dbdcfa46f367650bd7910d56b02f119d034062d94af0855b4e938558b122f891"
+      "2b50ff2715366d8979927355e8ae8da01c5888be32b01200cf10c2d5efbf3f8c",
+      "2b50ff2715366d8979927355e8ae8da01c5888be32b01200cf10c2d5efbf3f8c",
+      "2b50ff2715366d8979927355e8ae8da01c5888be32b01200cf10c2d5efbf3f8c"
     ]
   },
   "tileCount": 20736,
@@ -97,23 +97,23 @@
       ]
     },
     "FLAT_ISOLATED_WATER": {
-      "min": 11,
-      "max": 11,
-      "median": 11,
+      "min": 10,
+      "max": 10,
+      "median": 10,
       "all": [
-        11,
-        11,
-        11
+        10,
+        10,
+        10
       ]
     },
     "FLOATING_LAKE": {
-      "min": 302,
-      "max": 302,
-      "median": 302,
+      "min": 303,
+      "max": 303,
+      "median": 303,
       "all": [
-        302,
-        302,
-        302
+        303,
+        303,
+        303
       ]
     },
     "FLOATING_LAVA": {
@@ -127,13 +127,13 @@
       ]
     },
     "FLOATING_WATER": {
-      "min": 219,
-      "max": 219,
-      "median": 219,
+      "min": 150,
+      "max": 150,
+      "median": 150,
       "all": [
-        219,
-        219,
-        219
+        150,
+        150,
+        150
       ]
     },
     "ISLAND_1TILE": {
@@ -157,13 +157,13 @@
       ]
     },
     "MID_RIVER_CLIFF": {
-      "min": 1,
-      "max": 1,
-      "median": 1,
+      "min": 66,
+      "max": 66,
+      "median": 66,
       "all": [
-        1,
-        1,
-        1
+        66,
+        66,
+        66
       ]
     },
     "MULTI_ISLAND": {
@@ -177,13 +177,13 @@
       ]
     },
     "RIVER_CHUNK_GAP": {
-      "min": 8,
-      "max": 8,
-      "median": 8,
+      "min": 10,
+      "max": 10,
+      "median": 10,
       "all": [
-        8,
-        8,
-        8
+        10,
+        10,
+        10
       ]
     },
     "RIVER_MOUTH_DROP": {
@@ -197,23 +197,23 @@
       ]
     },
     "WATER_ABOVE_LAND": {
-      "min": 222,
-      "max": 222,
-      "median": 222,
+      "min": 237,
+      "max": 237,
+      "median": 237,
       "all": [
-        222,
-        222,
-        222
+        237,
+        237,
+        237
       ]
     },
     "WATER_CLIFF": {
-      "min": 222,
-      "max": 222,
-      "median": 222,
+      "min": 237,
+      "max": 237,
+      "median": 237,
       "all": [
-        222,
-        222,
-        222
+        237,
+        237,
+        237
       ]
     },
     "WATER_WATER_CLIFF": {
@@ -230,18 +230,18 @@
   "representativeAudit": {
     "summary": {
       "DESERT_SOIL_ON_SLOPE": 2,
-      "FLAT_ISOLATED_WATER": 11,
-      "FLOATING_LAKE": 302,
+      "FLAT_ISOLATED_WATER": 10,
+      "FLOATING_LAKE": 303,
       "FLOATING_LAVA": 73,
-      "FLOATING_WATER": 219,
+      "FLOATING_WATER": 150,
       "ISLAND_1TILE": 1,
       "ISOLATED_FLUID": 29,
-      "MID_RIVER_CLIFF": 1,
+      "MID_RIVER_CLIFF": 66,
       "MULTI_ISLAND": 15,
-      "RIVER_CHUNK_GAP": 8,
+      "RIVER_CHUNK_GAP": 10,
       "RIVER_MOUTH_DROP": 4,
-      "WATER_ABOVE_LAND": 222,
-      "WATER_CLIFF": 222,
+      "WATER_ABOVE_LAND": 237,
+      "WATER_CLIFF": 237,
       "WATER_WATER_CLIFF": 2283
     },
     "issues": {
@@ -289,11 +289,6 @@
           "details": "lake surf=35 terr=33 water_nbrs=0 terr_range=0"
         },
         {
-          "x": 28,
-          "y": -43,
-          "details": "lake surf=88 terr=86 water_nbrs=0 terr_range=1"
-        },
-        {
           "x": 47,
           "y": 68,
           "details": "lake surf=0 terr=-3 water_nbrs=0 terr_range=2"
@@ -318,12 +313,17 @@
         {
           "x": 31,
           "y": -46,
-          "details": "lake fluidSurf=88 terrainZ=67 depth=21"
+          "details": "lake fluidSurf=88 terrainZ=62 depth=26"
         },
         {
           "x": 33,
           "y": -48,
-          "details": "lake fluidSurf=88 terrainZ=67 depth=21"
+          "details": "lake fluidSurf=88 terrainZ=63 depth=25"
+        },
+        {
+          "x": 34,
+          "y": -54,
+          "details": "lake fluidSurf=107 terrainZ=89 depth=18"
         },
         {
           "x": 67,
@@ -2200,44 +2200,19 @@
           "details": "river terr=4 -> dry(-57,75) terr=3 gap=1"
         },
         {
-          "x": -55,
-          "y": 76,
-          "details": "river terr=8 -> dry(-56,76) terr=7 gap=1"
-        },
-        {
-          "x": -55,
-          "y": 77,
-          "details": "river terr=11 -> dry(-56,77) terr=9 gap=2"
-        },
-        {
-          "x": -55,
-          "y": 78,
-          "details": "river terr=13 -> dry(-56,78) terr=12 gap=1"
-        },
-        {
-          "x": -47,
-          "y": 77,
-          "details": "river terr=25 -> dry(-46,77) terr=22 gap=3"
-        },
-        {
           "x": -47,
           "y": 78,
-          "details": "river terr=33 -> dry(-46,78) terr=28 gap=5"
+          "details": "river terr=30 -> dry(-46,78) terr=28 gap=2"
         },
         {
           "x": -47,
           "y": 79,
-          "details": "river terr=39 -> dry(-46,79) terr=34 gap=5"
-        },
-        {
-          "x": -41,
-          "y": 77,
-          "details": "river terr=26 -> dry(-41,76) terr=22 gap=4"
+          "details": "river terr=37 -> dry(-46,79) terr=34 gap=3"
         },
         {
           "x": -40,
           "y": 77,
-          "details": "river terr=31 -> dry(-40,76) terr=27 gap=4"
+          "details": "river terr=28 -> dry(-40,76) terr=27 gap=1"
         },
         {
           "x": -40,
@@ -2247,7 +2222,7 @@
         {
           "x": -39,
           "y": 76,
-          "details": "river terr=31 -> dry(-40,76) terr=27 gap=4"
+          "details": "river terr=28 -> dry(-40,76) terr=27 gap=1"
         },
         {
           "x": -25,
@@ -2277,47 +2252,42 @@
         {
           "x": -25,
           "y": 54,
-          "details": "river terr=51 -> dry(-26,54) terr=48 gap=3"
+          "details": "river terr=49 -> dry(-26,54) terr=48 gap=1"
         },
         {
           "x": -25,
           "y": 55,
-          "details": "river terr=60 -> dry(-26,55) terr=57 gap=3"
-        },
-        {
-          "x": -25,
-          "y": 56,
-          "details": "river terr=69 -> dry(-26,56) terr=66 gap=3"
+          "details": "river terr=58 -> dry(-26,55) terr=57 gap=1"
         },
         {
           "x": -25,
           "y": 57,
-          "details": "river terr=80 -> dry(-26,57) terr=75 gap=5"
+          "details": "river terr=77 -> dry(-26,57) terr=75 gap=2"
         },
         {
           "x": -25,
           "y": 58,
-          "details": "river terr=91 -> dry(-26,58) terr=84 gap=7"
+          "details": "river terr=88 -> dry(-26,58) terr=84 gap=4"
         },
         {
           "x": -25,
           "y": 59,
-          "details": "river terr=100 -> dry(-26,59) terr=93 gap=7"
+          "details": "river terr=96 -> dry(-26,59) terr=93 gap=3"
         },
         {
           "x": -25,
           "y": 60,
-          "details": "river terr=110 -> dry(-26,60) terr=102 gap=8"
+          "details": "river terr=106 -> dry(-26,60) terr=102 gap=4"
         },
         {
           "x": -25,
           "y": 61,
-          "details": "river terr=120 -> dry(-26,61) terr=111 gap=9"
+          "details": "river terr=116 -> dry(-26,61) terr=111 gap=5"
         },
         {
           "x": -25,
           "y": 62,
-          "details": "river terr=131 -> dry(-26,62) terr=121 gap=10"
+          "details": "river terr=127 -> dry(-26,62) terr=121 gap=6"
         },
         {
           "x": -23,
@@ -2337,7 +2307,7 @@
         {
           "x": -22,
           "y": 54,
-          "details": "river terr=42 -> dry(-22,53) terr=38 gap=4"
+          "details": "river terr=39 -> dry(-22,53) terr=38 gap=1"
         },
         {
           "x": -18,
@@ -2345,109 +2315,64 @@
           "details": "river terr=194 -> dry(-19,71) terr=193 gap=1"
         },
         {
-          "x": -13,
-          "y": 61,
-          "details": "river terr=102 -> dry(-13,60) terr=96 gap=6"
-        },
-        {
           "x": -12,
           "y": 54,
-          "details": "river terr=31 -> dry(-12,53) terr=23 gap=8"
-        },
-        {
-          "x": -12,
-          "y": 58,
-          "details": "river terr=78 -> dry(-13,58) terr=76 gap=2"
-        },
-        {
-          "x": -12,
-          "y": 59,
-          "details": "river terr=90 -> dry(-13,59) terr=88 gap=2"
+          "details": "river terr=25 -> dry(-12,53) terr=23 gap=2"
         },
         {
           "x": -11,
           "y": 53,
-          "details": "river terr=31 -> dry(-12,53) terr=23 gap=8"
+          "details": "river terr=26 -> dry(-12,53) terr=23 gap=3"
         },
         {
           "x": -9,
           "y": 62,
-          "details": "river terr=119 -> dry(-9,61) terr=116 gap=3"
+          "details": "river terr=117 -> dry(-9,61) terr=116 gap=1"
         },
         {
           "x": -8,
           "y": 62,
-          "details": "river terr=124 -> dry(-8,61) terr=121 gap=3"
-        },
-        {
-          "x": -7,
-          "y": 59,
-          "details": "river terr=115 -> dry(-8,59) terr=113 gap=2"
-        },
-        {
-          "x": -7,
-          "y": 60,
-          "details": "river terr=120 -> dry(-8,60) terr=118 gap=2"
+          "details": "river terr=122 -> dry(-8,61) terr=121 gap=1"
         },
         {
           "x": -7,
           "y": 61,
-          "details": "river terr=124 -> dry(-8,61) terr=121 gap=3"
+          "details": "river terr=122 -> dry(-8,61) terr=121 gap=1"
         },
         {
           "x": -5,
           "y": 65,
-          "details": "river terr=138 -> dry(-4,65) terr=135 gap=3"
-        },
-        {
-          "x": -4,
-          "y": 60,
-          "details": "river terr=111 -> dry(-3,60) terr=110 gap=1"
+          "details": "river terr=136 -> dry(-4,65) terr=135 gap=1"
         },
         {
           "x": -4,
           "y": 61,
-          "details": "river terr=119 -> dry(-3,61) terr=116 gap=3"
+          "details": "river terr=118 -> dry(-3,61) terr=116 gap=2"
         },
         {
           "x": -4,
           "y": 62,
-          "details": "river terr=122 -> dry(-3,62) terr=120 gap=2"
+          "details": "river terr=121 -> dry(-3,62) terr=120 gap=1"
         },
         {
           "x": -3,
           "y": 63,
-          "details": "river terr=122 -> dry(-3,62) terr=120 gap=2"
+          "details": "river terr=121 -> dry(-3,62) terr=120 gap=1"
         },
         {
           "x": -2,
           "y": 63,
-          "details": "river terr=118 -> dry(-2,62) terr=115 gap=3"
-        },
-        {
-          "x": -2,
-          "y": 65,
-          "details": "river terr=127 -> dry(-1,65) terr=124 gap=3"
-        },
-        {
-          "x": -2,
-          "y": 66,
-          "details": "river terr=133 -> dry(-1,66) terr=131 gap=2"
+          "details": "river terr=116 -> dry(-2,62) terr=115 gap=1"
         },
         {
           "x": -1,
           "y": 63,
-          "details": "river terr=113 -> dry(-1,62) terr=109 gap=4"
-        },
-        {
-          "x": 0,
-          "y": 60,
-          "details": "river terr=89 -> dry(1,60) terr=87 gap=2"
+          "details": "river terr=112 -> dry(-1,62) terr=109 gap=3"
         },
         {
           "x": 0,
           "y": 61,
-          "details": "river terr=97 -> dry(1,61) terr=95 gap=2"
+          "details": "river terr=96 -> dry(1,61) terr=95 gap=1"
         },
         {
           "x": 0,
@@ -2457,52 +2382,47 @@
         {
           "x": 0,
           "y": 63,
-          "details": "river terr=107 -> dry(1,63) terr=104 gap=3"
+          "details": "river terr=106 -> dry(1,63) terr=104 gap=2"
         },
         {
           "x": 0,
           "y": 64,
-          "details": "river terr=112 -> dry(1,64) terr=108 gap=4"
+          "details": "river terr=110 -> dry(1,64) terr=108 gap=2"
         },
         {
           "x": 0,
           "y": 65,
-          "details": "river terr=118 -> dry(1,65) terr=113 gap=5"
+          "details": "river terr=116 -> dry(1,65) terr=113 gap=3"
         },
         {
           "x": 4,
           "y": 52,
-          "details": "river terr=25 -> dry(4,51) terr=19 gap=6"
+          "details": "river terr=22 -> dry(4,51) terr=19 gap=3"
         },
         {
           "x": 4,
           "y": 53,
-          "details": "river terr=35 -> dry(3,53) terr=29 gap=6"
+          "details": "river terr=32 -> dry(3,53) terr=29 gap=3"
         },
         {
           "x": 4,
           "y": 54,
-          "details": "river terr=46 -> dry(3,54) terr=40 gap=6"
+          "details": "river terr=44 -> dry(3,54) terr=40 gap=4"
         },
         {
           "x": 4,
           "y": 55,
-          "details": "river terr=57 -> dry(3,55) terr=50 gap=7"
-        },
-        {
-          "x": 5,
-          "y": 49,
-          "details": "river terr=10 -> dry(4,49) terr=9 gap=1"
+          "details": "river terr=55 -> dry(3,55) terr=50 gap=5"
         },
         {
           "x": 5,
           "y": 50,
-          "details": "river terr=16 -> dry(4,50) terr=14 gap=2"
+          "details": "river terr=15 -> dry(4,50) terr=14 gap=1"
         },
         {
           "x": 5,
           "y": 51,
-          "details": "river terr=22 -> dry(4,51) terr=19 gap=3"
+          "details": "river terr=20 -> dry(4,51) terr=19 gap=1"
         },
         {
           "x": 7,
@@ -2517,7 +2437,7 @@
         {
           "x": 8,
           "y": 49,
-          "details": "river terr=22 -> dry(8,48) terr=19 gap=3"
+          "details": "river terr=21 -> dry(8,48) terr=19 gap=2"
         },
         {
           "x": 9,
@@ -2565,9 +2485,14 @@
           "details": "river terr=30 -> dry(22,-10) terr=29 gap=1"
         },
         {
+          "x": 28,
+          "y": -43,
+          "details": "lake terr=86 -> dry(28,-44) terr=85 gap=1"
+        },
+        {
           "x": 29,
           "y": -44,
-          "details": "lake terr=86 -> dry(29,-45) terr=73 gap=13"
+          "details": "lake terr=86 -> dry(28,-44) terr=85 gap=1"
         },
         {
           "x": 29,
@@ -2577,22 +2502,12 @@
         {
           "x": 30,
           "y": -45,
-          "details": "lake terr=85 -> dry(29,-45) terr=73 gap=12"
+          "details": "lake terr=79 -> dry(29,-45) terr=67 gap=12"
         },
         {
           "x": 31,
           "y": -46,
-          "details": "lake terr=67 -> dry(30,-46) terr=57 gap=10"
-        },
-        {
-          "x": 31,
-          "y": -43,
-          "details": "river terr=92 -> dry(30,-43) terr=91 gap=1"
-        },
-        {
-          "x": 31,
-          "y": -42,
-          "details": "river terr=95 -> dry(30,-42) terr=93 gap=2"
+          "details": "lake terr=62 -> dry(30,-46) terr=51 gap=11"
         },
         {
           "x": 31,
@@ -2601,28 +2516,23 @@
         },
         {
           "x": 32,
-          "y": -3,
-          "details": "river terr=27 -> dry(31,-3) terr=25 gap=2"
-        },
-        {
-          "x": 32,
           "y": 3,
           "details": "river terr=18 -> dry(32,4) terr=17 gap=1"
         },
         {
           "x": 33,
-          "y": -48,
-          "details": "lake terr=67 -> dry(32,-48) terr=55 gap=12"
+          "y": -50,
+          "details": "river terr=53 -> dry(32,-50) terr=50 gap=3"
         },
         {
           "x": 33,
-          "y": -8,
-          "details": "river terr=50 -> dry(32,-8) terr=48 gap=2"
+          "y": -48,
+          "details": "lake terr=63 -> dry(32,-48) terr=50 gap=13"
         },
         {
           "x": 33,
           "y": -4,
-          "details": "river terr=43 -> dry(33,-3) terr=41 gap=2"
+          "details": "river terr=42 -> dry(33,-3) terr=41 gap=1"
         },
         {
           "x": 33,
@@ -2631,8 +2541,13 @@
         },
         {
           "x": 34,
+          "y": -53,
+          "details": "river terr=65 -> dry(33,-53) terr=64 gap=1"
+        },
+        {
+          "x": 34,
           "y": -44,
-          "details": "river terr=98 -> dry(33,-44) terr=96 gap=2"
+          "details": "river terr=97 -> dry(33,-44) terr=96 gap=1"
         },
         {
           "x": 34,
@@ -2645,14 +2560,14 @@
           "details": "river terr=115 -> dry(33,-41) terr=112 gap=3"
         },
         {
-          "x": 34,
-          "y": -7,
-          "details": "river terr=53 -> dry(34,-6) terr=52 gap=1"
+          "x": 35,
+          "y": -53,
+          "details": "river terr=77 -> dry(35,-52) terr=76 gap=1"
         },
         {
           "x": 35,
           "y": -51,
-          "details": "river terr=89 -> dry(35,-52) terr=81 gap=8"
+          "details": "river terr=89 -> dry(35,-52) terr=76 gap=13"
         },
         {
           "x": 35,
@@ -2662,7 +2577,7 @@
         {
           "x": 36,
           "y": -52,
-          "details": "river terr=89 -> dry(35,-52) terr=81 gap=8"
+          "details": "river terr=89 -> dry(35,-52) terr=76 gap=13"
         },
         {
           "x": 36,
@@ -2692,17 +2607,12 @@
         {
           "x": 39,
           "y": -58,
-          "details": "river terr=111 -> dry(39,-57) terr=100 gap=11"
+          "details": "river terr=106 -> dry(39,-57) terr=100 gap=6"
         },
         {
           "x": 39,
           "y": -47,
           "details": "river terr=105 -> dry(39,-48) terr=104 gap=1"
-        },
-        {
-          "x": 39,
-          "y": 2,
-          "details": "river terr=28 -> dry(39,3) terr=25 gap=3"
         },
         {
           "x": 40,
@@ -2715,59 +2625,19 @@
           "details": "river terr=117 -> dry(40,-48) terr=107 gap=10"
         },
         {
-          "x": 40,
-          "y": -14,
-          "details": "river terr=98 -> dry(39,-14) terr=96 gap=2"
-        },
-        {
-          "x": 40,
-          "y": -2,
-          "details": "river terr=61 -> dry(39,-2) terr=60 gap=1"
-        },
-        {
-          "x": 40,
-          "y": -1,
-          "details": "river terr=51 -> dry(39,-1) terr=50 gap=1"
-        },
-        {
-          "x": 40,
-          "y": 0,
-          "details": "river terr=44 -> dry(40,1) terr=43 gap=1"
-        },
-        {
           "x": 41,
           "y": -49,
-          "details": "river terr=107 -> dry(41,-50) terr=105 gap=2"
+          "details": "river terr=106 -> dry(41,-50) terr=105 gap=1"
         },
         {
           "x": 41,
           "y": -4,
-          "details": "river terr=70 -> dry(40,-4) terr=66 gap=4"
-        },
-        {
-          "x": 41,
-          "y": -3,
-          "details": "river terr=69 -> dry(41,-2) terr=67 gap=2"
-        },
-        {
-          "x": 41,
-          "y": -1,
-          "details": "river terr=58 -> dry(41,0) terr=54 gap=4"
+          "details": "river terr=68 -> dry(40,-4) terr=66 gap=2"
         },
         {
           "x": 41,
           "y": 6,
-          "details": "river terr=31 -> dry(41,7) terr=25 gap=6"
-        },
-        {
-          "x": 42,
-          "y": -56,
-          "details": "river terr=99 -> dry(41,-56) terr=97 gap=2"
-        },
-        {
-          "x": 42,
-          "y": -1,
-          "details": "river terr=65 -> dry(42,0) terr=62 gap=3"
+          "details": "river terr=29 -> dry(41,7) terr=25 gap=4"
         },
         {
           "x": 42,
@@ -2782,17 +2652,12 @@
         {
           "x": 43,
           "y": -51,
-          "details": "river terr=109 -> dry(42,-51) terr=106 gap=3"
+          "details": "river terr=108 -> dry(42,-51) terr=106 gap=2"
         },
         {
           "x": 43,
           "y": 7,
           "details": "river terr=39 -> dry(44,7) terr=38 gap=1"
-        },
-        {
-          "x": 44,
-          "y": 2,
-          "details": "river terr=59 -> dry(43,2) terr=58 gap=1"
         },
         {
           "x": 44,
@@ -2802,102 +2667,57 @@
         {
           "x": 45,
           "y": 0,
-          "details": "river terr=79 -> dry(44,0) terr=74 gap=5"
-        },
-        {
-          "x": 45,
-          "y": 1,
-          "details": "river terr=70 -> dry(44,1) terr=67 gap=3"
+          "details": "river terr=76 -> dry(44,0) terr=74 gap=2"
         },
         {
           "x": 45,
           "y": 5,
-          "details": "river terr=46 -> dry(45,6) terr=39 gap=7"
+          "details": "river terr=44 -> dry(45,6) terr=39 gap=5"
         },
         {
           "x": 46,
           "y": -1,
-          "details": "river terr=93 -> dry(45,-1) terr=89 gap=4"
+          "details": "river terr=90 -> dry(45,-1) terr=89 gap=1"
         },
         {
           "x": 46,
           "y": 5,
-          "details": "river terr=52 -> dry(46,6) terr=39 gap=13"
-        },
-        {
-          "x": 47,
-          "y": -2,
-          "details": "river terr=104 -> dry(46,-2) terr=101 gap=3"
+          "details": "river terr=49 -> dry(46,6) terr=39 gap=10"
         },
         {
           "x": 47,
           "y": 2,
-          "details": "river terr=72 -> dry(47,3) terr=67 gap=5"
+          "details": "river terr=69 -> dry(47,3) terr=67 gap=2"
         },
         {
           "x": 48,
           "y": -59,
-          "details": "river terr=143 -> dry(48,-60) terr=140 gap=3"
+          "details": "river terr=142 -> dry(48,-60) terr=140 gap=2"
         },
         {
           "x": 48,
           "y": -58,
-          "details": "river terr=150 -> dry(49,-58) terr=144 gap=6"
-        },
-        {
-          "x": 48,
-          "y": -3,
-          "details": "river terr=119 -> dry(47,-3) terr=116 gap=3"
+          "details": "river terr=149 -> dry(49,-58) terr=144 gap=5"
         },
         {
           "x": 48,
           "y": 1,
-          "details": "river terr=89 -> dry(48,2) terr=86 gap=3"
-        },
-        {
-          "x": 49,
-          "y": -60,
-          "details": "river terr=123 -> dry(49,-61) terr=121 gap=2"
-        },
-        {
-          "x": 50,
-          "y": -8,
-          "details": "river terr=178 -> dry(49,-8) terr=176 gap=2"
-        },
-        {
-          "x": 50,
-          "y": -7,
-          "details": "river terr=166 -> dry(49,-7) terr=162 gap=4"
+          "details": "river terr=87 -> dry(48,2) terr=86 gap=1"
         },
         {
           "x": 50,
           "y": -6,
-          "details": "river terr=158 -> dry(49,-6) terr=152 gap=6"
-        },
-        {
-          "x": 50,
-          "y": -5,
-          "details": "river terr=148 -> dry(49,-5) terr=145 gap=3"
+          "details": "river terr=154 -> dry(49,-6) terr=152 gap=2"
         },
         {
           "x": 54,
           "y": -2,
-          "details": "river terr=129 -> dry(55,-2) terr=109 gap=20"
-        },
-        {
-          "x": 55,
-          "y": -12,
-          "details": "river terr=205 -> dry(55,-13) terr=203 gap=2"
+          "details": "river terr=123 -> dry(55,-2) terr=103 gap=20"
         },
         {
           "x": 58,
           "y": 4,
-          "details": "river terr=21 -> dry(59,4) terr=11 gap=10"
-        },
-        {
-          "x": 58,
-          "y": 5,
-          "details": "river terr=9 -> dry(59,5) terr=8 gap=1"
+          "details": "river terr=15 -> dry(59,4) terr=11 gap=4"
         },
         {
           "x": 60,
@@ -2912,12 +2732,7 @@
         {
           "x": 60,
           "y": -62,
-          "details": "river terr=101 -> dry(61,-62) terr=99 gap=2"
-        },
-        {
-          "x": 60,
-          "y": -42,
-          "details": "river terr=222 -> dry(60,-43) terr=219 gap=3"
+          "details": "river terr=100 -> dry(61,-62) terr=99 gap=1"
         },
         {
           "x": 61,
@@ -2926,83 +2741,43 @@
         },
         {
           "x": 62,
-          "y": -61,
-          "details": "river terr=97 -> dry(62,-62) terr=94 gap=3"
-        },
-        {
-          "x": 62,
-          "y": -53,
-          "details": "river terr=172 -> dry(63,-53) terr=170 gap=2"
-        },
-        {
-          "x": 62,
           "y": -51,
-          "details": "river terr=196 -> dry(63,-51) terr=190 gap=6"
-        },
-        {
-          "x": 63,
-          "y": -61,
-          "details": "river terr=90 -> dry(63,-62) terr=88 gap=2"
-        },
-        {
-          "x": 63,
-          "y": -55,
-          "details": "river terr=136 -> dry(64,-55) terr=134 gap=2"
-        },
-        {
-          "x": 64,
-          "y": -61,
-          "details": "river terr=84 -> dry(64,-62) terr=81 gap=3"
+          "details": "river terr=195 -> dry(63,-51) terr=190 gap=5"
         },
         {
           "x": 64,
           "y": -44,
-          "details": "river terr=201 -> dry(65,-44) terr=197 gap=4"
+          "details": "river terr=200 -> dry(65,-44) terr=197 gap=3"
         },
         {
           "x": 64,
           "y": -12,
-          "details": "river terr=213 -> dry(64,-11) terr=211 gap=2"
+          "details": "river terr=212 -> dry(64,-11) terr=211 gap=1"
         },
         {
           "x": 65,
           "y": -64,
-          "details": "river terr=64 -> dry(66,-64) terr=61 gap=3"
+          "details": "river terr=62 -> dry(66,-64) terr=61 gap=1"
         },
         {
           "x": 65,
           "y": -63,
-          "details": "river terr=70 -> dry(66,-63) terr=66 gap=4"
-        },
-        {
-          "x": 65,
-          "y": -62,
-          "details": "river terr=74 -> dry(66,-62) terr=72 gap=2"
-        },
-        {
-          "x": 65,
-          "y": -57,
-          "details": "river terr=96 -> dry(65,-58) terr=94 gap=2"
+          "details": "river terr=68 -> dry(66,-63) terr=66 gap=2"
         },
         {
           "x": 65,
           "y": -43,
-          "details": "river terr=203 -> dry(65,-44) terr=197 gap=6"
+          "details": "river terr=200 -> dry(65,-44) terr=197 gap=3"
         },
         {
           "x": 65,
           "y": -10,
-          "details": "river terr=200 -> dry(65,-9) terr=195 gap=5"
-        },
-        {
-          "x": 66,
-          "y": -45,
-          "details": "river terr=183 -> dry(66,-46) terr=182 gap=1"
+          "details": "river terr=199 -> dry(65,-9) terr=195 gap=4"
         },
         {
           "x": 66,
           "y": -43,
-          "details": "river terr=194 -> dry(66,-44) terr=190 gap=4"
+          "details": "river terr=191 -> dry(66,-44) terr=190 gap=1"
         },
         {
           "x": 66,
@@ -3017,17 +2792,12 @@
         {
           "x": 66,
           "y": -12,
-          "details": "river terr=193 -> dry(66,-11) terr=190 gap=3"
+          "details": "river terr=191 -> dry(66,-11) terr=190 gap=1"
         },
         {
           "x": 66,
           "y": -9,
-          "details": "river terr=186 -> dry(66,-8) terr=178 gap=8"
-        },
-        {
-          "x": 67,
-          "y": -43,
-          "details": "river terr=183 -> dry(67,-44) terr=180 gap=3"
+          "details": "river terr=184 -> dry(66,-8) terr=178 gap=6"
         },
         {
           "x": 67,
@@ -3035,34 +2805,9 @@
           "details": "river terr=192 -> dry(68,-13) terr=189 gap=3"
         },
         {
-          "x": 67,
-          "y": -12,
-          "details": "river terr=187 -> dry(68,-12) terr=185 gap=2"
-        },
-        {
-          "x": 67,
-          "y": -11,
-          "details": "river terr=181 -> dry(68,-11) terr=180 gap=1"
-        },
-        {
-          "x": 67,
-          "y": -7,
-          "details": "river terr=163 -> dry(67,-6) terr=161 gap=2"
-        },
-        {
-          "x": 69,
-          "y": -64,
-          "details": "river terr=39 -> dry(70,-64) terr=36 gap=3"
-        },
-        {
-          "x": 69,
-          "y": -62,
-          "details": "river terr=49 -> dry(69,-63) terr=46 gap=3"
-        },
-        {
           "x": 69,
           "y": -60,
-          "details": "river terr=60 -> dry(70,-60) terr=56 gap=4"
+          "details": "river terr=58 -> dry(70,-60) terr=56 gap=2"
         },
         {
           "x": 69,
@@ -3071,38 +2816,18 @@
         },
         {
           "x": 70,
-          "y": -62,
-          "details": "river terr=43 -> dry(70,-63) terr=41 gap=2"
-        },
-        {
-          "x": 70,
           "y": -59,
           "details": "river terr=61 -> dry(70,-60) terr=56 gap=5"
         },
         {
           "x": 70,
-          "y": -43,
-          "details": "river terr=184 -> dry(70,-44) terr=180 gap=4"
-        },
-        {
-          "x": 70,
-          "y": -23,
-          "details": "river terr=227 -> dry(71,-23) terr=226 gap=1"
-        },
-        {
-          "x": 70,
           "y": -22,
-          "details": "river terr=222 -> dry(71,-22) terr=220 gap=2"
-        },
-        {
-          "x": 70,
-          "y": -21,
-          "details": "river terr=216 -> dry(71,-21) terr=215 gap=1"
+          "details": "river terr=221 -> dry(71,-22) terr=220 gap=1"
         },
         {
           "x": 70,
           "y": -18,
-          "details": "river terr=197 -> dry(70,-17) terr=195 gap=2"
+          "details": "river terr=196 -> dry(70,-17) terr=195 gap=1"
         },
         {
           "x": 70,
@@ -3117,12 +2842,7 @@
         {
           "x": 71,
           "y": -49,
-          "details": "river terr=156 -> dry(71,-50) terr=152 gap=4"
-        },
-        {
-          "x": 71,
-          "y": -43,
-          "details": "river terr=191 -> dry(71,-44) terr=187 gap=4"
+          "details": "river terr=156 -> dry(71,-50) terr=147 gap=9"
         },
         {
           "x": 71,
@@ -3132,72 +2852,47 @@
         {
           "x": 71,
           "y": -12,
-          "details": "river terr=169 -> dry(71,-11) terr=167 gap=2"
-        },
-        {
-          "x": 72,
-          "y": -43,
-          "details": "river terr=199 -> dry(72,-44) terr=195 gap=4"
+          "details": "river terr=168 -> dry(71,-11) terr=167 gap=1"
         },
         {
           "x": 72,
           "y": -39,
-          "details": "river terr=246 -> dry(71,-39) terr=242 gap=4"
+          "details": "river terr=243 -> dry(71,-39) terr=242 gap=1"
         },
         {
           "x": 72,
           "y": -24,
-          "details": "river terr=225 -> dry(72,-23) terr=221 gap=4"
+          "details": "river terr=223 -> dry(72,-23) terr=221 gap=2"
         },
         {
           "x": 72,
           "y": -14,
-          "details": "river terr=178 -> dry(72,-13) terr=173 gap=5"
-        },
-        {
-          "x": 72,
-          "y": -11,
-          "details": "river terr=157 -> dry(72,-10) terr=156 gap=1"
+          "details": "river terr=176 -> dry(72,-13) terr=173 gap=3"
         },
         {
           "x": 73,
           "y": -43,
-          "details": "river terr=206 -> dry(73,-44) terr=201 gap=5"
+          "details": "river terr=202 -> dry(73,-44) terr=201 gap=1"
         },
         {
           "x": 73,
           "y": -24,
-          "details": "river terr=220 -> dry(74,-24) terr=216 gap=4"
-        },
-        {
-          "x": 73,
-          "y": -23,
-          "details": "river terr=214 -> dry(73,-22) terr=213 gap=1"
+          "details": "river terr=218 -> dry(74,-24) terr=216 gap=2"
         },
         {
           "x": 73,
           "y": -14,
-          "details": "river terr=172 -> dry(74,-14) terr=169 gap=3"
+          "details": "river terr=170 -> dry(74,-14) terr=169 gap=1"
         },
         {
           "x": 73,
           "y": -13,
-          "details": "river terr=167 -> dry(73,-12) terr=161 gap=6"
-        },
-        {
-          "x": 73,
-          "y": -10,
-          "details": "river terr=145 -> dry(73,-9) terr=144 gap=1"
+          "details": "river terr=164 -> dry(73,-12) terr=161 gap=3"
         },
         {
           "x": 73,
           "y": -7,
-          "details": "river terr=135 -> dry(73,-6) terr=129 gap=6"
-        },
-        {
-          "x": 74,
-          "y": -44,
-          "details": "river terr=204 -> dry(73,-44) terr=201 gap=3"
+          "details": "river terr=132 -> dry(73,-6) terr=129 gap=3"
         },
         {
           "x": 74,
@@ -3206,33 +2901,18 @@
         },
         {
           "x": 74,
-          "y": -13,
-          "details": "river terr=157 -> dry(74,-12) terr=155 gap=2"
-        },
-        {
-          "x": 74,
-          "y": -9,
-          "details": "river terr=133 -> dry(74,-8) terr=131 gap=2"
-        },
-        {
-          "x": 74,
           "y": -6,
-          "details": "river terr=117 -> dry(74,-5) terr=110 gap=7"
+          "details": "river terr=114 -> dry(74,-5) terr=110 gap=4"
         },
         {
           "x": 75,
           "y": -13,
-          "details": "river terr=149 -> dry(75,-12) terr=143 gap=6"
+          "details": "river terr=145 -> dry(75,-12) terr=143 gap=2"
         },
         {
           "x": 76,
           "y": -21,
           "details": "river terr=206 -> dry(76,-20) terr=205 gap=1"
-        },
-        {
-          "x": 76,
-          "y": -12,
-          "details": "river terr=133 -> dry(76,-11) terr=130 gap=3"
         },
         {
           "x": 76,
@@ -3242,12 +2922,7 @@
         {
           "x": 77,
           "y": -45,
-          "details": "river terr=200 -> dry(78,-45) terr=198 gap=2"
-        },
-        {
-          "x": 77,
-          "y": -42,
-          "details": "river terr=229 -> dry(78,-42) terr=228 gap=1"
+          "details": "river terr=199 -> dry(78,-45) terr=198 gap=1"
         },
         {
           "x": 77,
@@ -3260,34 +2935,14 @@
           "details": "river terr=195 -> dry(77,-18) terr=193 gap=2"
         },
         {
-          "x": 77,
-          "y": -12,
-          "details": "river terr=125 -> dry(77,-11) terr=121 gap=4"
-        },
-        {
-          "x": 77,
-          "y": 0,
-          "details": "river terr=77 -> dry(77,1) terr=75 gap=2"
-        },
-        {
-          "x": 78,
-          "y": -44,
-          "details": "river terr=200 -> dry(78,-45) terr=198 gap=2"
-        },
-        {
           "x": 78,
           "y": -43,
-          "details": "river terr=211 -> dry(79,-43) terr=207 gap=4"
+          "details": "river terr=208 -> dry(79,-43) terr=207 gap=1"
         },
         {
           "x": 78,
           "y": -18,
           "details": "river terr=183 -> dry(78,-17) terr=179 gap=4"
-        },
-        {
-          "x": 79,
-          "y": -59,
-          "details": "river terr=48 -> dry(78,-59) terr=46 gap=2"
         }
       ],
       "ISLAND_1TILE": [
@@ -3446,9 +3101,334 @@
       ],
       "MID_RIVER_CLIFF": [
         {
+          "x": -55,
+          "y": 76,
+          "details": "river surf=9 (terr=5) -> water nbr surf=6 (terr=6) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -48,
+          "y": 75,
+          "details": "river surf=4 (terr=0) -> water nbr surf=1 (terr=1) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -47,
+          "y": 75,
+          "details": "river surf=5 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -46,
+          "y": 75,
+          "details": "river surf=6 (terr=2) -> water nbr surf=3 (terr=3) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -44,
+          "y": 78,
+          "details": "river surf=24 (terr=19) -> water nbr surf=20 (terr=20) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -43,
+          "y": 76,
+          "details": "river surf=17 (terr=14) -> water nbr surf=15 (terr=14) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -42,
+          "y": 74,
+          "details": "river surf=9 (terr=4) -> water nbr surf=5 (terr=6) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -42,
+          "y": 74,
+          "details": "river surf=9 (terr=6) -> water nbr surf=6 (terr=5) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -42,
+          "y": 75,
+          "details": "river surf=14 (terr=11) -> water nbr surf=11 (terr=10) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -42,
+          "y": 76,
+          "details": "river surf=19 (terr=14) -> water nbr surf=17 (terr=14) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -42,
+          "y": 77,
+          "details": "river surf=23 (terr=17) -> water nbr surf=21 (terr=17) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -41,
+          "y": 75,
+          "details": "river surf=17 (terr=12) -> water nbr surf=14 (terr=11) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -37,
+          "y": 77,
+          "details": "river surf=58 (terr=55) -> water nbr surf=56 (terr=55) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -15,
+          "y": 53,
+          "details": "river surf=8 (terr=3) -> water nbr surf=5 (terr=4) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -13,
+          "y": 55,
+          "details": "river surf=32 (terr=24) -> water nbr surf=28 (terr=22) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -13,
+          "y": 61,
+          "details": "river surf=103 (terr=96) -> water nbr surf=95 (terr=94) surf_diff=8 terr_diff=2"
+        },
+        {
+          "x": -11,
+          "y": 50,
+          "details": "river surf=11 (terr=6) -> water nbr surf=7 (terr=8) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -2,
+          "y": 52,
+          "details": "river surf=23 (terr=18) -> water nbr surf=19 (terr=20) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 2,
+          "y": 51,
+          "details": "river surf=12 (terr=9) -> water nbr surf=10 (terr=9) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 22,
+          "y": -62,
+          "details": "river surf=6 (terr=1) -> water nbr surf=2 (terr=1) surf_diff=4 terr_diff=0"
+        },
+        {
+          "x": 31,
+          "y": -46,
+          "details": "lake surf=88 (terr=62) -> water nbr surf=66 (terr=61) surf_diff=22 terr_diff=1"
+        },
+        {
+          "x": 33,
+          "y": -48,
+          "details": "lake surf=88 (terr=63) -> water nbr surf=66 (terr=63) surf_diff=22 terr_diff=0"
+        },
+        {
+          "x": 34,
+          "y": 2,
+          "details": "river surf=17 (terr=14) -> water nbr surf=13 (terr=12) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 35,
+          "y": -59,
+          "details": "river surf=111 (terr=106) -> water nbr surf=109 (terr=106) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 36,
+          "y": -58,
+          "details": "river surf=111 (terr=107) -> water nbr surf=109 (terr=107) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 36,
+          "y": 3,
+          "details": "river surf=11 (terr=8) -> water nbr surf=9 (terr=8) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 40,
+          "y": -57,
+          "details": "river surf=97 (terr=91) -> water nbr surf=94 (terr=90) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 41,
+          "y": -43,
+          "details": "river surf=126 (terr=123) -> water nbr surf=124 (terr=123) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 41,
+          "y": -42,
+          "details": "river surf=127 (terr=124) -> water nbr surf=125 (terr=124) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 41,
+          "y": -3,
+          "details": "river surf=70 (terr=67) -> water nbr surf=66 (terr=65) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 43,
+          "y": -47,
+          "details": "river surf=128 (terr=124) -> water nbr surf=125 (terr=123) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 43,
+          "y": -44,
+          "details": "river surf=130 (terr=125) -> water nbr surf=127 (terr=124) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 44,
+          "y": -49,
+          "details": "river surf=129 (terr=126) -> water nbr surf=126 (terr=125) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 45,
+          "y": -50,
+          "details": "river surf=130 (terr=126) -> water nbr surf=128 (terr=126) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 45,
+          "y": -49,
+          "details": "river surf=132 (terr=127) -> water nbr surf=129 (terr=126) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 45,
+          "y": 5,
+          "details": "river surf=47 (terr=44) -> water nbr surf=44 (terr=43) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 46,
+          "y": -49,
+          "details": "river surf=135 (terr=128) -> water nbr surf=133 (terr=128) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 46,
+          "y": -49,
+          "details": "river surf=135 (terr=128) -> water nbr surf=132 (terr=127) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 46,
+          "y": -48,
+          "details": "river surf=135 (terr=128) -> water nbr surf=132 (terr=127) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 47,
+          "y": -51,
+          "details": "river surf=136 (terr=129) -> water nbr surf=134 (terr=129) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 47,
+          "y": -51,
+          "details": "river surf=136 (terr=129) -> water nbr surf=133 (terr=128) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 47,
+          "y": -50,
+          "details": "river surf=136 (terr=129) -> water nbr surf=133 (terr=128) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 48,
+          "y": -52,
+          "details": "river surf=137 (terr=130) -> water nbr surf=134 (terr=129) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 49,
+          "y": -1,
+          "details": "river surf=103 (terr=99) -> water nbr surf=99 (terr=98) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": 50,
+          "y": 0,
+          "details": "river surf=101 (terr=98) -> water nbr surf=99 (terr=98) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 51,
+          "y": -59,
+          "details": "lake surf=127 (terr=120) -> water nbr surf=121 (terr=122) surf_diff=6 terr_diff=2"
+        },
+        {
+          "x": 52,
+          "y": -60,
+          "details": "river surf=125 (terr=119) -> water nbr surf=121 (terr=121) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 52,
+          "y": -60,
+          "details": "lake surf=125 (terr=121) -> water nbr surf=121 (terr=120) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": 56,
+          "y": 4,
+          "details": "river surf=10 (terr=2) -> water nbr surf=7 (terr=1) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 56,
+          "y": 5,
+          "details": "river surf=7 (terr=1) -> water nbr surf=4 (terr=1) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 56,
+          "y": 5,
+          "details": "river surf=7 (terr=1) -> water nbr surf=4 (terr=1) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 57,
+          "y": 4,
+          "details": "river surf=10 (terr=2) -> water nbr surf=4 (terr=1) surf_diff=6 terr_diff=1"
+        },
+        {
+          "x": 58,
+          "y": 5,
+          "details": "river surf=10 (terr=3) -> water nbr surf=4 (terr=1) surf_diff=6 terr_diff=2"
+        },
+        {
+          "x": 58,
+          "y": 5,
+          "details": "river surf=10 (terr=3) -> water nbr surf=4 (terr=1) surf_diff=6 terr_diff=2"
+        },
+        {
+          "x": 69,
+          "y": -58,
+          "details": "river surf=67 (terr=62) -> water nbr surf=63 (terr=64) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 69,
+          "y": -56,
+          "details": "river surf=74 (terr=67) -> water nbr surf=70 (terr=68) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": 72,
+          "y": -58,
+          "details": "river surf=47 (terr=40) -> water nbr surf=43 (terr=41) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": 73,
+          "y": -63,
+          "details": "lake surf=28 (terr=23) -> water nbr surf=25 (terr=22) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 74,
+          "y": 6,
+          "details": "river surf=7 (terr=3) -> water nbr surf=5 (terr=3) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 75,
+          "y": 6,
+          "details": "river surf=8 (terr=4) -> water nbr surf=5 (terr=3) surf_diff=3 terr_diff=1"
+        },
+        {
           "x": 76,
           "y": -5,
           "details": "river surf=105 (terr=101) -> water nbr surf=101 (terr=99) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 76,
+          "y": 7,
+          "details": "river surf=6 (terr=3) -> water nbr surf=4 (terr=3) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 78,
+          "y": -11,
+          "details": "river surf=111 (terr=105) -> water nbr surf=108 (terr=104) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 78,
+          "y": -6,
+          "details": "river surf=96 (terr=93) -> water nbr surf=94 (terr=93) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 79,
+          "y": -59,
+          "details": "river surf=49 (terr=43) -> water nbr surf=43 (terr=42) surf_diff=6 terr_diff=1"
+        },
+        {
+          "x": 79,
+          "y": -57,
+          "details": "lake surf=51 (terr=42) -> water nbr surf=43 (terr=44) surf_diff=8 terr_diff=2"
         }
       ],
       "MULTI_ISLAND": [
@@ -3568,6 +3548,16 @@
           "x": 63,
           "y": -55,
           "details": "river surf=137 -> dry(64,-55) terr=134"
+        },
+        {
+          "x": 63,
+          "y": -54,
+          "details": "river surf=149 -> dry(64,-54) terr=148"
+        },
+        {
+          "x": 76,
+          "y": -48,
+          "details": "river surf=184 -> dry(76,-49) terr=183"
         }
       ],
       "RIVER_MOUTH_DROP": [
@@ -3601,42 +3591,42 @@
         {
           "x": -55,
           "y": 76,
-          "details": "river surf=9 terr=8 -> land(-56,76) terr=7 cliff=2"
+          "details": "river surf=9 terr=6 -> land(-56,76) terr=7 cliff=2"
         },
         {
           "x": -55,
           "y": 77,
-          "details": "river surf=12 terr=11 -> land(-56,77) terr=9 cliff=3"
+          "details": "river surf=12 terr=8 -> land(-56,77) terr=9 cliff=3"
         },
         {
           "x": -55,
           "y": 78,
-          "details": "river surf=14 terr=13 -> land(-56,78) terr=12 cliff=2"
+          "details": "river surf=14 terr=9 -> land(-56,78) terr=12 cliff=2"
         },
         {
           "x": -47,
           "y": 77,
-          "details": "river surf=26 terr=25 -> land(-46,77) terr=22 cliff=4"
+          "details": "river surf=26 terr=22 -> land(-46,77) terr=22 cliff=4"
         },
         {
           "x": -47,
           "y": 78,
-          "details": "river surf=34 terr=33 -> land(-46,78) terr=28 cliff=6"
+          "details": "river surf=34 terr=30 -> land(-46,78) terr=28 cliff=6"
         },
         {
           "x": -47,
           "y": 79,
-          "details": "river surf=40 terr=39 -> land(-46,79) terr=34 cliff=6"
+          "details": "river surf=40 terr=37 -> land(-46,79) terr=34 cliff=6"
         },
         {
           "x": -41,
           "y": 77,
-          "details": "river surf=27 terr=26 -> land(-41,76) terr=22 cliff=5"
+          "details": "river surf=27 terr=21 -> land(-41,76) terr=22 cliff=5"
         },
         {
           "x": -40,
           "y": 77,
-          "details": "river surf=32 terr=31 -> land(-40,76) terr=27 cliff=5"
+          "details": "river surf=32 terr=28 -> land(-40,76) terr=27 cliff=5"
         },
         {
           "x": -40,
@@ -3646,7 +3636,7 @@
         {
           "x": -39,
           "y": 76,
-          "details": "river surf=32 terr=31 -> land(-40,76) terr=27 cliff=5"
+          "details": "river surf=32 terr=28 -> land(-40,76) terr=27 cliff=5"
         },
         {
           "x": -25,
@@ -3676,47 +3666,47 @@
         {
           "x": -25,
           "y": 54,
-          "details": "river surf=52 terr=51 -> land(-26,54) terr=48 cliff=4"
+          "details": "river surf=52 terr=49 -> land(-26,54) terr=48 cliff=4"
         },
         {
           "x": -25,
           "y": 55,
-          "details": "river surf=61 terr=60 -> land(-26,55) terr=57 cliff=4"
+          "details": "river surf=61 terr=58 -> land(-26,55) terr=57 cliff=4"
         },
         {
           "x": -25,
           "y": 56,
-          "details": "river surf=70 terr=69 -> land(-26,56) terr=66 cliff=4"
+          "details": "river surf=70 terr=66 -> land(-26,56) terr=66 cliff=4"
         },
         {
           "x": -25,
           "y": 57,
-          "details": "river surf=81 terr=80 -> land(-26,57) terr=75 cliff=6"
+          "details": "river surf=81 terr=77 -> land(-26,57) terr=75 cliff=6"
         },
         {
           "x": -25,
           "y": 58,
-          "details": "river surf=92 terr=91 -> land(-26,58) terr=84 cliff=8"
+          "details": "river surf=92 terr=88 -> land(-26,58) terr=84 cliff=8"
         },
         {
           "x": -25,
           "y": 59,
-          "details": "river surf=101 terr=100 -> land(-26,59) terr=93 cliff=8"
+          "details": "river surf=101 terr=96 -> land(-26,59) terr=93 cliff=8"
         },
         {
           "x": -25,
           "y": 60,
-          "details": "river surf=111 terr=110 -> land(-26,60) terr=102 cliff=9"
+          "details": "river surf=111 terr=106 -> land(-26,60) terr=102 cliff=9"
         },
         {
           "x": -25,
           "y": 61,
-          "details": "river surf=121 terr=120 -> land(-26,61) terr=111 cliff=10"
+          "details": "river surf=121 terr=116 -> land(-26,61) terr=111 cliff=10"
         },
         {
           "x": -25,
           "y": 62,
-          "details": "river surf=132 terr=131 -> land(-26,62) terr=121 cliff=11"
+          "details": "river surf=132 terr=127 -> land(-26,62) terr=121 cliff=11"
         },
         {
           "x": -23,
@@ -3736,7 +3726,7 @@
         {
           "x": -22,
           "y": 54,
-          "details": "river surf=43 terr=42 -> land(-22,53) terr=38 cliff=5"
+          "details": "river surf=43 terr=39 -> land(-22,53) terr=38 cliff=5"
         },
         {
           "x": -18,
@@ -3746,107 +3736,107 @@
         {
           "x": -13,
           "y": 61,
-          "details": "river surf=103 terr=102 -> land(-13,60) terr=96 cliff=7"
+          "details": "river surf=103 terr=96 -> land(-13,60) terr=96 cliff=7"
         },
         {
           "x": -12,
           "y": 54,
-          "details": "river surf=32 terr=31 -> land(-12,53) terr=23 cliff=9"
+          "details": "river surf=32 terr=25 -> land(-12,53) terr=23 cliff=9"
         },
         {
           "x": -12,
           "y": 58,
-          "details": "river surf=79 terr=78 -> land(-13,58) terr=76 cliff=3"
+          "details": "river surf=79 terr=73 -> land(-13,58) terr=76 cliff=3"
         },
         {
           "x": -12,
           "y": 59,
-          "details": "river surf=91 terr=90 -> land(-13,59) terr=88 cliff=3"
+          "details": "river surf=91 terr=86 -> land(-13,59) terr=88 cliff=3"
         },
         {
           "x": -11,
           "y": 53,
-          "details": "river surf=32 terr=31 -> land(-12,53) terr=23 cliff=9"
+          "details": "river surf=32 terr=26 -> land(-12,53) terr=23 cliff=9"
         },
         {
           "x": -9,
           "y": 62,
-          "details": "river surf=120 terr=119 -> land(-9,61) terr=116 cliff=4"
+          "details": "river surf=120 terr=117 -> land(-9,61) terr=116 cliff=4"
         },
         {
           "x": -8,
           "y": 62,
-          "details": "river surf=125 terr=124 -> land(-8,61) terr=121 cliff=4"
+          "details": "river surf=125 terr=122 -> land(-8,61) terr=121 cliff=4"
         },
         {
           "x": -7,
           "y": 59,
-          "details": "river surf=116 terr=115 -> land(-8,59) terr=113 cliff=3"
+          "details": "river surf=116 terr=113 -> land(-8,59) terr=113 cliff=3"
         },
         {
           "x": -7,
           "y": 60,
-          "details": "river surf=121 terr=120 -> land(-8,60) terr=118 cliff=3"
+          "details": "river surf=121 terr=118 -> land(-8,60) terr=118 cliff=3"
         },
         {
           "x": -7,
           "y": 61,
-          "details": "river surf=125 terr=124 -> land(-8,61) terr=121 cliff=4"
+          "details": "river surf=125 terr=122 -> land(-8,61) terr=121 cliff=4"
         },
         {
           "x": -5,
           "y": 65,
-          "details": "river surf=139 terr=138 -> land(-4,65) terr=135 cliff=4"
+          "details": "river surf=139 terr=136 -> land(-4,65) terr=135 cliff=4"
         },
         {
           "x": -4,
           "y": 60,
-          "details": "river surf=112 terr=111 -> land(-3,60) terr=110 cliff=2"
+          "details": "river surf=112 terr=109 -> land(-3,60) terr=110 cliff=2"
         },
         {
           "x": -4,
           "y": 61,
-          "details": "river surf=120 terr=119 -> land(-3,61) terr=116 cliff=4"
+          "details": "river surf=120 terr=118 -> land(-3,61) terr=116 cliff=4"
         },
         {
           "x": -4,
           "y": 62,
-          "details": "river surf=123 terr=122 -> land(-3,62) terr=120 cliff=3"
+          "details": "river surf=123 terr=121 -> land(-3,62) terr=120 cliff=3"
         },
         {
           "x": -3,
           "y": 63,
-          "details": "river surf=123 terr=122 -> land(-3,62) terr=120 cliff=3"
+          "details": "river surf=123 terr=121 -> land(-3,62) terr=120 cliff=3"
         },
         {
           "x": -2,
           "y": 63,
-          "details": "river surf=119 terr=118 -> land(-2,62) terr=115 cliff=4"
+          "details": "river surf=119 terr=116 -> land(-2,62) terr=115 cliff=4"
         },
         {
           "x": -2,
           "y": 65,
-          "details": "river surf=128 terr=127 -> land(-1,65) terr=124 cliff=4"
+          "details": "river surf=128 terr=123 -> land(-1,65) terr=124 cliff=4"
         },
         {
           "x": -2,
           "y": 66,
-          "details": "river surf=134 terr=133 -> land(-1,66) terr=131 cliff=3"
+          "details": "river surf=134 terr=129 -> land(-1,66) terr=131 cliff=3"
         },
         {
           "x": -1,
           "y": 63,
-          "details": "river surf=114 terr=113 -> land(-1,62) terr=109 cliff=5"
+          "details": "river surf=114 terr=112 -> land(-1,62) terr=109 cliff=5"
         },
         {
           "x": 0,
           "y": 60,
-          "details": "river surf=90 terr=89 -> land(1,60) terr=87 cliff=3"
+          "details": "river surf=90 terr=87 -> land(1,60) terr=87 cliff=3"
         },
         {
           "x": 0,
           "y": 61,
-          "details": "river surf=98 terr=97 -> land(1,61) terr=95 cliff=3"
+          "details": "river surf=98 terr=96 -> land(1,61) terr=95 cliff=3"
         },
         {
           "x": 0,
@@ -3856,52 +3846,52 @@
         {
           "x": 0,
           "y": 63,
-          "details": "river surf=108 terr=107 -> land(1,63) terr=104 cliff=4"
+          "details": "river surf=108 terr=106 -> land(1,63) terr=104 cliff=4"
         },
         {
           "x": 0,
           "y": 64,
-          "details": "river surf=113 terr=112 -> land(1,64) terr=108 cliff=5"
+          "details": "river surf=113 terr=110 -> land(1,64) terr=108 cliff=5"
         },
         {
           "x": 0,
           "y": 65,
-          "details": "river surf=119 terr=118 -> land(1,65) terr=113 cliff=6"
+          "details": "river surf=119 terr=116 -> land(1,65) terr=113 cliff=6"
         },
         {
           "x": 4,
           "y": 52,
-          "details": "river surf=26 terr=25 -> land(4,51) terr=19 cliff=7"
+          "details": "river surf=26 terr=22 -> land(4,51) terr=19 cliff=7"
         },
         {
           "x": 4,
           "y": 53,
-          "details": "river surf=36 terr=35 -> land(3,53) terr=29 cliff=7"
+          "details": "river surf=36 terr=32 -> land(3,53) terr=29 cliff=7"
         },
         {
           "x": 4,
           "y": 54,
-          "details": "river surf=47 terr=46 -> land(3,54) terr=40 cliff=7"
+          "details": "river surf=47 terr=44 -> land(3,54) terr=40 cliff=7"
         },
         {
           "x": 4,
           "y": 55,
-          "details": "river surf=58 terr=57 -> land(3,55) terr=50 cliff=8"
+          "details": "river surf=58 terr=55 -> land(3,55) terr=50 cliff=8"
         },
         {
           "x": 5,
           "y": 49,
-          "details": "river surf=11 terr=10 -> land(4,49) terr=9 cliff=2"
+          "details": "river surf=11 terr=9 -> land(4,49) terr=9 cliff=2"
         },
         {
           "x": 5,
           "y": 50,
-          "details": "river surf=17 terr=16 -> land(4,50) terr=14 cliff=3"
+          "details": "river surf=17 terr=15 -> land(4,50) terr=14 cliff=3"
         },
         {
           "x": 5,
           "y": 51,
-          "details": "river surf=23 terr=22 -> land(4,51) terr=19 cliff=4"
+          "details": "river surf=23 terr=20 -> land(4,51) terr=19 cliff=4"
         },
         {
           "x": 7,
@@ -3916,7 +3906,7 @@
         {
           "x": 8,
           "y": 49,
-          "details": "river surf=23 terr=22 -> land(8,48) terr=19 cliff=4"
+          "details": "river surf=23 terr=21 -> land(8,48) terr=19 cliff=4"
         },
         {
           "x": 9,
@@ -3964,9 +3954,19 @@
           "details": "river surf=31 terr=30 -> land(22,-10) terr=29 cliff=2"
         },
         {
+          "x": 28,
+          "y": -43,
+          "details": "lake surf=88 terr=86 -> land(28,-44) terr=85 cliff=3"
+        },
+        {
+          "x": 29,
+          "y": -58,
+          "details": "river surf=54 terr=47 -> land(28,-58) terr=51 cliff=3"
+        },
+        {
           "x": 29,
           "y": -44,
-          "details": "lake surf=88 terr=86 -> land(29,-45) terr=73 cliff=15"
+          "details": "lake surf=88 terr=86 -> land(28,-44) terr=85 cliff=3"
         },
         {
           "x": 29,
@@ -3976,22 +3976,27 @@
         {
           "x": 30,
           "y": -45,
-          "details": "lake surf=88 terr=85 -> land(29,-45) terr=73 cliff=15"
+          "details": "lake surf=88 terr=79 -> land(29,-45) terr=67 cliff=21"
+        },
+        {
+          "x": 31,
+          "y": -47,
+          "details": "river surf=42 terr=34 -> land(31,-48) terr=38 cliff=4"
         },
         {
           "x": 31,
           "y": -46,
-          "details": "lake surf=88 terr=67 -> land(30,-46) terr=57 cliff=31"
+          "details": "lake surf=88 terr=62 -> land(30,-46) terr=51 cliff=37"
         },
         {
           "x": 31,
           "y": -43,
-          "details": "river surf=93 terr=92 -> land(30,-43) terr=91 cliff=2"
+          "details": "river surf=93 terr=90 -> land(30,-43) terr=91 cliff=2"
         },
         {
           "x": 31,
           "y": -42,
-          "details": "river surf=96 terr=95 -> land(30,-42) terr=93 cliff=3"
+          "details": "river surf=96 terr=92 -> land(30,-42) terr=93 cliff=3"
         },
         {
           "x": 31,
@@ -4000,8 +4005,13 @@
         },
         {
           "x": 32,
+          "y": -47,
+          "details": "river surf=54 terr=48 -> land(32,-48) terr=50 cliff=4"
+        },
+        {
+          "x": 32,
           "y": -3,
-          "details": "river surf=28 terr=27 -> land(31,-3) terr=25 cliff=3"
+          "details": "river surf=28 terr=25 -> land(31,-3) terr=25 cliff=3"
         },
         {
           "x": 32,
@@ -4010,18 +4020,23 @@
         },
         {
           "x": 33,
+          "y": -50,
+          "details": "river surf=54 terr=53 -> land(32,-50) terr=50 cliff=4"
+        },
+        {
+          "x": 33,
           "y": -48,
-          "details": "lake surf=88 terr=67 -> land(32,-48) terr=55 cliff=33"
+          "details": "lake surf=88 terr=63 -> land(32,-48) terr=50 cliff=38"
         },
         {
           "x": 33,
           "y": -8,
-          "details": "river surf=51 terr=50 -> land(32,-8) terr=48 cliff=3"
+          "details": "river surf=51 terr=48 -> land(32,-8) terr=48 cliff=3"
         },
         {
           "x": 33,
           "y": -4,
-          "details": "river surf=44 terr=43 -> land(33,-3) terr=41 cliff=3"
+          "details": "river surf=44 terr=42 -> land(33,-3) terr=41 cliff=3"
         },
         {
           "x": 33,
@@ -4031,12 +4046,17 @@
         {
           "x": 34,
           "y": -54,
-          "details": "lake surf=107 terr=93 -> land(33,-54) terr=97 cliff=10"
+          "details": "lake surf=107 terr=89 -> land(33,-54) terr=92 cliff=15"
+        },
+        {
+          "x": 34,
+          "y": -53,
+          "details": "river surf=66 terr=65 -> land(33,-53) terr=64 cliff=2"
         },
         {
           "x": 34,
           "y": -44,
-          "details": "river surf=99 terr=98 -> land(33,-44) terr=96 cliff=3"
+          "details": "river surf=99 terr=97 -> land(33,-44) terr=96 cliff=3"
         },
         {
           "x": 34,
@@ -4051,12 +4071,17 @@
         {
           "x": 34,
           "y": -7,
-          "details": "river surf=54 terr=53 -> land(34,-6) terr=52 cliff=2"
+          "details": "river surf=54 terr=52 -> land(34,-6) terr=52 cliff=2"
+        },
+        {
+          "x": 35,
+          "y": -53,
+          "details": "river surf=78 terr=77 -> land(35,-52) terr=76 cliff=2"
         },
         {
           "x": 35,
           "y": -51,
-          "details": "river surf=90 terr=89 -> land(35,-52) terr=81 cliff=9"
+          "details": "river surf=90 terr=89 -> land(35,-52) terr=76 cliff=14"
         },
         {
           "x": 35,
@@ -4066,7 +4091,7 @@
         {
           "x": 36,
           "y": -52,
-          "details": "river surf=90 terr=89 -> land(35,-52) terr=81 cliff=9"
+          "details": "river surf=90 terr=89 -> land(35,-52) terr=76 cliff=14"
         },
         {
           "x": 36,
@@ -4096,7 +4121,7 @@
         {
           "x": 39,
           "y": -58,
-          "details": "river surf=112 terr=111 -> land(39,-57) terr=100 cliff=12"
+          "details": "river surf=112 terr=106 -> land(39,-57) terr=100 cliff=12"
         },
         {
           "x": 39,
@@ -4106,7 +4131,7 @@
         {
           "x": 39,
           "y": 2,
-          "details": "river surf=29 terr=28 -> land(39,3) terr=25 cliff=4"
+          "details": "river surf=29 terr=25 -> land(39,3) terr=25 cliff=4"
         },
         {
           "x": 40,
@@ -4121,57 +4146,57 @@
         {
           "x": 40,
           "y": -14,
-          "details": "river surf=99 terr=98 -> land(39,-14) terr=96 cliff=3"
+          "details": "river surf=99 terr=93 -> land(39,-14) terr=96 cliff=3"
         },
         {
           "x": 40,
           "y": -2,
-          "details": "river surf=62 terr=61 -> land(39,-2) terr=60 cliff=2"
+          "details": "river surf=62 terr=59 -> land(39,-2) terr=60 cliff=2"
         },
         {
           "x": 40,
           "y": -1,
-          "details": "river surf=52 terr=51 -> land(39,-1) terr=50 cliff=2"
+          "details": "river surf=52 terr=48 -> land(39,-1) terr=50 cliff=2"
         },
         {
           "x": 40,
           "y": 0,
-          "details": "river surf=45 terr=44 -> land(40,1) terr=43 cliff=2"
+          "details": "river surf=45 terr=40 -> land(40,1) terr=43 cliff=2"
         },
         {
           "x": 41,
           "y": -49,
-          "details": "river surf=108 terr=107 -> land(41,-50) terr=105 cliff=3"
+          "details": "river surf=108 terr=106 -> land(41,-50) terr=105 cliff=3"
         },
         {
           "x": 41,
           "y": -4,
-          "details": "river surf=71 terr=70 -> land(40,-4) terr=66 cliff=5"
+          "details": "river surf=71 terr=68 -> land(40,-4) terr=66 cliff=5"
         },
         {
           "x": 41,
           "y": -3,
-          "details": "river surf=70 terr=69 -> land(41,-2) terr=67 cliff=3"
+          "details": "river surf=70 terr=67 -> land(41,-2) terr=67 cliff=3"
         },
         {
           "x": 41,
           "y": -1,
-          "details": "river surf=59 terr=58 -> land(41,0) terr=54 cliff=5"
+          "details": "river surf=59 terr=54 -> land(41,0) terr=54 cliff=5"
         },
         {
           "x": 41,
           "y": 6,
-          "details": "river surf=32 terr=31 -> land(41,7) terr=25 cliff=7"
+          "details": "river surf=32 terr=29 -> land(41,7) terr=25 cliff=7"
         },
         {
           "x": 42,
           "y": -56,
-          "details": "river surf=100 terr=99 -> land(41,-56) terr=97 cliff=3"
+          "details": "river surf=100 terr=96 -> land(41,-56) terr=97 cliff=3"
         },
         {
           "x": 42,
           "y": -1,
-          "details": "river surf=66 terr=65 -> land(42,0) terr=62 cliff=4"
+          "details": "river surf=66 terr=61 -> land(42,0) terr=62 cliff=4"
         },
         {
           "x": 42,
@@ -4186,7 +4211,7 @@
         {
           "x": 43,
           "y": -51,
-          "details": "river surf=110 terr=109 -> land(42,-51) terr=106 cliff=4"
+          "details": "river surf=110 terr=108 -> land(42,-51) terr=106 cliff=4"
         },
         {
           "x": 43,
@@ -4196,7 +4221,7 @@
         {
           "x": 44,
           "y": 2,
-          "details": "river surf=60 terr=59 -> land(43,2) terr=58 cliff=2"
+          "details": "river surf=60 terr=56 -> land(43,2) terr=58 cliff=2"
         },
         {
           "x": 44,
@@ -4206,102 +4231,137 @@
         {
           "x": 45,
           "y": 0,
-          "details": "river surf=80 terr=79 -> land(44,0) terr=74 cliff=6"
+          "details": "river surf=80 terr=76 -> land(44,0) terr=74 cliff=6"
         },
         {
           "x": 45,
           "y": 1,
-          "details": "river surf=71 terr=70 -> land(44,1) terr=67 cliff=4"
+          "details": "river surf=71 terr=66 -> land(44,1) terr=67 cliff=4"
         },
         {
           "x": 45,
           "y": 5,
-          "details": "river surf=47 terr=46 -> land(45,6) terr=39 cliff=8"
+          "details": "river surf=47 terr=44 -> land(45,6) terr=39 cliff=8"
         },
         {
           "x": 46,
           "y": -1,
-          "details": "river surf=94 terr=93 -> land(45,-1) terr=89 cliff=5"
+          "details": "river surf=94 terr=90 -> land(45,-1) terr=89 cliff=5"
         },
         {
           "x": 46,
           "y": 5,
-          "details": "river surf=53 terr=52 -> land(46,6) terr=39 cliff=14"
+          "details": "river surf=53 terr=49 -> land(46,6) terr=39 cliff=14"
         },
         {
           "x": 47,
           "y": -2,
-          "details": "river surf=105 terr=104 -> land(46,-2) terr=101 cliff=4"
+          "details": "river surf=105 terr=100 -> land(46,-2) terr=101 cliff=4"
         },
         {
           "x": 47,
           "y": 2,
-          "details": "river surf=73 terr=72 -> land(47,3) terr=67 cliff=6"
+          "details": "river surf=73 terr=69 -> land(47,3) terr=67 cliff=6"
         },
         {
           "x": 48,
           "y": -59,
-          "details": "river surf=144 terr=143 -> land(48,-60) terr=140 cliff=4"
+          "details": "river surf=144 terr=142 -> land(48,-60) terr=140 cliff=4"
         },
         {
           "x": 48,
           "y": -58,
-          "details": "river surf=151 terr=150 -> land(49,-58) terr=144 cliff=7"
+          "details": "river surf=151 terr=149 -> land(49,-58) terr=144 cliff=7"
         },
         {
           "x": 48,
           "y": -3,
-          "details": "river surf=120 terr=119 -> land(47,-3) terr=116 cliff=4"
+          "details": "river surf=120 terr=114 -> land(47,-3) terr=116 cliff=4"
         },
         {
           "x": 48,
           "y": 1,
-          "details": "river surf=90 terr=89 -> land(48,2) terr=86 cliff=4"
+          "details": "river surf=90 terr=87 -> land(48,2) terr=86 cliff=4"
         },
         {
           "x": 49,
           "y": -60,
-          "details": "river surf=124 terr=123 -> land(49,-61) terr=121 cliff=3"
+          "details": "river surf=124 terr=120 -> land(49,-61) terr=121 cliff=3"
         },
         {
           "x": 50,
           "y": -8,
-          "details": "river surf=179 terr=178 -> land(49,-8) terr=176 cliff=3"
+          "details": "river surf=179 terr=173 -> land(49,-8) terr=176 cliff=3"
         },
         {
           "x": 50,
           "y": -7,
-          "details": "river surf=167 terr=166 -> land(49,-7) terr=162 cliff=5"
+          "details": "river surf=167 terr=162 -> land(49,-7) terr=162 cliff=5"
         },
         {
           "x": 50,
           "y": -6,
-          "details": "river surf=159 terr=158 -> land(49,-6) terr=152 cliff=7"
+          "details": "river surf=159 terr=154 -> land(49,-6) terr=152 cliff=7"
         },
         {
           "x": 50,
           "y": -5,
-          "details": "river surf=149 terr=148 -> land(49,-5) terr=145 cliff=4"
+          "details": "river surf=149 terr=143 -> land(49,-5) terr=145 cliff=4"
+        },
+        {
+          "x": 53,
+          "y": -6,
+          "details": "river surf=166 terr=160 -> land(54,-6) terr=164 cliff=2"
         },
         {
           "x": 54,
           "y": -2,
-          "details": "river surf=130 terr=129 -> land(55,-2) terr=109 cliff=21"
+          "details": "river surf=130 terr=123 -> land(55,-2) terr=103 cliff=27"
         },
         {
           "x": 55,
           "y": -12,
-          "details": "river surf=206 terr=205 -> land(55,-13) terr=203 cliff=3"
+          "details": "river surf=206 terr=200 -> land(55,-13) terr=203 cliff=3"
+        },
+        {
+          "x": 55,
+          "y": -11,
+          "details": "river surf=202 terr=196 -> land(55,-10) terr=199 cliff=3"
+        },
+        {
+          "x": 55,
+          "y": -3,
+          "details": "river surf=106 terr=99 -> land(55,-2) terr=103 cliff=3"
+        },
+        {
+          "x": 58,
+          "y": -7,
+          "details": "river surf=154 terr=147 -> land(57,-7) terr=151 cliff=3"
+        },
+        {
+          "x": 58,
+          "y": -6,
+          "details": "river surf=142 terr=135 -> land(58,-5) terr=139 cliff=3"
         },
         {
           "x": 58,
           "y": 4,
-          "details": "river surf=22 terr=21 -> land(59,4) terr=11 cliff=11"
+          "details": "river surf=22 terr=15 -> land(59,4) terr=11 cliff=11"
         },
         {
           "x": 58,
           "y": 5,
-          "details": "river surf=10 terr=9 -> land(59,5) terr=8 cliff=2"
+          "details": "river surf=10 terr=3 -> land(59,5) terr=8 cliff=2"
+        },
+        {
+          "x": 59,
+          "y": -9,
+          "details": "river surf=190 terr=184 -> land(58,-9) terr=188 cliff=2"
+        },
+        {
+          "x": 59,
+          "y": -8,
+          "details": "river surf=178 terr=172 -> land(59,-7) terr=175 cliff=3"
         },
         {
           "x": 60,
@@ -4316,12 +4376,12 @@
         {
           "x": 60,
           "y": -62,
-          "details": "river surf=102 terr=101 -> land(61,-62) terr=99 cliff=3"
+          "details": "river surf=102 terr=100 -> land(61,-62) terr=99 cliff=3"
         },
         {
           "x": 60,
           "y": -42,
-          "details": "river surf=223 terr=222 -> land(60,-43) terr=219 cliff=4"
+          "details": "river surf=223 terr=218 -> land(60,-43) terr=219 cliff=4"
         },
         {
           "x": 61,
@@ -4331,82 +4391,82 @@
         {
           "x": 62,
           "y": -61,
-          "details": "river surf=98 terr=97 -> land(62,-62) terr=94 cliff=4"
+          "details": "river surf=98 terr=92 -> land(62,-62) terr=94 cliff=4"
         },
         {
           "x": 62,
           "y": -53,
-          "details": "river surf=173 terr=172 -> land(63,-53) terr=170 cliff=3"
+          "details": "river surf=173 terr=169 -> land(63,-53) terr=170 cliff=3"
         },
         {
           "x": 62,
           "y": -51,
-          "details": "river surf=197 terr=196 -> land(63,-51) terr=190 cliff=7"
+          "details": "river surf=197 terr=195 -> land(63,-51) terr=190 cliff=7"
         },
         {
           "x": 63,
           "y": -61,
-          "details": "river surf=91 terr=90 -> land(63,-62) terr=88 cliff=3"
+          "details": "river surf=91 terr=85 -> land(63,-62) terr=88 cliff=3"
         },
         {
           "x": 63,
           "y": -55,
-          "details": "river surf=137 terr=136 -> land(64,-55) terr=134 cliff=3"
+          "details": "river surf=137 terr=132 -> land(64,-55) terr=134 cliff=3"
         },
         {
           "x": 64,
           "y": -61,
-          "details": "river surf=85 terr=84 -> land(64,-62) terr=81 cliff=4"
+          "details": "river surf=85 terr=80 -> land(64,-62) terr=81 cliff=4"
         },
         {
           "x": 64,
           "y": -44,
-          "details": "river surf=202 terr=201 -> land(65,-44) terr=197 cliff=5"
+          "details": "river surf=202 terr=200 -> land(65,-44) terr=197 cliff=5"
         },
         {
           "x": 64,
           "y": -12,
-          "details": "river surf=214 terr=213 -> land(64,-11) terr=211 cliff=3"
+          "details": "river surf=214 terr=212 -> land(64,-11) terr=211 cliff=3"
         },
         {
           "x": 65,
           "y": -64,
-          "details": "river surf=65 terr=64 -> land(66,-64) terr=61 cliff=4"
+          "details": "river surf=65 terr=62 -> land(66,-64) terr=61 cliff=4"
         },
         {
           "x": 65,
           "y": -63,
-          "details": "river surf=71 terr=70 -> land(66,-63) terr=66 cliff=5"
+          "details": "river surf=71 terr=68 -> land(66,-63) terr=66 cliff=5"
         },
         {
           "x": 65,
           "y": -62,
-          "details": "river surf=75 terr=74 -> land(66,-62) terr=72 cliff=3"
+          "details": "river surf=75 terr=71 -> land(66,-62) terr=72 cliff=3"
         },
         {
           "x": 65,
           "y": -57,
-          "details": "river surf=97 terr=96 -> land(65,-58) terr=94 cliff=3"
+          "details": "river surf=97 terr=92 -> land(65,-58) terr=94 cliff=3"
         },
         {
           "x": 65,
           "y": -43,
-          "details": "river surf=204 terr=203 -> land(65,-44) terr=197 cliff=7"
+          "details": "river surf=204 terr=200 -> land(65,-44) terr=197 cliff=7"
         },
         {
           "x": 65,
           "y": -10,
-          "details": "river surf=201 terr=200 -> land(65,-9) terr=195 cliff=6"
+          "details": "river surf=201 terr=199 -> land(65,-9) terr=195 cliff=6"
         },
         {
           "x": 66,
           "y": -45,
-          "details": "river surf=184 terr=183 -> land(66,-46) terr=182 cliff=2"
+          "details": "river surf=184 terr=182 -> land(66,-46) terr=182 cliff=2"
         },
         {
           "x": 66,
           "y": -43,
-          "details": "river surf=195 terr=194 -> land(66,-44) terr=190 cliff=5"
+          "details": "river surf=195 terr=191 -> land(66,-44) terr=190 cliff=5"
         },
         {
           "x": 66,
@@ -4421,17 +4481,17 @@
         {
           "x": 66,
           "y": -12,
-          "details": "river surf=194 terr=193 -> land(66,-11) terr=190 cliff=4"
+          "details": "river surf=194 terr=191 -> land(66,-11) terr=190 cliff=4"
         },
         {
           "x": 66,
           "y": -9,
-          "details": "river surf=187 terr=186 -> land(66,-8) terr=178 cliff=9"
+          "details": "river surf=187 terr=184 -> land(66,-8) terr=178 cliff=9"
         },
         {
           "x": 67,
           "y": -43,
-          "details": "river surf=184 terr=183 -> land(67,-44) terr=180 cliff=4"
+          "details": "river surf=184 terr=179 -> land(67,-44) terr=180 cliff=4"
         },
         {
           "x": 67,
@@ -4441,32 +4501,32 @@
         {
           "x": 67,
           "y": -12,
-          "details": "river surf=188 terr=187 -> land(68,-12) terr=185 cliff=3"
+          "details": "river surf=188 terr=185 -> land(68,-12) terr=185 cliff=3"
         },
         {
           "x": 67,
           "y": -11,
-          "details": "river surf=182 terr=181 -> land(68,-11) terr=180 cliff=2"
+          "details": "river surf=182 terr=179 -> land(68,-11) terr=180 cliff=2"
         },
         {
           "x": 67,
           "y": -7,
-          "details": "river surf=164 terr=163 -> land(67,-6) terr=161 cliff=3"
+          "details": "river surf=164 terr=159 -> land(67,-6) terr=161 cliff=3"
         },
         {
           "x": 69,
           "y": -64,
-          "details": "river surf=40 terr=39 -> land(70,-64) terr=36 cliff=4"
+          "details": "river surf=40 terr=36 -> land(70,-64) terr=36 cliff=4"
         },
         {
           "x": 69,
           "y": -62,
-          "details": "river surf=50 terr=49 -> land(69,-63) terr=46 cliff=4"
+          "details": "river surf=50 terr=45 -> land(69,-63) terr=46 cliff=4"
         },
         {
           "x": 69,
           "y": -60,
-          "details": "river surf=61 terr=60 -> land(70,-60) terr=56 cliff=5"
+          "details": "river surf=61 terr=58 -> land(70,-60) terr=56 cliff=5"
         },
         {
           "x": 69,
@@ -4476,7 +4536,7 @@
         {
           "x": 70,
           "y": -62,
-          "details": "river surf=44 terr=43 -> land(70,-63) terr=41 cliff=3"
+          "details": "river surf=44 terr=40 -> land(70,-63) terr=41 cliff=3"
         },
         {
           "x": 70,
@@ -4486,27 +4546,27 @@
         {
           "x": 70,
           "y": -43,
-          "details": "river surf=185 terr=184 -> land(70,-44) terr=180 cliff=5"
+          "details": "river surf=185 terr=180 -> land(70,-44) terr=180 cliff=5"
         },
         {
           "x": 70,
           "y": -23,
-          "details": "river surf=228 terr=227 -> land(71,-23) terr=226 cliff=2"
+          "details": "river surf=228 terr=226 -> land(71,-23) terr=226 cliff=2"
         },
         {
           "x": 70,
           "y": -22,
-          "details": "river surf=223 terr=222 -> land(71,-22) terr=220 cliff=3"
+          "details": "river surf=223 terr=221 -> land(71,-22) terr=220 cliff=3"
         },
         {
           "x": 70,
           "y": -21,
-          "details": "river surf=217 terr=216 -> land(71,-21) terr=215 cliff=2"
+          "details": "river surf=217 terr=215 -> land(71,-21) terr=215 cliff=2"
         },
         {
           "x": 70,
           "y": -18,
-          "details": "river surf=198 terr=197 -> land(70,-17) terr=195 cliff=3"
+          "details": "river surf=198 terr=196 -> land(70,-17) terr=195 cliff=3"
         },
         {
           "x": 70,
@@ -4526,12 +4586,12 @@
         {
           "x": 71,
           "y": -49,
-          "details": "river surf=158 terr=156 -> land(71,-50) terr=152 cliff=6"
+          "details": "river surf=158 terr=156 -> land(71,-50) terr=147 cliff=11"
         },
         {
           "x": 71,
           "y": -43,
-          "details": "river surf=192 terr=191 -> land(71,-44) terr=187 cliff=5"
+          "details": "river surf=192 terr=187 -> land(71,-44) terr=187 cliff=5"
         },
         {
           "x": 71,
@@ -4541,77 +4601,77 @@
         {
           "x": 71,
           "y": -12,
-          "details": "river surf=170 terr=169 -> land(71,-11) terr=167 cliff=3"
+          "details": "river surf=170 terr=168 -> land(71,-11) terr=167 cliff=3"
         },
         {
           "x": 72,
           "y": -43,
-          "details": "river surf=200 terr=199 -> land(72,-44) terr=195 cliff=5"
+          "details": "river surf=200 terr=195 -> land(72,-44) terr=195 cliff=5"
         },
         {
           "x": 72,
           "y": -39,
-          "details": "river surf=247 terr=246 -> land(71,-39) terr=242 cliff=5"
+          "details": "river surf=247 terr=243 -> land(71,-39) terr=242 cliff=5"
         },
         {
           "x": 72,
           "y": -24,
-          "details": "river surf=226 terr=225 -> land(72,-23) terr=221 cliff=5"
+          "details": "river surf=226 terr=223 -> land(72,-23) terr=221 cliff=5"
         },
         {
           "x": 72,
           "y": -14,
-          "details": "river surf=179 terr=178 -> land(72,-13) terr=173 cliff=6"
+          "details": "river surf=179 terr=176 -> land(72,-13) terr=173 cliff=6"
         },
         {
           "x": 72,
           "y": -11,
-          "details": "river surf=158 terr=157 -> land(72,-10) terr=156 cliff=2"
+          "details": "river surf=158 terr=154 -> land(72,-10) terr=156 cliff=2"
         },
         {
           "x": 73,
           "y": -43,
-          "details": "river surf=207 terr=206 -> land(73,-44) terr=201 cliff=6"
+          "details": "river surf=207 terr=202 -> land(73,-44) terr=201 cliff=6"
         },
         {
           "x": 73,
           "y": -24,
-          "details": "river surf=221 terr=220 -> land(74,-24) terr=216 cliff=5"
+          "details": "river surf=221 terr=218 -> land(74,-24) terr=216 cliff=5"
         },
         {
           "x": 73,
           "y": -23,
-          "details": "river surf=215 terr=214 -> land(73,-22) terr=213 cliff=2"
+          "details": "river surf=215 terr=213 -> land(73,-22) terr=213 cliff=2"
         },
         {
           "x": 73,
           "y": -14,
-          "details": "river surf=173 terr=172 -> land(74,-14) terr=169 cliff=4"
+          "details": "river surf=173 terr=170 -> land(74,-14) terr=169 cliff=4"
         },
         {
           "x": 73,
           "y": -13,
-          "details": "river surf=168 terr=167 -> land(73,-12) terr=161 cliff=7"
+          "details": "river surf=168 terr=164 -> land(73,-12) terr=161 cliff=7"
         },
         {
           "x": 73,
           "y": -10,
-          "details": "river surf=146 terr=145 -> land(73,-9) terr=144 cliff=2"
+          "details": "river surf=146 terr=142 -> land(73,-9) terr=144 cliff=2"
         },
         {
           "x": 73,
           "y": -7,
-          "details": "river surf=136 terr=135 -> land(73,-6) terr=129 cliff=7"
+          "details": "river surf=136 terr=132 -> land(73,-6) terr=129 cliff=7"
         },
         {
           "x": 74,
           "y": -63,
-          "details": "river surf=28 terr=25 -> land(74,-64) terr=26 cliff=2"
+          "details": "river surf=28 terr=23 -> land(74,-64) terr=26 cliff=2"
         },
         {
           "x": 74,
           "y": -44,
-          "details": "river surf=205 terr=204 -> land(73,-44) terr=201 cliff=4"
+          "details": "river surf=205 terr=201 -> land(73,-44) terr=201 cliff=4"
         },
         {
           "x": 74,
@@ -4621,22 +4681,27 @@
         {
           "x": 74,
           "y": -13,
-          "details": "river surf=158 terr=157 -> land(74,-12) terr=155 cliff=3"
+          "details": "river surf=158 terr=153 -> land(74,-12) terr=155 cliff=3"
         },
         {
           "x": 74,
           "y": -9,
-          "details": "river surf=134 terr=133 -> land(74,-8) terr=131 cliff=3"
+          "details": "river surf=134 terr=131 -> land(74,-8) terr=131 cliff=3"
         },
         {
           "x": 74,
           "y": -6,
-          "details": "river surf=118 terr=117 -> land(74,-5) terr=110 cliff=8"
+          "details": "river surf=118 terr=114 -> land(74,-5) terr=110 cliff=8"
+        },
+        {
+          "x": 75,
+          "y": -49,
+          "details": "river surf=160 terr=155 -> land(75,-50) terr=157 cliff=3"
         },
         {
           "x": 75,
           "y": -13,
-          "details": "river surf=150 terr=149 -> land(75,-12) terr=143 cliff=7"
+          "details": "river surf=150 terr=145 -> land(75,-12) terr=143 cliff=7"
         },
         {
           "x": 76,
@@ -4646,7 +4711,7 @@
         {
           "x": 76,
           "y": -12,
-          "details": "river surf=134 terr=133 -> land(76,-11) terr=130 cliff=4"
+          "details": "river surf=134 terr=128 -> land(76,-11) terr=130 cliff=4"
         },
         {
           "x": 76,
@@ -4656,12 +4721,12 @@
         {
           "x": 77,
           "y": -45,
-          "details": "river surf=201 terr=200 -> land(78,-45) terr=198 cliff=3"
+          "details": "river surf=201 terr=199 -> land(78,-45) terr=198 cliff=3"
         },
         {
           "x": 77,
           "y": -42,
-          "details": "river surf=230 terr=229 -> land(78,-42) terr=228 cliff=2"
+          "details": "river surf=230 terr=226 -> land(78,-42) terr=228 cliff=2"
         },
         {
           "x": 77,
@@ -4676,22 +4741,22 @@
         {
           "x": 77,
           "y": -12,
-          "details": "river surf=126 terr=125 -> land(77,-11) terr=121 cliff=5"
+          "details": "river surf=126 terr=121 -> land(77,-11) terr=121 cliff=5"
         },
         {
           "x": 77,
           "y": 0,
-          "details": "river surf=78 terr=77 -> land(77,1) terr=75 cliff=3"
+          "details": "river surf=78 terr=74 -> land(77,1) terr=75 cliff=3"
         },
         {
           "x": 78,
           "y": -44,
-          "details": "river surf=201 terr=200 -> land(78,-45) terr=198 cliff=3"
+          "details": "river surf=201 terr=197 -> land(78,-45) terr=198 cliff=3"
         },
         {
           "x": 78,
           "y": -43,
-          "details": "river surf=212 terr=211 -> land(79,-43) terr=207 cliff=5"
+          "details": "river surf=212 terr=208 -> land(79,-43) terr=207 cliff=5"
         },
         {
           "x": 78,
@@ -4701,7 +4766,7 @@
         {
           "x": 79,
           "y": -59,
-          "details": "river surf=49 terr=48 -> land(78,-59) terr=46 cliff=3"
+          "details": "river surf=49 terr=43 -> land(78,-59) terr=46 cliff=3"
         }
       ],
       "WATER_CLIFF": [
@@ -5076,9 +5141,19 @@
           "details": "river surf=31 -> dry(22,-10) terr=29 cliff=2"
         },
         {
+          "x": 28,
+          "y": -43,
+          "details": "lake surf=88 -> dry(28,-44) terr=85 cliff=3"
+        },
+        {
+          "x": 29,
+          "y": -58,
+          "details": "river surf=54 -> dry(28,-58) terr=51 cliff=3"
+        },
+        {
           "x": 29,
           "y": -44,
-          "details": "lake surf=88 -> dry(29,-45) terr=73 cliff=15"
+          "details": "lake surf=88 -> dry(28,-44) terr=85 cliff=3"
         },
         {
           "x": 29,
@@ -5088,12 +5163,17 @@
         {
           "x": 30,
           "y": -45,
-          "details": "lake surf=88 -> dry(29,-45) terr=73 cliff=15"
+          "details": "lake surf=88 -> dry(29,-45) terr=67 cliff=21"
+        },
+        {
+          "x": 31,
+          "y": -47,
+          "details": "river surf=42 -> dry(31,-48) terr=38 cliff=4"
         },
         {
           "x": 31,
           "y": -46,
-          "details": "lake surf=88 -> dry(30,-46) terr=57 cliff=31"
+          "details": "lake surf=88 -> dry(30,-46) terr=51 cliff=37"
         },
         {
           "x": 31,
@@ -5112,6 +5192,11 @@
         },
         {
           "x": 32,
+          "y": -47,
+          "details": "river surf=54 -> dry(32,-48) terr=50 cliff=4"
+        },
+        {
+          "x": 32,
           "y": -3,
           "details": "river surf=28 -> dry(31,-3) terr=25 cliff=3"
         },
@@ -5122,8 +5207,13 @@
         },
         {
           "x": 33,
+          "y": -50,
+          "details": "river surf=54 -> dry(32,-50) terr=50 cliff=4"
+        },
+        {
+          "x": 33,
           "y": -48,
-          "details": "lake surf=88 -> dry(32,-48) terr=55 cliff=33"
+          "details": "lake surf=88 -> dry(32,-48) terr=50 cliff=38"
         },
         {
           "x": 33,
@@ -5143,7 +5233,12 @@
         {
           "x": 34,
           "y": -54,
-          "details": "lake surf=107 -> dry(33,-54) terr=97 cliff=10"
+          "details": "lake surf=107 -> dry(33,-54) terr=92 cliff=15"
+        },
+        {
+          "x": 34,
+          "y": -53,
+          "details": "river surf=66 -> dry(33,-53) terr=64 cliff=2"
         },
         {
           "x": 34,
@@ -5167,8 +5262,13 @@
         },
         {
           "x": 35,
+          "y": -53,
+          "details": "river surf=78 -> dry(35,-52) terr=76 cliff=2"
+        },
+        {
+          "x": 35,
           "y": -51,
-          "details": "river surf=90 -> dry(35,-52) terr=81 cliff=9"
+          "details": "river surf=90 -> dry(35,-52) terr=76 cliff=14"
         },
         {
           "x": 35,
@@ -5178,7 +5278,7 @@
         {
           "x": 36,
           "y": -52,
-          "details": "river surf=90 -> dry(35,-52) terr=81 cliff=9"
+          "details": "river surf=90 -> dry(35,-52) terr=76 cliff=14"
         },
         {
           "x": 36,
@@ -5396,14 +5496,39 @@
           "details": "river surf=149 -> dry(49,-5) terr=145 cliff=4"
         },
         {
+          "x": 53,
+          "y": -6,
+          "details": "river surf=166 -> dry(54,-6) terr=164 cliff=2"
+        },
+        {
           "x": 54,
           "y": -2,
-          "details": "river surf=130 -> dry(55,-2) terr=109 cliff=21"
+          "details": "river surf=130 -> dry(55,-2) terr=103 cliff=27"
         },
         {
           "x": 55,
           "y": -12,
           "details": "river surf=206 -> dry(55,-13) terr=203 cliff=3"
+        },
+        {
+          "x": 55,
+          "y": -11,
+          "details": "river surf=202 -> dry(55,-10) terr=199 cliff=3"
+        },
+        {
+          "x": 55,
+          "y": -3,
+          "details": "river surf=106 -> dry(55,-2) terr=103 cliff=3"
+        },
+        {
+          "x": 58,
+          "y": -7,
+          "details": "river surf=154 -> dry(57,-7) terr=151 cliff=3"
+        },
+        {
+          "x": 58,
+          "y": -6,
+          "details": "river surf=142 -> dry(58,-5) terr=139 cliff=3"
         },
         {
           "x": 58,
@@ -5414,6 +5539,16 @@
           "x": 58,
           "y": 5,
           "details": "river surf=10 -> dry(59,5) terr=8 cliff=2"
+        },
+        {
+          "x": 59,
+          "y": -9,
+          "details": "river surf=190 -> dry(58,-9) terr=188 cliff=2"
+        },
+        {
+          "x": 59,
+          "y": -8,
+          "details": "river surf=178 -> dry(59,-7) terr=175 cliff=3"
         },
         {
           "x": 60,
@@ -5638,7 +5773,7 @@
         {
           "x": 71,
           "y": -49,
-          "details": "river surf=158 -> dry(71,-50) terr=152 cliff=6"
+          "details": "river surf=158 -> dry(71,-50) terr=147 cliff=11"
         },
         {
           "x": 71,
@@ -5744,6 +5879,11 @@
           "x": 74,
           "y": -6,
           "details": "river surf=118 -> dry(74,-5) terr=110 cliff=8"
+        },
+        {
+          "x": 75,
+          "y": -49,
+          "details": "river surf=160 -> dry(75,-50) terr=157 cliff=3"
         },
         {
           "x": 75,

--- a/tools/baselines/seed997555_size64_region_-2_-2_2_2.json
+++ b/tools/baselines/seed997555_size64_region_-2_-2_2_2.json
@@ -14,9 +14,9 @@
     "deterministic": true,
     "distinctHashes": 1,
     "hashes": [
-      "a910d1346d2fdfcc8c55a8a18fcd4487ef014f7bcb5f1b067da84fda332050cc",
-      "a910d1346d2fdfcc8c55a8a18fcd4487ef014f7bcb5f1b067da84fda332050cc",
-      "a910d1346d2fdfcc8c55a8a18fcd4487ef014f7bcb5f1b067da84fda332050cc"
+      "58212d1a68abde4f2f0fc39275aef871c210ec22209999d09b9dafd079b5178c",
+      "58212d1a68abde4f2f0fc39275aef871c210ec22209999d09b9dafd079b5178c",
+      "58212d1a68abde4f2f0fc39275aef871c210ec22209999d09b9dafd079b5178c"
     ]
   },
   "tileCount": 6400,
@@ -85,13 +85,13 @@
       ]
     },
     "FLOATING_WATER": {
-      "min": 23,
-      "max": 23,
-      "median": 23,
+      "min": 12,
+      "max": 12,
+      "median": 12,
       "all": [
-        23,
-        23,
-        23
+        12,
+        12,
+        12
       ]
     },
     "ISOLATED_FLUID": {
@@ -102,6 +102,16 @@
         12,
         12,
         12
+      ]
+    },
+    "MID_RIVER_CLIFF": {
+      "min": 4,
+      "max": 4,
+      "median": 4,
+      "all": [
+        4,
+        4,
+        4
       ]
     },
     "MULTI_ISLAND": {
@@ -159,8 +169,9 @@
     "summary": {
       "FLAT_ISOLATED_WATER": 21,
       "FLOATING_LAKE": 184,
-      "FLOATING_WATER": 23,
+      "FLOATING_WATER": 12,
       "ISOLATED_FLUID": 12,
+      "MID_RIVER_CLIFF": 4,
       "MULTI_ISLAND": 2,
       "RIVER_CHUNK_GAP": 1,
       "WATER_ABOVE_LAND": 25,
@@ -1219,14 +1230,9 @@
           "details": "river terr=58 -> dry(-29,29) terr=57 gap=1"
         },
         {
-          "x": -26,
-          "y": -25,
-          "details": "river terr=148 -> dry(-25,-25) terr=147 gap=1"
-        },
-        {
           "x": -25,
           "y": -7,
-          "details": "river terr=158 -> dry(-25,-6) terr=151 gap=7"
+          "details": "river terr=153 -> dry(-25,-6) terr=151 gap=2"
         },
         {
           "x": -25,
@@ -1236,82 +1242,32 @@
         {
           "x": -24,
           "y": -7,
-          "details": "river terr=150 -> dry(-23,-7) terr=143 gap=7"
+          "details": "river terr=145 -> dry(-23,-7) terr=143 gap=2"
         },
         {
           "x": -24,
           "y": -6,
-          "details": "river terr=139 -> dry(-23,-6) terr=132 gap=7"
+          "details": "river terr=134 -> dry(-23,-6) terr=132 gap=2"
         },
         {
           "x": -24,
           "y": -5,
-          "details": "river terr=130 -> dry(-24,-4) terr=123 gap=7"
-        },
-        {
-          "x": -23,
-          "y": -5,
-          "details": "river terr=121 -> dry(-23,-4) terr=117 gap=4"
+          "details": "river terr=125 -> dry(-24,-4) terr=123 gap=2"
         },
         {
           "x": -22,
           "y": -5,
-          "details": "river terr=115 -> dry(-22,-4) terr=109 gap=6"
-        },
-        {
-          "x": -21,
-          "y": -5,
-          "details": "river terr=108 -> dry(-20,-5) terr=107 gap=1"
-        },
-        {
-          "x": -21,
-          "y": -4,
-          "details": "river terr=104 -> dry(-20,-4) terr=102 gap=2"
-        },
-        {
-          "x": -21,
-          "y": -3,
-          "details": "river terr=98 -> dry(-20,-3) terr=97 gap=1"
-        },
-        {
-          "x": -21,
-          "y": -2,
-          "details": "river terr=90 -> dry(-20,-2) terr=89 gap=1"
-        },
-        {
-          "x": -21,
-          "y": 2,
-          "details": "river terr=45 -> dry(-22,2) terr=44 gap=1"
-        },
-        {
-          "x": -19,
-          "y": -30,
-          "details": "river terr=99 -> dry(-19,-29) terr=97 gap=2"
-        },
-        {
-          "x": -18,
-          "y": -30,
-          "details": "river terr=92 -> dry(-18,-29) terr=89 gap=3"
-        },
-        {
-          "x": -18,
-          "y": 1,
-          "details": "river terr=50 -> dry(-17,1) terr=48 gap=2"
-        },
-        {
-          "x": -17,
-          "y": -30,
-          "details": "river terr=87 -> dry(-16,-30) terr=82 gap=5"
+          "details": "river terr=111 -> dry(-22,-4) terr=109 gap=2"
         },
         {
           "x": -17,
           "y": -28,
-          "details": "river terr=73 -> dry(-17,-27) terr=69 gap=4"
+          "details": "river terr=70 -> dry(-17,-27) terr=69 gap=1"
         },
         {
           "x": -16,
           "y": -29,
-          "details": "river terr=71 -> dry(-15,-29) terr=64 gap=7"
+          "details": "river terr=67 -> dry(-15,-29) terr=64 gap=3"
         }
       ],
       "ISOLATED_FLUID": [
@@ -1376,6 +1332,28 @@
           "details": "lake surf=34 surrounded by dry"
         }
       ],
+      "MID_RIVER_CLIFF": [
+        {
+          "x": -31,
+          "y": 16,
+          "details": "river surf=39 (terr=36) -> water nbr surf=37 (terr=36) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -26,
+          "y": -25,
+          "details": "river surf=149 (terr=145) -> water nbr surf=147 (terr=145) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -20,
+          "y": 3,
+          "details": "river surf=39 (terr=36) -> water nbr surf=37 (terr=36) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -14,
+          "y": -28,
+          "details": "river surf=41 (terr=35) -> water nbr surf=38 (terr=34) surf_diff=3 terr_diff=1"
+        }
+      ],
       "MULTI_ISLAND": [
         {
           "x": 16,
@@ -1429,12 +1407,12 @@
         {
           "x": -26,
           "y": -25,
-          "details": "river surf=149 terr=148 -> land(-25,-25) terr=147 cliff=2"
+          "details": "river surf=149 terr=145 -> land(-25,-25) terr=147 cliff=2"
         },
         {
           "x": -25,
           "y": -7,
-          "details": "river surf=159 terr=158 -> land(-25,-6) terr=151 cliff=8"
+          "details": "river surf=159 terr=153 -> land(-25,-6) terr=151 cliff=8"
         },
         {
           "x": -25,
@@ -1444,82 +1422,82 @@
         {
           "x": -24,
           "y": -7,
-          "details": "river surf=151 terr=150 -> land(-23,-7) terr=143 cliff=8"
+          "details": "river surf=151 terr=145 -> land(-23,-7) terr=143 cliff=8"
         },
         {
           "x": -24,
           "y": -6,
-          "details": "river surf=140 terr=139 -> land(-23,-6) terr=132 cliff=8"
+          "details": "river surf=140 terr=134 -> land(-23,-6) terr=132 cliff=8"
         },
         {
           "x": -24,
           "y": -5,
-          "details": "river surf=131 terr=130 -> land(-24,-4) terr=123 cliff=8"
+          "details": "river surf=131 terr=125 -> land(-24,-4) terr=123 cliff=8"
         },
         {
           "x": -23,
           "y": -5,
-          "details": "river surf=122 terr=121 -> land(-23,-4) terr=117 cliff=5"
+          "details": "river surf=122 terr=116 -> land(-23,-4) terr=117 cliff=5"
         },
         {
           "x": -22,
           "y": -5,
-          "details": "river surf=116 terr=115 -> land(-22,-4) terr=109 cliff=7"
+          "details": "river surf=116 terr=111 -> land(-22,-4) terr=109 cliff=7"
         },
         {
           "x": -21,
           "y": -5,
-          "details": "river surf=109 terr=108 -> land(-20,-5) terr=107 cliff=2"
+          "details": "river surf=109 terr=104 -> land(-20,-5) terr=107 cliff=2"
         },
         {
           "x": -21,
           "y": -4,
-          "details": "river surf=105 terr=104 -> land(-20,-4) terr=102 cliff=3"
+          "details": "river surf=105 terr=101 -> land(-20,-4) terr=102 cliff=3"
         },
         {
           "x": -21,
           "y": -3,
-          "details": "river surf=99 terr=98 -> land(-20,-3) terr=97 cliff=2"
+          "details": "river surf=99 terr=96 -> land(-20,-3) terr=97 cliff=2"
         },
         {
           "x": -21,
           "y": -2,
-          "details": "river surf=91 terr=90 -> land(-20,-2) terr=89 cliff=2"
+          "details": "river surf=91 terr=88 -> land(-20,-2) terr=89 cliff=2"
         },
         {
           "x": -21,
           "y": 2,
-          "details": "river surf=46 terr=45 -> land(-22,2) terr=44 cliff=2"
+          "details": "river surf=46 terr=43 -> land(-22,2) terr=44 cliff=2"
         },
         {
           "x": -19,
           "y": -30,
-          "details": "river surf=100 terr=99 -> land(-19,-29) terr=97 cliff=3"
+          "details": "river surf=100 terr=95 -> land(-19,-29) terr=97 cliff=3"
         },
         {
           "x": -18,
           "y": -30,
-          "details": "river surf=93 terr=92 -> land(-18,-29) terr=89 cliff=4"
+          "details": "river surf=93 terr=87 -> land(-18,-29) terr=89 cliff=4"
         },
         {
           "x": -18,
           "y": 1,
-          "details": "river surf=51 terr=50 -> land(-17,1) terr=48 cliff=3"
+          "details": "river surf=51 terr=46 -> land(-17,1) terr=48 cliff=3"
         },
         {
           "x": -17,
           "y": -30,
-          "details": "river surf=88 terr=87 -> land(-16,-30) terr=82 cliff=6"
+          "details": "river surf=88 terr=82 -> land(-16,-30) terr=82 cliff=6"
         },
         {
           "x": -17,
           "y": -28,
-          "details": "river surf=74 terr=73 -> land(-17,-27) terr=69 cliff=5"
+          "details": "river surf=74 terr=70 -> land(-17,-27) terr=69 cliff=5"
         },
         {
           "x": -16,
           "y": -29,
-          "details": "river surf=72 terr=71 -> land(-15,-29) terr=64 cliff=8"
+          "details": "river surf=72 terr=67 -> land(-15,-29) terr=64 cliff=8"
         }
       ],
       "WATER_CLIFF": [

--- a/tools/baselines/seed9999_size32_region_-4_-4_4_4.json
+++ b/tools/baselines/seed9999_size32_region_-4_-4_4_4.json
@@ -14,9 +14,9 @@
     "deterministic": true,
     "distinctHashes": 1,
     "hashes": [
-      "ecd8817a49da1a674e68268925199e031342864240a01d7fa5011ff3320af34c",
-      "ecd8817a49da1a674e68268925199e031342864240a01d7fa5011ff3320af34c",
-      "ecd8817a49da1a674e68268925199e031342864240a01d7fa5011ff3320af34c"
+      "f7cf80cd7430e2170b35a9ccf03dcc96e49ab9319d23c4825abd1737be67a932",
+      "f7cf80cd7430e2170b35a9ccf03dcc96e49ab9319d23c4825abd1737be67a932",
+      "f7cf80cd7430e2170b35a9ccf03dcc96e49ab9319d23c4825abd1737be67a932"
     ]
   },
   "tileCount": 20736,
@@ -95,13 +95,13 @@
       ]
     },
     "FLOATING_WATER": {
-      "min": 44,
-      "max": 44,
-      "median": 44,
+      "min": 23,
+      "max": 23,
+      "median": 23,
       "all": [
-        44,
-        44,
-        44
+        23,
+        23,
+        23
       ]
     },
     "ISOLATED_FLUID": {
@@ -112,6 +112,16 @@
         23,
         23,
         23
+      ]
+    },
+    "MID_RIVER_CLIFF": {
+      "min": 31,
+      "max": 31,
+      "median": 31,
+      "all": [
+        31,
+        31,
+        31
       ]
     },
     "MULTI_ISLAND": {
@@ -125,33 +135,33 @@
       ]
     },
     "RIVER_CHUNK_GAP": {
-      "min": 9,
-      "max": 9,
-      "median": 9,
+      "min": 10,
+      "max": 10,
+      "median": 10,
       "all": [
-        9,
-        9,
-        9
+        10,
+        10,
+        10
       ]
     },
     "WATER_ABOVE_LAND": {
-      "min": 44,
-      "max": 44,
-      "median": 44,
+      "min": 46,
+      "max": 46,
+      "median": 46,
       "all": [
-        44,
-        44,
-        44
+        46,
+        46,
+        46
       ]
     },
     "WATER_CLIFF": {
-      "min": 44,
-      "max": 44,
-      "median": 44,
+      "min": 46,
+      "max": 46,
+      "median": 46,
       "all": [
-        44,
-        44,
-        44
+        46,
+        46,
+        46
       ]
     },
     "WATER_WATER_CLIFF": {
@@ -170,12 +180,13 @@
       "DESERT_SOIL_ON_SLOPE": 48,
       "FLAT_ISOLATED_WATER": 17,
       "FLOATING_LAKE": 4767,
-      "FLOATING_WATER": 44,
+      "FLOATING_WATER": 23,
       "ISOLATED_FLUID": 23,
+      "MID_RIVER_CLIFF": 31,
       "MULTI_ISLAND": 2,
-      "RIVER_CHUNK_GAP": 9,
-      "WATER_ABOVE_LAND": 44,
-      "WATER_CLIFF": 44,
+      "RIVER_CHUNK_GAP": 10,
+      "WATER_ABOVE_LAND": 46,
+      "WATER_CLIFF": 46,
       "WATER_WATER_CLIFF": 843
     },
     "issues": {
@@ -24347,19 +24358,9 @@
       ],
       "FLOATING_WATER": [
         {
-          "x": -40,
-          "y": 19,
-          "details": "river terr=121 -> dry(-39,19) terr=120 gap=1"
-        },
-        {
-          "x": -40,
-          "y": 20,
-          "details": "river terr=118 -> dry(-39,20) terr=117 gap=1"
-        },
-        {
           "x": -36,
           "y": 24,
-          "details": "lake terr=102 -> dry(-36,25) terr=90 gap=12"
+          "details": "lake terr=99 -> dry(-36,25) terr=87 gap=12"
         },
         {
           "x": -35,
@@ -24367,129 +24368,44 @@
           "details": "river terr=103 -> dry(-35,25) terr=99 gap=4"
         },
         {
-          "x": -35,
-          "y": 29,
-          "details": "river terr=33 -> dry(-36,29) terr=32 gap=1"
-        },
-        {
-          "x": -34,
-          "y": 28,
-          "details": "river terr=54 -> dry(-35,28) terr=50 gap=4"
-        },
-        {
-          "x": -33,
-          "y": 17,
-          "details": "river terr=124 -> dry(-34,17) terr=122 gap=2"
-        },
-        {
-          "x": -33,
-          "y": 30,
-          "details": "river terr=42 -> dry(-33,31) terr=36 gap=6"
-        },
-        {
-          "x": -32,
-          "y": 27,
-          "details": "river terr=86 -> dry(-33,27) terr=83 gap=3"
-        },
-        {
           "x": -32,
           "y": 28,
-          "details": "river terr=76 -> dry(-33,28) terr=69 gap=7"
+          "details": "river terr=71 -> dry(-33,28) terr=69 gap=2"
         },
         {
           "x": -32,
           "y": 29,
-          "details": "river terr=64 -> dry(-33,29) terr=56 gap=8"
-        },
-        {
-          "x": -32,
-          "y": 31,
-          "details": "river terr=41 -> dry(-33,31) terr=36 gap=5"
-        },
-        {
-          "x": -32,
-          "y": 32,
-          "details": "river terr=32 -> dry(-33,32) terr=28 gap=4"
+          "details": "river terr=58 -> dry(-33,29) terr=56 gap=2"
         },
         {
           "x": -31,
           "y": 19,
-          "details": "river terr=124 -> dry(-32,19) terr=117 gap=7"
-        },
-        {
-          "x": -31,
-          "y": 20,
-          "details": "river terr=116 -> dry(-32,20) terr=114 gap=2"
-        },
-        {
-          "x": -30,
-          "y": 30,
-          "details": "river terr=62 -> dry(-31,30) terr=60 gap=2"
-        },
-        {
-          "x": -30,
-          "y": 31,
-          "details": "river terr=50 -> dry(-31,31) terr=48 gap=2"
-        },
-        {
-          "x": -30,
-          "y": 32,
-          "details": "river terr=38 -> dry(-31,32) terr=37 gap=1"
-        },
-        {
-          "x": -2,
-          "y": 33,
-          "details": "river terr=48 -> dry(-2,34) terr=46 gap=2"
+          "details": "river terr=118 -> dry(-32,19) terr=117 gap=1"
         },
         {
           "x": -1,
           "y": 34,
-          "details": "river terr=30 -> dry(-1,35) terr=20 gap=10"
-        },
-        {
-          "x": 0,
-          "y": 34,
-          "details": "river terr=18 -> dry(0,35) terr=17 gap=1"
-        },
-        {
-          "x": 29,
-          "y": -42,
-          "details": "river terr=225 -> dry(29,-41) terr=224 gap=1"
+          "details": "river terr=25 -> dry(-1,35) terr=20 gap=5"
         },
         {
           "x": 38,
           "y": -39,
-          "details": "river terr=97 -> dry(39,-39) terr=88 gap=9"
+          "details": "river terr=91 -> dry(39,-39) terr=88 gap=3"
         },
         {
           "x": 39,
           "y": -40,
-          "details": "river terr=98 -> dry(39,-39) terr=88 gap=10"
-        },
-        {
-          "x": 39,
-          "y": -38,
-          "details": "river terr=78 -> dry(40,-38) terr=76 gap=2"
-        },
-        {
-          "x": 39,
-          "y": -36,
-          "details": "river terr=76 -> dry(40,-36) terr=75 gap=1"
+          "details": "river terr=93 -> dry(39,-39) terr=88 gap=5"
         },
         {
           "x": 40,
           "y": -40,
-          "details": "river terr=87 -> dry(40,-39) terr=81 gap=6"
-        },
-        {
-          "x": 41,
-          "y": -40,
-          "details": "river terr=78 -> dry(41,-39) terr=76 gap=2"
+          "details": "river terr=83 -> dry(40,-39) terr=81 gap=2"
         },
         {
           "x": 42,
           "y": -49,
-          "details": "river terr=38 -> dry(42,-50) terr=31 gap=7"
+          "details": "river terr=34 -> dry(42,-50) terr=31 gap=3"
         },
         {
           "x": 42,
@@ -24498,23 +24414,13 @@
         },
         {
           "x": 43,
-          "y": -49,
-          "details": "river terr=26 -> dry(43,-50) terr=22 gap=4"
-        },
-        {
-          "x": 43,
           "y": -35,
           "details": "river terr=69 -> dry(43,-36) terr=68 gap=1"
         },
         {
           "x": 44,
-          "y": -43,
-          "details": "river terr=39 -> dry(45,-43) terr=37 gap=2"
-        },
-        {
-          "x": 44,
           "y": -42,
-          "details": "river terr=47 -> dry(45,-42) terr=42 gap=5"
+          "details": "river terr=45 -> dry(45,-42) terr=42 gap=3"
         },
         {
           "x": 44,
@@ -24684,6 +24590,163 @@
           "details": "lake surf=27 surrounded by dry"
         }
       ],
+      "MID_RIVER_CLIFF": [
+        {
+          "x": -44,
+          "y": 31,
+          "details": "river surf=30 (terr=24) -> water nbr surf=28 (terr=24) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -42,
+          "y": 30,
+          "details": "river surf=31 (terr=26) -> water nbr surf=29 (terr=26) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -42,
+          "y": 31,
+          "details": "river surf=29 (terr=26) -> water nbr surf=26 (terr=25) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -42,
+          "y": 32,
+          "details": "river surf=23 (terr=20) -> water nbr surf=21 (terr=20) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -41,
+          "y": 30,
+          "details": "river surf=30 (terr=25) -> water nbr surf=26 (terr=25) surf_diff=4 terr_diff=0"
+        },
+        {
+          "x": -40,
+          "y": 29,
+          "details": "river surf=32 (terr=26) -> water nbr surf=28 (terr=24) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -40,
+          "y": 30,
+          "details": "river surf=28 (terr=24) -> water nbr surf=25 (terr=24) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": -39,
+          "y": 29,
+          "details": "river surf=31 (terr=26) -> water nbr surf=28 (terr=25) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -39,
+          "y": 30,
+          "details": "river surf=28 (terr=25) -> water nbr surf=25 (terr=24) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -38,
+          "y": 29,
+          "details": "river surf=31 (terr=26) -> water nbr surf=28 (terr=25) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -38,
+          "y": 30,
+          "details": "river surf=28 (terr=25) -> water nbr surf=25 (terr=24) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -36,
+          "y": 24,
+          "details": "river surf=103 (terr=98) -> water nbr surf=99 (terr=99) surf_diff=4 terr_diff=1"
+        },
+        {
+          "x": -36,
+          "y": 31,
+          "details": "river surf=26 (terr=23) -> water nbr surf=23 (terr=22) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -35,
+          "y": 30,
+          "details": "river surf=30 (terr=24) -> water nbr surf=27 (terr=23) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -33,
+          "y": 20,
+          "details": "river surf=111 (terr=106) -> water nbr surf=108 (terr=105) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -33,
+          "y": 21,
+          "details": "river surf=108 (terr=105) -> water nbr surf=106 (terr=105) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -32,
+          "y": 21,
+          "details": "river surf=111 (terr=106) -> water nbr surf=108 (terr=105) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -31,
+          "y": 20,
+          "details": "river surf=117 (terr=110) -> water nbr surf=114 (terr=109) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -31,
+          "y": 34,
+          "details": "river surf=23 (terr=20) -> water nbr surf=19 (terr=18) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -30,
+          "y": 34,
+          "details": "river surf=23 (terr=20) -> water nbr surf=19 (terr=18) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": -29,
+          "y": 34,
+          "details": "river surf=22 (terr=19) -> water nbr surf=19 (terr=18) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": -28,
+          "y": 34,
+          "details": "river surf=21 (terr=18) -> water nbr surf=19 (terr=18) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -25,
+          "y": 32,
+          "details": "river surf=26 (terr=20) -> water nbr surf=24 (terr=20) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -24,
+          "y": 33,
+          "details": "river surf=26 (terr=21) -> water nbr surf=24 (terr=21) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -24,
+          "y": 34,
+          "details": "river surf=24 (terr=21) -> water nbr surf=22 (terr=21) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": -24,
+          "y": 35,
+          "details": "river surf=22 (terr=19) -> water nbr surf=20 (terr=19) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 41,
+          "y": -37,
+          "details": "river surf=73 (terr=70) -> water nbr surf=70 (terr=69) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 44,
+          "y": -49,
+          "details": "lake surf=20 (terr=15) -> water nbr surf=17 (terr=15) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 44,
+          "y": -49,
+          "details": "river surf=20 (terr=15) -> water nbr surf=17 (terr=15) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 45,
+          "y": -46,
+          "details": "river surf=25 (terr=22) -> water nbr surf=23 (terr=22) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 48,
+          "y": -37,
+          "details": "river surf=40 (terr=36) -> water nbr surf=38 (terr=36) surf_diff=2 terr_diff=0"
+        }
+      ],
       "MULTI_ISLAND": [
         {
           "x": -33,
@@ -24733,6 +24796,11 @@
           "details": "river surf=21 -> dry(-33,34) terr=20"
         },
         {
+          "x": -21,
+          "y": 31,
+          "details": "river surf=58 -> dry(-21,32) terr=57"
+        },
+        {
           "x": 47,
           "y": -35,
           "details": "river surf=56 -> dry(48,-35) terr=50"
@@ -24747,17 +24815,17 @@
         {
           "x": -40,
           "y": 19,
-          "details": "river surf=122 terr=121 -> land(-39,19) terr=120 cliff=2"
+          "details": "river surf=122 terr=120 -> land(-39,19) terr=120 cliff=2"
         },
         {
           "x": -40,
           "y": 20,
-          "details": "river surf=119 terr=118 -> land(-39,20) terr=117 cliff=2"
+          "details": "river surf=119 terr=117 -> land(-39,20) terr=117 cliff=2"
         },
         {
           "x": -36,
           "y": 24,
-          "details": "lake surf=103 terr=102 -> land(-36,25) terr=90 cliff=13"
+          "details": "lake surf=103 terr=99 -> land(-36,25) terr=87 cliff=16"
         },
         {
           "x": -35,
@@ -24767,127 +24835,137 @@
         {
           "x": -35,
           "y": 29,
-          "details": "river surf=34 terr=33 -> land(-36,29) terr=32 cliff=2"
+          "details": "river surf=34 terr=29 -> land(-36,29) terr=32 cliff=2"
         },
         {
           "x": -34,
           "y": 28,
-          "details": "river surf=55 terr=54 -> land(-35,28) terr=50 cliff=5"
+          "details": "river surf=55 terr=49 -> land(-35,28) terr=50 cliff=5"
         },
         {
           "x": -33,
           "y": 17,
-          "details": "river surf=125 terr=124 -> land(-34,17) terr=122 cliff=3"
+          "details": "river surf=125 terr=120 -> land(-34,17) terr=122 cliff=3"
         },
         {
           "x": -33,
           "y": 30,
-          "details": "river surf=43 terr=42 -> land(-33,31) terr=36 cliff=7"
+          "details": "river surf=43 terr=36 -> land(-33,31) terr=36 cliff=7"
         },
         {
           "x": -32,
           "y": 27,
-          "details": "river surf=87 terr=86 -> land(-33,27) terr=83 cliff=4"
+          "details": "river surf=87 terr=81 -> land(-33,27) terr=83 cliff=4"
         },
         {
           "x": -32,
           "y": 28,
-          "details": "river surf=77 terr=76 -> land(-33,28) terr=69 cliff=8"
+          "details": "river surf=77 terr=71 -> land(-33,28) terr=69 cliff=8"
         },
         {
           "x": -32,
           "y": 29,
-          "details": "river surf=65 terr=64 -> land(-33,29) terr=56 cliff=9"
+          "details": "river surf=65 terr=58 -> land(-33,29) terr=56 cliff=9"
         },
         {
           "x": -32,
           "y": 31,
-          "details": "river surf=42 terr=41 -> land(-33,31) terr=36 cliff=6"
+          "details": "river surf=42 terr=36 -> land(-33,31) terr=36 cliff=6"
         },
         {
           "x": -32,
           "y": 32,
-          "details": "river surf=33 terr=32 -> land(-33,32) terr=28 cliff=5"
+          "details": "river surf=33 terr=28 -> land(-33,32) terr=28 cliff=5"
         },
         {
           "x": -31,
           "y": 19,
-          "details": "river surf=125 terr=124 -> land(-32,19) terr=117 cliff=8"
+          "details": "river surf=125 terr=118 -> land(-32,19) terr=117 cliff=8"
         },
         {
           "x": -31,
           "y": 20,
-          "details": "river surf=117 terr=116 -> land(-32,20) terr=114 cliff=3"
+          "details": "river surf=117 terr=110 -> land(-32,20) terr=114 cliff=3"
         },
         {
           "x": -30,
           "y": 30,
-          "details": "river surf=63 terr=62 -> land(-31,30) terr=60 cliff=3"
+          "details": "river surf=63 terr=57 -> land(-31,30) terr=60 cliff=3"
         },
         {
           "x": -30,
           "y": 31,
-          "details": "river surf=51 terr=50 -> land(-31,31) terr=48 cliff=3"
+          "details": "river surf=51 terr=45 -> land(-31,31) terr=48 cliff=3"
         },
         {
           "x": -30,
           "y": 32,
-          "details": "river surf=39 terr=38 -> land(-31,32) terr=37 cliff=2"
+          "details": "river surf=39 terr=34 -> land(-31,32) terr=37 cliff=2"
+        },
+        {
+          "x": -20,
+          "y": 30,
+          "details": "river surf=82 terr=75 -> land(-20,31) terr=79 cliff=3"
+        },
+        {
+          "x": -12,
+          "y": 11,
+          "details": "river surf=179 terr=173 -> land(-11,11) terr=177 cliff=2"
         },
         {
           "x": -2,
           "y": 33,
-          "details": "river surf=49 terr=48 -> land(-2,34) terr=46 cliff=3"
+          "details": "river surf=49 terr=43 -> land(-2,34) terr=46 cliff=3"
         },
         {
           "x": -1,
           "y": 34,
-          "details": "river surf=31 terr=30 -> land(-1,35) terr=20 cliff=11"
+          "details": "river surf=31 terr=25 -> land(-1,35) terr=20 cliff=11"
         },
         {
           "x": 0,
           "y": 34,
-          "details": "river surf=19 terr=18 -> land(0,35) terr=17 cliff=2"
+          "details": "river surf=19 terr=12 -> land(0,35) terr=17 cliff=2"
         },
         {
           "x": 29,
           "y": -42,
-          "details": "river surf=226 terr=225 -> land(29,-41) terr=224 cliff=2"
+          "details": "river surf=226 terr=220 -> land(29,-41) terr=224 cliff=2"
         },
         {
           "x": 38,
           "y": -39,
-          "details": "river surf=98 terr=97 -> land(39,-39) terr=88 cliff=10"
+          "details": "river surf=98 terr=91 -> land(39,-39) terr=88 cliff=10"
         },
         {
           "x": 39,
           "y": -40,
-          "details": "river surf=99 terr=98 -> land(39,-39) terr=88 cliff=11"
+          "details": "river surf=99 terr=93 -> land(39,-39) terr=88 cliff=11"
         },
         {
           "x": 39,
           "y": -38,
-          "details": "river surf=79 terr=78 -> land(40,-38) terr=76 cliff=3"
+          "details": "river surf=79 terr=73 -> land(40,-38) terr=76 cliff=3"
         },
         {
           "x": 39,
           "y": -36,
-          "details": "river surf=77 terr=76 -> land(40,-36) terr=75 cliff=2"
+          "details": "river surf=77 terr=71 -> land(40,-36) terr=75 cliff=2"
         },
         {
           "x": 40,
           "y": -40,
-          "details": "river surf=88 terr=87 -> land(40,-39) terr=81 cliff=7"
+          "details": "river surf=88 terr=83 -> land(40,-39) terr=81 cliff=7"
         },
         {
           "x": 41,
           "y": -40,
-          "details": "river surf=79 terr=78 -> land(41,-39) terr=76 cliff=3"
+          "details": "river surf=79 terr=74 -> land(41,-39) terr=76 cliff=3"
         },
         {
           "x": 42,
           "y": -49,
-          "details": "river surf=39 terr=38 -> land(42,-50) terr=31 cliff=8"
+          "details": "river surf=39 terr=34 -> land(42,-50) terr=31 cliff=8"
         },
         {
           "x": 42,
@@ -24897,7 +24975,7 @@
         {
           "x": 43,
           "y": -49,
-          "details": "river surf=27 terr=26 -> land(43,-50) terr=22 cliff=5"
+          "details": "river surf=27 terr=22 -> land(43,-50) terr=22 cliff=5"
         },
         {
           "x": 43,
@@ -24907,12 +24985,12 @@
         {
           "x": 44,
           "y": -43,
-          "details": "river surf=40 terr=39 -> land(45,-43) terr=37 cliff=3"
+          "details": "river surf=40 terr=36 -> land(45,-43) terr=37 cliff=3"
         },
         {
           "x": 44,
           "y": -42,
-          "details": "river surf=48 terr=47 -> land(45,-42) terr=42 cliff=6"
+          "details": "river surf=48 terr=45 -> land(45,-42) terr=42 cliff=6"
         },
         {
           "x": 44,
@@ -24979,7 +25057,7 @@
         {
           "x": -36,
           "y": 24,
-          "details": "lake surf=103 -> dry(-36,25) terr=90 cliff=13"
+          "details": "lake surf=103 -> dry(-36,25) terr=87 cliff=16"
         },
         {
           "x": -35,
@@ -25055,6 +25133,16 @@
           "x": -30,
           "y": 32,
           "details": "river surf=39 -> dry(-31,32) terr=37 cliff=2"
+        },
+        {
+          "x": -20,
+          "y": 30,
+          "details": "river surf=82 -> dry(-20,31) terr=79 cliff=3"
+        },
+        {
+          "x": -12,
+          "y": 11,
+          "details": "river surf=179 -> dry(-11,11) terr=177 cliff=2"
         },
         {
           "x": -2,

--- a/tools/baselines/seed99_size32_region_-4_-4_4_4.json
+++ b/tools/baselines/seed99_size32_region_-4_-4_4_4.json
@@ -14,9 +14,9 @@
     "deterministic": true,
     "distinctHashes": 1,
     "hashes": [
-      "250c3e93030bb6f4d470f8126b34ddf83a3a88eb2c6775ea57a749e4348813f3",
-      "250c3e93030bb6f4d470f8126b34ddf83a3a88eb2c6775ea57a749e4348813f3",
-      "250c3e93030bb6f4d470f8126b34ddf83a3a88eb2c6775ea57a749e4348813f3"
+      "2406c8c01790bef83498525cf513219f53cee68ae464311efa3e89615e9b44a2",
+      "2406c8c01790bef83498525cf513219f53cee68ae464311efa3e89615e9b44a2",
+      "2406c8c01790bef83498525cf513219f53cee68ae464311efa3e89615e9b44a2"
     ]
   },
   "tileCount": 20736,
@@ -106,13 +106,13 @@
       ]
     },
     "FLOATING_WATER": {
-      "min": 12,
-      "max": 12,
-      "median": 12,
+      "min": 10,
+      "max": 10,
+      "median": 10,
       "all": [
-        12,
-        12,
-        12
+        10,
+        10,
+        10
       ]
     },
     "ISOLATED_FLUID": {
@@ -123,6 +123,16 @@
         1,
         1,
         1
+      ]
+    },
+    "MID_RIVER_CLIFF": {
+      "min": 6,
+      "max": 6,
+      "median": 6,
+      "all": [
+        6,
+        6,
+        6
       ]
     },
     "MULTI_ISLAND": {
@@ -171,8 +181,9 @@
       "DESERT_SOIL_ON_SLOPE": 2,
       "FLAT_ISOLATED_WATER": 1,
       "FLOATING_LAKE": 4,
-      "FLOATING_WATER": 12,
+      "FLOATING_WATER": 10,
       "ISOLATED_FLUID": 1,
+      "MID_RIVER_CLIFF": 6,
       "MULTI_ISLAND": 2,
       "WATER_ABOVE_LAND": 12,
       "WATER_CLIFF": 12,
@@ -228,16 +239,6 @@
         },
         {
           "x": 36,
-          "y": -64,
-          "details": "river terr=17 -> dry(35,-64) terr=13 gap=4"
-        },
-        {
-          "x": 36,
-          "y": -63,
-          "details": "river terr=13 -> dry(35,-63) terr=11 gap=2"
-        },
-        {
-          "x": 36,
           "y": -62,
           "details": "river terr=10 -> dry(35,-62) terr=9 gap=1"
         },
@@ -289,6 +290,38 @@
           "details": "lake surf=0 surrounded by dry"
         }
       ],
+      "MID_RIVER_CLIFF": [
+        {
+          "x": 34,
+          "y": -63,
+          "details": "river surf=9 (terr=6) -> water nbr surf=7 (terr=6) surf_diff=2 terr_diff=0"
+        },
+        {
+          "x": 36,
+          "y": -63,
+          "details": "river surf=14 (terr=10) -> water nbr surf=11 (terr=10) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 37,
+          "y": -63,
+          "details": "river surf=16 (terr=12) -> water nbr surf=13 (terr=12) surf_diff=3 terr_diff=0"
+        },
+        {
+          "x": 38,
+          "y": -63,
+          "details": "river surf=18 (terr=15) -> water nbr surf=14 (terr=13) surf_diff=4 terr_diff=2"
+        },
+        {
+          "x": 43,
+          "y": -60,
+          "details": "river surf=6 (terr=3) -> water nbr surf=3 (terr=2) surf_diff=3 terr_diff=1"
+        },
+        {
+          "x": 44,
+          "y": -61,
+          "details": "river surf=9 (terr=6) -> water nbr surf=5 (terr=4) surf_diff=4 terr_diff=2"
+        }
+      ],
       "MULTI_ISLAND": [
         {
           "x": 5,
@@ -310,12 +343,12 @@
         {
           "x": 36,
           "y": -64,
-          "details": "river surf=18 terr=17 -> land(35,-64) terr=13 cliff=5"
+          "details": "river surf=18 terr=13 -> land(35,-64) terr=13 cliff=5"
         },
         {
           "x": 36,
           "y": -63,
-          "details": "river surf=14 terr=13 -> land(35,-63) terr=11 cliff=3"
+          "details": "river surf=14 terr=10 -> land(35,-63) terr=11 cliff=3"
         },
         {
           "x": 36,

--- a/tools/bed_report.py
+++ b/tools/bed_report.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""River/lake bed depth report — quality/measurement tool (no bug gating).
+
+The #223 instrument. Dumps worlds across seeds (terrain+fluid) and
+reports, per seed and in aggregate:
+
+  - river bed depth histogram (water column at each river tile,
+    fluidSurf - terrainZ): the pre-#223 world was ~95% exactly 1 z;
+    canyon/rift reaches now deepen to 4-9 z where valley walls stand
+    >= ~16 z over the water or the rift field is hot.
+  - canyon mileage: fraction of river tiles >= 5 z deep, and the
+    contiguous runs they form (a healthy world shows a few long runs,
+    not speckle).
+  - lake bodies by size class with max/median bed depth.
+  - graben candidates: inland lakes (surface above sea level) whose
+    interior reaches >= 8 z — the rift-lake signature (natural deep
+    basins like calderas also land here; the point is variety exists).
+
+Usage:
+  python3 tools/bed_report.py                     # default seeds, w64
+  python3 tools/bed_report.py --seeds 42,314 --worldSize 128
+  python3 tools/bed_report.py --files a.json b.json
+
+seaLevel is 0 in dump coordinates.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import Counter, deque
+
+DEFAULT_SEEDS = [4, 7, 42, 99, 123, 555, 777, 1337]
+
+DEEP_RIVER_Z = 5      # river tile counts as canyon mileage at this depth
+GRABEN_LAKE_Z = 8     # inland lake counts as deep-bed at this depth
+
+SIZE_CLASSES = [(1, 15, "tiny 1-15"), (16, 100, "small 16-100"),
+                (101, 1000, "mid 101-1000"), (1001, 10**9, "large >1000")]
+
+
+def run_dump(seed, world_size, plates=None):
+    half = world_size // 2
+    region = f"{-half},{-half},{half - 1},{half - 1}"
+    cmd = [
+        "cabal", "run", "-v0", "exe:synarchy", "--",
+        "--dump=terrain,fluid",
+        "--seed", str(seed),
+        "--worldSize", str(world_size),
+        "--region", region,
+    ]
+    if plates is not None:
+        cmd += ["--plates", str(plates)]
+    print(f"  generating seed {seed} (w{world_size})...",
+          file=sys.stderr, flush=True)
+    out = subprocess.run(cmd, stdout=subprocess.PIPE,
+                         stderr=subprocess.DEVNULL, check=True)
+    return json.loads(out.stdout)
+
+
+def cluster_sizes(tiles, link_radius=2):
+    """Sizes of connected clusters over a tile set, linking within
+    Chebyshev link_radius (rivers are thin; radius 2 bridges the odd
+    1-tile gap along a channel)."""
+    seen = set()
+    sizes = []
+    for start in tiles:
+        if start in seen:
+            continue
+        q = deque([start])
+        seen.add(start)
+        n = 0
+        while q:
+            x, y = q.popleft()
+            n += 1
+            for dx in range(-link_radius, link_radius + 1):
+                for dy in range(-link_radius, link_radius + 1):
+                    t = (x + dx, y + dy)
+                    if t in tiles and t not in seen:
+                        seen.add(t)
+                        q.append(t)
+        sizes.append(n)
+    sizes.sort(reverse=True)
+    return sizes
+
+
+def lake_bodies(lake_depth):
+    """Connected lake bodies (4-adjacency) -> list of sorted depth lists."""
+    seen = set()
+    bodies = []
+    for start in lake_depth:
+        if start in seen:
+            continue
+        q = deque([start])
+        seen.add(start)
+        depths = []
+        while q:
+            x, y = q.popleft()
+            depths.append(lake_depth[(x, y)])
+            for t in ((x + 1, y), (x - 1, y), (x, y + 1), (x, y - 1)):
+                if t in lake_depth and t not in seen:
+                    seen.add(t)
+                    q.append(t)
+        depths.sort()
+        bodies.append(depths)
+    return bodies
+
+
+def analyze(tiles, label):
+    river_hist = Counter()
+    deep_river = set()
+    lake_depth = {}
+    lake_surf = {}
+    for t in tiles:
+        ft = t.get("fluidType")
+        if ft not in ("river", "lake"):
+            continue
+        fs, tz = t.get("fluidSurf"), t.get("terrainZ")
+        if fs is None or tz is None:
+            continue
+        d = fs - tz
+        if ft == "river":
+            river_hist[d] += 1
+            if d >= DEEP_RIVER_Z:
+                deep_river.add((t["x"], t["y"]))
+        else:
+            lake_depth[(t["x"], t["y"])] = d
+            lake_surf[(t["x"], t["y"])] = fs
+
+    print(f"\n--- {label} ---")
+
+    n_river = sum(river_hist.values())
+    if n_river:
+        top = " ".join(f"{k}:{100 * v / n_river:.1f}%"
+                       for k, v in sorted(river_hist.items()))
+        print(f"rivers: {n_river} tiles | {top}")
+        runs = cluster_sizes(deep_river)
+        canyon_pct = 100 * len(deep_river) / n_river
+        print(f"  canyon mileage (>= {DEEP_RIVER_Z} z): "
+              f"{len(deep_river)} tiles ({canyon_pct:.1f}%) in "
+              f"{len(runs)} runs, longest {runs[:5]}")
+    else:
+        print("rivers: none in region")
+
+    bodies = lake_bodies(lake_depth)
+    for lo, hi, name in SIZE_CLASSES:
+        sel = [b for b in bodies if lo <= len(b) <= hi]
+        if not sel:
+            continue
+        maxs = sorted(b[-1] for b in sel)
+        meds = sorted(b[len(b) // 2] for b in sel)
+        n = len(sel)
+        print(f"  lakes {name:14s}: {n:4d} bodies | "
+              f"max-depth p50={maxs[n // 2]:3d} p90={maxs[int(n * .9)]:3d} "
+              f"| med-depth p50={meds[n // 2]:3d}")
+    # deep-bed lakes (graben signature; includes natural deep basins)
+    graben = sum(1 for depths in bodies if depths[-1] >= GRABEN_LAKE_Z)
+    print(f"  deep-bed lakes (max >= {GRABEN_LAKE_Z} z): "
+          f"{graben} of {len(bodies)} bodies")
+
+    return {
+        "river_tiles": n_river,
+        "river_le1": sum(v for k, v in river_hist.items() if k <= 1),
+        "canyon_tiles": len(deep_river),
+        "lake_bodies": len(bodies),
+        "deep_lakes": graben,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(description="River/lake bed depth report")
+    ap.add_argument("--seeds", default=None,
+                    help="comma-separated seeds (default: canonical 8)")
+    ap.add_argument("--worldSize", type=int, default=64)
+    ap.add_argument("--plates", type=int, default=None)
+    ap.add_argument("--files", nargs="*", default=None,
+                    help="analyze pre-dumped JSON files instead of generating")
+    args = ap.parse_args()
+
+    if args.files:
+        runs = [(f, json.load(open(f))) for f in args.files]
+    else:
+        seeds = ([int(s) for s in args.seeds.split(",")]
+                 if args.seeds else DEFAULT_SEEDS)
+        runs = [(f"seed {s}", run_dump(s, args.worldSize, args.plates))
+                for s in seeds]
+
+    agg = Counter()
+    for label, tiles in runs:
+        for k, v in analyze(tiles, label).items():
+            agg[k] += v
+
+    print(f"\n=== SUMMARY ({len(runs)} worlds) ===")
+    rt = agg["river_tiles"]
+    if rt:
+        print(f"  river tiles {rt}: depth<=1 {100 * agg['river_le1'] / rt:.1f}%"
+              f", canyon mileage {100 * agg['canyon_tiles'] / rt:.1f}%")
+    print(f"  lake bodies {agg['lake_bodies']}, "
+          f"deep-bed (>= {GRABEN_LAKE_Z} z) {agg['deep_lakes']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #223.

Investigation summary + agreed approach: https://github.com/coghex/synarchy/issues/223#issuecomment-4872304376 (interactive session 2026-07-02/03; all four design decisions confirmed by the owner).

## What this does

**Rivers** — the final channel-bed fit topped every river tile to exactly `surface − depthFromRadius(width)`, flat across the cross-section: **92–96% of river tiles were 1 z deep** in every setting. `computeCarveDelta` now consumes a per-tile bed depth (`computeBedDepth`):

- **Ordinary reaches keep the historical flat shallow fit exactly** (the issue explicitly wants lowland rivers to stay shallow/flat — they're accurate).
- **Confined reaches** (valley walls ≥ ~16 z above the water within 2 tiles — calibrated on a wall-height census, see below) and **rifted reaches** (new tectonic field) deepen to 4–9 z, with a **thalweg cross-section** (deepest at the centreline, 1 z shallower per wing tile out) and **pool/riffle noise** (±1–2 z, ~12-tile wavelength) so deep beds read as carved channels, not flat boxes.
- The boost is smoothed along the channel (2 passes over river 4-neighbours) and may only deepen while the bed stays **above sea level** — **zero river/lake/ocean classification flips vs master** on diffed seeds.

**Lakes** — there was **no bed model at all** (bed = natural basin floor; big lakes were already deep by accident, small ones all pans, zero tectonic correlation). New `World.Fluid.Lake.Graben` pass: inland lakes (surface > sea) of ≥ 24 tiles whose footprint-mean rift intensity ≥ 0.35 get a graben profile — untouched shore shelf (rings 0–1), 3 z/tile walls from ring 2, floor at `surface − (8..24 by intensity)` with ±2 z relief noise. Rides the existing serialized `wlCarveDelta` plumbing (Timeline zeroed it for the seabed handoff; grabens are inland-only, so no overlap), strictly lower-only, and **alias seam copies carve identically** (verified: near-seam lake pairs produce identical deepened-tile counts).

**Rift field** — `World.Plate.riftCellIntensity` / `riftFieldMemo`: the #220 tectonic cell-field machinery sampling **Divergent** boundary strength with a tighter fade (nearR 16 / fadeR 64 vs the coast's 40/200 — rift valleys hug the spreading boundary). Shared cell-centre sampling factored into `cellBoundarySample` (pure code motion for the coastal path; wrap-exact grid unchanged).

## Calibration evidence

- Wall-height census (seed 42 w128): radius-2 scan is the honest "channel wall" signal (radius 4 reads nearby hills as confinement — first cut boosted 40% of river mileage; shipped constants land at ~15%).
- Post-change seed 42 w128: 80.8% of river tiles stay depth 1; deep (≥5 z) = 5.3% in 69 contiguous runs (top: 95, 70, 53 tiles) — canyon stretches, not speckle.
- Cross-seed (`tools/bed_report.py`, 8 seeds w64): canyon mileage **3.2%–25.3% by seed** (real per-world tectonic character), aggregate 13.8%, depth ≤ 1 at 67%.
- Graben verification (temp instrumentation, since removed): seed 1337 lake of 856 tiles deepens 718; seed 7's 30k-tile inland sea (riftMean 0.36 — a Tanganyika analogue) deepens 11k tiles; lakes whose natural floors already beat the target correctly no-op.

## Save / compat

Values-only worldgen change (no serialized layout change; identification, surfaces, and masks untouched — beds only). Fresh gen only; loaded saves keep their serialized carve deltas verbatim → **no save-version bump** (per the #221 precedent).

## Testing

- New `Test.Headless.WorldGen.BedDepth` (11 examples): rift field bounds / memo≡direct / wrap-exactness; bed model base-fit preservation, caps, sea clamp; graben eligibility gates + shore shelf.
- `SYNARCHY_FULL_TESTS=1 cabal test synarchy-test-headless`: **523/523**.
- `tools/world_baseline.py`: 21/21 recaptured, deterministic (tier-3 rebaseline in its own commit).
- `tools/world_check.py`: **21/21 PASS, 0 bugs**.
- `tools/test_audit.py`: 35/35.
- Fresh full build (`--builddir=dist-force`): zero warnings (CI `-Werror` safe).
- New measurement tool `tools/bed_report.py` (coast_report pattern) for ongoing bed-depth QA.

GUI eyeball still pending (headless session) — canyon reaches and graben lakes are worth a visual pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)