### PR TITLE
Unify duplicated magic constants (blood ratio, UI layer, max_stamina, climb height, deco base, aware range)

### DIFF
--- a/scripts/unit_stats.lua
+++ b/scripts/unit_stats.lua
@@ -75,6 +75,8 @@ stats.activityMultiplier = activityMultiplier
 local derived = {
     -- Stamina pool size = endurance * 10. Larger endurance means
     -- the unit can exert itself longer before stamina runs out.
+    -- NB: mirrored on the Haskell side by Combat.Resolution.maxStaminaFor
+    -- (the combat thread can't call into Lua) — change in lockstep.
     max_stamina = function(uid)
         local e = unit.getStat(uid, "endurance")
         return e and e * 10 or nil

--- a/src/Combat/Resolution.hs
+++ b/src/Combat/Resolution.hs
@@ -644,6 +644,17 @@ statOr name def inst = HM.lookupDefault def name (uiStats inst)
 skillOr ∷ Text → Float → UnitInstance → Float
 skillOr name def inst = HM.lookupDefault def name (uiSkills inst)
 
+-- | The unit's stamina pool size. max_stamina is canonically a DERIVED
+--   stat in Lua's @scripts/unit_stats.lua@ (@stats.get@: an explicit
+--   per-unit \"max_stamina\" attribute wins, else @endurance × 10@) and
+--   is never written back into uiStats, so the combat thread can't just
+--   read it — this helper mirrors that dispatch exactly. If the Lua
+--   formula changes, change this in lockstep.
+maxStaminaFor ∷ UnitInstance → Float
+maxStaminaFor inst = case HM.lookup "max_stamina" (uiStats inst) of
+    Just m  → m
+    Nothing → statOr "endurance" 1.0 inst * 10.0
+
 weightedReachFactor ∷ Float → Float
 weightedReachFactor bladeCm = clamp 0.0 1.0 (bladeCm / 100.0)
 
@@ -1017,7 +1028,7 @@ computeSeverity sm im atk tdef mEquipped natW tgt partId kind mode allocRoll kin
         -- A winded fighter still hits (floor 0.3); absent stamina ⇒ full.
         staminaFrac = case HM.lookup "stamina" (uiStats atk) of
             Nothing → 1.0
-            Just s  → let maxS = statOr "endurance" 1.0 atk * 10.0
+            Just s  → let maxS = maxStaminaFor atk
                       in if maxS ≤ 0 then 1.0 else clamp 0.3 1.0 (s / maxS)
         pain     = painFor atk
         work     = eHuman * str * modeWork mode * skillEff * staminaFrac
@@ -1295,11 +1306,9 @@ staminaCostFraction Heavy = 0.25
 --   (the same tick path that handles walking drain), so we don't fire
 --   UnitCollapse / UnitKill from here.
 --
---   max_stamina is recomputed live in Lua's unit_stats wrapper as
---   `endurance × 10`, but the engine doesn't have that derivation —
---   it only sees what's actually stored in uiStats. We use the live
---   "endurance" stat to compute the same value so a unit with a fresh
---   buff or wound to endurance pays the right fraction.
+--   max_stamina comes from 'maxStaminaFor' (the mirror of Lua's
+--   unit_stats derivation), computed from the live stats so a unit
+--   with a fresh buff or wound to endurance pays the right fraction.
 applyStaminaDrain ∷ EngineEnv → Word32 → AttackMode → IO ()
 applyStaminaDrain env atkRaw mode =
     atomicModifyIORef' (unitManagerRef env) $ \um →
@@ -1309,9 +1318,7 @@ applyStaminaDrain env atkRaw mode =
             Just inst →
                 let stamina   = HM.lookupDefault 0.0 "stamina"
                                                   (uiStats inst)
-                    endurance = HM.lookupDefault 1.0 "endurance"
-                                                  (uiStats inst)
-                    maxStam   = endurance * 10.0
+                    maxStam   = maxStaminaFor inst
                     cost      = staminaCostFraction mode * maxStam
                     new       = max 0.0 (stamina - cost)
                     -- Stance spent on the swing (absent ⇒ full 1.0).

--- a/src/Combat/Wounds.hs
+++ b/src/Combat/Wounds.hs
@@ -48,7 +48,7 @@ import Engine.Core.Log (logDebug, LogCategory(..))
 import qualified Engine.Core.Queue as Q
 import Unit.Types (UnitId(..), UnitInstance(..), UnitDef(..)
                   , UnitManager(..), BodyPart(..), Wound(..), woundEffSeverity
-                  , Scar(..))
+                  , Scar(..), bloodMassRatio)
 import Unit.Command.Types (UnitCommand(..))
 import qualified System.Random as Random
 import World.State.Types (WorldState(..))
@@ -694,7 +694,7 @@ tickOneUnit gt def dt infMgr mClim gen0 inst
                                 mergedImm
             newBlood   = uiBlood inst - totalDrain
             bodyMass   = HM.lookupDefault 70.0 "body_mass" (uiStats inst)
-            maxBlood   = bodyMass * 0.075
+            maxBlood   = bodyMass * bloodMassRatio
             unconsCut  = maxBlood * unconsciousFraction
             newWoundsR = reverse newWounds
             -- Gangrene death: a VITAL part rotted past the lethal threshold.

--- a/src/Engine/Scripting/Lua/API/Units.hs
+++ b/src/Engine/Scripting/Lua/API/Units.hs
@@ -1531,8 +1531,8 @@ unitGetInsulationFn env = do
 
 -- | unit.getBlood(uid) → { current, max } | nil
 --
---   max is body_mass × 0.075 (real-world blood ratio). current is
---   the spawn-time-seeded value minus per-tick bleed loss. Both in
+--   max is body_mass × 'bloodMassRatio'. current is the
+--   spawn-time-seeded value minus per-tick bleed loss. Both in
 --   litres.
 unitGetBloodFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 unitGetBloodFn env = do
@@ -1550,7 +1550,7 @@ unitGetBloodFn env = do
                                                  (uiStats inst)
                             rate = maybe 0.0 (\d → bleedRateFor d inst)
                                      (HM.lookup (uiDefName inst) (umDefs um))
-                        in return $ Just (uiBlood inst, bm * 0.075, rate)
+                        in return $ Just (uiBlood inst, bm * bloodMassRatio, rate)
             case mPair of
                 Nothing → Lua.pushnil >> return 1
                 Just (cur, mx, rate) → do

--- a/src/Sim/Fluid/Active.hs
+++ b/src/Sim/Fluid/Active.hs
@@ -15,6 +15,7 @@ import Control.Monad.ST (ST, runST)
 import Data.STRef (STRef, newSTRef, readSTRef, writeSTRef, modifySTRef')
 import World.Chunk.Types (ChunkCoord(..), chunkSize)
 import World.Fluid.Types (FluidCell(..))
+import World.SideFace.Base (SideDecoType(..), sideDecoBase)
 import Sim.State.Types (SimWorldState(..), SimChunkState(..))
 import Sim.Fluid.Types (ActiveFluidCell(..), volumePerLevel, volumeToSurface)
 
@@ -432,7 +433,9 @@ phaseWaterfall mv decoMv terrainV changedRef = do
                                         { afcVolume = afcVolume d + fromIntegral actual })
                             fd ← readSTRef flowDirRef
                             writeSTRef flowDirRef (fd .|. ((1 ∷ Word8) `shiftL` dirBit))
-                            MVU.write decoMv idx (17 + fromIntegral (dirBit `mod` 4))
+                            MVU.write decoMv idx
+                                (sideDecoBase DecoWaterfall
+                                    + fromIntegral (dirBit `mod` 4))
                             writeSTRef changedRef True
                 newFD ← readSTRef flowDirRef
                 when (newFD ≠ afcFlowDir afc) $ do

--- a/src/UI/Render.hs
+++ b/src/UI/Render.hs
@@ -24,10 +24,14 @@ import Engine.Scene.Base (LayerId(..))
 import Engine.Scene.Types.Batch (RenderBatch(..), RenderItem(..), TextRenderBatch(..))
 import UI.Types
 import UI.Manager (getVisiblePages, getElementAbsolutePosition, getBoxTextureSet)
+import World.Grid (uiLayerThreshold)
 
--- | Base layer offset for UI (world uses 0-9)
+-- | Base layer offset for UI (world uses the layers below it). Derived
+--   from 'World.Grid.uiLayerThreshold' — the same value that drives
+--   'Engine.Scene.Batch.Visibility.isUILayer' and the scene render
+--   split — so the two pipelines can't disagree about where UI starts.
 uiLayerBase ∷ Int
-uiLayerBase = 10
+uiLayerBase = let LayerId t = uiLayerThreshold in fromIntegral t
 
 unLayerId ∷ LayerId → Word32
 unLayerId (LayerId i) = fromIntegral i

--- a/src/Unit/LineOfSight.hs
+++ b/src/Unit/LineOfSight.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE Strict, UnicodeSyntax #-}
 -- | Per-unit line-of-sight. A unit's visible tile set is the
 -- intersection of:
---   * a circular radius (perception * 6 tiles),
+--   * a circular radius (perception × 'awareRangeTiles' tiles),
 --   * a 120° cone centered on the unit's facing direction,
 --   * line-of-sight against terrain Z (a hill in the way blocks vision).
 --
@@ -43,7 +43,8 @@ unitVisibleTiles env uid = do
                         wtd ← readIORef (wsTilesRef ws)
                         let perception = HM.lookupDefault 1.0 "perception"
                                             (uiStats inst)
-                            radius = max 1 (floor (perception * 6) ∷ Int)
+                            radius = max 1 (floor (realToFrac perception
+                                                   * awareRangeTiles) ∷ Int)
                             ux = floor (uiGridX inst) ∷ Int
                             uy = floor (uiGridY inst) ∷ Int
                             uz = uiGridZ inst

--- a/src/Unit/Thread/Command.hs
+++ b/src/Unit/Thread/Command.hs
@@ -730,14 +730,14 @@ isTransitioning _                   = False
 --   max_hydration / max_hunger / carrying_capacity / strength_base.
 --   No-op if any of height/bulk/bodyfat is missing (e.g. for unit
 --   types that don't declare a body block).
--- | Spawn-time blood-volume seed in litres. Real-world ratio is
---   ~7.5 % of body_mass — applied via the rolled stats map so units
---   without a body block (no body_mass) start at 0 and won't bleed.
+-- | Spawn-time blood-volume seed in litres ('bloodMassRatio' of
+--   body_mass) — applied via the rolled stats map so units without a
+--   body block (no body_mass) start at 0 and won't bleed.
 --   The wound-tick code computes max_blood lazily from current
 --   body_mass on each read, so wasting/regrowth carries through.
 bloodSeedFromStats ∷ HM.HashMap Text Float → Float
 bloodSeedFromStats s = case HM.lookup "body_mass" s of
-    Just bm → bm * 0.075
+    Just bm → bm * bloodMassRatio
     Nothing → 0.0
 
 -- | Movement-speed multiplier derived from the unit's wounds + blood.
@@ -767,7 +767,7 @@ injurySpeedMult inst =
         torsoSev = sum [ woundEffSeverity w
                        | w ← uiWounds inst, woundPart w == "torso" ]
         bodyMass = HM.lookupDefault 70.0 "body_mass" (uiStats inst)
-        maxBlood = bodyMass * 0.075
+        maxBlood = bodyMass * bloodMassRatio
         bloodFrac = if maxBlood > 0
                     then max 0 (min 1 (uiBlood inst / maxBlood))
                     else 1
@@ -812,7 +812,7 @@ seedBodyComposition rolled =
                 -- own frame mass, so a tiny animal's healthy lean/fat are
                 -- never clamped above its own body mass — body composition
                 -- stays coherent at ANY size (mouse → dragon), which keeps
-                -- every mass-derived quantity (blood = body·0.075,
+                -- every mass-derived quantity (blood = body·bloodMassRatio,
                 -- max_salt = body·k, BMR = 22·(body−fat)+…) sane. At human
                 -- bulk these reproduce the old 0.44h² / 4.4h² floors.
                 minFat    = minFatFrac  * bodyMass

--- a/src/Unit/Thread/Movement.hs
+++ b/src/Unit/Thread/Movement.hs
@@ -61,6 +61,11 @@ data UnitMoveStats = UnitMoveStats
                                --   pullup vs has to wall-climb first.
     }
 
+-- | Baseline human body height in metres — the default when a unit
+--   declares no "height" stat.
+baselineUnitHeight ∷ Float
+baselineUnitHeight = 1.8
+
 defaultMoveStats ∷ UnitMoveStats
 defaultMoveStats = UnitMoveStats
     { umsBodyMass  = 70.0
@@ -69,17 +74,18 @@ defaultMoveStats = UnitMoveStats
     , umsDexterity = 1.0
     , umsStrength  = 1.0
     , umsRunThreshold = 1.0e9  -- no def → never auto-run (sentinel high)
-    , umsHeight    = 1.8       -- baseline human height
+    , umsHeight    = baselineUnitHeight
     }
 
 -- | Metres of body height needed to mantle one full z-level. A unit's
 --   climb "reach" (z-levels it can pull up onto without wall-climbing) is
---   height / this. Tuned so a baseline acolyte (1.8 m) reaches exactly
---   1 z — i.e. a 1-z cliff is handled entirely by the pullup, with no
---   vertical wall-climb, matching "acolytes are tall enough to climb a
---   1-z cliff and should go almost straight to the pullup".
+--   height / this. EQUAL to 'baselineUnitHeight' by design — a baseline
+--   acolyte (1.8 m) reaches exactly 1 z, i.e. a 1-z cliff is handled
+--   entirely by the pullup, with no vertical wall-climb, matching
+--   "acolytes are tall enough to climb a 1-z cliff and should go almost
+--   straight to the pullup".
 heightPerClimbZ ∷ Float
-heightPerClimbZ = 1.8
+heightPerClimbZ = baselineUnitHeight
 
 -- | How many z-levels the unit can mantle (pull up onto) given its height.
 climbReachZ ∷ UnitMoveStats → Float
@@ -128,7 +134,8 @@ tickAllMovement dt env utsRef = do
                 , umsDexterity = HM.lookupDefault 1.0  "dexterity"  (uiStats  inst)
                 , umsStrength  = HM.lookupDefault 1.0  "strength"   (uiStats  inst)
                 , umsRunThreshold = runFrac * maxSp
-                , umsHeight    = HM.lookupDefault 1.8  "height"     (uiStats  inst)
+                , umsHeight    = HM.lookupDefault baselineUnitHeight
+                                                       "height"     (uiStats  inst)
                 }
             Nothing → defaultMoveStats
     uts ← readIORef utsRef

--- a/src/Unit/Types.hs
+++ b/src/Unit/Types.hs
@@ -4,6 +4,7 @@ module Unit.Types
     , StatModifier(..)
     , Wound(..)
     , woundEffSeverity
+    , bloodMassRatio
     , Scar(..)
     , BodyPart(..)
     , NaturalWeapon(..)
@@ -176,6 +177,14 @@ data Wound = Wound
 woundEffSeverity ∷ Wound → Float
 woundEffSeverity w =
     max (woundSeverity w * (1 - woundHeal w)) (woundNecrosis w)
+
+-- | Blood volume as a fraction of body mass (litres per kg) — the
+--   real-world ~7.5 % ratio. Single source of truth for every
+--   max-blood computation (spawn seed, wound tick, speed penalty,
+--   Lua info panel); max_blood is always recomputed live from the
+--   CURRENT body_mass so wasting/regrowth carries through.
+bloodMassRatio ∷ Float
+bloodMassRatio = 0.075
 
 -- | A healed-over wound left as a permanent mark. Descriptive record
 --   for now (shown in the unit's Status tab); the data is here to hang
@@ -545,7 +554,7 @@ data UnitInstance = UnitInstance
       --   (scaled by constitution). Shown in the Status tab via immunity.png.
     , uiBlood       ∷ !Float
       -- ^ Current blood volume in litres. Spawn-time seeded to
-      --   body_mass × 0.075 (≈7.5 % real-world ratio). Drained by
+      --   body_mass × 'bloodMassRatio'. Drained by
       --   bleeding wounds in the wound tick. Below 30 % of max
       --   → Collapsed pose; ≤ 0 → Dead pose + exsanguination
       --   death event. Max is recomputed from body_mass each read


### PR DESCRIPTION
Closes #388

## Approach

Each of the six duplicated constants now has a single named source of truth; all sites reference it. Values are identical everywhere, so behaviour is unchanged.

- **Blood/body-mass ratio `0.075`** → new `Unit.Types.bloodMassRatio`, used by the spawn seed (`bloodSeedFromStats`), the wound tick (`Combat.Wounds`), the injury speed penalty (`injurySpeedMult`), and Lua `unit.getBlood`.
- **UI layer threshold `10`** → `UI.Render.uiLayerBase` now derives from `World.Grid.uiLayerThreshold` (the same constant that drives `isUILayer`, the scene render split, and command record) instead of restating it.
- **`max_stamina = endurance × 10`** → new `Combat.Resolution.maxStaminaFor` mirrors Lua's `stats.get` dispatch exactly (an explicit per-unit `max_stamina` stat wins, else `endurance × 10`); both the severity stamina-fraction and `applyStaminaDrain` route through it. The combat thread can't call into Lua, so this stays a documented mirror — the canonical Lua formula in `scripts/unit_stats.lua` now carries a lockstep note pointing here. (Side effect called out in the issue: a stat override on `max_stamina` is now honoured by the Haskell side too.)
- **Climb height `1.8`** → new `Unit.Thread.Movement.baselineUnitHeight`; `heightPerClimbZ`, `defaultMoveStats.umsHeight`, and the per-unit height fallback all derive from it, naming the intentional equality.
- **Waterfall deco base `17`** → `Sim.Fluid.Active` now uses the existing `World.SideFace.Base.sideDecoBase DecoWaterfall`.
- **Awareness range `6`** → the FOV radius in `Unit.LineOfSight` references `awareRangeTiles`, matching the perception-range path in the same module that already did.

## Tested

- `cabal build all` + both test-suite builds — clean; changed modules recompiled warning-free (CI enforces `-Werror`).
- `cabal test synarchy-test-headless` — 539 examples, 0 failures.
- `python3 tools/world_check.py` — 21/21 seeds PASS (bare `--dump` output unaffected).
- `python3 tools/test_audit.py` — all 35 groups pass.
- `python3 tools/physiology_probe.py` — ALL SCENARIOS PASSED (covers the blood-ratio sites).
- `python3 tools/movement_probe.py` on default, `cliff`, `ramp`, `ramp_detour` — all PASS (covers `heightPerClimbZ`/`umsHeight`).
- `python3 tools/combat_anim_probe.py --target acolyte` — swing + death anims PASS (covers `maxStaminaFor`). Note: the probe's **default** bear_brown config currently fails identically on unmodified master (units climb off the flat strip and never engage) — pre-existing drift, not from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)