### PR TITLE
[tech-debt] Name UI/Sim magic offsets + operator/logic nits

### DIFF
--- a/src/Sim/Thread.hs
+++ b/src/Sim/Thread.hs
@@ -30,6 +30,27 @@ import Sim.State.Types (SimState(..), SimWorldState(..), SimChunkState(..)
 import Sim.Fluid.Types (fluidCellToActive, activeToFluidCell)
 import Sim.Fluid.Active (simulateActiveTick)
 
+-- | Settle-tick countdown for a freshly generated/loaded chunk. Newly
+--   generated fluid starts further from equilibrium than a
+--   previously-settled chunk being nudged awake, so it gets a longer
+--   countdown than 'reactivateSettleTicks'.
+newChunkSettleTicks ∷ Int
+newChunkSettleTicks = 64
+
+-- | Settle-tick countdown for a chunk that was already settled and is
+--   being re-agitated: a world reactivation, a tile edit, or an edit
+--   that lands before the chunk has ever loaded. Shorter than
+--   'newChunkSettleTicks' since it's re-equilibrating, not settling
+--   from scratch.
+reactivateSettleTicks ∷ Int
+reactivateSettleTicks = 24
+
+-- | Hard cap on synchronous settle iterations for 'SimFastSettleAll'
+--   (the dump path) — a safety net against runaway settling, not
+--   expected to be hit in practice.
+maxFastSettleIterations ∷ Int
+maxFastSettleIterations = 500
+
 startSimThread ∷ EngineEnv → IO ThreadState
 startSimThread env = do
     logger ← readIORef (loggerRef env)
@@ -137,7 +158,7 @@ handleSimCommand env logger simStateRef cmd = do
             writeIORef simStateRef $
                 modifyWorld pid (\sws → sws
                     { swsActive = True
-                    , swsChunks = HM.map (\scs → scs { scsSettleTicks = 24 })
+                    , swsChunks = HM.map (\scs → scs { scsSettleTicks = reactivateSettleTicks })
                                          (swsChunks sws)
                     }) ss
             logDebug logger CatWorld $ "Sim: world activated " <> tshow pid
@@ -164,7 +185,7 @@ handleSimCommand env logger simStateRef cmd = do
                     { scsFluid       = fluidMap
                     , scsTerrain     = terrainMap
                     , scsGenFluid    = fluidMap
-                    , scsSettleTicks = 64
+                    , scsSettleTicks = newChunkSettleTicks
                     , scsActive      = False
                     , scsActiveFluid = V.replicate sz Nothing
                     , scsEquilTicks  = 0
@@ -189,13 +210,13 @@ handleSimCommand env logger simStateRef cmd = do
                     Just scs → scs { scsFluid       = fluidMap
                                    , scsTerrain     = terrainMap
                                    , scsGenFluid    = fluidMap
-                                   , scsSettleTicks = 24
+                                   , scsSettleTicks = reactivateSettleTicks
                                    }
                     Nothing  → SimChunkState
                         { scsFluid       = fluidMap
                         , scsTerrain     = terrainMap
                         , scsGenFluid    = fluidMap
-                        , scsSettleTicks = 24
+                        , scsSettleTicks = reactivateSettleTicks
                         , scsActive      = False
                         , scsActiveFluid = V.replicate sz Nothing
                         , scsEquilTicks  = 0
@@ -236,12 +257,11 @@ handleSimCommand env logger simStateRef cmd = do
             -- guarded against was removed), so scsFluid is already fresh.
             -- Run sim ticks synchronously (no sleeping) for every world
             -- until all its chunks are settled and inactive. Capped at
-            -- maxIterations as a safety net. Explicitly unpause — the dump
-            -- path pauses the sim before chunks load, but simulateActiveTick
-            -- is a no-op while paused, so the synchronous settle below would
-            -- do nothing.
-            let maxIterations = 500 ∷ Int
-                settled = HM.map (fastSettleWorld maxIterations) (ssWorlds ss)
+            -- maxFastSettleIterations as a safety net. Explicitly unpause —
+            -- the dump path pauses the sim before chunks load, but
+            -- simulateActiveTick is a no-op while paused, so the synchronous
+            -- settle below would do nothing.
+            let settled = HM.map (fastSettleWorld maxFastSettleIterations) (ssWorlds ss)
                 -- Mark every chunk dirty so the whole settled state is
                 -- emitted to the world thread.
                 dirtied = HM.map (\sws →

--- a/src/UI/Manager.hs
+++ b/src/UI/Manager.hs
@@ -447,7 +447,7 @@ isPointInElement (px, py) element mgr =
         Nothing → False
         Just (ex, ey) →
             let (w, h) = ueSize element
-            in px ≥ ex ∧ px ≤ (ex + w) &&
+            in px ≥ ex ∧ px ≤ (ex + w) ∧
                py ≥ ey ∧ py ≤ (ey + h)
 
 -- | Walk every visible element in paint order, yielding the elements

--- a/src/UI/TextBuffer.hs
+++ b/src/UI/TextBuffer.hs
@@ -15,7 +15,7 @@ module UI.TextBuffer
 
 import UPrelude
 import qualified Data.Text as T
-import UI.Focus (TextBuffer(..))
+import UI.Types (TextBuffer(..))
 
 -- | Insert character at cursor position
 insertChar ∷ Char → TextBuffer → TextBuffer

--- a/src/UI/Tooltip.hs
+++ b/src/UI/Tooltip.hs
@@ -42,6 +42,17 @@ import UI.Manager
 hintLineGap ∷ Float
 hintLineGap = 2
 
+-- | Title-line leading: fudge added past 'tsFontSize' to cover descender
+--   overshoot. Shared by the size pass ('computeBoxSize') and the layout
+--   pass ('repositionAndAnimate') so they can't drift apart.
+titleLeadingPx ∷ Float
+titleLeadingPx = 4
+
+-- | Hint-line leading, same purpose as 'titleLeadingPx' but for the
+--   (smaller) hint font.
+hintLeadingPx ∷ Float
+hintLeadingPx = 3
+
 -- | Split the hint on '\n' so multi-line hints render as a stack of
 --   text elements instead of a single overflow line. Empty Maybe ⇒
 --   no lines.
@@ -53,7 +64,7 @@ hintLines content = case ttHint content of
 -- | Per-line height (cap + leading). Used both for layout (computing
 --   total hint section height) and for the per-line Y stepping.
 hintLineHeight ∷ TooltipStyle → Float
-hintLineHeight style = tsHintFontSize style + 3
+hintLineHeight style = tsHintFontSize style + hintLeadingPx
 
 -- | Run one frame of the tooltip subsystem. Called from the render
 --   loop after input has been applied and before 'renderUIPages'.
@@ -377,7 +388,7 @@ repositionAndAnimate _pageH content (mx, my) (fbW, fbH) fontCache mgr =
         -- Section dimensions. Anything with a 0 height is treated as
         -- "missing" and skipped from the stack.
         titleH = case ttText content of
-            Just _ | isFontSet (tsFont style) → tsFontSize style + 4
+            Just _ | isFontSet (tsFont style) → tsFontSize style + titleLeadingPx
             _ → 0
         hintLineN = length (hintLines content)
         hintH = if hintLineN > 0 ∧ isFontSet (tsFont style)
@@ -454,7 +465,7 @@ stackSections ∷ (Float, Float, Float) → Float → Float → Float → Float
               → (Float, Float, Float, Float, Float)
 stackSections (gTSep, gSepH, gHSpr) titleH sepH hintH spriteH =
     let advance prevHadContent gapHere y h
-          | h ≤ 0 = (y, y, False ∨ prevHadContent)
+          | h ≤ 0 = (y, y, prevHadContent)
           | prevHadContent = (y + gapHere, y + gapHere + h, True)
           | otherwise = (y, y + h, True)
         (titleY, after1, h1) = advance False 0     0      titleH
@@ -505,7 +516,7 @@ computeBoxSize ∷ FontCache → TooltipStyle → TooltipContent → (Float, Flo
 computeBoxSize fontCache style content =
     let titleW = textPixelWidth fontCache style content
         titleH = case ttText content of
-            Just _ | isFontSet (tsFont style) → tsFontSize style + 4
+            Just _ | isFontSet (tsFont style) → tsFontSize style + titleLeadingPx
             _ → 0
         hintW = hintPixelWidth fontCache style content
         hintLineN = length (hintLines content)


### PR DESCRIPTION
Closes #390

## Summary

Five small readability/consistency fixes, no behavior change:

- `UI/Tooltip.hs`: named the inlined `+4` (title leading) and `+3`
  (hint leading) fudge factors as `titleLeadingPx`/`hintLeadingPx`,
  used at all three call sites (`hintLineHeight`,
  `repositionAndAnimate`, `computeBoxSize`) so the size and layout
  passes can't diverge. Also dropped the no-op `False ∨ prevHadContent`
  in `stackSections`'s `advance` helper (simplifies to
  `prevHadContent`).
- `UI/Manager.hs:450` (`isPointInElement`): replaced the stray `&&`
  with `∧` to match the codebase's exclusive use of the unicode
  operator.
- `UI/TextBuffer.hs`: import `TextBuffer(..)` from `UI.Types` (where
  it's defined) instead of via `UI.Focus`'s re-export.
- `Sim/Thread.hs`: named the `64`/`24` settle-tick counts as
  `newChunkSettleTicks`/`reactivateSettleTicks` with a comment
  explaining why a freshly-loaded chunk gets a longer countdown than
  a re-agitated one (edit/reactivation), and promoted the local
  `maxIterations = 500` in `SimFastSettleAll` to a top-level
  `maxFastSettleIterations` constant.

## Testing

- `cabal build all` — clean, no warnings introduced
- `cabal test synarchy-test-headless --test-options='--match "Tooltip"'` — 5/5 pass
- `cabal test synarchy-test-headless --test-options='--match "Sim"'` — 6/6 pass
- `cabal test synarchy-test-headless` (full suite) — 523/523 pass
- `python3 tools/world_check.py` — 21/21 seeds pass
- `python3 tools/test_audit.py` — 35/35 groups pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)