### PR TITLE
Wire night perception into combat awareness (#315)

### DIFF
--- a/src/Unit/LineOfSight.hs
+++ b/src/Unit/LineOfSight.hs
@@ -10,6 +10,7 @@
 module Unit.LineOfSight
     ( unitVisibleTiles
     , unitAwareness
+    , nightPerceptionFactor
     ) where
 
 import UPrelude
@@ -84,6 +85,8 @@ unitVisibleTiles env uid = do
 --
 --   Perception widens the range; facing is the defender's last sim
 --   heading (set by movement — a unit that walked up to its foe faces it).
+--   Result is scaled by 'nightPerceptionFactor': a defender senses an
+--   incoming blow less reliably in the dark (#315).
 unitAwareness ∷ EngineEnv → UnitInstance → UnitInstance → IO Float
 unitAwareness env defender attacker = do
     let defX = uiGridX defender
@@ -101,11 +104,32 @@ unitAwareness env defender attacker = do
         -- Same half-angle-60° cone test as the vision FOV (cos²60 = 0.25).
         inFacingCone = dist < 1.0e-4 ∨ (dot ≥ 0 ∧ dot * dot ≥ 0.25 * lenSq)
     blocked ← losBlockedBetween env defender attacker
-    pure $! if dist > perceptionRange ∨ blocked
+    sunAngle ← readIORef (sunAngleRef env)
+    pure $! nightPerceptionFactor sunAngle *
+            if dist > perceptionRange ∨ blocked
             then 0.0
             else if inFacingCone           then 1.0
             else if dist ≤ awareCloseRadius then awarePeripheral
             else 0.0
+
+-- | Multiplier on awareness from time of day: 1.0 at noon, dipping to
+--   'nightPerceptionFloor' at midnight, ramping smoothly through
+--   dawn/dusk. A cosine keyed to 'sunAngle' peaking at 0.5 (noon) and
+--   troughing at 0.0\/1.0 (midnight) — the mapping 'WorldTime' documents
+--   (@World.Time.Types@) — rather than reusing 'computeAmbientLight'
+--   (@Engine.Loop.Frame@), whose own phase is tuned for the lighting
+--   shader, not gameplay, and shouldn't be coupled to this.
+nightPerceptionFactor ∷ Float → Float
+nightPerceptionFactor sunAngle =
+    let angle = (sunAngle - 0.5) * 2 * π
+        height = cos angle ∷ Float
+    in nightPerceptionFloor + (1.0 - nightPerceptionFloor) * (height + 1.0) / 2.0
+
+-- | Awareness multiplier at deepest night (midnight). Reduced, not
+--   eliminated — an ambush still lands more easily at night, but a
+--   defender isn't stone-blind.
+nightPerceptionFloor ∷ Float
+nightPerceptionFloor = 0.5
 
 -- | Terrain line-of-sight between two units (true ⇒ a hill/wall blocks
 --   the sightline). Falls back to "clear" when no world is loaded (the

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -163,6 +163,7 @@ test-suite synarchy-test-headless
                    Test.Headless.Unit.Injury
                    Test.Headless.Unit.Fall
                    Test.Headless.Unit.Stats
+                   Test.Headless.Unit.NightPerception
                    Test.Headless.Item.Temperature
                    Test.Headless.Item.BuffYaml
                    Test.Headless.World.Save.Sanitize

--- a/test-headless/Spec.hs
+++ b/test-headless/Spec.hs
@@ -23,6 +23,7 @@ import qualified Test.Headless.Unit.Anim as AnimTest
 import qualified Test.Headless.Unit.Injury as InjuryTest
 import qualified Test.Headless.Unit.Fall as FallTest
 import qualified Test.Headless.Unit.Stats as StatsTest
+import qualified Test.Headless.Unit.NightPerception as NightPerception
 import qualified Test.Headless.Item.Temperature as ItemTemp
 import qualified Test.Headless.Item.BuffYaml as ItemBuffYaml
 import qualified Test.Headless.World.Save.Sanitize as SaveSanitize
@@ -77,6 +78,7 @@ main = hspec $ do
     describe "Unit.Injury" InjuryTest.spec
     describe "Unit.Fall" FallTest.spec
     describe "Unit.Stats" StatsTest.spec
+    describe "Unit.NightPerception" NightPerception.spec
     describe "Item.Temperature" ItemTemp.spec
     describe "Item.BuffYaml" ItemBuffYaml.spec
     describe "World.Save.Sanitize" SaveSanitize.spec

--- a/test-headless/Test/Headless/Unit/NightPerception.hs
+++ b/test-headless/Test/Headless/Unit/NightPerception.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE Strict, UnicodeSyntax #-}
+-- | Pure tests for 'nightPerceptionFactor' (#315): the day/night
+--   multiplier on combat awareness. Asserts the ramp is smooth, peaks
+--   at noon, troughs (but never zeroes) at midnight, and is symmetric
+--   around dawn/dusk — not balance numbers.
+module Test.Headless.Unit.NightPerception (spec) where
+
+import UPrelude
+import Test.Hspec
+import Unit.LineOfSight (nightPerceptionFactor)
+
+spec ∷ Spec
+spec = describe "nightPerceptionFactor" $ do
+    it "is full (1.0) at noon" $
+        nightPerceptionFactor 0.5 `shouldBe` 1.0
+    it "is reduced but non-zero at midnight" $ do
+        nightPerceptionFactor 0.0 `shouldSatisfy` (> 0.0)
+        nightPerceptionFactor 0.0 `shouldSatisfy` (< 1.0)
+    it "midnight (0.0) and the wrap-around (1.0) agree" $
+        nightPerceptionFactor 0.0 `shouldBe` nightPerceptionFactor 1.0
+    it "noon is strictly brighter than any other time of day" $ do
+        nightPerceptionFactor 0.5 `shouldSatisfy` (> nightPerceptionFactor 0.25)
+        nightPerceptionFactor 0.5 `shouldSatisfy` (> nightPerceptionFactor 0.75)
+        nightPerceptionFactor 0.5 `shouldSatisfy` (> nightPerceptionFactor 0.0)
+    it "dawn and dusk are symmetric around noon/midnight" $
+        nightPerceptionFactor 0.25 `shouldBe` nightPerceptionFactor 0.75
+    it "morning ramps monotonically up to noon" $ do
+        nightPerceptionFactor 0.1 `shouldSatisfy` (< nightPerceptionFactor 0.3)
+        nightPerceptionFactor 0.3 `shouldSatisfy` (< nightPerceptionFactor 0.5)
+    it "evening ramps monotonically down from noon" $ do
+        nightPerceptionFactor 0.5 `shouldSatisfy` (> nightPerceptionFactor 0.7)
+        nightPerceptionFactor 0.7 `shouldSatisfy` (> nightPerceptionFactor 0.9)


### PR DESCRIPTION
Closes #315 (perception half only — see below)

## Approach

`unitAwareness` (`src/Unit/LineOfSight.hs`) gates active combat dodge on
LOS + facing cone + perception range, but was time-of-day-blind: night was
purely a lighting change with zero mechanical consequence.

This wires the world clock's existing `sunAngle` into that gate. A new
pure `nightPerceptionFactor ∷ Float → Float` computes a smooth cosine ramp
keyed to `sunAngle`'s documented mapping (`World.Time.Types`: 0.0/1.0 =
midnight, 0.5 = noon, 0.25/0.75 = dawn/dusk) — full awareness (1.0) at
noon, floored at 0.5 (reduced, not eliminated) at midnight, symmetric
through dawn and dusk. `unitAwareness` multiplies its result by this
factor before returning, so ambushes land more easily at night without
making defenders totally blind.

Deliberately does *not* reuse `computeAmbientLight` (`Engine.Loop.Frame`)
— that curve's phase is tuned for the lighting shader, not gameplay, and
coupling the two would leak a rendering concern into combat.

### Scope

Issue #315 named two hooks: night perception (this PR) and a
sleep/circadian need. Per discussion, the sleep half is out of scope here
— it has its own open design questions (new need meter vs. reusing
stamina, whether it drives new AI rest behaviour) that the repo owner
wants to work out directly rather than have guessed. Split out as #479.

## Testing

- New pure hspec suite `Test.Headless.Unit.NightPerception` (7 cases):
  full at noon, reduced-not-zero at midnight, midnight/wrap agreement,
  noon strictly brightest, dawn/dusk symmetry, monotonic ramps both
  directions.
- `cabal test synarchy-test-headless` — 530 examples, 0 failures.
- `python3 tools/world_check.py` — 21/21 seeds PASS (no worldgen-output
  change, so no baseline recapture needed).
- `python3 tools/test_audit.py` — all 35 test groups pass.
- Full library + test-suite rebuild with `-Wall -Werror` — clean.