### PR TITLE
Document headless behavior probes + add opt-in aggregate runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,15 @@ stays in seconds and the expensive gates run once, at the end.
    w128 volcano exposure case, +~25 s), then re-capture baselines
    `python3 tools/world_baseline.py` (~7 min) and re-run world_check.
    Remember the save-version bump.
+4. **Behavior probes — opt-in, not a default gate.** ~27 headless
+   `tools/*_probe.py` scripts each boot a real engine and gate one
+   specific system/bug (combat anim, movement, construction, saves,
+   physiology, ...) — see `tools/README.md` for the full list. They're
+   slow (each pays its own engine-boot cost, more when it generates a
+   real world) and aren't run as part of tiers 1–3. Run the ones
+   relevant to what you touched, or `python3 tools/run_probes.py
+   --only <substrings>` (bare `run_probes.py` runs all of them — low
+   tens of minutes, only for a deliberate full sweep).
 
 Baselines (`tools/baselines/`) are **tracked in git** (#421): a fresh
 clone/worktree can run world_check directly, and a tier-3 re-capture

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,9 +1,13 @@
-# World generation development tools
+# Development tools
 
-Python scripts for auditing, checking determinism, and regression-testing
-the world generation pipeline.
+Python scripts for auditing/regression-testing world generation, and for
+driving/verifying engine and game-logic behavior against a real headless
+engine instance.
 
-## Scripts
+## World generation tools
+
+Scripts for auditing, checking determinism, and regression-testing the
+world generation pipeline (dump-only — no TCP, no interaction).
 
 ### `world_audit.py`
 Runs the `synarchy --dump` command (or reads a pre-generated dump) and
@@ -73,7 +77,7 @@ each check correctly identifies the issue it's meant to catch.
 python3 tools/test_audit.py
 ```
 
-## Workflow
+### Workflow
 
 Before committing a change:
 ```bash
@@ -99,6 +103,99 @@ gate on every PR. Worldgen output is bit-identical across macOS/aarch64
 so there is one set of baselines for all platforms — a worldgen-output PR
 that forgets to rebaseline fails CI.
 
+## Behavior probes (headless engine)
+
+Unlike the worldgen tools above (which shell out to `--dump`, no TCP), these
+scripts boot a **real headless engine** (`--headless --port NNNN`), drive it
+over the debug-console TCP protocol (see the repo-root `CLAUDE.md` "Headless
+Mode & Debug Console" section for the protocol itself), and assert on the
+result. They're first-class regression harnesses — each one is the gate for
+a specific system or bug, referenced from `CLAUDE.md` and PR descriptions —
+but because they boot a full engine (and some generate a real world on top
+of that), they're **much slower** than the dump-only tools above: a few
+seconds of engine boot at minimum, tens of seconds to a couple of minutes
+when a scenario needs actual world generation. They are not part of the
+default test tiers; run the ones relevant to what you changed.
+
+Each probe is self-contained (own `main()`, own engine boot/teardown, own
+default port chosen to avoid the user's GUI on 8008) and prints PASS/FAIL
+plus `sys.exit(0 or 1)`. Most take `--port` to avoid colliding with another
+running instance; two (`cargo_capacity_probe.py`, `disarm_probe.py`) take no
+flags at all and hardcode their port.
+
+**Gotcha:** not every probe uses `argparse` — the two flagless ones above
+have no `--help` handling either, so passing `--help` doesn't print usage
+and exit, it silently runs the *actual probe* (which boots a real engine and
+can hang for minutes if you weren't expecting that). Check the header
+docstring instead of reaching for `--help` when in doubt.
+
+"Boot" below is `arena` (flat synthetic terrain via
+`scripts/movement_arena.lua`, no world generation — fast) or `worldgen`
+(generates a real world at a given seed/size — slower, scales with size).
+
+| Probe | Gates | Boot | Purpose |
+|-------|-------|------|---------|
+| `cargo_capacity_probe.py` | #189 | arena | `depositToCargo` weighs the actual `ItemInstance` (fill + nested contents), not the item def's base weight. |
+| `chop_probe.py` | #97 | worldgen | Chop-designation layer + chop AI + `wood_log` yield, end to end. |
+| `collapse_crawl_probe.py` | #304 | arena | Collapse↔crawl pose hysteresis in `tickInjuries`. |
+| `combat_anim_probe.py` | general combat/animation guard | worldgen | Drives a real fight headless; samples `currentAnim` to verify swing and death animations actually play. |
+| `concussion_revive_probe.py` | #304 | arena (shares boot helpers with `collapse_crawl_probe.py`) | `checkRevive` concussion-band hysteresis (companion to `collapse_crawl_probe.py`). |
+| `construction_probe.py` | #96 | arena | `construct_job` AI end-to-end: claim, material sourcing, progress accrual, piece placement, staking, dead-claimant release. |
+| `craft_probe.py` | #325, #326, #343, #327 | arena | `craft.*` API: catalogue, execute, work stations, crafter-derived quality, smelting. |
+| `disarm_probe.py` | #193 | worldgen | Disabled-hand auto-drop must re-fire. |
+| `flora_growth_probe.py` | #332 | worldgen | Derived flora growth/age/phase under the advancing calendar; fruiting-window gating; survives save/load. |
+| `follow_command_priority_probe.py` | #306 | arena | Follow-command priority against other AI goals. |
+| `foraging_probe.py` | #94 | worldgen | Foraging AI + harvestable-flora gating. |
+| `infection_probe.py` | general infection-system guard | arena | Infection growth / antiseptic prevention / antibiotic cure / sepsis meter, end-to-end. |
+| `injury_log_probe.py` | logging arc (general) | arena | Injury-log stream roundtrip: `injury.emit`/`drainEvents`, `unit.injure`, `emitEventForUnit` tagging. |
+| `item_instance_probe.py` | #67 | worldgen | Per-instance item identity. |
+| `item_temp_probe.py` | #344 | worldgen | Item temperature model. |
+| `location_content_probe.py` | #90, #91 | worldgen + arena | Location content spawning + ruin probe. |
+| `location_overlay_probe.py` | #89 | worldgen + arena | World-gen location-overlay placement. |
+| `lua_orphan_prune_probe.py` | #195 | worldgen | Lua per-id AI state is pruned (not inherited by id reuse) after a save load. |
+| `medic_coord_probe.py` | squad-medic coordination (general) | arena | `bestMedicFor`/`medicAvailable` distance-discounted selection fix. |
+| `movement_probe.py` | movement arc (general, closed) | arena | Obstacle-course movement (pathing/climbs/falls/ramps) via `movement_arena.lua` courses; `--list` shows courses. |
+| `multiworld_save_probe.py` | #214, #219 | worldgen + arena | Multi-world save → quit → restart → load; cross-page entity survival. |
+| `physiology_probe.py` | homeostasis (general) | arena | Thermoregulation/circulation sanity across controlled environments (temperate/arctic/humid-heat). |
+| `repair_item_probe.py` | #300 | worldgen | `unit.repairItem` primitive. |
+| `repair_probe.py` | #301 | arena | Repair policy layer (station-gated repair on top of #300). |
+| `role_probe.py` | #265 | worldgen | Derived unit-role hysteresis/demotion/work-XP growth. |
+| `save_pause_probe.py` | #42 | worldgen | Save/load pause-semantics regression. |
+| `thermo_altitude_probe.py` | #308 | worldgen (size 128) | Altitude-lapse thermal effect. |
+
+Invocation is bare `python3 tools/<name>.py` for sane defaults; most accept
+`--port`/`--seed`/`--size` overrides and a handful have scenario-specific
+flags (`--course`, `--phase`, `--attacker`/`--target`, ...) — see the
+script's header docstring for its exact flag set.
+
+### `run_probes.py` — opt-in aggregate runner
+
+Runs a selection of the probes above back-to-back and prints a per-probe
+PASS/FAIL summary, exiting non-zero if any failed.
+
+```bash
+# Run everything (slow — boots ~27 engines in sequence)
+python3 tools/run_probes.py
+
+# Run a subset, matched by substring against the probe name
+python3 tools/run_probes.py --only combat,movement
+
+# List known probes and exit
+python3 tools/run_probes.py --list
+
+# Override --port on probes that support it (the two flagless ones keep
+# their own hardcoded port regardless)
+python3 tools/run_probes.py --port 9500
+```
+
+It shells out to each probe as its own subprocess and runs them
+**sequentially, one engine at a time** — it does not attempt to make probes
+share a single running engine (they're independent scripts with their own
+boot/teardown, not built around an injectable engine handle), so the total
+cost is roughly the sum of each probe's own boot + scenario time. That
+makes a full run slow (easily 15+ minutes); it is *not* part of any default
+test tier — see `CLAUDE.md` Testing Tiers.
+
 ## Directory layout
 ```
 tools/
@@ -108,6 +205,8 @@ tools/
 ├── world_baseline.py       (capture reference outputs)
 ├── world_check.py          (regression suite runner)
 ├── test_audit.py           (unit tests)
+├── run_probes.py           (opt-in aggregate behavior-probe runner)
+├── *_probe.py              (headless behavior probes — see above)
 └── baselines/
     ├── _seeds.json         (seed list config)
     └── seed*.json          (per-seed baseline data)

--- a/tools/lua_orphan_prune_probe.py
+++ b/tools/lua_orphan_prune_probe.py
@@ -239,7 +239,8 @@ def main() -> int:
 
         # Save + load. The engine fires onSaveLoaded after the load
         # settles; the reconcile should prune A while keeping B.
-        print(f"saveWorld -> {send(args.port, f'return engine.saveWorld(\"arena\",\"{SAVE_NAME}\")')}")
+        save_cmd = f'return engine.saveWorld("arena","{SAVE_NAME}")'
+        print(f"saveWorld -> {send(args.port, save_cmd)}")
         # saveWorld returns on enqueue — wait for the file to actually land
         # before loading, or loadSave races the write / reads a stale dir.
         if not wait_save_written(SAVE_NAME):
@@ -250,7 +251,8 @@ def main() -> int:
         # the Lua loop can't tick script update()s against the half-restored
         # singletons during the load window.
         send(args.port, "engine.setPaused(false); return 'ok'", expect_result=False)
-        print(f"loadSave -> {send(args.port, f'return engine.loadSave(\"{SAVE_NAME}\")')}")
+        load_cmd = f'return engine.loadSave("{SAVE_NAME}")'
+        print(f"loadSave -> {send(args.port, load_cmd)}")
         # Right after loadSave returns (world thread hasn't finished the load),
         # the engine must already be paused — frozen for the load window.
         load_paused = send(args.port, "return engine.isPaused()")

--- a/tools/run_probes.py
+++ b/tools/run_probes.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Opt-in aggregate runner for the headless behavior probes (#370).
+
+Each `tools/*_probe.py` script is a self-contained regression harness: it
+boots its own headless engine (`--headless --port NNNN`), drives a scenario
+over the debug-console TCP protocol, asserts on the result, and exits 0/1.
+They're normally run one at a time, by hand, whichever is relevant to a
+change. This script runs a selection of them back-to-back and prints a
+single PASS/FAIL summary.
+
+Probes are run SEQUENTIALLY, one full engine boot+teardown at a time — this
+script does not attempt to make probes share a running engine (they're
+independent scripts, each owning its own boot/teardown, not built around an
+injectable engine handle). A full run is therefore slow: expect low tens of
+minutes. This is NOT part of any default test tier (see CLAUDE.md Testing
+Tiers) — run it deliberately, and prefer `--only` to scope it to what your
+change touches.
+
+Usage:
+  python3 tools/run_probes.py                  # run everything
+  python3 tools/run_probes.py --only combat,movement
+  python3 tools/run_probes.py --list
+  python3 tools/run_probes.py --port 9500       # override --port where supported
+  python3 tools/run_probes.py --timeout 300
+
+Exit 0 = all selected probes passed. 1 = at least one failed. 2 = bad
+invocation (e.g. --only matched nothing).
+"""
+from __future__ import annotations
+import argparse
+import os
+import signal
+import subprocess
+import sys
+import time
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# (key, script filename, supports --port, one-line purpose for --list)
+PROBES = [
+    ("cargo_capacity", "cargo_capacity_probe.py", False,
+     "depositToCargo weighs the actual ItemInstance, not the def base weight (#189)"),
+    ("chop", "chop_probe.py", True,
+     "chop-designation layer + chop AI + wood_log yield (#97)"),
+    ("collapse_crawl", "collapse_crawl_probe.py", True,
+     "collapse<->crawl pose hysteresis in tickInjuries (#304)"),
+    ("combat_anim", "combat_anim_probe.py", True,
+     "real fight headless; verifies swing/death animations play"),
+    ("concussion_revive", "concussion_revive_probe.py", True,
+     "checkRevive concussion-band hysteresis (#304)"),
+    ("construction", "construction_probe.py", True,
+     "construct_job AI end-to-end: claim/source/progress/place/stake/release (#96)"),
+    ("craft", "craft_probe.py", True,
+     "craft.* API: catalogue, execute, stations, quality, smelting (#325/#326/#343/#327)"),
+    ("disarm", "disarm_probe.py", False,
+     "disabled-hand auto-drop must re-fire (#193)"),
+    ("flora_growth", "flora_growth_probe.py", True,
+     "derived flora growth/age/phase under the advancing calendar (#332)"),
+    ("follow_command_priority", "follow_command_priority_probe.py", True,
+     "follow-command priority against other AI goals (#306)"),
+    ("foraging", "foraging_probe.py", True,
+     "foraging AI + harvestable-flora gating (#94)"),
+    ("infection", "infection_probe.py", True,
+     "infection growth/prevention/cure/sepsis loop end-to-end"),
+    ("injury_log", "injury_log_probe.py", True,
+     "injury-log stream roundtrip: emit/drain, unit.injure, emitEventForUnit"),
+    ("item_instance", "item_instance_probe.py", True,
+     "per-instance item identity (#67)"),
+    ("item_temp", "item_temp_probe.py", True,
+     "item temperature model (#344)"),
+    ("location_content", "location_content_probe.py", True,
+     "location content spawning + ruin probe (#90, #91)"),
+    ("location_overlay", "location_overlay_probe.py", True,
+     "world-gen location-overlay placement (#89)"),
+    ("lua_orphan_prune", "lua_orphan_prune_probe.py", True,
+     "Lua per-id AI state pruned (not inherited) after a save load (#195)"),
+    ("medic_coord", "medic_coord_probe.py", True,
+     "bestMedicFor/medicAvailable distance-discounted selection fix"),
+    ("movement", "movement_probe.py", True,
+     "obstacle-course movement: pathing/climbs/falls/ramps"),
+    ("multiworld_save", "multiworld_save_probe.py", True,
+     "multi-world save -> quit -> restart -> load; cross-page survival (#214, #219)"),
+    ("physiology", "physiology_probe.py", True,
+     "thermoregulation/circulation sanity across controlled environments"),
+    ("repair_item", "repair_item_probe.py", True,
+     "unit.repairItem primitive (#300)"),
+    ("repair", "repair_probe.py", True,
+     "repair policy layer, station-gated (#301)"),
+    ("role", "role_probe.py", True,
+     "derived unit-role hysteresis/demotion/work-XP growth (#265)"),
+    ("save_pause", "save_pause_probe.py", True,
+     "save/load pause-semantics regression (#42)"),
+    ("thermo_altitude", "thermo_altitude_probe.py", True,
+     "altitude-lapse thermal effect (#308)"),
+]
+
+DEFAULT_TIMEOUT = 600.0
+
+
+def select(only: str | None) -> list[tuple[str, str, bool, str]]:
+    if not only:
+        return list(PROBES)
+    needles = [n.strip() for n in only.split(",") if n.strip()]
+    selected = [p for p in PROBES if any(n in p[0] or n in p[1] for n in needles)]
+    return selected
+
+
+def run_one(script: str, supports_port: bool, port: int | None, timeout: float):
+    cmd = ["python3", os.path.join("tools", script)]
+    if port is not None and supports_port:
+        cmd += ["--port", str(port)]
+    start = time.time()
+    proc = subprocess.Popen(
+        cmd, cwd=REPO_ROOT,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True, start_new_session=True,
+    )
+    timed_out = False
+    try:
+        out, _ = proc.communicate(timeout=timeout)
+        rc = proc.returncode
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            out, _ = proc.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            out, _ = proc.communicate()
+        rc = -1
+    elapsed = time.time() - start
+    ok = (rc == 0) and not timed_out
+    return ok, timed_out, elapsed, out or ""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                  formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--only", default=None,
+                     help="comma-separated substrings matched against probe key/filename")
+    ap.add_argument("--list", action="store_true", help="list known probes and exit")
+    ap.add_argument("--port", type=int, default=None,
+                     help="override --port on probes that support it (default: avoids 8008; "
+                          "each probe keeps its own default if unset)")
+    ap.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT,
+                     help=f"per-probe wall-clock timeout in seconds (default {DEFAULT_TIMEOUT:.0f})")
+    ap.add_argument("--tail", type=int, default=25,
+                     help="lines of captured output to print for a failing probe")
+    args = ap.parse_args()
+
+    if args.port == 8008:
+        sys.exit("refusing --port 8008: that's the user's GUI port, see CLAUDE.md")
+
+    chosen = select(args.only)
+    if not chosen:
+        print(f"--only {args.only!r} matched no probes; see --list", file=sys.stderr)
+        return 2
+
+    if args.list:
+        for key, script, supports_port, purpose in chosen:
+            flag = "" if supports_port else "  (no --port flag)"
+            print(f"{key:28s} {script:32s} {purpose}{flag}")
+        return 0
+
+    print(f"Running {len(chosen)} probe(s) sequentially "
+          f"(timeout {args.timeout:.0f}s each)...\n")
+
+    results = []
+    for i, (key, script, supports_port, purpose) in enumerate(chosen, 1):
+        print(f"[{i}/{len(chosen)}] {script} ... ", end="", flush=True)
+        ok, timed_out, elapsed, out = run_one(script, supports_port, args.port, args.timeout)
+        status = "TIMEOUT" if timed_out else ("PASS" if ok else "FAIL")
+        print(f"{status} ({elapsed:.1f}s)")
+        if not ok and args.tail > 0:
+            tail_lines = out.splitlines()[-args.tail:]
+            for ln in tail_lines:
+                print(f"    {ln}")
+        results.append((key, script, status, elapsed))
+
+    passed = sum(1 for _, _, status, _ in results if status == "PASS")
+    total_time = sum(elapsed for _, _, _, elapsed in results)
+    print(f"\n{passed}/{len(results)} passed, total {total_time:.1f}s")
+    if passed != len(results):
+        print("FAILED:")
+        for key, script, status, _ in results:
+            if status != "PASS":
+                print(f"  {status:8s} {script}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #370

## Approach

**Part A** — `tools/README.md` gains a new "Behavior probes (headless engine)" section: a table cataloguing all 27 `tools/*_probe.py` scripts with a one-line purpose, which issue each one gates (where applicable — several are general regression guards rather than single-issue), and whether they boot a flat arena (fast) or generate a real world (slower, scales with size). The intro/title is broadened from "World generation development tools" to "Development tools" so it no longer reads as worldgen-only, and the existing worldgen-tools content is unchanged, just re-headed under its own subsection.

Also documents a gotcha I hit while writing this: two probes (`cargo_capacity_probe.py`, `disarm_probe.py`) take no CLI args at all and don't implement `--help` — passing `--help` doesn't print usage, it silently runs the actual probe (which boots a real engine). Cost me a 2-minute hang while surveying flags; saved future readers from the same.

**Part B** — `tools/run_probes.py`: an opt-in aggregate runner. Since every probe already owns its own engine boot/teardown (no shared harness module to hook into), it runs the selected probes as subprocesses **sequentially** rather than attempting real engine reuse — reworking 27 independent scripts to share a live engine would be a much bigger change than this issue's scope, and the acceptance criteria explicitly allows "clearly documents the per-probe boot cost" as the alternative. Each probe's own PASS/FAIL exit code is captured; failures print a tail of captured output. Supports:
- `--only combat,movement` — substring-matched subset (also previewable via `--list`)
- `--port N` — forwarded to probes whose argparse supports `--port` (two don't; left alone)
- `--timeout N` — per-probe wall-clock cap; on expiry the whole process group is killed (`start_new_session=True` + `killpg`) so a hung probe can't leave an orphaned `cabal run`/engine process behind

`CLAUDE.md`'s Testing Tiers gained a new tier 4 entry pointing at this — explicitly opt-in, not part of the default gates (each probe pays its own multi-second-to-minutes engine boot).

**Bonus fix** — `lua_orphan_prune_probe.py` had a pre-existing `SyntaxError`: two f-strings with a nested backslash-escaped quote inside the expression part, which is only legal under PEP 701 (Python 3.12+) and fails to parse on 3.9–3.11. Found this because `run_probes.py` would otherwise report the probe as a spurious failure regardless of the actual system it gates. One-line fix (pull the inner f-string into a variable first) — no behavior change.

## Tested

- `python3 -m py_compile` on every file under `tools/` — all compile clean (confirmed no other files share the PEP 701 syntax issue).
- `python3 tools/run_probes.py --list`, `--only combat,movement --list`, `--only zzz_nonexistent` (exit 2), `--help` — all behave as documented, no engine boot triggered.
- `python3 tools/run_probes.py --only concussion_revive` — real functional run: boots the engine, PASS, exits 0, no orphaned `synarchy`/`cabal run` process afterward.
- `python3 tools/run_probes.py --only concussion_revive --timeout 5` — forced timeout: reports `TIMEOUT`, exits 1, process group killed cleanly (verified via `ps`/`lsof` — no orphan, port freed).
- Tier 2 (`CLAUDE.md` Testing Tiers): `cabal test synarchy-test-headless` (533 examples, 0 failures), `python3 tools/world_check.py --quick` (6/6 PASS), `python3 tools/test_audit.py` (35/35 test groups pass) — no engine/game-logic code touched, run for hygiene.

No Haskell code changed; no save-version bump needed.