### PR TITLE
Refresh README to describe Synarchy as a full game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,74 @@
 # Synarchy
 
-synarchy is a modularized graphics engine for 2D sprites and animations written in haskell using the vulkan bindings.
+Synarchy is a colony/survival simulation game with procedurally generated worlds, written in Haskell on a custom Vulkan renderer. Units live on a tile-based world with real geology, hydrology, and weather; they fight, build, craft, farm, and get hurt in a layered combat/injury/physiology simulation, all driven from a Lua scripting layer on top of the engine.
 
 ## Prerequisites
 
-to run you just need vulkan installed, for development you need the vulkan sdk, glslang, and validation layers installed, as well as GHC (GHC2024) and cabal (>3.4), any other libraries will be installed by cabal.  This project has only been tested on macos, but will work on linux as well, and windows with some modifications.
+To run you just need Vulkan installed. For development you need the Vulkan SDK, glslang, and validation layers installed, as well as GHC (GHC2024) and cabal (>3.4) — any other libraries will be installed by cabal. This project is developed primarily on macOS but works on Linux with minor adjustments (see `CLAUDE.md`).
 
 ## Building
 
-`cabal build synarchy`
+`cabal build synarchy`, or `cabal build all` to build the library and executable together (this does **not** build the test suites — see Testing below).
 
 ## Usage
 
-to run the program, use `cabal run synarchy`, to run the tests use `cabal test`, or you can of course run the binary directly. use "ENGINE_DEBUG=Vulkan,Graphics,etc..." to get debug output from those modules.
+To run the game, use `cabal run synarchy`. Use `ENGINE_DEBUG=Vulkan,Graphics,etc...` to get debug output from those subsystems.
 
-## Development
+The engine also supports a **headless mode** (no window, no GPU) for scripted world generation, automated testing, and agent workflows — see the Debug Console section below and `CLAUDE.md` for the full headless API (world generation, unit/combat queries, save/load, dump mode).
 
-- data is split into `Base.hs` and `Types.hs`, base files have no local dependencies, and types files have everything else.
-- the project is organized as follows:
-    - README, CHANGELOG, LICENSE, cabal file
-    - src
-        - UPrelude (unicode and other utilities)
-        - Math (math utilities and types)
-        - Engine
-            - Asset (loading and managing assets)
-            - Core (main engine functionality/continuation monad/resource handling)
-            - Event (event handling)
-            - Graphics (vulkan and graphics functionality)
-                - Vulkan (vulkan specific functionality)
-                - Window (windowing and input handling (glfw))
-                - Font (font rendering)
-            - Input (input handling)
-            - Scene (scene graph and rendering)
-            - Scripting (lua scripting support)
-            - Loop
-                - main loop and timing
-        - UI
-            - code for the ui system
-        - World
-            - code for the world
-    - app (here Main.hs controls the draw loop)
-    - assets (images and other data)
-    - cbits (c code for text rasterization library and lua debug info)
-    - config (yaml config files)
-    - scripts (lua scripts)
-    - test (unit tests are really just for the base engine and most of the functionality is tested in the app)
+## Testing
 
-## Task List
+`cabal test` builds and runs the test suites. `synarchy-test-headless` (hspec unit/integration tests, no GPU) is the one to reach for during iteration:
 
-- [x] initialize Vulkan and GLFW
-- [x] load and render multiple textured sprites
-- [x] multiple shader support through asset manager
-- [x] sprite manager for batch processing
-- [x] scene creation and switching
-- [x] UI
-- [x] basic world generation
-- [x] animation
-- [ ] hotloading
-- [ ] game (working title: "Ecce Homo")
+```bash
+cabal test synarchy-test-headless
+```
+
+`tools/` also has a large suite of Python-driven checks: world-generation regression tools (`world_check.py`, `world_audit.py`, ...) and ~20 headless **behavior probes** that boot a real headless engine to regression-test specific systems (combat animation, movement, physiology, crafting, construction, save/load, and more — see `tools/README.md`). `CLAUDE.md` documents which tier of tests to run for a given kind of change.
+
+## Gameplay & simulation systems
+
+- **World generation** (`World.Generate`, `World.Geology`, `World.Hydrology`, `World.Fluid`, `World.Flora`) — tectonic plates, erosion, rivers, glaciers, lakes, ore deposits, and vegetation placement over a chunked, cylindrical (wraparound) world with LOD-based zoom rendering.
+- **Units & AI** (`Unit.*`, driven from `scripts/unit_ai.lua` and friends) — pathing, movement, wildlife and NPC behavior, derived work roles (miner/woodcutter/builder/smith/laborer), and a physiology/homeostasis model (thermoregulation, hunger, stamina).
+- **Combat & injury** (`Combat.*`) — layered penetration damage, weapon/armor degradation, wounds, infection, and a medical treatment arc, surfaced through combat/injury log panels.
+- **Construction & crafting** (`Building.*`, `Structure.*`, `Craft.*`, `Item.*`, `Equipment.*`) — buildings and structure pieces raised via designation + build AI, a recipe-driven crafting system with work stations, and item instances with condition/sharpness and repair.
+- **Locations** (`Location.*`) — premade structure stamps placed into procedural worlds.
+- **UI** (`UI.*`) — focus management, text input, and rendering, with layout and behavior driven from Lua.
+
+## Project structure
+
+- `README`, `CHANGELOG`, `LICENSE`, cabal file
+- `src/` — library source (360+ modules)
+  - `UPrelude` — unicode prelude and shared utilities (imported instead of the standard `Prelude`)
+  - `Math` — math utilities and types
+  - `Engine/`
+    - `Asset` — loading and managing assets
+    - `Core` — the `EngineM` continuation-passing monad, state, and resource handling
+    - `Event` — event handling
+    - `Graphics` — Vulkan rendering, windowing/input (GLFW), font rendering
+    - `Input` — input handling
+    - `Scene` — scene graph, batching, and rendering
+    - `Scripting` — the Lua scripting bridge and its API modules
+    - `Loop` — main loop and timing
+  - `World` — procedural world generation, geology, hydrology, fluids, flora, chunk/tile state, save/load
+  - `Unit` — units, movement, pathing, line of sight, animation
+  - `Combat` — damage resolution and wounds
+  - `Craft` — recipe execution
+  - `Building` / `Structure` — buildings and structure pieces
+  - `Item` / `Equipment` / `Substance` / `LootTable` — items, equipment, materials, loot tables
+  - `Location` — premade structure stamps
+  - `Infection` — wound infection simulation
+  - `Sim` — simulation glue (e.g. active fluids)
+  - `UI` — focus, text input, tooltips, UI rendering
+- `app/Main.hs` — executable entry point (draw loop)
+- `test/`, `test-headless/` — hspec test suites (`synarchy-test-graphical`, `synarchy-test-headless`)
+- `tools/` — Python worldgen regression tools and headless behavior probes (see `tools/README.md`)
+- `cbits/` — C code (stb_truetype font rasterization, Lua debug FFI)
+- `config/` — YAML config (keybinds, video, pathing, notifications, world-gen defaults)
+- `data/` — game data YAML (buildings, items, units, flora, recipes, materials, structure packs, ...)
+- `assets/` — textures and fonts
+- `scripts/` — Lua scripts driving game logic (UI, AI, world management, item/building loaders)
+- `docs/` — design notes and audit history
 
 ## Debug Console
 
@@ -100,10 +111,12 @@ The debug console has access to the full Lua environment. Key namespaces:
 - `camera` — camera control (`goToTile`, `getPosition`)
 - `engine` — engine control (`quit`)
 
+`CLAUDE.md` documents the much larger headless/dump API surface (unit and combat queries, construction, crafting, save/load, and the various turnkey test probes) in detail.
+
 ### Configuration
 
-Set `SYNARCHY_DEBUG_PORT` to change the port (default: 8008).
+The default port is 8008. Pass `--port` to both the engine and the client to use a different one, e.g. `cabal run synarchy -- --headless --port 9008` and `./debug-console.py --port 9008`.
 
 ## Known Issues
 
-- on macos you will get junk in stdout, apple says there is no way around this, which is wild, even redirecting stdout doesnt work
+- On macOS you will get junk in stdout — Apple says there is no way around this, which is wild, even redirecting stdout doesn't work.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Synarchy
 
-Synarchy is a colony/survival simulation game with procedurally generated worlds, written in Haskell on a custom Vulkan renderer. Units live on a tile-based world with real geology, hydrology, and weather; they fight, build, craft, farm, and get hurt in a layered combat/injury/physiology simulation, all driven from a Lua scripting layer on top of the engine.
+Synarchy is a Haskell/Vulkan engine. It runs Ecce Homo, a colony/survival simulation game with procedurally generated worlds. This repository holds both: the engine (`src/Engine`) and the game built on it (world generation, units, combat, construction, crafting, UI — Haskell + Lua).
 
 ## Prerequisites
 
-To run you just need Vulkan installed. For development you need the Vulkan SDK, glslang, and validation layers installed, as well as GHC (GHC2024) and cabal (>3.4) — any other libraries will be installed by cabal. This project is developed primarily on macOS but works on Linux with minor adjustments (see `CLAUDE.md`).
+Vulkan to run. Vulkan SDK, glslang, and validation layers to develop, plus GHC (GHC2024) and cabal (>3.4) — other dependencies are installed by cabal. Developed primarily on macOS; works on Linux with minor adjustments (see `CLAUDE.md`).
 
 ## Building
 
@@ -12,9 +12,9 @@ To run you just need Vulkan installed. For development you need the Vulkan SDK, 
 
 ## Usage
 
-To run the game, use `cabal run synarchy`. Use `ENGINE_DEBUG=Vulkan,Graphics,etc...` to get debug output from those subsystems.
+`cabal run synarchy` to run the game. `ENGINE_DEBUG=Vulkan,Graphics,etc...` for debug output from those subsystems.
 
-The engine also supports a **headless mode** (no window, no GPU) for scripted world generation, automated testing, and agent workflows — see the Debug Console section below and `CLAUDE.md` for the full headless API (world generation, unit/combat queries, save/load, dump mode).
+The engine also has a **headless mode** (no window, no GPU) for scripted world generation, automated testing, and agent workflows — see the Debug Console section below and `CLAUDE.md` for the full headless API (world generation, unit/combat queries, save/load, dump mode).
 
 ## Testing
 
@@ -120,3 +120,11 @@ The default port is 8008. Pass `--port` to both the engine and the client to use
 ## Known Issues
 
 - On macOS you will get junk in stdout — Apple says there is no way around this, which is wild, even redirecting stdout doesn't work.
+
+## Contributing
+
+Issues and PRs are welcome — bug reports, feature requests, and design discussion included. Read `CLAUDE.md` first: it covers build commands, testing tiers, save/load conventions, and headless-agent workflows.
+
+## License
+
+MIT — see `LICENSE`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Synarchy is a Haskell/Vulkan engine. It runs Ecce Homo, a colony/survival simula
 
 ## Prerequisites
 
-Vulkan to run. Vulkan SDK, glslang, and validation layers to develop, plus GHC (GHC2024) and cabal (>3.4) — other dependencies are installed by cabal. Developed primarily on macOS; works on Linux with minor adjustments (see `CLAUDE.md`).
+Vulkan to run. Vulkan SDK, glslang, and validation layers to develop, plus GHC (GHC2024) and cabal (>=3.16, matching `synarchy.cabal`'s `cabal-version` field) — other dependencies are installed by cabal. Developed primarily on macOS; works on Linux with minor adjustments (see `CLAUDE.md`).
 
 ## Building
 
@@ -24,7 +24,7 @@ The engine also has a **headless mode** (no window, no GPU) for scripted world g
 cabal test synarchy-test-headless
 ```
 
-`tools/` also has a large suite of Python-driven checks: world-generation regression tools (`world_check.py`, `world_audit.py`, ...) and ~20 headless **behavior probes** that boot a real headless engine to regression-test specific systems (combat animation, movement, physiology, crafting, construction, save/load, and more — see `tools/README.md`). `CLAUDE.md` documents which tier of tests to run for a given kind of change.
+`tools/` also has a large suite of Python-driven checks: world-generation regression tools (`world_check.py`, `world_audit.py`, ...), documented in `tools/README.md`, and ~20 headless **behavior probes** that boot a real headless engine to regression-test specific systems (combat animation, movement, physiology, crafting, construction, save/load, and more). `CLAUDE.md` documents each probe and which tier of tests to run for a given kind of change.
 
 ## Gameplay & simulation systems
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cabal test synarchy-test-headless
   - `UI` — focus, text input, tooltips, UI rendering
 - `app/Main.hs` — executable entry point (draw loop)
 - `test/`, `test-headless/` — hspec test suites (`synarchy-test-graphical`, `synarchy-test-headless`)
-- `tools/` — Python worldgen regression tools and headless behavior probes (see `tools/README.md`)
+- `tools/` — Python worldgen regression tools (see `tools/README.md`) and headless behavior probes (see `CLAUDE.md`)
 - `cbits/` — C code (stb_truetype font rasterization, Lua debug FFI)
 - `config/` — YAML config (keybinds, video, pathing, notifications, world-gen defaults)
 - `data/` — game data YAML (buildings, items, units, flora, recipes, materials, structure packs, ...)


### PR DESCRIPTION
Closes #466

## Approach

Docs-only change. Rewrote the README to reflect the current state of the project instead of describing it as just a graphics engine:

- Reframed the opening description as a colony/survival sim game built on a custom Haskell/Vulkan engine.
- Added a "Gameplay & simulation systems" section summarizing world generation, units/AI, combat/injury, construction/crafting, locations, and UI at a high level.
- Rewrote the project-structure tree to match the current `src/` layout (World, Unit, Combat, Craft, Building, Structure, Item, Equipment, Location, Infection, Sim, UI, plus the existing Engine breakdown), and added `tools/`, `data/`, `docs/` to the top-level listing.
- Kept `cabal build synarchy`, `cabal run synarchy`, and `cabal test` as documented, and added a short pointer to `cabal build all` and the headless test/probe tooling for anyone who needs more than the basics (with a pointer to `CLAUDE.md` for the full tiered-testing story).
- Removed the old task list that framed "game" as future work.
- Kept the Debug Console section (still accurate) but fixed a stale claim: the `SYNARCHY_DEBUG_PORT` env var doesn't exist anywhere in the code — the port is actually set via `--port` on both the engine and `debug-console.py`. Corrected the Configuration note to match.

## Tested

- Read through `src/`, `app/Main.hs`, `debug-console.py`, `tools/`, `data/`, `config/`, `scripts/`, `docs/`, and `synarchy.cabal` to confirm the structure/commands described actually match the repo.
- Grepped for `SYNARCHY_DEBUG_PORT` and `8008` to confirm how the port is actually configured before rewriting that section.
- Confirmed `debug-console.py` is executable and its `--port` default (8008) matches `app/Main.hs`.
- No code changed, so no build/test suite run — nothing executes differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)