### PR TITLE
Replace unsafePerformIO fresh-buffer idiom with unsafeCreate / runST

### DIFF
--- a/src/World/Flora/Placement.hs
+++ b/src/World/Flora/Placement.hs
@@ -14,7 +14,8 @@ import World.Types
 import World.Vegetation (isBarrenMaterial)
 import World.Weather.Types (ClimateState(..))
 import World.Weather.Lookup (lookupLocalClimate, LocalClimate(..))
-import System.IO.Unsafe (unsafePerformIO)
+import Control.Monad.ST (runST)
+import Control.Monad.Primitive (PrimMonad, PrimState)
 
 -- * Chunk Flora Computation
 
@@ -32,7 +33,7 @@ computeChunkFlora seed worldSize coord surfMap surfMats surfSlopes
 
         tileOrder = shuffledIndices seed cx cy chunkArea
 
-        allInstances = unsafePerformIO $ do
+        allInstances = runST $ do
             occupied ← VUM.replicate chunkArea (0 ∷ Word8)
             let go [] acc = return (reverse acc)
                 go (idx:rest) acc = do
@@ -72,7 +73,7 @@ computeChunkFlora seed worldSize coord surfMap surfMats surfSlopes
 
     in FloraChunkData allInstances
 
-markOccupied ∷ VUM.IOVector Word8 → Int → Int → Int → Int → IO ()
+markOccupied ∷ PrimMonad m ⇒ VUM.MVector (PrimState m) Word8 → Int → Int → Int → Int → m ()
 markOccupied occupied cx cy radius chunkSz =
     forM_ [negate radius .. radius] $ \dx →
         forM_ [negate radius .. radius] $ \dy → do

--- a/src/World/Preview.hs
+++ b/src/World/Preview.hs
@@ -11,7 +11,6 @@ import Control.DeepSeq (NFData)
 import qualified Data.Vector as V
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Internal as BSI
-import System.IO.Unsafe (unsafePerformIO)
 import World.Types (ZoomChunkEntry(..), WorldGenParams(..))
 import World.Render.Zoom.Types (zoomTileSize)
 
@@ -55,9 +54,7 @@ buildPreviewFromPixels params cache pixels =
                  , BS.index chunkPx (off + 3) )
             else (0, 0, 0, 255)
 
-        pixelData = unsafePerformIO $ do
-            fptr ← BSI.mallocByteString totalBytes
-            withForeignPtr fptr $ \ptr → do
+        pixelData = BSI.unsafeCreate totalBytes $ \ptr → do
                 -- Fill background
                 forM_ [0 .. imgW * imgH - 1] $ \i → do
                     pokeByteOff ptr (i * 4 + 0) (0 ∷ Word8)
@@ -99,8 +96,6 @@ buildPreviewFromPixels params cache pixels =
                         writePixel (px + 2) (py + 1) rr rg rb ra
                         writePixel (px + 3) (py + 1) rr rg rb ra
 
-            return $ BSI.fromForeignPtr fptr 0 totalBytes
-
     in PreviewImage imgW imgH pixelData
 
 -- * Fallback: Build Preview from ZoomChunkEntry summary (used when per-chunk pixel data is not available)
@@ -113,9 +108,7 @@ buildPreviewImage params cache =
         imgH      = worldSize
         totalBytes = imgW * imgH * 4
 
-        pixelData = unsafePerformIO $ do
-            fptr ← BSI.mallocByteString totalBytes
-            withForeignPtr fptr $ \ptr → do
+        pixelData = BSI.unsafeCreate totalBytes $ \ptr → do
                 forM_ [0 .. imgW * imgH - 1] $ \i → do
                     pokeByteOff ptr (i * 4 + 0) (0 ∷ Word8)
                     pokeByteOff ptr (i * 4 + 1) (0 ∷ Word8)
@@ -143,8 +136,6 @@ buildPreviewImage params cache =
                                 pokeByteOff ptr (idx + 3) a
                         writePixel px
                         writePixel ((px + 1) `mod` imgW)
-
-            return $ BSI.fromForeignPtr fptr 0 totalBytes
 
     in PreviewImage imgW imgH pixelData
 

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -700,6 +700,7 @@ library
                  , vector
                  , vector-algorithms
                  , vector-th-unbox
+                 , primitive
                  , cereal
                  , yaml
                  , aeson


### PR DESCRIPTION
Closes #438

## Approach

Two small, mechanical sites (the only `unsafePerformIO` uses in `src/World/`, per the issue):

1. **`src/World/Preview.hs`** (2 sites) — `buildPreviewFromPixels` and `buildPreviewImage` used `unsafePerformIO $ do { fptr <- mallocByteString; withForeignPtr fptr $ \ptr -> ...; return (fromForeignPtr fptr 0 n) }` to assemble RGBA pixel data. Replaced with `Data.ByteString.Internal.unsafeCreate`, which is exactly this allocate-fill-freeze pattern with the unsafety already contained/audited inside `bytestring` itself — no more bare `unsafePerformIO`/`NOINLINE` hazard in this module.
2. **`src/World/Flora/Placement.hs`** — `computeChunkFlora`'s occupancy-grid fold (`VUM.replicate` + recursive `go`) ran under `unsafePerformIO` purely to get a mutable `IOVector`. Moved it into `runST`, and generalized `markOccupied`'s signature from `VUM.IOVector Word8 → ... → IO ()` to `PrimMonad m ⇒ VUM.MVector (PrimState m) Word8 → ... → m ()` — the existing `VUM.replicate`/`read`/`write` calls are already generic over `PrimMonad` so the body is otherwise unchanged. Added `primitive` to the library's `build-depends` (needed for `Control.Monad.Primitive`; was previously only pulled in transitively via `vector`).

No behavior change: same allocate-fill-freeze pattern, same traversal order (the flora placement fold's `go` recursion and tile order are untouched — only the monad it runs in changed).

## Tested

- `cabal build all` with a temporary `ghc-options: -Werror` scoped to `package synarchy` (matching CI's config step) — clean full rebuild, no warnings.
- `cabal test synarchy-test-headless` — 533 examples, 0 failures.
- `python3 tools/world_check.py` — 21/21 seeds PASS (confirms flora placement order/output is byte-identical after the `runST` change).
- `python3 tools/test_audit.py` — 35/35 test groups pass.
- `grep -rn unsafePerformIO src/` — zero remaining hits.

No save-version bump (no serialized data changes, per the issue's scope note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)