### PR TITLE
[cbits] Harden lua_debug.c reentrancy trap + font_stb.c size checks

### DIFF
--- a/cbits/font_stb.c
+++ b/cbits/font_stb.c
@@ -15,16 +15,20 @@ unsigned char* stb_load_font (const char* path, int* size_out) {
     // get file size
     fseek(f, 0, SEEK_END);
     long size = ftell(f);
+    if (size < 0) {
+        fclose(f);
+        return NULL;
+    }
     fseek(f, 0, SEEK_SET);
     // allocate and read
-    unsigned char* buffer = (unsigned char*)malloc(size);
+    unsigned char* buffer = (unsigned char*)malloc((size_t)size);
     if (!buffer) {
         fclose(f);
         return NULL;
     }
-    size_t read = fread(buffer, 1, size, f);
+    size_t read = fread(buffer, 1, (size_t)size, f);
     fclose(f);
-    if (read != size) {
+    if (read != (size_t)size) {
         free(buffer);
         return NULL;
     }

--- a/cbits/lua_debug.c
+++ b/cbits/lua_debug.c
@@ -2,28 +2,24 @@
 #include <lauxlib.h>
 #include <string.h>
 
-// Buffer to hold the short_src (lua_Debug.short_src is char[LUA_IDSIZE])
-// LUA_IDSIZE is typically 60
-static char source_buffer[256];
-
-int get_lua_caller_info(lua_State *L, int level, 
-                        const char **source, int *line) {
+// Caller supplies the output buffer (of size buf_size) so this function
+// has no shared state — safe to call from multiple Lua states/threads
+// without a reentrancy/lifetime hazard on the returned source pointer.
+int get_lua_caller_info(lua_State *L, int level,
+                        char *source_buf, int buf_size, int *line) {
     lua_Debug ar;
     if (!lua_getstack(L, level, &ar)) {
-        *source = "<unknown>";
         *line = 0;
         return 0;
     }
     if (!lua_getinfo(L, "Sl", &ar)) {
-        *source = "<unknown>";
         *line = 0;
         return 0;
     }
-    // Copy short_src to our buffer (it's a char array in the struct)
-    strncpy(source_buffer, ar.short_src, sizeof(source_buffer) - 1);
-    source_buffer[sizeof(source_buffer) - 1] = '\0';
-    
-    *source = source_buffer;
+    // Copy short_src into the caller's buffer (it's a char array in the struct)
+    strncpy(source_buf, ar.short_src, buf_size - 1);
+    source_buf[buf_size - 1] = '\0';
+
     *line = ar.currentline;
     return 1;
 }

--- a/src/Engine/Scripting/Lua/Debug.hs
+++ b/src/Engine/Scripting/Lua/Debug.hs
@@ -17,21 +17,25 @@ data SourceInfo = SourceInfo
     } deriving (Show, Eq)
 
 foreign import ccall unsafe "get_lua_caller_info"
-    c_get_lua_caller_info ∷ Ptr () → CInt → Ptr CString → Ptr CInt → IO CInt
+    c_get_lua_caller_info ∷ Ptr () → CInt → CString → CInt → Ptr CInt → IO CInt
+
+-- | Size of the caller-supplied buffer for the short_src string
+-- (lua_Debug.short_src is char[LUA_IDSIZE], LUA_IDSIZE is typically 60).
+sourceBufSize ∷ Int
+sourceBufSize = 256
 
 -- | Get source info for a given stack level
 -- Level 0 = current function, 1 = caller, 2 = caller's caller, etc.
 getSourceInfo ∷ Int → LuaE e (Maybe SourceInfo)
 getSourceInfo level = do
     State lPtr ← Lua.state
-    Lua.liftIO $ alloca $ \sourcePtr →
+    Lua.liftIO $ allocaArray sourceBufSize $ \sourceBuf →
         alloca $ \linePtr → do
-            result ← c_get_lua_caller_info lPtr (fromIntegral level) sourcePtr linePtr
+            result ← c_get_lua_caller_info lPtr (fromIntegral level) sourceBuf (fromIntegral sourceBufSize) linePtr
             if result ≡ 0
                 then return Nothing
                 else do
-                    sourceCStr ← peek sourcePtr
-                    source ← peekCString sourceCStr
+                    source ← peekCString sourceBuf
                     line ← peek linePtr
                     return $ Just SourceInfo
                         { siSource = source


### PR DESCRIPTION
Closes #440

## Approach

Two small, independent C hardening fixes:

1. **`cbits/lua_debug.c`** — `get_lua_caller_info` previously wrote the Lua `short_src` string into a file-`static` buffer and returned a pointer into it, an undocumented reentrancy/lifetime trap (a second call invalidates the previous pointer; a second Lua state on another thread would race it). Changed the signature to take a caller-supplied buffer + size instead, removing the shared state entirely. Updated the Haskell `foreign import` (`src/Engine/Scripting/Lua/Debug.hs`) to allocate a 256-byte stack buffer with `allocaArray` and pass it down, matching the previous buffer size (`LUA_IDSIZE` is typically 60).
2. **`cbits/font_stb.c`** — `stb_load_font` now checks `ftell` for `-1` (closing the file and returning `NULL` instead of wrapping a negative into a huge `malloc`), and casts `size` to `size_t` before comparing against `fread`'s return value and before passing it to `malloc`/`fread`, fixing the signed/unsigned comparison mismatch.

Both are error-path-only changes — no behavior change on the happy path, no save-version bump.

## Tested

- `cabal build all` — full project builds clean.
- `cabal test synarchy-test-headless` — 533 examples, 0 failures.
- `python3 tools/world_check.py` — 21/21 seeds PASS.
- `python3 tools/test_audit.py` — 35/35 test groups pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)