### PR TITLE
#441 Drop fromJust from the UPrelude re-export list

### DIFF
--- a/src/Engine/Scene/Batch/Text.hs
+++ b/src/Engine/Scene/Batch/Text.hs
@@ -86,7 +86,9 @@ groupByFontAndLayer nodes =
       -- guarantees nodeFont is Just for every element here.
       keyed = map (\grp → case grp of
                       [] → error "Empty group"
-                      (n:_) → ((fromJust $ nodeFont n, nodeLayer n), grp)) grouped
+                      (n:_) → case nodeFont n of
+                                Nothing → error "groupByFontAndLayer: nodeFont invariant violated"
+                                Just f → ((f, nodeLayer n), grp)) grouped
   in keyed
 
 convertToTextBatches ∷ V.Vector TextRenderBatch → V.Vector TextBatch

--- a/src/Engine/Scene/Render.hs
+++ b/src/Engine/Scene/Render.hs
@@ -2,6 +2,7 @@
 module Engine.Scene.Render where
 
 import UPrelude
+import Data.Maybe (fromJust)
 import qualified Data.Vector as V
 import qualified Data.Vector.Storable as VS
 import qualified Data.Map as Map

--- a/src/UPrelude.hs
+++ b/src/UPrelude.hs
@@ -46,7 +46,7 @@ import Control.Monad.State (get, gets, modify)
 import Control.Monad.Unicode ( (=≪), (↢), (↣), (≫), (≫=) )
 import Control.Applicative.Unicode ( (∅), (⊛) )
 
-import Data.Maybe (fromMaybe, isJust, fromJust, isNothing, catMaybes, listToMaybe, maybeToList)
+import Data.Maybe (fromMaybe, isJust, isNothing, catMaybes, listToMaybe, maybeToList)
 import Data.Bits ((.&.), (.|.), zeroBits, testBit, setBit, clearBit, complement, shiftL, shiftR, rotateL, rotateR, bit, popCount, xor)
 
 import Foreign.C.String (peekCString)


### PR DESCRIPTION
Closes #441

## Approach

Removed `fromJust` from `UPrelude`'s `Data.Maybe` re-export line so future uses require an explicit local import — a speed bump against undocumented partial-function use, per the issue.

The two existing call sites (the only ones in the project) were each handled per the issue's two allowed options:
- `src/Engine/Scene/Render.hs`: added a local `import Data.Maybe (fromJust)` and kept its existing safety comment as-is (invariant guaranteed by the caller, `drawFrame`).
- `src/Engine/Scene/Batch/Text.hs`: `groupByFontAndLayer` was already inside a `case` on the list head, so it was refactored to a total pattern — the documented invariant (the `isJust` filter upstream guarantees `nodeFont` is `Just`) is now an explicit `error` branch instead of a `fromJust` call.

## Testing

- `cabal build all` — clean full rebuild (UPrelude change forces one), no warnings.
- `cabal build synarchy-test-headless` — builds clean.
- `cabal test synarchy-test-headless` — 523 examples, 0 failures.
- `python3 tools/world_check.py` — 21/21 seeds PASS.
- `python3 tools/test_audit.py` — all 35 test groups passed.

No save-format or worldgen-output changes; no save version bump needed.