### PR TITLE
#301 Repair model + stations/items (condition/sharpness as station-gated recipes)

### DIFF
--- a/data/buildings/furnace.yaml
+++ b/data/buildings/furnace.yaml
@@ -27,9 +27,12 @@ buildings:
     storage_capacity: 100.0
 
     # Work-station operations (#326). Recipe `station` kinds this
-    # building can run, plus "repair" for the repair flows (#301):
-    # condition restoration happens at the furnace (reforging), edge
-    # honing at the workbench.
+    # building can run, plus "repair_condition" for the repair flows
+    # (#301): condition restoration (reforging) happens at the
+    # furnace; edge honing ("repair_sharpness") lives at the workbench
+    # instead — the two axes are split operations so findStation/
+    # executeAt routes to the right station instead of either matching
+    # a shared generic "repair" tag.
     operations:
       - smelt
-      - repair
+      - repair_condition

--- a/data/buildings/workbench.yaml
+++ b/data/buildings/workbench.yaml
@@ -23,10 +23,12 @@ buildings:
     storage_capacity: 100.0
 
     # Work-station operations (#326): forge (bars → blades/tools),
-    # assemble (components → goods), and "repair" for the repair flows
-    # (#301) — sharpness honing lives here, per the shared-station
-    # decision on the crafting epic (#324).
+    # assemble (components → goods), and "repair_sharpness" for the
+    # repair flows (#301) — edge honing lives here, per the
+    # shared-station decision on the crafting epic (#324); condition
+    # restoration ("repair_condition") is the furnace's job instead —
+    # see furnace.yaml for why the axes are split operations.
     operations:
       - forge
       - assemble
-      - repair
+      - repair_sharpness

--- a/data/items/whetstone.yaml
+++ b/data/items/whetstone.yaml
@@ -1,0 +1,14 @@
+items:
+  # Repair consumable (#301): honing an edge at the workbench burns one
+  # of these (repair.repairAt / repair_sharpness, data/recipes/
+  # repair.yaml). Fully consumed per use rather than a multi-use
+  # wearing tool — the simplest cost model that still ties sharpness
+  # repair into the economy; a "wears down over N uses" refinement is
+  # future work, not settled by this issue.
+  - name: "whetstone"
+    display_name: "Whetstone"
+    sprite: "assets/textures/items/material/whetstone.png"
+    weight: 0.3
+    category: "Materials"
+    make: "acolyte"
+    material: "stone"

--- a/data/recipes/basic.yaml
+++ b/data/recipes/basic.yaml
@@ -8,8 +8,8 @@
 #   station:   station operation, e.g. "smelt"/"forge"    (required)
 #              — matched against a building def's `operations:` list
 #              (#326): craft.executeAt only runs at a Built building
-#              offering it (furnace = smelt+repair, workbench =
-#              forge+assemble+repair)
+#              offering it (furnace = smelt+repair_condition,
+#              workbench = forge+assemble+repair_sharpness)
 #   inputs:    list of { item, count }; count defaults 1  (required)
 #   fuel:      optional single { item, count } consumed alongside the
 #              inputs (fuel item content arrives with the smelting
@@ -23,6 +23,11 @@
 #              quality = skill level, blended 70/30 with the knowledge
 #              level when the recipe is knowledge-gated, clamped 0-100.
 #              Omitted = quality rolls from the item def's spec.
+#   repair_axis: optional "condition"/"sharpness" (#301) — marks this a
+#              REPAIR recipe run through repair.repairAt (targets an
+#              existing item instance) rather than craft.execute/
+#              executeAt, which refuse repair-tagged recipes. See
+#              data/recipes/repair.yaml.
 #
 # Outputs spawn factory-new: condition + sharpness 100.
 recipes:

--- a/data/recipes/repair.yaml
+++ b/data/recipes/repair.yaml
@@ -1,0 +1,40 @@
+# Repair flows (#301) — the policy layer on top of the unit.repairItem
+# primitive (#300). These are ordinary recipe entries (same schema as
+# data/recipes/basic.yaml) tagged with `repair_axis`, which marks them
+# as REPAIR rather than craft: repair.repairAt (Engine.Scripting.Lua.
+# API.Repair) targets an existing item instance and restores that axis
+# to 100 instead of producing `outputs`. craft.execute/executeAt refuse
+# repair-tagged recipes.
+#
+# Sharpness and condition are separate-but-similar wear axes (Item/
+# Types.hs) restored at separate stations, so each gets its own
+# station operation ("repair_condition" / "repair_sharpness" —
+# data/buildings/furnace.yaml, workbench.yaml) rather than sharing a
+# generic "repair" tag that could route to either building.
+#
+# Cost is material-gated (ties repair into the existing economy, like
+# crafting): reforging a damaged body burns furnace fuel; honing an
+# edge burns a whetstone (fully consumed per use — see data/items/
+# whetstone.yaml for why not a multi-use wearing tool). One visit
+# always restores the axis fully to 100, whether the item arrived
+# lightly worn or fully broken (condition 0) — a metered/partial
+# restore is a possible future refinement, not settled here.
+recipes:
+  - id: repair_condition
+    name: "Reforge (restore condition)"
+    station: repair_condition
+    repair_axis: condition
+    inputs:
+      - item: lignite_chunk
+        count: 1
+    work: 15
+    outputs: []
+  - id: repair_sharpness
+    name: "Hone edge (restore sharpness)"
+    station: repair_sharpness
+    repair_axis: sharpness
+    inputs:
+      - item: whetstone
+        count: 1
+    work: 10
+    outputs: []

--- a/src/Building/Types.hs
+++ b/src/Building/Types.hs
@@ -87,8 +87,10 @@ data BuildingDef = BuildingDef
     , bdOperations  ∷ ![Text]
       -- ^ Work-station operations this building offers once Built
       --   (#326): recipe `station` kinds it can run ("smelt", "forge",
-      --   "assemble", …) plus "repair" for the repair flows (#301).
-      --   Empty (default) = not a work station. craft.executeAt
+      --   "assemble", …) plus "repair_condition"/"repair_sharpness"
+      --   for the repair flows (#301) — split per wear axis so
+      --   findStation/executeAt route unambiguously to the right
+      --   station. Empty (default) = not a work station. craft.executeAt
       --   validates the recipe's rdStation against this list;
       --   building.findStation routes by it.
     , bdAnimations  ∷ !(HM.HashMap Text Animation)

--- a/src/Craft/Types.hs
+++ b/src/Craft/Types.hs
@@ -19,6 +19,8 @@ module Craft.Types
     , RecipeManager(..)
     , emptyRecipeManager
     , lookupRecipe
+    , RepairAxis(..)
+    , repairAxisName
     ) where
 
 import UPrelude
@@ -30,6 +32,23 @@ data RecipeIngredient = RecipeIngredient
     { riItem  ∷ !Text   -- ^ item def name (Item.Types.idName)
     , riCount ∷ !Int    -- ^ how many; parser defaults omitted counts to 1
     } deriving (Show, Eq)
+
+-- | Which wear axis a repair recipe (#301) restores. A proper sum
+--   type rather than raw Text so an invalid value CANNOT reach
+--   RecipeDef — Engine.Asset.YamlRecipes' parser is the only producer
+--   of a `Just Text` axis and rejects anything but "condition"/
+--   "sharpness" at parse time (a malformed recipe never enters the
+--   catalogue), and every RepairAxis consumer pattern-matches both
+--   constructors exhaustively (no wildcard fallback), so a future
+--   third axis can't silently alias onto the wrong one either.
+data RepairAxis = RepairCondition | RepairSharpness
+    deriving (Show, Eq)
+
+-- | The YAML/Lua-facing spelling of an axis — round-trips with the
+--   `repair_axis` vocabulary ("condition"/"sharpness").
+repairAxisName ∷ RepairAxis → Text
+repairAxisName RepairCondition = "condition"
+repairAxisName RepairSharpness = "sharpness"
 
 -- | One recipe from the YAML catalogue.
 data RecipeDef = RecipeDef
@@ -53,8 +72,7 @@ data RecipeDef = RecipeDef
                                               --   output quality (#343);
                                               --   Nothing = quality rolls
                                               --   from the item def's spec
-    , rdRepairAxis ∷ !(Maybe Text)            -- ^ #301: "condition" or
-                                              --   "sharpness" marks this as
+    , rdRepairAxis ∷ !(Maybe RepairAxis)      -- ^ #301: Just marks this as
                                               --   a REPAIR recipe rather
                                               --   than a craft — it targets
                                               --   an existing item instance

--- a/src/Craft/Types.hs
+++ b/src/Craft/Types.hs
@@ -53,6 +53,18 @@ data RecipeDef = RecipeDef
                                               --   output quality (#343);
                                               --   Nothing = quality rolls
                                               --   from the item def's spec
+    , rdRepairAxis ∷ !(Maybe Text)            -- ^ #301: "condition" or
+                                              --   "sharpness" marks this as
+                                              --   a REPAIR recipe rather
+                                              --   than a craft — it targets
+                                              --   an existing item instance
+                                              --   (repair.repairAt) instead
+                                              --   of producing rdOutputs.
+                                              --   Nothing (the default) is
+                                              --   an ordinary craft recipe;
+                                              --   craft.execute/executeAt
+                                              --   refuse recipes with this
+                                              --   set.
     } deriving (Show, Eq)
 
 -- | Everything a craft consumes: inputs plus the fuel line, if any.

--- a/src/Engine/Asset/YamlRecipes.hs
+++ b/src/Engine/Asset/YamlRecipes.hs
@@ -46,7 +46,18 @@ data RecipeYamlDef = RecipeYamlDef
 
 instance FromJSON RecipeYamlDef where
     parseJSON = withObject "RecipeYamlDef" $ \v → do
-        rid ← v .: "id"
+        rid  ← v .: "id"
+        axis ← v .:? "repair_axis"
+        -- Reject anything but the two known axes HERE, at the only
+        -- entry point for repair_axis, so a typo (e.g. "sharpnes")
+        -- fails the whole file's load instead of silently becoming a
+        -- recipe that repairs the wrong axis (Craft.Types.RepairAxis
+        -- is what makes that failure mode impossible downstream).
+        case axis of
+            Just a | a ≢ "condition" ∧ a ≢ "sharpness" →
+                fail (T.unpack ("repair_axis must be \"condition\" or "
+                                 <> "\"sharpness\", got " <> a))
+            _ → pure ()
         RecipeYamlDef rid
             ⊚ v .:? "name" .!= rid
             ⊛ v .:  "station"
@@ -56,7 +67,7 @@ instance FromJSON RecipeYamlDef where
             ⊛ v .:  "outputs"
             ⊛ v .:? "knowledge"
             ⊛ v .:? "skill"
-            ⊛ v .:? "repair_axis"
+            ⊛ pure axis
 
 newtype RecipeYamlFile = RecipeYamlFile
     { ryfRecipes ∷ [RecipeYamlDef]

--- a/src/Engine/Asset/YamlRecipes.hs
+++ b/src/Engine/Asset/YamlRecipes.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE Strict, UnicodeSyntax, DeriveGeneric, OverloadedStrings #-}
 -- | YAML loader for data/recipes/*.yaml. Mirrors Engine.Asset.YamlInfection.
 --   The on-disk schema is documented in data/recipes/basic.yaml.
+--   `repair_axis` (#301) marks a recipe as a REPAIR flow (data/recipes/
+--   repair.yaml) rather than a craft — see Craft.Types.rdRepairAxis.
 module Engine.Asset.YamlRecipes
     ( RecipeYamlIngredient(..)
     , RecipeYamlDef(..)
@@ -39,6 +41,7 @@ data RecipeYamlDef = RecipeYamlDef
     , ryOutputs   ∷ ![RecipeYamlIngredient]
     , ryKnowledge ∷ !(Maybe Text)
     , rySkill     ∷ !(Maybe Text)
+    , ryRepairAxis ∷ !(Maybe Text)
     } deriving (Show, Eq, Generic)
 
 instance FromJSON RecipeYamlDef where
@@ -53,6 +56,7 @@ instance FromJSON RecipeYamlDef where
             ⊛ v .:  "outputs"
             ⊛ v .:? "knowledge"
             ⊛ v .:? "skill"
+            ⊛ v .:? "repair_axis"
 
 newtype RecipeYamlFile = RecipeYamlFile
     { ryfRecipes ∷ [RecipeYamlDef]

--- a/src/Engine/Scripting/Lua/API.hs
+++ b/src/Engine/Scripting/Lua/API.hs
@@ -64,6 +64,7 @@ import Engine.Scripting.Lua.API.Equipment
 import Engine.Scripting.Lua.API.Substance
 import Engine.Scripting.Lua.API.Infection
 import Engine.Scripting.Lua.API.Craft
+import Engine.Scripting.Lua.API.Repair
 import Engine.Scripting.Lua.API.Locations
 import Engine.Scripting.Lua.API.LootTables
 import Engine.Scripting.Lua.API.Flora
@@ -516,6 +517,18 @@ registerLuaAPI lst env backendState = Lua.runWith lst $ do
   registerLuaFunction "execute"  (craftExecuteFn env)
   registerLuaFunction "executeAt" (craftExecuteAtFn env)
   Lua.setglobal (Lua.Name "craft")
+
+  -- Repair global (#301) — the policy layer on top of unit.repairItem
+  -- (#300): repair flows are recipe entries tagged with a repair axis
+  -- (data/recipes/repair.yaml), gated on the same Built/adjacent
+  -- station rules as craft.executeAt. get/getNames are read-only,
+  -- restricted to repair-tagged recipes; repairAt runs one repair
+  -- against a targeted item instance.
+  Lua.newtable
+  registerLuaFunction "get"      (repairGetFn env)
+  registerLuaFunction "getNames" (repairGetNamesFn env)
+  registerLuaFunction "repairAt" (repairAtFn env)
+  Lua.setglobal (Lua.Name "repair")
 
   -- Loot table global — weighted rolls against data/loot_tables/*.yaml
   -- (loaded via engine.loadLootTableYaml). Consumed by a `loot_table`

--- a/src/Engine/Scripting/Lua/API/Buildings.hs
+++ b/src/Engine/Scripting/Lua/API/Buildings.hs
@@ -720,7 +720,8 @@ buildingGetStorageWeightFn env = do
                     return 1
 
 -- | building.getOperations(bid) → array of operation tags from the
---   def ("smelt", "forge", "assemble", "repair", …). Empty array for
+--   def ("smelt", "forge", "assemble", "repair_condition",
+--   "repair_sharpness", …). Empty array for
 --   buildings that aren't work stations. nil if the bid or its def is
 --   gone. Def-level data (#326) — what the station CAN do; whether it
 --   currently can (Built) is getActivity's business.

--- a/src/Engine/Scripting/Lua/API/Craft.hs
+++ b/src/Engine/Scripting/Lua/API/Craft.hs
@@ -14,6 +14,8 @@ module Engine.Scripting.Lua.API.Craft
     , craftGetNamesFn
     , craftExecuteFn
     , craftExecuteAtFn
+    , pushRecipe
+    , validateStation
     ) where
 
 import UPrelude
@@ -59,6 +61,7 @@ loadRecipeYamlFn env = do
                             , rdOutputs   = map ingr (ryOutputs d)
                             , rdKnowledge = ryKnowledge d
                             , rdSkill     = rySkill d
+                            , rdRepairAxis = ryRepairAxis d
                             }
                     atomicModifyIORef' (recipeManagerRef env) $ \m →
                         (RecipeManager
@@ -84,6 +87,39 @@ pushIngredient i = do
     Lua.pushinteger (fromIntegral (riCount i))
     Lua.setfield (-2) "count"
 
+-- | Push a RecipeDef as a Lua table: { id, name, station, work,
+--   knowledge?, skill?, repairAxis?, inputs = [{item,count}…],
+--   fuel = {item,count}?, outputs = [{item,count}…] }. Shared by
+--   craft.get and repair.get (Engine.Scripting.Lua.API.Repair) so both
+--   accessors report the identical shape.
+pushRecipe ∷ RecipeDef → Lua.LuaE Lua.Exception ()
+pushRecipe d = do
+    Lua.newtable
+    let putS k v = Lua.pushstring (TE.encodeUtf8 v)
+                   >> Lua.setfield (-2) k
+        putN k v = Lua.pushnumber (Lua.Number (realToFrac v))
+                   >> Lua.setfield (-2) k
+    putS "id"      (rdId d)
+    putS "name"    (rdName d)
+    putS "station" (rdStation d)
+    putN "work"    (rdWork d)
+    forM_ (rdKnowledge d)  $ putS "knowledge"
+    forM_ (rdSkill d)      $ putS "skill"
+    forM_ (rdRepairAxis d) $ putS "repairAxis"
+    Lua.newtable
+    forM_ (zip [1..] (rdInputs d)) $ \(i, ing) → do
+        pushIngredient ing
+        Lua.rawseti (-2) i
+    Lua.setfield (-2) "inputs"
+    forM_ (rdFuel d) $ \f → do
+        pushIngredient f
+        Lua.setfield (-2) "fuel"
+    Lua.newtable
+    forM_ (zip [1..] (rdOutputs d)) $ \(i, ing) → do
+        pushIngredient ing
+        Lua.rawseti (-2) i
+    Lua.setfield (-2) "outputs"
+
 -- | craft.get(id) → table | nil. Read-only access to one recipe:
 --   { id, name, station, work, knowledge?, skill?,
 --     inputs = [{item,count}…], fuel = {item,count}?,
@@ -100,32 +136,7 @@ craftGetFn env = do
                 pure (lookupRecipe key m)
             case mDef of
                 Nothing → Lua.pushnil >> return 1
-                Just d → do
-                    Lua.newtable
-                    let putS k v = Lua.pushstring (TE.encodeUtf8 v)
-                                   >> Lua.setfield (-2) k
-                        putN k v = Lua.pushnumber (Lua.Number (realToFrac v))
-                                   >> Lua.setfield (-2) k
-                    putS "id"      (rdId d)
-                    putS "name"    (rdName d)
-                    putS "station" (rdStation d)
-                    putN "work"    (rdWork d)
-                    forM_ (rdKnowledge d) $ putS "knowledge"
-                    forM_ (rdSkill d)     $ putS "skill"
-                    Lua.newtable
-                    forM_ (zip [1..] (rdInputs d)) $ \(i, ing) → do
-                        pushIngredient ing
-                        Lua.rawseti (-2) i
-                    Lua.setfield (-2) "inputs"
-                    forM_ (rdFuel d) $ \f → do
-                        pushIngredient f
-                        Lua.setfield (-2) "fuel"
-                    Lua.newtable
-                    forM_ (zip [1..] (rdOutputs d)) $ \(i, ing) → do
-                        pushIngredient ing
-                        Lua.rawseti (-2) i
-                    Lua.setfield (-2) "outputs"
-                    return 1
+                Just d  → pushRecipe d >> return 1
 
 -- | craft.getNames() → array of all loaded recipe ids.
 craftGetNamesFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
@@ -231,6 +242,8 @@ executeCraft env uid rid = do
     rm ← readIORef (recipeManagerRef env)
     case lookupRecipe rid rm of
         Nothing → return (Left ("unknown recipe " <> rid))
+        Just recipe | rdRepairAxis recipe ≢ Nothing →
+            return (Left (rid <> " is a repair recipe: use repair.repairAt"))
         Just recipe → do
             im ← readIORef (itemManagerRef env)
             case mapM (resolve im) (rdOutputs recipe) of

--- a/src/Engine/Scripting/Lua/API/Craft.hs
+++ b/src/Engine/Scripting/Lua/API/Craft.hs
@@ -61,7 +61,7 @@ loadRecipeYamlFn env = do
                             , rdOutputs   = map ingr (ryOutputs d)
                             , rdKnowledge = ryKnowledge d
                             , rdSkill     = rySkill d
-                            , rdRepairAxis = ryRepairAxis d
+                            , rdRepairAxis = toRepairAxis ⊚ ryRepairAxis d
                             }
                     atomicModifyIORef' (recipeManagerRef env) $ \m →
                         (RecipeManager
@@ -77,6 +77,12 @@ loadRecipeYamlFn env = do
             return 1
   where
     ingr i = RecipeIngredient { riItem = ryiItem i, riCount = ryiCount i }
+    -- Total given Engine.Asset.YamlRecipes' parser already rejects any
+    -- repair_axis value but "condition"/"sharpness" — this is the ONE
+    -- place raw YAML text becomes a RepairAxis; every consumer past
+    -- this point works with the sum type, not a string to compare.
+    toRepairAxis "sharpness" = RepairSharpness
+    toRepairAxis _           = RepairCondition
 
 -- | Push a RecipeIngredient as a Lua `{ item, count }` table.
 pushIngredient ∷ RecipeIngredient → Lua.LuaE Lua.Exception ()
@@ -105,7 +111,7 @@ pushRecipe d = do
     putN "work"    (rdWork d)
     forM_ (rdKnowledge d)  $ putS "knowledge"
     forM_ (rdSkill d)      $ putS "skill"
-    forM_ (rdRepairAxis d) $ putS "repairAxis"
+    forM_ (rdRepairAxis d) $ \axis → putS "repairAxis" (repairAxisName axis)
     Lua.newtable
     forM_ (zip [1..] (rdInputs d)) $ \(i, ing) → do
         pushIngredient ing

--- a/src/Engine/Scripting/Lua/API/Repair.hs
+++ b/src/Engine/Scripting/Lua/API/Repair.hs
@@ -1,0 +1,166 @@
+{-# LANGUAGE Strict, UnicodeSyntax, OverloadedStrings #-}
+-- | Lua surface for the repair policy layer (#301): the station/axis
+--   model on top of the `unit.repairItem` primitive (#300). Repair
+--   flows are ordinary RecipeDef entries (data/recipes/repair.yaml)
+--   tagged with `rdRepairAxis` — "condition" (restored at the furnace,
+--   station "repair_condition") or "sharpness" (honed at the
+--   workbench, station "repair_sharpness") — so they reuse the same
+--   catalogue, station-gating (Engine.Scripting.Lua.API.Craft.
+--   validateStation), and all-or-nothing ingredient consumption
+--   (Craft.Execute.consumeIngredients) as ordinary crafts, but target
+--   an EXISTING item instance instead of producing new ones.
+--
+--   repair.repairAt always restores the targeted axis fully to 100 (a
+--   broken, 0-condition item repairs the same way as a lightly worn
+--   one) — the "how much per action" question the epic (#299/#301)
+--   left open, settled here as full-restore-per-visit for simplicity;
+--   partial/metered restoration is a future refinement, not a
+--   rebalance of what's built here. An axis already at 100 refuses
+--   before any cost is consumed, so an AI (#302) can't waste a
+--   whetstone honing an already-keen edge.
+module Engine.Scripting.Lua.API.Repair
+    ( repairGetFn
+    , repairGetNamesFn
+    , repairAtFn
+    ) where
+
+import UPrelude
+import qualified Data.Text.Encoding as TE
+import qualified Data.HashMap.Strict as HM
+import qualified HsLua as Lua
+import Data.IORef (readIORef, atomicModifyIORef')
+import Engine.Core.State (EngineEnv(..))
+import Craft.Types (RecipeManager(..), RecipeDef(..), lookupRecipe)
+import Craft.Execute (consumeIngredients)
+import Engine.Scripting.Lua.API.Craft (pushRecipe, validateStation)
+import Item.Types (ItemInstance(..), ItemManager)
+import Unit.Types (UnitId(..), UnitInstance(..), UnitManager(..))
+import Building.Types (BuildingId(..))
+import Engine.Scripting.Lua.API.Units (applyRepairToUnit, findHeldItemById)
+
+-- | repair.get(id) → table | nil. Same shape as craft.get, restricted
+--   to recipes tagged with a repair axis.
+repairGetFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+repairGetFn env = do
+    idArg ← Lua.tostring 1
+    case idArg of
+        Nothing → Lua.pushnil >> return 1
+        Just idBS → do
+            let key = TE.decodeUtf8 idBS
+            mDef ← Lua.liftIO $ do
+                m ← readIORef (recipeManagerRef env)
+                pure (lookupRecipe key m)
+            case mDef of
+                Just d | rdRepairAxis d ≢ Nothing → pushRecipe d >> return 1
+                _ → Lua.pushnil >> return 1
+
+-- | repair.getNames() → array of repair-tagged recipe ids only.
+repairGetNamesFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+repairGetNamesFn env = do
+    m ← Lua.liftIO $ readIORef (recipeManagerRef env)
+    let names = [ rdId d | d ← HM.elems (rmDefs m), rdRepairAxis d ≢ Nothing ]
+    Lua.newtable
+    forM_ (zip [1..] names) $ \(i, n) → do
+        Lua.pushstring (TE.encodeUtf8 n)
+        Lua.rawseti (-2) i
+    return 1
+
+-- | repair.repairAt(uid, recipeId, instanceId, bid) → table | nil, err?.
+--   The station-gated repair verb: `recipeId` must be a repair-tagged
+--   recipe, `bid` must be a Built station on the unit's page offering
+--   that recipe's station operation with the unit adjacent (same gate
+--   as craft.executeAt), and the targeted instance (searched across
+--   inventory/equipment/accessories, same reach as unit.repairItem)
+--   must not already be at 100 on the recipe's axis. On success,
+--   consumes the recipe's inputs/fuel from the unit's inventory
+--   all-or-nothing and restores the axis fully to 100, returning the
+--   same { defName, condition, sharpness, conditionApplied,
+--   sharpnessApplied } shape as unit.repairItem. On refusal, returns
+--   nil plus a reason and touches nothing.
+repairAtFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+repairAtFn env = do
+    idArg    ← Lua.tointeger 1
+    ridArg   ← Lua.tostring 2
+    instArg  ← Lua.tointeger 3
+    bidArg   ← Lua.tointeger 4
+    case (idArg, ridArg, instArg, bidArg) of
+        (Just n, Just ridBS, Just iidI, Just b) → do
+            let uid = UnitId (fromIntegral n)
+                rid = TE.decodeUtf8 ridBS
+                iid = fromIntegral iidI ∷ Word64
+                bid = BuildingId (fromIntegral b)
+            result ← Lua.liftIO $ runRepairAt env uid rid iid bid
+            case result of
+                Left err → do
+                    Lua.pushnil
+                    Lua.pushstring (TE.encodeUtf8 err)
+                    return 2
+                Right (defName, cond1, sharp1, cApp, sApp) → do
+                    Lua.newtable
+                    Lua.pushstring (TE.encodeUtf8 defName)
+                    Lua.setfield (-2) "defName"
+                    Lua.pushnumber (Lua.Number (realToFrac cond1))
+                    Lua.setfield (-2) "condition"
+                    Lua.pushnumber (Lua.Number (realToFrac sharp1))
+                    Lua.setfield (-2) "sharpness"
+                    Lua.pushnumber (Lua.Number (realToFrac cApp))
+                    Lua.setfield (-2) "conditionApplied"
+                    Lua.pushnumber (Lua.Number (realToFrac sApp))
+                    Lua.setfield (-2) "sharpnessApplied"
+                    return 1
+        _ → do
+            Lua.pushnil
+            Lua.pushstring (TE.encodeUtf8
+                ("repair.repairAt: expected (uid, recipeId, instanceId, buildingId)" ∷ Text))
+            return 2
+
+runRepairAt ∷ EngineEnv → UnitId → Text → Word64 → BuildingId
+            → IO (Either Text (Text, Float, Float, Float, Float))
+runRepairAt env uid rid iid bid = do
+    rm ← readIORef (recipeManagerRef env)
+    case lookupRecipe rid rm of
+        Nothing → return (Left ("unknown recipe " <> rid))
+        Just recipe → case rdRepairAxis recipe of
+            Nothing → return (Left (rid <> " is not a repair recipe"))
+            Just axis → do
+                gate ← validateStation env uid rid bid
+                case gate of
+                    Left err → return (Left err)
+                    Right () → do
+                        itemMgr ← readIORef (itemManagerRef env)
+                        atomicModifyIORef' (unitManagerRef env) $ \um →
+                            applyRepairAt axis recipe iid itemMgr uid um
+
+-- | The pure atomic step: find the targeted instance, refuse if
+--   already full on the recipe's axis, consume the recipe's demands
+--   all-or-nothing, then restore that axis to 100. All three checks
+--   run before any mutation, so a refusal at any stage leaves the unit
+--   manager untouched.
+applyRepairAt ∷ Text → RecipeDef → Word64 → ItemManager → UnitId
+              → UnitManager
+              → (UnitManager, Either Text (Text, Float, Float, Float, Float))
+applyRepairAt axis recipe iid itemMgr uid um = case HM.lookup uid (umInstances um) of
+    Nothing → (um, Left "no such unit")
+    Just u → case findHeldItemById iid u of
+        Nothing → (um, Left "no such item instance")
+        Just it →
+            let current = axisValue axis it
+            in if current ≥ 100
+                then (um, Left ("already at full " <> axis))
+                else case consumeIngredients recipe (uiInventory u) of
+                    Left err → (um, Left err)
+                    Right inv' →
+                        let u1 = u { uiInventory = inv' }
+                            delta = 100 - current
+                            (condD, sharpD) = case axis of
+                                "sharpness" → (0, delta)
+                                _           → (delta, 0)
+                        in case applyRepairToUnit iid condD sharpD itemMgr u1 of
+                            Nothing → (um, Left "no such item instance")
+                            Just (u2, r) →
+                                ( um { umInstances = HM.insert uid u2
+                                                               (umInstances um) }
+                                , Right r )
+  where
+    axisValue "sharpness" = iiSharpness
+    axisValue _           = iiCondition

--- a/src/Engine/Scripting/Lua/API/Repair.hs
+++ b/src/Engine/Scripting/Lua/API/Repair.hs
@@ -30,7 +30,8 @@ import qualified Data.HashMap.Strict as HM
 import qualified HsLua as Lua
 import Data.IORef (readIORef, atomicModifyIORef')
 import Engine.Core.State (EngineEnv(..))
-import Craft.Types (RecipeManager(..), RecipeDef(..), lookupRecipe)
+import Craft.Types (RecipeManager(..), RecipeDef(..), lookupRecipe,
+                    RepairAxis(..), repairAxisName)
 import Craft.Execute (consumeIngredients)
 import Engine.Scripting.Lua.API.Craft (pushRecipe, validateStation)
 import Item.Types (ItemInstance(..), ItemManager)
@@ -136,7 +137,7 @@ runRepairAt env uid rid iid bid = do
 --   all-or-nothing, then restore that axis to 100. All three checks
 --   run before any mutation, so a refusal at any stage leaves the unit
 --   manager untouched.
-applyRepairAt ∷ Text → RecipeDef → Word64 → ItemManager → UnitId
+applyRepairAt ∷ RepairAxis → RecipeDef → Word64 → ItemManager → UnitId
               → UnitManager
               → (UnitManager, Either Text (Text, Float, Float, Float, Float))
 applyRepairAt axis recipe iid itemMgr uid um = case HM.lookup uid (umInstances um) of
@@ -146,15 +147,15 @@ applyRepairAt axis recipe iid itemMgr uid um = case HM.lookup uid (umInstances u
         Just it →
             let current = axisValue axis it
             in if current ≥ 100
-                then (um, Left ("already at full " <> axis))
+                then (um, Left ("already at full " <> repairAxisName axis))
                 else case consumeIngredients recipe (uiInventory u) of
                     Left err → (um, Left err)
                     Right inv' →
                         let u1 = u { uiInventory = inv' }
                             delta = 100 - current
                             (condD, sharpD) = case axis of
-                                "sharpness" → (0, delta)
-                                _           → (delta, 0)
+                                RepairCondition → (delta, 0)
+                                RepairSharpness → (0, delta)
                         in case applyRepairToUnit iid condD sharpD itemMgr u1 of
                             Nothing → (um, Left "no such item instance")
                             Just (u2, r) →
@@ -162,5 +163,5 @@ applyRepairAt axis recipe iid itemMgr uid um = case HM.lookup uid (umInstances u
                                                                (umInstances um) }
                                 , Right r )
   where
-    axisValue "sharpness" = iiSharpness
-    axisValue _           = iiCondition
+    axisValue RepairCondition = iiCondition
+    axisValue RepairSharpness = iiSharpness

--- a/src/Engine/Scripting/Lua/API/Units.hs
+++ b/src/Engine/Scripting/Lua/API/Units.hs
@@ -89,6 +89,8 @@ module Engine.Scripting.Lua.API.Units
     , unitGetWeaponClassFn
     , unitModifyItemFillFn
     , unitRepairItemFn
+    , applyRepairToUnit
+    , findHeldItemById
     , unitAddItemFn
     , unitGetItemTempFn
     , unitSetItemTempFn
@@ -1744,36 +1746,12 @@ unitRepairItemFn env = do
             mRes ← Lua.liftIO $ atomicModifyIORef' (unitManagerRef env) $ \um →
                 case HM.lookup uid (umInstances um) of
                     Nothing   → (um, Nothing)
-                    Just inst →
-                        -- Inventory, then equipment, then worn accessories;
-                        -- an instance id is unique to one physical item so at
-                        -- most one branch fires.
-                        let commit inst' = um { umInstances =
-                                  HM.insert uid inst' (umInstances um) }
-                        in case repairInList iid condD sharpD (uiInventory inst) of
-                            Just (inv', _, r) →
-                                (commit inst { uiInventory = inv' }, Just r)
-                            Nothing →
-                              case repairInEquip iid condD sharpD
-                                                 (uiEquipment inst) of
-                                Just (eq', _, r) →
-                                    (commit inst { uiEquipment = eq' }, Just r)
-                                Nothing →
-                                  case repairInList iid condD sharpD
-                                                    (uiAccessories inst) of
-                                    Just (accs', _, r) →
-                                        -- Re-derive buffs from the WHOLE worn
-                                        -- list (with the repaired instance in
-                                        -- it), in equip order, so a same-source
-                                        -- duplicate's last-equipped copy stays
-                                        -- the live one — repairing an older
-                                        -- duplicate must not hijack the buff.
-                                        let mods' = refreshAccessoryBuffs itemMgr
-                                                      accs' (uiModifiers inst)
-                                        in ( commit inst { uiAccessories = accs'
-                                                         , uiModifiers   = mods' }
-                                           , Just r )
-                                    Nothing → (um, Nothing)
+                    Just inst → case applyRepairToUnit iid condD sharpD itemMgr inst of
+                        Nothing            → (um, Nothing)
+                        Just (inst', r) →
+                            ( um { umInstances = HM.insert uid inst'
+                                                           (umInstances um) }
+                            , Just r )
             case mRes of
                 Nothing → Lua.pushnil >> return 1
                 Just (defName, cond1, sharp1, cApp, sApp) → do
@@ -1848,6 +1826,28 @@ refreshAccessoryBuffs ∷ ItemManager → [ItemInstance]
                       → HM.HashMap Text [StatModifier]
 refreshAccessoryBuffs itemMgr accs mods0 =
     foldl' (\mods inst → applyAccessoryBuffs itemMgr inst mods) mods0 accs
+
+-- | The pure core of unit.repairItem (#300) and the repair.repairAt
+--   policy layer (#301): search inventory, then equipment, then worn
+--   accessories for `iid` and apply the deltas there, refreshing
+--   condition-scaled accessory buffs same as above. Nothing if the unit
+--   holds no instance with that id.
+applyRepairToUnit ∷ Word64 → Float → Float → ItemManager → UnitInstance
+                  → Maybe (UnitInstance, (Text, Float, Float, Float, Float))
+applyRepairToUnit iid condD sharpD itemMgr inst =
+    case repairInList iid condD sharpD (uiInventory inst) of
+        Just (inv', _, r) → Just (inst { uiInventory = inv' }, r)
+        Nothing →
+          case repairInEquip iid condD sharpD (uiEquipment inst) of
+            Just (eq', _, r) → Just (inst { uiEquipment = eq' }, r)
+            Nothing →
+              case repairInList iid condD sharpD (uiAccessories inst) of
+                Just (accs', _, r) →
+                    let mods' = refreshAccessoryBuffs itemMgr accs'
+                                                       (uiModifiers inst)
+                    in Just (inst { uiAccessories = accs'
+                                  , uiModifiers   = mods' }, r)
+                Nothing → Nothing
 
 -- | Apply one accessory's buffs to a modifier map: def lookup + the
 --   shared Unit.Stats.applyItemBuffs. The modifier source is the item's

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -475,6 +475,7 @@ library
                      Craft.Execute
                      Engine.Asset.YamlRecipes
                      Engine.Scripting.Lua.API.Craft
+                     Engine.Scripting.Lua.API.Repair
                      Location.Types
                      Location.Overlay.Types
                      Location.Overlay

--- a/test-headless/Test/Headless/Craft/Execute.hs
+++ b/test-headless/Test/Headless/Craft/Execute.hs
@@ -44,6 +44,7 @@ daggerRecipe = RecipeDef
     , rdOutputs   = [RecipeIngredient "steel_dagger" 1]
     , rdKnowledge = Nothing
     , rdSkill     = Just "smithing"
+    , rdRepairAxis = Nothing
     }
 
 -- | A fuelled variant whose fuel line repeats an input item.
@@ -73,7 +74,42 @@ spec = do
                         ryFuel d `shouldBe` Nothing
                         ryKnowledge d `shouldBe` Nothing
                         rySkill d `shouldBe` Just "smithing"
+                        ryRepairAxis d `shouldBe` Nothing
                         map ryiItem (ryOutputs d) `shouldBe` ["steel_dagger"]
+                    ds → expectationFailure $
+                        "expected exactly one recipe, got " <> show (length ds)
+
+        it "parses the shipped data/recipes/repair.yaml (#301)" $ do
+            r ← Yaml.decodeFileEither "data/recipes/repair.yaml"
+            case r of
+                Left err → expectationFailure (show err)
+                Right f  → case ryfRecipes f of
+                    [cond, sharp] → do
+                        ryId cond `shouldBe` "repair_condition"
+                        ryStation cond `shouldBe` "repair_condition"
+                        ryRepairAxis cond `shouldBe` Just "condition"
+                        map ryiItem (ryInputs cond) `shouldBe` ["lignite_chunk"]
+                        ryOutputs cond `shouldBe` []
+                        ryId sharp `shouldBe` "repair_sharpness"
+                        ryStation sharp `shouldBe` "repair_sharpness"
+                        ryRepairAxis sharp `shouldBe` Just "sharpness"
+                        map ryiItem (ryInputs sharp) `shouldBe` ["whetstone"]
+                        ryOutputs sharp `shouldBe` []
+                    ds → expectationFailure $
+                        "expected exactly two recipes, got " <> show (length ds)
+
+        it "repair_axis defaults to Nothing when omitted" $ do
+            let src = BS8.pack $ unlines
+                    [ "recipes:"
+                    , "  - id: plain_craft"
+                    , "    station: forge"
+                    , "    inputs: []"
+                    , "    outputs: []"
+                    ]
+            case parseFile src of
+                Left err → expectationFailure (show err)
+                Right f  → case ryfRecipes f of
+                    [d] → ryRepairAxis d `shouldBe` Nothing
                     ds → expectationFailure $
                         "expected exactly one recipe, got " <> show (length ds)
 

--- a/test-headless/Test/Headless/Craft/Execute.hs
+++ b/test-headless/Test/Headless/Craft/Execute.hs
@@ -113,6 +113,20 @@ spec = do
                     ds → expectationFailure $
                         "expected exactly one recipe, got " <> show (length ds)
 
+        it "rejects an invalid repair_axis instead of silently defaulting" $ do
+            let src = BS8.pack $ unlines
+                    [ "recipes:"
+                    , "  - id: broken_repair"
+                    , "    station: repair_sharpness"
+                    , "    repair_axis: sharpnes"  -- typo: not "sharpness"
+                    , "    inputs: []"
+                    , "    outputs: []"
+                    ]
+            case parseFile src of
+                Left _  → pure ()
+                Right _ → expectationFailure
+                    "expected a parse failure for an invalid repair_axis"
+
         it "defaults name/work/count and reads fuel + knowledge" $ do
             let src = BS8.pack $ unlines
                     [ "recipes:"

--- a/tools/craft_probe.py
+++ b/tools/craft_probe.py
@@ -309,8 +309,8 @@ def main():
         passed = check(passed, not ok_e and "not built" in msg,
                        "executeAt refused at unbuilt station", msg)
         ops = jget(port, f"return building.getOperations({bid_f})")
-        ok = isinstance(ops, list) and sorted(ops) == ["repair", "smelt"]
-        passed = check(passed, ok, "furnace advertises smelt+repair", ops)
+        ok = isinstance(ops, list) and sorted(ops) == ["repair_condition", "smelt"]
+        passed = check(passed, ok, "furnace advertises smelt+repair_condition", ops)
         send(port, f"building.addBuildProgress({bid_f}, 200); return 'ok'")
         act = send(port, f"return building.getActivity({bid_f})").strip('"')
         passed = check(passed, act == "built", "furnace reaches built", act)
@@ -332,12 +332,17 @@ def main():
         hit = send(port, f"local b=building.findStation('forge'); return b or -1")
         passed = check(passed, int(float(hit)) == bid_w,
                        "findStation('forge') → workbench", hit)
-        # Both stations advertise "repair" — the routing hook the repair
-        # flows (#301/#302) plug into.
+        # The repair flows (#301/#302) split condition/sharpness into
+        # separate station operations, so findStation routes each to
+        # its own building instead of a shared generic "repair" tag.
         hit = send(port,
-                   f"local b=building.findStation('repair', 2, 2); return b or -1")
-        passed = check(passed, int(float(hit)) in (bid_f, bid_w),
-                       "findStation('repair') finds a station", hit)
+                   f"local b=building.findStation('repair_condition', 2, 2); return b or -1")
+        passed = check(passed, int(float(hit)) == bid_f,
+                       "findStation('repair_condition') → furnace", hit)
+        hit = send(port,
+                   f"local b=building.findStation('repair_sharpness', 2, 2); return b or -1")
+        passed = check(passed, int(float(hit)) == bid_w,
+                       "findStation('repair_sharpness') → workbench", hit)
 
         # Success at the right station: same consumption as craft.execute.
         send(port, f"unit.addItem({uid},'steel_bar'); "

--- a/tools/repair_probe.py
+++ b/tools/repair_probe.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Repair probe (#301) — the policy layer on top of unit.repairItem (#300).
+
+Boots a headless engine on a flat arena, loads defs + data/recipes +
+data/buildings, spawns an acolyte, degrades a weapon's condition and
+sharpness directly via unit.repairItem (the #300 primitive — the only
+way to simulate wear headless without a real combat pass), then checks
+the repair.* Lua API end-to-end:
+
+  1. Catalogue: repair.getNames lists exactly the two shipped repair
+     recipes (repair_condition, repair_sharpness) and NOT the ordinary
+     craft recipes; repair.get returns the repairAxis field craft.get
+     also exposes but ordinary recipes omit.
+  2. craft.execute/executeAt refuse repair-tagged recipes with a clear
+     "use repair.repairAt" reason, leaving inventory untouched.
+  3. repair.repairAt refuses: unknown recipe id, a non-repair recipe
+     id, an unbuilt station, the WRONG station for the axis (a
+     condition recipe at the workbench and vice versa — the split
+     operations from #301 must route correctly), a non-adjacent unit,
+     and an unknown item instance — all leaving inventory + item state
+     untouched.
+  4. Station-gated success: repair_condition at the BUILT furnace
+     consumes 1 lignite_chunk and restores a degraded weapon's
+     condition fully to 100 (sharpness untouched); repair_sharpness at
+     the BUILT workbench consumes 1 whetstone and restores sharpness
+     fully to 100 (condition untouched). Instance id is preserved.
+  5. A fully broken (condition 0) item repairs the same way as a
+     lightly worn one (full restore, same cost).
+  6. An axis already at 100 refuses ("already at full ...") before any
+     cost is consumed.
+  7. Short cost (no lignite_chunk / no whetstone) refuses with nothing
+     consumed and the item unchanged.
+
+Usage: python3 tools/repair_probe.py [--port 9319]
+"""
+import argparse, glob, json, socket, subprocess, sys, time
+
+SPROOT = "/tmp"
+
+
+def send(port, lua, timeout=10.0):
+    with socket.create_connection(("localhost", port), timeout=timeout) as s:
+        s.settimeout(timeout)
+        f = s.makefile("rw")
+        f.readline()              # banner
+        f.write(lua + "\n")
+        f.flush()
+        return f.readline().strip().lstrip("> ").strip()
+
+
+def jget(port, lua, timeout=10.0):
+    raw = send(port, lua, timeout)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw.strip('"')
+
+
+def boot(port, log_path):
+    log = open(log_path, "w")
+    proc = subprocess.Popen(
+        ["cabal", "run", "-v0", "exe:synarchy", "--",
+         "--headless", "--port", str(port)],
+        stdout=log, stderr=subprocess.STDOUT)
+    for _ in range(300):
+        time.sleep(0.2)
+        if proc.poll() is not None:
+            sys.exit(f"engine exited before READY; see {log_path}")
+        try:
+            if "READY" in open(log_path).read():
+                return proc
+        except FileNotFoundError:
+            pass
+    proc.kill()
+    sys.exit("engine never printed READY")
+
+
+def bootstrap(port):
+    """Load defs + the flat arena (the loading screen doesn't run headless)."""
+    for pattern, fn in [
+        ("data/substances/*.yaml", "engine.loadSubstanceYaml"),
+        ("data/items/*.yaml",      "engine.loadItemYaml"),
+        ("data/equipment/*.yaml",  "engine.loadEquipmentYaml"),
+        ("data/materials/*.yaml",  "engine.loadMaterialYaml"),
+        ("data/vegetation/*.yaml", "engine.loadVegetationYaml"),
+        ("data/units/*.yaml",      "engine.loadUnitYaml"),
+        ("data/recipes/*.yaml",    "engine.loadRecipeYaml"),
+        ("data/buildings/*.yaml",  "engine.loadBuildingYaml"),
+    ]:
+        for path in sorted(glob.glob(pattern)):
+            send(port, f"{fn}('{path}'); return 'ok'")
+    send(port,
+         "return require('scripts.movement_arena').buildCourse('flat').name")
+    for _ in range(60):
+        raw = send(port, "return world.getActiveWorldId()").strip().strip('"')
+        if raw and raw not in ("null", "nil"):
+            break
+        time.sleep(0.5)
+    else:
+        sys.exit("arena page never became the active world")
+    send(port, "return world.loadChunksInRegion(-1, -1, 2, 2)")
+    send(port, "return world.waitForChunks(60)", timeout=65.0)
+    # unit_ai is auto-loaded at engine boot and its update() tick wanders
+    # every spawned unit headless. The station checks assume the unit
+    # STAYS on its spawn tile for footprint adjacency (same trick as
+    # craft_probe / movement_probe) — nothing under test needs the AI.
+    send(port,
+         "pcall(function() require('scripts.unit_ai').update = function() end end); "
+         "return 'ai-off'")
+
+
+def count_item(port, uid, name):
+    return int(float(send(port,
+        f"local c=0; for _,it in ipairs(unit.getInventory({uid}) or {{}}) do "
+        f"if it.defName=='{name}' then c=c+1 end end; return c")))
+
+
+def spawn_station(port, uid, def_name, gx, gy, materials):
+    """Spawn def_name at (gx, gy), deliver build materials from the unit
+    through the real machinery, and build it fully. Returns the built
+    building id."""
+    raw = send(port, f"return building.spawn('{def_name}', {gx}, {gy})")
+    try:
+        bid = int(float(raw))
+    except ValueError:
+        sys.exit(f"building.spawn('{def_name}') failed: {raw}")
+    for _ in range(50):
+        if send(port, f"return building.getInfo({bid}) and 'yes' or 'no'"
+                ).strip('"') == "yes":
+            break
+        time.sleep(0.1)
+    else:
+        sys.exit(f"{def_name} instance never appeared")
+    for item, count in materials.items():
+        send(port,
+             f"for i=1,{count} do unit.addItem({uid},'{item}'); "
+             f"unit.transferItemToBuilding({uid},{bid},'{item}') end; "
+             f"return 'ok'")
+    sat = send(port, f"return building.areMaterialsSatisfied({bid}) "
+                     f"and 'yes' or 'no'").strip('"')
+    if sat != "yes":
+        sys.exit(f"{def_name} materials not satisfied after delivery")
+    send(port, f"building.addBuildProgress({bid}, 100000); return 'ok'")
+    act = send(port, f"return building.getActivity({bid})").strip('"')
+    if act != "built":
+        sys.exit(f"{def_name} never reached built (got {act})")
+    return bid
+
+
+def spawn_weapon(port, uid, cond=100.0, sharp=100.0):
+    """Add a fresh axe_steel and force its wear axes to exact values,
+    then return its instanceId. axe_steel's condition rolls in [80,100]
+    at spawn (idConditionSpec), so setting an exact target needs two
+    repairItem deltas: a large negative one to floor both axes at 0
+    regardless of the roll, then a precise positive one from that known
+    floor (unit.repairItem's delta is ADDITIVE + clamped, not a set)."""
+    send(port, f"unit.addItem({uid}, 'axe_steel'); return 'ok'")
+    axes = jget(port,
+        f"local out={{}}; for _,it in ipairs(unit.getInventory({uid}) or {{}}) do "
+        f"if it.defName=='axe_steel' then out[#out+1]=it.instanceId end end; "
+        f"return out")
+    iid = int(axes[-1])
+    send(port, f"unit.repairItem({uid}, {iid}, -1000, -1000); return 'ok'")
+    send(port, f"unit.repairItem({uid}, {iid}, {cond}, {sharp}); return 'ok'")
+    return iid
+
+
+def axe_state(port, uid, iid):
+    r = jget(port,
+        f"for _,it in ipairs(unit.getInventory({uid}) or {{}}) do "
+        f"if it.instanceId=={iid} then return {{cond=it.condition,"
+        f"sharp=it.sharpness}} end end; return nil")
+    return r
+
+
+def repair_at(port, uid, recipe_id, iid, bid):
+    """→ (result: dict|None, err: str)."""
+    raw = jget(port,
+        f"local r,err = repair.repairAt({uid}, '{recipe_id}', {iid}, {bid}); "
+        f"if r then return r end; return 'ERR:'..tostring(err)")
+    if isinstance(raw, dict):
+        return raw, ""
+    return None, str(raw)
+
+
+def check(passed, ok, label, detail=""):
+    print(f"  [{'PASS' if ok else 'FAIL'}] {label}" + (f": {detail}" if detail else ""))
+    return passed and ok
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=9319)
+    args = ap.parse_args()
+    port = args.port
+    passed = True
+
+    proc = boot(port, f"{SPROOT}/repair_probe_engine.log")
+    try:
+        bootstrap(port)
+        uid = int(float(send(port, "return unit.spawn('acolyte', 2, 2)")))
+        if uid < 0:
+            sys.exit("unit.spawn failed")
+        time.sleep(1.0)
+
+        # --- 1. Catalogue ---
+        names = jget(port, "return repair.getNames()")
+        ok = (isinstance(names, list)
+              and set(names) == {"repair_condition", "repair_sharpness"})
+        passed = check(passed, ok, "getNames lists only the repair recipes", names)
+        r = jget(port, "return repair.get('repair_condition')")
+        ok = (isinstance(r, dict) and r.get("station") == "repair_condition"
+              and r.get("repairAxis") == "condition"
+              and r.get("inputs") == [{"item": "lignite_chunk", "count": 1}])
+        passed = check(passed, ok, "repair.get('repair_condition') shape", r)
+        r = jget(port, "return repair.get('repair_sharpness')")
+        ok = (isinstance(r, dict) and r.get("station") == "repair_sharpness"
+              and r.get("repairAxis") == "sharpness"
+              and r.get("inputs") == [{"item": "whetstone", "count": 1}])
+        passed = check(passed, ok, "repair.get('repair_sharpness') shape", r)
+        ok = send(port, "return repair.get('forge_steel_dagger') and 'yes' or 'nil'"
+                  ).strip('"') == "nil"
+        passed = check(passed, ok, "repair.get refuses an ordinary craft recipe")
+        r = jget(port, "return craft.get('repair_condition')")
+        ok = isinstance(r, dict) and "repairAxis" in r
+        passed = check(passed, ok, "craft.get also exposes repairAxis", r)
+
+        # --- 2. craft.execute/executeAt refuse repair recipes ---
+        bars0 = count_item(port, uid, "lignite_chunk")
+        ok_e, msg = jget(port,
+            f"local ok,err = craft.execute({uid}, 'repair_condition'); "
+            f"return {{ok, tostring(err)}}")
+        ok = (ok_e is False and "repair recipe" in msg
+              and count_item(port, uid, "lignite_chunk") == bars0)
+        passed = check(passed, ok, "craft.execute refuses a repair recipe", msg)
+
+        # --- Build both stations, fully. ---
+        bid_f = spawn_station(port, uid, "furnace", 3, 2,
+                              {"granite_chunk": 6, "steel_bar": 2})
+        bid_w = spawn_station(port, uid, "workbench", 1, 2,
+                              {"wood_log": 4, "steel_hardware": 4,
+                               "steel_bar": 2})
+
+        # --- 3. Refusals ---
+        iid = spawn_weapon(port, uid, cond=40.0, sharp=100.0)
+        ok_e, msg = repair_at(port, uid, "no_such_recipe", iid, bid_f)
+        passed = check(passed, ok_e is None and "unknown recipe" in msg,
+                       "unknown recipe refused", msg)
+        ok_e, msg = repair_at(port, uid, "forge_steel_dagger", iid, bid_f)
+        passed = check(passed, ok_e is None and "not a repair recipe" in msg,
+                       "non-repair recipe id refused", msg)
+        ok_e, msg = repair_at(port, uid, "repair_condition", iid, 99999)
+        passed = check(passed, ok_e is None and "no such building" in msg,
+                       "unknown building refused", msg)
+        bid_ghost = int(float(send(port,
+            "return building.spawn('furnace', 6, 2)")))
+        for _ in range(50):        # spawn is queued to the building thread
+            if send(port, f"return building.getInfo({bid_ghost}) and 'yes' or 'no'"
+                    ).strip('"') == "yes":
+                break
+            time.sleep(0.1)
+        else:
+            sys.exit("ghost furnace instance never appeared")
+        ok_e, msg = repair_at(port, uid, "repair_condition", iid, bid_ghost)
+        passed = check(passed, ok_e is None and "not built" in msg,
+                       "unbuilt station refused", msg)
+        # Wrong station for the axis: condition recipe at the workbench,
+        # sharpness recipe at the furnace — the #301 split must hold.
+        ok_e, msg = repair_at(port, uid, "repair_condition", iid, bid_w)
+        passed = check(passed, ok_e is None and "does not offer" in msg,
+                       "condition recipe refused at the workbench", msg)
+        ok_e, msg = repair_at(port, uid, "repair_sharpness", iid, bid_f)
+        passed = check(passed, ok_e is None and "does not offer" in msg,
+                       "sharpness recipe refused at the furnace", msg)
+        # Non-adjacent unit.
+        uid2 = int(float(send(port, "return unit.spawn('acolyte', 12, 12)")))
+        time.sleep(0.5)
+        iid2 = spawn_weapon(port, uid2, cond=40.0, sharp=100.0)
+        ok_e, msg = repair_at(port, uid2, "repair_condition", iid2, bid_f)
+        passed = check(passed, ok_e is None and "not adjacent" in msg,
+                       "far unit refused (not adjacent)", msg)
+        # Unknown item instance on the (adjacent) probe unit.
+        ok_e, msg = repair_at(port, uid, "repair_condition", 999999, bid_f)
+        passed = check(passed, ok_e is None and "no such item instance" in msg,
+                       "unknown instance refused", msg)
+
+        # --- 4. Station-gated success: condition at the furnace ---
+        send(port, f"unit.addItem({uid}, 'lignite_chunk'); return 'ok'")
+        fuel0 = count_item(port, uid, "lignite_chunk")
+        before = axe_state(port, uid, iid)
+        r, msg = repair_at(port, uid, "repair_condition", iid, bid_f)
+        after = axe_state(port, uid, iid)
+        ok = (r is not None and r["condition"] == 100 and r["sharpness"] == 100
+              and abs(r["conditionApplied"] - 60.0) < 0.01
+              and r["sharpnessApplied"] == 0
+              and count_item(port, uid, "lignite_chunk") == fuel0 - 1
+              and before["cond"] == 40 and after["cond"] == 100
+              and after["sharp"] == before["sharp"])
+        passed = check(passed, ok,
+                       "repair_condition at furnace: fuel consumed, condition->100, sharpness untouched",
+                       f"r={r} before={before} after={after}")
+
+        # --- Sharpness at the workbench ---
+        iid_s = spawn_weapon(port, uid, cond=100.0, sharp=25.0)
+        send(port, f"unit.addItem({uid}, 'whetstone'); return 'ok'")
+        stone0 = count_item(port, uid, "whetstone")
+        r, msg = repair_at(port, uid, "repair_sharpness", iid_s, bid_w)
+        after_s = axe_state(port, uid, iid_s)
+        ok = (r is not None and r["sharpness"] == 100 and r["condition"] == 100
+              and abs(r["sharpnessApplied"] - 75.0) < 0.01
+              and r["conditionApplied"] == 0
+              and count_item(port, uid, "whetstone") == stone0 - 1
+              and after_s["sharp"] == 100 and after_s["cond"] == 100)
+        passed = check(passed, ok,
+                       "repair_sharpness at workbench: whetstone consumed, sharpness->100, condition untouched",
+                       f"r={r} after={after_s}")
+
+        # --- 5. Fully broken (condition 0) repairs the same way ---
+        iid_broken = spawn_weapon(port, uid, cond=0.0, sharp=100.0)
+        send(port, f"unit.addItem({uid}, 'lignite_chunk'); return 'ok'")
+        r, msg = repair_at(port, uid, "repair_condition", iid_broken, bid_f)
+        ok = (r is not None and r["condition"] == 100
+              and abs(r["conditionApplied"] - 100.0) < 0.01)
+        passed = check(passed, ok, "broken (condition 0) item repairs fully", f"r={r}")
+
+        # --- 6. Already-full axis refuses before consuming anything ---
+        fuel_before = count_item(port, uid, "lignite_chunk")
+        ok_e, msg = repair_at(port, uid, "repair_condition", iid_broken, bid_f)
+        ok = (ok_e is None and "already at full" in msg
+              and count_item(port, uid, "lignite_chunk") == fuel_before)
+        passed = check(passed, ok, "already-full axis refused, nothing consumed", msg)
+
+        # --- 7. Short cost refuses, nothing consumed ---
+        iid_poor = spawn_weapon(port, uid, cond=10.0, sharp=100.0)
+        while count_item(port, uid, "lignite_chunk") > 0:
+            send(port, f"unit.removeItem({uid}, 'lignite_chunk'); return 'ok'")
+        ok_e, msg = repair_at(port, uid, "repair_condition", iid_poor, bid_f)
+        state = axe_state(port, uid, iid_poor)
+        ok = (ok_e is None and "missing" in msg and "lignite_chunk" in msg
+              and state["cond"] == 10)
+        passed = check(passed, ok, "short fuel refused, item untouched", msg)
+
+        print("\n" + ("ALL REPAIR CHECKS PASSED" if passed else "SOME FAILED"))
+        return 0 if passed else 1
+    finally:
+        try:
+            send(port, "engine.quit()")
+        except Exception:
+            pass
+        time.sleep(1.0)
+        proc.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #301

## Context

Part of the equipment-repair epic (#299). The issue was explicitly flagged "design-heavy — discuss the model before building." I opened a design-discussion question (station↔axis mapping, cost model, restore semantics) but it went unanswered, so I proceeded on my own best judgment using the recommended defaults, documented below — please push back on any of these in review, they're easy to change.

## Design decisions made here

- **Station↔axis routing:** the already-landed `furnace.yaml`/`workbench.yaml` (#326, PR #465) both advertised a shared generic `"repair"` operation tag, which would let `findStation`/`executeAt` route a condition-repair to the workbench or a sharpness-repair to the furnace indiscriminately. Split into distinct `repair_condition` (furnace only) and `repair_sharpness` (workbench only) operations so routing is unambiguous.
- **Cost model:** material-gated, matching how crafting ties into the economy. Reforging (furnace) burns 1 `lignite_chunk`; honing (workbench) burns 1 new `whetstone` item (fully consumed per use — a "wears down over N uses" tool is a possible future refinement, not required here).
- **Restore semantics:** one repair action/visit always restores the targeted axis fully to 100, whether the item arrived lightly worn or fully broken (condition 0) — the simplest model satisfying "broken items repairable." An axis already at 100 refuses before any cost is consumed (so an AI can't waste a whetstone on an already-keen edge).

## Approach

Repair flows are **ordinary `RecipeDef` entries** (`data/recipes/repair.yaml`) tagged with a new optional `repair_axis` field ("condition"/"sharpness"), rather than a parallel system — they reuse the existing recipe catalogue, `validateStation` station-gating (#326), and `consumeIngredients` all-or-nothing consumption. What's new:

- A `repair.*` Lua API (`get`/`getNames`/`repairAt`) — `repair.repairAt(uid, recipeId, instanceId, bid)` targets an **existing** item instance (via the #300 `unit.repairItem` primitive) instead of producing new outputs like `craft.execute`/`executeAt` do.
- `craft.execute`/`executeAt` now refuse repair-tagged recipes with a clear "use repair.repairAt" redirect, since they share the same `RecipeManager`.
- Extracted the shared "find this instance across inventory/equipment/accessories and repair it, refreshing condition-scaled accessory buffs" core out of `Units.hs` into `applyRepairToUnit`, reused by both `unit.repairItem` and `repair.repairAt`.
- New `whetstone` item def; `furnace`/`workbench` operations renamed per the routing fix above.

## Tested

- `cabal test synarchy-test-headless` — 525 examples, 0 failures (added repair_axis YAML schema tests: shipped `data/recipes/repair.yaml` parses, defaults to `Nothing` when omitted).
- `python3 tools/craft_probe.py` — all pass, confirms the station-operation rename didn't regress #326's station tests (updated its two assertions that referenced the old shared `"repair"` tag).
- New `python3 tools/repair_probe.py` — 19 checks: catalogue (get/getNames scoped to repair recipes only), `craft.execute` refusing a repair recipe, station/axis routing (including refusing a condition recipe at the workbench and vice versa), unbuilt-station / non-adjacent / unknown-building / unknown-instance refusals, cost consumption + full restore (including from a fully broken item), already-full-axis refusal, and short-cost refusal — all leaving state untouched on failure.
- `python3 tools/world_check.py` — 21/21 (no worldgen change).
- `python3 tools/test_audit.py` — 35/35.
- Fresh `cabal build all` + `cabal build synarchy-test-graphical` — zero warnings on a from-scratch worktree build.
- No save-version bump: `RecipeDef`/repair data aren't persisted (loaded fresh from YAML at startup, same as ordinary recipes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)