### PR TITLE
#265 Derived unit roles: emergent skill-derived labels weight work selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,6 +316,26 @@ phase; the stake phase runs LAST (the staked portal spawns its roster,
 which would contaminate later phases). Structure build costs live in
 the pack YAML's `build:` block (`data/structure_packs/*.yaml`).
 
+### Testing derived unit roles headless
+
+Roles (#265) are DERIVED labels, never assigned: the highest work
+skill ≥ 30 (with +5 switch hysteresis) names the role — mining→Miner,
+woodcutting→Woodcutter, construction→Builder, smithing→Smith, else
+Laborer; units with no work skills (wildlife, technomule) have none.
+Definitions + weights live in `scripts/unit_roles.lua`; the role
+multiplies matching work-action ENTRY utilities (on-role ×1.4,
+off-role ×0.7 — never the 6.0 in-progress locks, never survival/
+combat/orders). Skills grow with use (dig→mining, fell→woodcutting,
+piece placed→construction), so units specialise emergently. Query with
+`unitAi.getRole(uid)`; the unit-info header Role row displays it.
+
+Turnkey harness: **`python3 tools/role_probe.py`** — the #265 gate.
+Boots headless on a real world (needs a tree) and asserts derivation +
+hysteresis + demotion, no-role species, steering (same geometry, a
+woodcutter picks the chop job while a miner picks the dig job), and
+work-XP growth incl. the legacy-save lazy seeding path
+(`grantWorkXP`).
+
 ### Testing crafting recipes headless
 
 Turnkey harness: **`python3 tools/craft_probe.py`** — the

--- a/data/units/acolyte.yaml
+++ b/data/units/acolyte.yaml
@@ -65,6 +65,17 @@ units:
       # per completed tile (dig_xp_per_tile in unit_ai params).
       # Acolytes arrive as novice excavators — wide spread.
       mining:  { base: 25.0, range: 30.0 }
+      # Woodcutting: scales chop rate in the chop AI the same way —
+      # factor = 0.5 + woodcutting/100. Gains XP per felled tree
+      # (chop_xp_per_fell). Feeds the derived Woodcutter role (#265).
+      # Same novice spread as mining so a fresh cohort has a natural
+      # mix of talents.
+      woodcutting: { base: 25.0, range: 30.0 }
+      # Construction: scales the construct AI's build-progress rate —
+      # factor = 0.5 + construction/100. Gains XP per structure piece
+      # placed (construct_xp_per_piece). Feeds the derived Builder
+      # role (#265).
+      construction: { base: 25.0, range: 30.0 }
       # Leap/grapple: acolytes arrive untrained — a lunge is a rare,
       # costly move only a skilled fighter pulls off, so these grow with
       # XP from a low base rather than starting combat-ready.

--- a/scripts/unit_ai.lua
+++ b/scripts/unit_ai.lua
@@ -29,6 +29,9 @@ package.loaded["scripts.unit_ai"] = unitAi
 -- Shared comfort/ordered/sprint speed model (see movement_speed.lua).
 local mv = require("scripts.movement_speed")
 local brain = require("scripts.brain")
+-- Derived roles (#265): skill-derived labels that weight work-action
+-- ENTRY utilities (locks stay untouched — see unit_roles.lua header).
+local roles = require("scripts.unit_roles")
 
 -- Report a FAILED job/task to the player as a red unit_warning in the
 -- event log (and the unit's per-unit Log). The engine coalesces
@@ -43,6 +46,20 @@ local function reportFailure(uid, msg)
     else
         engine.emitEventForUnit("unit_warning", msg, uid)
     end
+end
+
+-- Grant work-skill XP, seeding the key first when it's missing:
+-- unit.addXP no-ops on a skill the unit doesn't have, and units from
+-- saves that predate a skill (woodcutting/construction, #265) lack the
+-- key. Seed at the acolyte.yaml base (25) so a legacy veteran starts a
+-- new skill as the same novice a fresh spawn rolls around.
+local WORK_SKILL_SEED = 25.0
+local function grantWorkXP(uid, skill, amount)
+    if amount <= 0 then return end
+    if not unit.getSkill(uid, skill) then
+        unit.setSkill(uid, skill, WORK_SKILL_SEED)
+    end
+    unit.addXP(uid, skill, amount)
 end
 
 -----------------------------------------------------------
@@ -69,6 +86,12 @@ end
 -- a routine goal; and a goal only climbs above a command when the
 -- underlying NEED (thirst→drink/refill) does, which is derived. See the
 -- FOLLOW_COMMAND_UTILITY block and the per-action notes for the values.
+--
+-- Derived roles (#265) reshuffle preference WITHIN the routine band
+-- only: work ENTRY utilities are multiplied by ×1.4 (on-role) / ×0.7
+-- (off-role), capped by construction below the 6.0 locks (max weighted
+-- entry = deliver 4.0 · 1.4 = 5.6), so a role can never lift routine
+-- work over a player order or drop an in-progress job's lock.
 local config = {
     acolyte = {
         thought_interval = 1.0,    -- seconds between decisions
@@ -234,6 +257,9 @@ local config = {
         construct_lock_utility  = 6.0,
         construct_rate          = 1.0,
         construct_claim_timeout = 30.0,  -- stale-claim expiry (seconds)
+        construct_xp_per_piece  = 1.0,   -- construction XP per placed
+                                         -- piece (#265; diminishing via
+                                         -- applySkillXP, like mining)
         -- Auto-store materials. Utility curve = base · fill³ where
         -- fill = carrying_weight / carrying_capacity. Below ~65 %
         -- full the action sits under wander (0.8); past that it
@@ -296,6 +322,9 @@ local config = {
                                       -- deliberately slower than foraging)
         chop_equip_seconds   = 1.0,
         chop_claim_timeout   = 30.0,  -- stale-claim expiry (seconds)
+        chop_xp_per_fell     = 2.0,   -- woodcutting XP per felled tree
+                                      -- (#265): a fell is one chunky job
+                                      -- vs dig's 1.0/tile
         chop_stock_target    = 20,    -- colony logs at which urgency floors
         chop_stock_floor     = 0.5,
         chop_bare_speed      = 0.25,  -- no axe: hacking with what's at hand
@@ -376,6 +405,10 @@ local SEARCH_DIRECTIONS = {
 --   commandedTask      = { x, y, speed, startedAt } | nil,
 --   knownWaterSources  = { {x, y}, ... },   -- dedup'd by distance;
 --                                           -- empty list = none known
+--   role               = "miner"|"woodcutter"|"builder"|"smith"
+--                        |"laborer"| nil,   -- derived each thought
+--                                           -- tick (unit_roles.lua);
+--                                           -- nil = not a worker
 -- }
 unitAi.aiState = unitAi.aiState or {}
 local aiState = unitAi.aiState
@@ -2519,7 +2552,9 @@ local function deliverUtility(uid, s, params)
     if not target then return -math.huge end
 
     s.deliveryPendingTarget = target
-    return params.deliver_utility
+    -- Role weight (#265) on the entry only — the 6.0 claim lock above
+    -- stays flat. Max weighted entry = 4.0 · 1.4 = 5.6 < 6.0.
+    return params.deliver_utility * roles.weight(s, "deliver_to_build_site")
 end
 
 local function deliverExecute(uid, s, params)
@@ -2699,6 +2734,7 @@ local function storeMaterialsUtility(uid, s, params)
 
     s.storeTarget = target.bid
     return params.store_base_utility * fill * fill * fill
+         * roles.weight(s, "store_materials")
 end
 
 local function storeMaterialsExecute(uid, s, params)
@@ -2862,6 +2898,7 @@ local function buildNearbyUtility(uid, s, params)
     end
 
     return params.build_base_utility * fill * distFactor
+         * roles.weight(s, "build_nearby")
 end
 
 local function buildNearbyExecute(uid, s, params)
@@ -3104,6 +3141,7 @@ local function constructUtility(uid, s, params)
     s.constructCandidate = cand
     local distFactor = math.max(0, 1 - cand.dist / params.construct_scan_range)
     return params.construct_base_utility * distFactor
+         * roles.weight(s, "construct_job")
 end
 
 -- Stand position: centre of the neighbouring tile nearest the unit —
@@ -3281,13 +3319,20 @@ local function constructExecute(uid, s, params)
         local elapsed = now - (s.lastConstructAt or now)
         s.lastConstructAt = now
         if elapsed > 0 then
-            local delta = params.construct_rate * elapsed / job.work
+            -- Construction skill scales the pour rate the same way
+            -- mining scales dig and woodcutting scales chop: level 50
+            -- ≈ baseline, level 0 half rate (#265).
+            local conSkill = unit.getSkill(uid, "construction") or 25.0
+            local delta = params.construct_rate * (0.5 + conSkill / 100.0)
+                        * elapsed / job.work
             job.progress = (job.progress or 0) + delta
             construction.addJobProgress(wid, job.x, job.y, delta)
         end
         if (job.progress or 0) >= 1.0 then
             placeStructurePiece(job)
             construction.setJobStatus(wid, job.x, job.y, "complete")
+            grantWorkXP(uid, "construction",
+                        params.construct_xp_per_piece or 0)
             releaseConstructJob(s, uid)
         end
         return
@@ -3430,6 +3475,7 @@ local function digUtility(uid, s, params)
 
     local distFactor = math.max(0, 1 - dist / params.dig_scan_range)
     return params.dig_base_utility * math.min(speed, 1.0) * distFactor
+         * roles.weight(s, "dig_designation")
 end
 
 -- Corner geometry (grid space, matches mdCorners order NW,NE,SE,SW):
@@ -3747,6 +3793,7 @@ local function chopUtility(uid, s, params)
     local distFactor = math.max(0, 1 - dist / params.chop_scan_range)
     return params.chop_base_utility * distFactor
          * woodStockFactor(uid, params)
+         * roles.weight(s, "chop_designation")
 end
 
 local function chopExecute(uid, s, params)
@@ -3833,10 +3880,15 @@ local function chopExecute(uid, s, params)
         local dt = math.min(now - (s.lastChopAt or now), 2.0)
         s.lastChopAt = now
         -- Muscle swings the axe; an axe bites deeper than bare hands.
+        -- Woodcutting skill rides along like mining does for dig:
+        -- level 50 ≈ baseline, level 0 half rate (#265). Legacy-save
+        -- units without the key fell at the yaml novice base.
         local strength = unit.getStat(uid, "strength") or 1.0
         local speed = bestChopSpeed(uid, params)
+        local wcSkill = unit.getSkill(uid, "woodcutting") or 25.0
         s.chopProgress = (s.chopProgress or 0)
-                       + params.chop_rate * speed * strength * dt
+                       + params.chop_rate * speed * strength
+                       * (0.5 + wcSkill / 100.0) * dt
         if s.chopProgress >= 1.0 then
             -- Felled. The "wood" tag scopes the harvest so a shared
             -- tile can't trade its berry bush for the tree; the yield
@@ -3844,6 +3896,7 @@ local function chopExecute(uid, s, params)
             -- nil result (species died / raced) still completes.
             world.harvestFlora(job.x, job.y, "wood")
             chop.cancelDesignation(job.x, job.y)
+            grantWorkXP(uid, "woodcutting", params.chop_xp_per_fell or 0)
             chopComplete(uid, s)
         end
         return
@@ -4538,6 +4591,11 @@ local function tickOne(uid, defName)
 
     if engine.gameTime() < s.nextActionAt then return end
 
+    -- Re-derive the unit's role (#265) once per thought tick, before
+    -- scoring — the work entry utilities below read s.role via
+    -- roles.weight.
+    roles.update(uid, s)
+
     -- Score every action; pick the highest. Ties → first in list.
     local bestAction, bestScore = nil, -math.huge
     for _, a in ipairs(actList) do
@@ -4732,6 +4790,15 @@ end
 -----------------------------------------------------------
 function unitAi.getState(uid)
     return aiState[uid]
+end
+
+-- | Public: the unit's derived role (#265) — "miner" | "woodcutter" |
+--   "builder" | "smith" | "laborer", or nil for non-workers (wildlife,
+--   technomule) and units the AI hasn't ticked yet. The unit-info
+--   panel maps it through unit_roles.display for the header Role row.
+function unitAi.getRole(uid)
+    local s = aiState[uid]
+    return s and s.role or nil
 end
 
 -- | Public: how many acolytes are currently standing within Chebyshev

--- a/scripts/unit_info_v2.lua
+++ b/scripts/unit_info_v2.lua
@@ -65,6 +65,7 @@ unitInfoV2.lastContentTab = nil
 -- Header
 unitInfoV2.headerNameLabelId   = nil  -- the name row; refreshed per active unit (#264)
 unitInfoV2.headerTypeLabelId   = nil  -- the "acolyte" row; refreshed per active unit
+unitInfoV2.headerRoleLabelId   = nil  -- the role row; refreshed per active unit from unit_ai (#265)
 unitInfoV2.headerActionLabelId = nil  -- the action row; refreshed per active unit from unit_ai
 
 -- Equipment section. equipRect is the section rect; equipElements is
@@ -3318,10 +3319,11 @@ end
 -----------------------------------------------------------
 -- Header: stacks Name / Type / Role / Action rows in a virtual rect.
 -- No box around it; section boundaries are marked by horizontal rules.
--- Name (#264), Type and Action are live — Name shows the unit's personal
--- name (or species label for the unnamed), Type shows the unit's def
--- name, Action shows the current AI action mapped through ACTION_DISPLAY
--- below. Role remains a placeholder (see #265).
+-- All four rows are live — Name shows the unit's personal name (#264,
+-- or species label for the unnamed), Type shows the unit's def name,
+-- Role shows the derived role (#265, unitAi.getRole mapped through
+-- unit_roles.display; "—" for non-workers), Action shows the current
+-- AI action mapped through ACTION_DISPLAY below.
 -----------------------------------------------------------
 
 -- Map unit_ai action names → human-readable display strings.
@@ -3340,24 +3342,30 @@ local ACTION_DISPLAY = {
     build_nearby       = "Working",
     deliver_to_build_site = "Delivering materials",
     store_materials       = "Storing materials",
+    construct_job      = "Constructing",
+    dig_designation    = "Digging",
+    chop_designation   = "Chopping",
+    forage             = "Foraging",
+    pickup_ground      = "Picking up",
+    treat_ally         = "Treating ally",
+    engage             = "Engaging",
+    retreat            = "Retreating",
+    attack_target      = "Fighting",
 }
 
 local function placeHeader(x, y, w, h)
-    -- Row 4 starts as a dash; the tick refresh fills it in from the
-    -- selected unit's currentAction.
-    local rows = { "Name", "acolyte", "Role", "—" }
+    -- Rows 3 and 4 start as dashes; the tick refresh fills them in
+    -- from the selected unit's derived role and currentAction.
+    local rows = { "Name", "acolyte", "—", "—" }
     local rowH = math.floor(h / #rows)
     local fontSize = 16
     for i, text in ipairs(rows) do
-        local isLive = (i == 1 or i == 2 or i == 4)  -- name + type + action are real content
         local lblId = label.new({
             name     = "unit_info_v2_header_row" .. i,
             text     = text,
             font     = hud.menuFont,
             fontSize = fontSize,
-            color    = isLive
-                          and {1.0, 1.0, 1.0, 1.0}      -- bright
-                          or  {0.75, 0.75, 0.75, 1.0},  -- placeholders: dim
+            color    = {1.0, 1.0, 1.0, 1.0},
             page     = unitInfoV2.page,
             uiscale  = 1.0,
         })
@@ -3371,6 +3379,8 @@ local function placeHeader(x, y, w, h)
             unitInfoV2.headerNameLabelId = lblId
         elseif i == 2 then
             unitInfoV2.headerTypeLabelId = lblId
+        elseif i == 3 then
+            unitInfoV2.headerRoleLabelId = lblId
         elseif i == 4 then
             unitInfoV2.headerActionLabelId = lblId
         end
@@ -3644,15 +3654,26 @@ function unitInfoV2.update(dt)
         label.setText(unitInfoV2.headerTypeLabelId, typeName)
     end
 
-    -- Header action row: pull currentAction from unit_ai and map it
-    -- through ACTION_DISPLAY. Unmapped names show raw so unknown
-    -- actions are visible rather than blank.
-    if unitInfoV2.activeUid and unitInfoV2.headerActionLabelId then
+    -- Header role + action rows: pull the derived role (#265) and
+    -- currentAction from unit_ai. Actions map through ACTION_DISPLAY;
+    -- unmapped names show raw so unknown actions are visible rather
+    -- than blank. Non-workers (wildlife, technomule) have no role and
+    -- show "—".
+    if unitInfoV2.activeUid
+       and (unitInfoV2.headerRoleLabelId or unitInfoV2.headerActionLabelId) then
         local unitAi = require("scripts.unit_ai")
         local aiSt = unitAi.getState and unitAi.getState(unitInfoV2.activeUid)
-        local action = aiSt and aiSt.currentAction
-        local text = (action and (ACTION_DISPLAY[action] or action)) or "—"
-        label.setText(unitInfoV2.headerActionLabelId, text)
+        if unitInfoV2.headerRoleLabelId then
+            local unitRoles = require("scripts.unit_roles")
+            local role = aiSt and aiSt.role
+            label.setText(unitInfoV2.headerRoleLabelId,
+                          unitRoles.display(role) or "—")
+        end
+        if unitInfoV2.headerActionLabelId then
+            local action = aiSt and aiSt.currentAction
+            local text = (action and (ACTION_DISPLAY[action] or action)) or "—"
+            label.setText(unitInfoV2.headerActionLabelId, text)
+        end
     end
 
     -- Refresh every visible tab's portrait. Prefer the unit def's

--- a/scripts/unit_roles.lua
+++ b/scripts/unit_roles.lua
@@ -1,0 +1,148 @@
+-- Derived unit roles (#265).
+--
+-- A role is a LABEL derived from a unit's work skills — never assigned,
+-- never stored engine-side. The highest work skill at or above
+-- THRESHOLD names the role; a unit with no work skill that high is a
+-- generalist "laborer", and a unit with no work skills at all (wildlife,
+-- technomule) has no role. Because skills grow with use (dig grants
+-- mining XP, chop grants woodcutting XP, …) and the role in turn
+-- weights the matching work actions' utilities, units gradually
+-- specialise into whatever they're naturally good at — emergent
+-- professions, no player bookkeeping.
+--
+-- The derived role lives on the unit's aiState (`s.role`) and is
+-- recomputed every thought tick with hysteresis (SWITCH_MARGIN) so two
+-- close skills can't flap the label back and forth. Nothing here needs
+-- save support: skills already persist in uiSkills, and re-deriving on
+-- load lands on the same answer.
+--
+-- Weighting contract (see the utility ladder in unit_ai.lua): weights
+-- apply ONLY to work-action ENTRY utilities, never to in-progress lock
+-- values (6.0). Boosting a lock would climb past player orders (7.0);
+-- dampening one would let another work entry steal an in-progress job.
+-- Entry utilities top out at deliver's 4.0, so ON_ROLE must stay below
+-- 6.0/4.0 = 1.5 to keep every weighted entry inside the routine band.
+
+local M = package.loaded["scripts.unit_roles"] or {}
+package.loaded["scripts.unit_roles"] = M
+
+-- Derivation order is the tie-break: earlier entries win an exact
+-- skill tie, so listing is deterministic (pairs() order is not).
+--
+-- `family` groups the work actions a role prefers. smith has no work
+-- actions yet — the craft AI is #329 — so its family ("craft") appears
+-- in no ACTION_FAMILY entry and the role stays weight-neutral: a pure
+-- label until crafting gives it work to favor.
+M.ROLES = {
+    { name = "miner",      display = "Miner",      skill = "mining",       family = "mine"  },
+    { name = "woodcutter", display = "Woodcutter", skill = "woodcutting",  family = "wood"  },
+    { name = "builder",    display = "Builder",    skill = "construction", family = "build" },
+    { name = "smith",      display = "Smith",      skill = "smithing",     family = "craft" },
+}
+
+-- Work action → family. deliver/store/build_nearby serve build sites,
+-- so they ride with the Builder. Need- and order-driven actions
+-- (forage, pickup_ground, follow_command, survival, combat) are
+-- deliberately absent: roles only steer ROUTINE work preference.
+M.ACTION_FAMILY = {
+    dig_designation       = "mine",
+    chop_designation      = "wood",
+    construct_job         = "build",
+    build_nearby          = "build",
+    deliver_to_build_site = "build",
+    store_materials       = "build",
+}
+
+M.THRESHOLD     = 30.0   -- min skill to claim a specialist role
+M.SWITCH_MARGIN = 5.0    -- hysteresis: challenger must beat the
+                         -- incumbent (or the threshold, on demotion
+                         -- to laborer) by this much
+M.ON_ROLE       = 1.4    -- entry-utility boost for the role's family
+M.OFF_ROLE      = 0.7    -- entry-utility damp for other work families
+
+local byName = {}
+for _, r in ipairs(M.ROLES) do byName[r.name] = r end
+
+-- Families that actually map to work actions (smith's "craft" won't
+-- appear here until #329 lands crafting work actions).
+local familyHasActions = {}
+for _, fam in pairs(M.ACTION_FAMILY) do familyHasActions[fam] = true end
+
+-- Display string for a role name ("laborer" is the generalist default
+-- and has no ROLES entry). nil → nil so callers can render "—".
+function M.display(role)
+    if not role then return nil end
+    if role == "laborer" then return "Laborer" end
+    local r = byName[role]
+    return r and r.display or role
+end
+
+-- Re-derive s.role from the unit's current EFFECTIVE work skills
+-- (getSkill includes modifiers). Called once per thought tick.
+function M.update(uid, s)
+    local best, bestLvl, any = nil, -1, false
+    for _, r in ipairs(M.ROLES) do
+        local lvl = unit.getSkill(uid, r.skill)
+        if lvl then
+            any = true
+            if lvl > bestLvl then best, bestLvl = r.name, lvl end
+        end
+    end
+    if not any then
+        -- No work skills at all: not a worker (wildlife, technomule).
+        s.role = nil
+        return
+    end
+
+    local candidate = (bestLvl >= M.THRESHOLD) and best or "laborer"
+    local cur = s.role
+    if cur == candidate or cur == nil then
+        s.role = candidate
+        return
+    end
+
+    if cur == "laborer" then
+        -- Promotion out of laborer: the threshold is the gate.
+        s.role = candidate
+        return
+    end
+
+    -- cur is a specialist role. Hysteresis:
+    local curDef = byName[cur]
+    local curLvl = curDef and unit.getSkill(uid, curDef.skill) or 0
+    if candidate == "laborer" then
+        -- Demote only when the incumbent skill has clearly sunk below
+        -- the threshold (an expiring modifier hovering at 30 must not
+        -- flap Miner ↔ Laborer).
+        if curLvl < M.THRESHOLD - M.SWITCH_MARGIN then
+            s.role = "laborer"
+        end
+        return
+    end
+    -- Specialist → different specialist: the challenger must beat the
+    -- incumbent's skill by the margin, not just edge past it.
+    if bestLvl >= curLvl + M.SWITCH_MARGIN then
+        s.role = candidate
+    end
+end
+
+-- Entry-utility multiplier for `actionName` under the unit's current
+-- role. 1.0 whenever the role has no opinion: non-work actions,
+-- role-less units, laborers, and roles whose family has no actions
+-- yet (smith).
+function M.weight(s, actionName)
+    local family = M.ACTION_FAMILY[actionName]
+    if not family then return 1.0 end
+    local role = s and s.role
+    if not role or role == "laborer" then return 1.0 end
+    local r = byName[role]
+    if not r then return 1.0 end
+    if r.family == family then return M.ON_ROLE end
+    -- Off-role damp only for roles that HAVE a work family to favor —
+    -- a smith dampening dig/chop/build while owning no work actions
+    -- would just idle more.
+    if not familyHasActions[r.family] then return 1.0 end
+    return M.OFF_ROLE
+end
+
+return M

--- a/tools/role_probe.py
+++ b/tools/role_probe.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Derived unit-role probe (#265) — the gate for scripts/unit_roles.lua.
+
+Boots a headless engine on a real generated world (the steering phase
+needs a choppable tree, and the arena has no flora), then checks:
+
+  1. Derivation: a fresh acolyte derives SOME role within a few thought
+     ticks (spawn skill rolls land on laborer or a natural specialist);
+     forcing mining high derives "miner"; a challenger inside the
+     SWITCH_MARGIN does NOT flip the role (hysteresis) while one past
+     the margin does; dropping every work skill below the threshold
+     demotes to "laborer"; a technomule (no work skills) derives no
+     role at all.
+  2. Steering: with a chop designation (real tree) and a mine
+     designation live at comparable distance, a woodcutting-skilled
+     unit picks chop_designation as its first work action and a
+     mining-skilled unit picks dig_designation — the ON_ROLE/OFF_ROLE
+     entry weights (1.4 / 0.7) beat the geometry, and the two runs
+     share the same geometry so a distance bias can't fake a pass.
+  3. XP: felling the tree grows the feller's woodcutting skill
+     (chop_xp_per_fell through grantWorkXP), and completing a structure
+     floor grows construction (construct_xp_per_piece) — including the
+     lazy seeding path for units that lack the key.
+
+Usage: python3 tools/role_probe.py [--port 9265] [--seed 42]
+       [--size 64] [--plates 3]
+"""
+import argparse, glob, json, socket, subprocess, sys, time
+
+SPROOT = "/tmp"
+
+
+def send(port, lua, timeout=10.0):
+    with socket.create_connection(("localhost", port), timeout=timeout) as s:
+        s.settimeout(timeout)
+        f = s.makefile("rw")
+        f.readline()              # banner
+        f.write(lua + "\n")
+        f.flush()
+        return f.readline().strip().lstrip("> ").strip()
+
+
+def jget(port, lua, timeout=10.0):
+    raw = send(port, lua, timeout)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw.strip('"')
+
+
+def boot(port, log_path):
+    log = open(log_path, "w")
+    proc = subprocess.Popen(
+        ["cabal", "run", "-v0", "exe:synarchy", "--",
+         "--headless", "--port", str(port)],
+        stdout=log, stderr=subprocess.STDOUT)
+    for _ in range(300):
+        time.sleep(0.2)
+        try:
+            if "READY" in open(log_path).read():
+                return proc
+        except FileNotFoundError:
+            pass
+    sys.exit("engine never printed READY")
+
+
+def bootstrap(port):
+    for pattern, fn in [
+        ("data/substances/*.yaml", "engine.loadSubstanceYaml"),
+        ("data/infections/*.yaml", "engine.loadInfectionYaml"),
+        ("data/items/*.yaml",      "engine.loadItemYaml"),
+        ("data/equipment/*.yaml",  "engine.loadEquipmentYaml"),
+        ("data/materials/*.yaml",  "engine.loadMaterialYaml"),
+        ("data/flora/*.yaml",      "engine.loadFloraYaml"),
+        ("data/units/*.yaml",      "engine.loadUnitYaml"),
+    ]:
+        for path in sorted(glob.glob(pattern)):
+            send(port, f"{fn}('{path}'); return 'ok'")
+
+
+def find_wood(port, span=4):
+    """Nearest wood-tagged harvestable tile; (gx, gy, species) or None."""
+    for sx in range(-span * 16, span * 16 + 1, 32):
+        for sy in range(-span * 16, span * 16 + 1, 32):
+            r = jget(port,
+                     f"return world.findHarvestableFlora({sx},{sy},64,'wood')")
+            if isinstance(r, dict):
+                return r["gx"], r["gy"], r["id"]
+    return None
+
+
+def spawn_worker(port, x, y):
+    """Spawn an acolyte, quiet its find_water goal (the water-search
+    spiral outranks menial work and walks scouts off cliffs), and
+    return its uid (or -1)."""
+    uid_s = send(port, f"local u=unit.spawn('acolyte',{x},{y}); return u")
+    try:
+        uid = int(float(uid_s.strip('"')))
+    except ValueError:
+        return -1
+    time.sleep(2.0)
+    quiet = send(port,
+                 f"local ai=require('scripts.unit_ai'); "
+                 f"local s=ai.getState({uid}); "
+                 f"if s then ai.markGoalAccomplished(s,'find_water'); "
+                 f"unit.stop({uid}); return 'ok' "
+                 f"else return 'nostate' end").strip('"')
+    return uid if quiet == "ok" else -1
+
+
+def set_work_skills(port, uid, mining, woodcutting, construction, smithing):
+    send(port,
+         f"unit.setSkill({uid},'mining',{mining}); "
+         f"unit.setSkill({uid},'woodcutting',{woodcutting}); "
+         f"unit.setSkill({uid},'construction',{construction}); "
+         f"unit.setSkill({uid},'smithing',{smithing}); return 'ok'")
+
+
+def get_role(port, uid):
+    return send(port,
+                f"local ai=require('scripts.unit_ai'); "
+                f"return ai.getRole({uid}) or 'none'").strip('"')
+
+
+def wait_role(port, uid, want, seconds=8.0):
+    """Poll until the derived role equals `want` (a couple of thought
+    ticks); returns the final observed role."""
+    deadline = time.time() + seconds
+    role = get_role(port, uid)
+    while time.time() < deadline:
+        if role == want:
+            return role
+        time.sleep(1.0)
+        role = get_role(port, uid)
+    return role
+
+
+def first_work_action(port, uid, seconds=45.0):
+    """Poll currentAction until it becomes a designation work action."""
+    deadline = time.time() + seconds
+    while time.time() < deadline:
+        act = send(port,
+                   f"local ai=require('scripts.unit_ai'); "
+                   f"local s=ai.getState({uid}); "
+                   f"return s and s.currentAction or 'none'").strip('"')
+        if act in ("chop_designation", "dig_designation"):
+            return act
+        time.sleep(1.0)
+    return "timeout"
+
+
+def get_skill(port, uid, name):
+    v = jget(port, f"return unit.getSkill({uid},'{name}') or -1")
+    return float(v) if isinstance(v, (int, float)) else -1.0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=9265)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--size", type=int, default=64)
+    ap.add_argument("--plates", type=int, default=3)
+    args = ap.parse_args()
+    port = args.port
+    passed = True
+
+    proc = boot(port, f"{SPROOT}/role_probe_engine.log")
+    try:
+        bootstrap(port)
+        send(port, f"world.init('probe', {args.seed}, {args.size}, "
+                   f"{args.plates}); return 'ok'")
+        send(port, "return world.waitForInit(300)", timeout=310)
+        send(port, "world.show('probe'); return 'ok'")
+        send(port, "return world.loadChunksInRegion(-4, -4, 4, 4)", timeout=30)
+        send(port, "return world.waitForChunks(120)", timeout=125)
+        send(port, "engine.loadScript('scripts/unit_stats.lua', 0.1); "
+                   "return 'ok'")
+        send(port, "engine.loadScript('scripts/unit_resources.lua', 0.2); "
+                   "return 'ok'")
+        send(port, "engine.loadScript('scripts/unit_ai.lua', 0.1); "
+                   "return 'ok'")
+
+        found = find_wood(port)
+        if not found:
+            print("  [FAIL] no wood-harvestable flora in the loaded region "
+                  "(try another seed)")
+            return 1
+        tx, ty, species = found
+
+        # --- 1. Derivation + hysteresis (unit a, near the tree) ---
+        ua = spawn_worker(port, tx + 3, ty)
+        if ua < 0:
+            print("  [FAIL] could not spawn derivation unit")
+            return 1
+
+        deadline = time.time() + 8.0
+        role0 = get_role(port, ua)
+        while role0 == "none" and time.time() < deadline:
+            time.sleep(1.0)
+            role0 = get_role(port, ua)
+        ok = role0 != "none"
+        passed &= ok
+        print(f"  [{'PASS' if ok else 'FAIL'}] fresh acolyte derives a "
+              f"role from spawn skill rolls: {role0}")
+
+        set_work_skills(port, ua, 60, 10, 10, 10)
+        r = wait_role(port, ua, "miner")
+        passed &= r == "miner"
+        print(f"  [{'PASS' if r == 'miner' else 'FAIL'}] mining 60 → miner: "
+              f"{r}")
+
+        # Challenger inside the switch margin (63 < 60 + 5): stays miner.
+        send(port, f"unit.setSkill({ua},'woodcutting',63); return 'ok'")
+        time.sleep(4.0)
+        r = get_role(port, ua)
+        passed &= r == "miner"
+        print(f"  [{'PASS' if r == 'miner' else 'FAIL'}] woodcutting 63 vs "
+              f"mining 60 stays miner (hysteresis): {r}")
+
+        # Challenger past the margin (70 ≥ 65): flips.
+        send(port, f"unit.setSkill({ua},'woodcutting',70); return 'ok'")
+        r = wait_role(port, ua, "woodcutter")
+        passed &= r == "woodcutter"
+        print(f"  [{'PASS' if r == 'woodcutter' else 'FAIL'}] woodcutting 70 "
+              f"→ woodcutter: {r}")
+
+        # Everything below threshold: generalist.
+        set_work_skills(port, ua, 10, 10, 10, 10)
+        r = wait_role(port, ua, "laborer")
+        passed &= r == "laborer"
+        print(f"  [{'PASS' if r == 'laborer' else 'FAIL'}] all skills 10 → "
+              f"laborer: {r}")
+
+        send(port, f"unit.destroy({ua}); return 'ok'")
+
+        # Technomule: balance/climbing only — no work skills, no role.
+        um_s = send(port, f"local u=unit.spawn('technomule',{tx + 4},{ty}); "
+                          f"return u")
+        try:
+            um = int(float(um_s.strip('"')))
+        except ValueError:
+            um = -1
+        time.sleep(4.0)
+        r = get_role(port, um) if um >= 0 else "spawnfail"
+        passed &= r == "none"
+        print(f"  [{'PASS' if r == 'none' else 'FAIL'}] technomule has no "
+              f"role: {r}")
+        if um >= 0:
+            send(port, f"unit.destroy({um}); return 'ok'")
+
+        # --- 2. Steering: same geometry, opposite roles ---
+        # Chop designation on the tree; mine designation on a flat dry
+        # tile nearby. Workers spawn between the two.
+        spot = send(port,
+                    f"for r=2,5 do for dx=-r,r do for dy=-r,r do "
+                    f"local x,y={tx}+dx,{ty}+dy; "
+                    f"if world.getSlopeAt(x,y)==0 and not world.getFluidAt(x,y)"
+                    f" and not world.getFloraAt(x,y) then "
+                    f"return x..','..y end end end end; return 'none'"
+                    ).strip('"')
+        if spot == "none":
+            print("  [FAIL] no flat diggable tile near the tree")
+            return 1
+        dx, dy = (int(v) for v in spot.split(","))
+        send(port, f"chop.designate('probe',{tx},{ty},{tx},{ty}); "
+                   f"return 'ok'")
+        send(port, f"world.designateMine('probe',{dx},{dy},{dx},{dy}); "
+                   f"return 'ok'")
+        time.sleep(0.5)
+        mx, my = (tx + dx) // 2, (ty + dy) // 2
+
+        picks = {}
+        for label, skills in [("woodcutter", (10, 60, 10, 10)),
+                              ("miner",      (60, 10, 10, 10))]:
+            u = spawn_worker(port, mx + 1, my + 1)
+            if u < 0:
+                print(f"  [FAIL] could not spawn {label} steering unit")
+                return 1
+            set_work_skills(port, u, *skills)
+            picks[label] = first_work_action(port, u)
+            send(port, f"unit.destroy({u}); return 'ok'")
+            time.sleep(1.0)
+
+        ok = picks["woodcutter"] == "chop_designation"
+        passed &= ok
+        print(f"  [{'PASS' if ok else 'FAIL'}] woodcutter picks the chop "
+              f"job first: {picks['woodcutter']}")
+        ok = picks["miner"] == "dig_designation"
+        passed &= ok
+        print(f"  [{'PASS' if ok else 'FAIL'}] miner picks the dig job "
+              f"first (same geometry): {picks['miner']}")
+
+        # --- 3. XP growth (unit c fells the tree, then lays a floor) ---
+        uc = spawn_worker(port, tx + 2, ty)
+        if uc < 0:
+            print("  [FAIL] could not spawn XP unit")
+            return 1
+        set_work_skills(port, uc, 5, 55, 40, 10)
+        wc_before = get_skill(port, uc, "woodcutting")
+
+        deadline = time.time() + 90.0
+        felled = False
+        while time.time() < deadline:
+            time.sleep(2.0)
+            d = jget(port, f"return chop.getDesignationAt('probe',{tx},{ty})")
+            if not isinstance(d, dict):
+                felled = True
+                break
+        wc_after = get_skill(port, uc, "woodcutting")
+        ok = felled and wc_after > wc_before
+        passed &= ok
+        print(f"  [{'PASS' if ok else 'FAIL'}] felling grants woodcutting "
+              f"XP: felled={felled} {wc_before} → {wc_after}")
+
+        # Floor build: material from inventory, then construction XP.
+        # Re-skill the feller into a builder first (construction 60 →
+        # derives "builder", construct job on-role) so the still-live
+        # dig designation can't outbid the floor.
+        set_work_skills(port, uc, 5, 10, 60, 10)
+        con_before = get_skill(port, uc, "construction")
+        fspot = send(port,
+                     f"for r=2,5 do for fx=-r,r do for fy=-r,r do "
+                     f"local x,y={tx}+fx,{ty}+fy; "
+                     f"if world.getSlopeAt(x,y)==0 and not world.getFluidAt(x,y)"
+                     f" and not world.getFloraAt(x,y)"
+                     f" and not world.getMineDesignationAt('probe',x,y) then "
+                     f"return x..','..y end end end end; return 'none'"
+                     ).strip('"')
+        if fspot == "none":
+            print("  [FAIL] no flat buildable tile for the floor")
+            return 1
+        px, py = (int(v) for v in fspot.split(","))
+        send(port, f"unit.addItem({uc},'steel_plate',0); return 'ok'")
+        send(port, f"construction.designate('probe',{px},{py},{px},{py},"
+                   f"'structure','dungeon_1','floor'); return 'ok'")
+        deadline = time.time() + 90.0
+        floored = False
+        while time.time() < deadline:
+            time.sleep(2.0)
+            if send(port,
+                    f"return structure.hasAt({px},{py},'floor')") == "true":
+                floored = True
+                break
+        con_after = get_skill(port, uc, "construction")
+        ok = floored and con_after > con_before
+        passed &= ok
+        print(f"  [{'PASS' if ok else 'FAIL'}] placing a floor grants "
+              f"construction XP: built={floored} {con_before} → {con_after}")
+
+        print("\n" + ("ALL ROLE CHECKS PASSED" if passed else "SOME FAILED"))
+        return 0 if passed else 1
+    finally:
+        try:
+            send(port, "engine.quit()")
+        except Exception:
+            pass
+        time.sleep(1.0)
+        proc.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #265.

## What a role is (design settled interactively with the user)

A role is **derived, never assigned** — no role field, no assignment UI, no save change. The highest work skill at or above **30** names the role, with **+5 hysteresis** on any switch so two close skills can't flap the label:

| Role | Derived from | Work actions it favors |
|------|--------------|------------------------|
| Miner | `mining` | `dig_designation` |
| Woodcutter | `woodcutting` *(new skill)* | `chop_designation` |
| Builder | `construction` *(new skill)* | `construct_job`, `build_nearby`, `deliver_to_build_site`, `store_materials` |
| Smith | `smithing` | *(none until craft AI #329 — weight-neutral label)* |
| Laborer | default when nothing clears 30 | — |

Species with no work skills (wildlife, technomule) derive no role and show "—".

The role feeds **back** into work selection: on-role work entry utilities ×1.4, off-role ×0.7 (never zeroed — a miner still hauls when there's nothing to dig). Since skills grow with use, units specialise emergently into whatever their spawn rolls made them good at — DF-style emergent professions with zero player bookkeeping.

## The load-bearing constraint

Weights apply **only to work-action entry utilities, never the 6.0 in-progress locks** — boosting a lock would climb past player orders (7.0); dampening one would let another work entry steal an in-progress job. Max weighted entry is deliver's 4.0 × 1.4 = 5.6 < 6.0, so the #306 utility ladder is untouched in both directions (documented in the ladder comment and `scripts/unit_roles.lua`'s header).

## Foundation added along the way

Chop and construction had no skills to derive from, so:
- **New acolyte skills** `woodcutting` + `construction` (base 25 ± 30, mining's novice spread — a fresh cohort has a natural mix of talents).
- **XP** from the existing AI: `chop_xp_per_fell` (2.0) on fell, `construct_xp_per_piece` (1.0) on piece placement, mirroring dig's `dig_xp_per_tile`.
- **Work-rate scaling** with the same `(0.5 + skill/100)` shape mining already applies to dig: woodcutting scales chop rate, construction scales build-pour rate.
- **Legacy saves:** `unit.addXP` no-ops on missing skill keys, so `grantWorkXP` lazy-seeds absent keys at the yaml base (25) — old-save veterans start the new skills as the same novices fresh spawns roll, and their chop/build rates don't regress (`or 25.0` fallbacks).

**No save bump:** `uiSkills` is an open serialized HashMap (new keys are just data) and `s.role` re-derives identically on load.

## UI

The `unit_info_v2` header **Role row goes live** (`unitAi.getRole` → `unit_roles.display`) — the half of #30 that was deferred to this issue. Also filled in the work/combat action names missing from `ACTION_DISPLAY` (dig/chop/construct/forage/pickup/treat/engage/retreat/attack previously showed raw action ids in the header).

## Defaults chosen without user input (flagged for review)

The user selected the derived-role model, utility weighting, Lua-table data home, and display-only UI interactively; these two were my recommendations that went unanswered:
- adding the `woodcutting`/`construction` skill foundation (vs deriving from activity time),
- giving the new skills work-rate teeth (vs XP/derivation only).

Also tunables: threshold 30, margin 5, weights 1.4/0.7, XP amounts — all constants in `scripts/unit_roles.lua` / the unit_ai params block.

## Validation

- **New gate `tools/role_probe.py` — 10/10**: derivation from spawn rolls, forced-skill derivation, hysteresis (63 vs 60 holds, 70 flips), demotion to laborer, technomule has no role, steering both directions on **shared geometry** (woodcutter picks chop while miner picks dig), felling grants woodcutting XP, floor placement grants construction XP.
- **`tools/chop_probe.py`** (touched chop execute): all green.
- **`tools/construction_probe.py`** (touched construct execute): 14/14.
- **`cabal test synarchy-test-headless`**: 1 of 1 passed.
- **`tools/test_audit.py`**: 35/35.
- No worldgen/Haskell changes — Lua + YAML + probe only; baselines unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)