### PR TITLE
Make the front-wall vegetation lift seam-aware (#423)

### DIFF
--- a/src/Location/Overlay.hs
+++ b/src/Location/Overlay.hs
@@ -28,7 +28,6 @@ module Location.Overlay
     ( computeLocationOverlay
     , ChunkMetrics(..)
     , chunkMetricsAt
-    , chunkSeamChebyshev
     ) where
 
 import UPrelude
@@ -37,7 +36,7 @@ import qualified Data.Text as T
 import qualified Data.Vector as V
 import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
-import World.Chunk.Types (ChunkCoord(..), chunkSize, wrapChunkCoordU)
+import World.Chunk.Types (ChunkCoord(..), chunkSize, wrapChunkCoordU, chunkSeamChebyshev)
 import World.Plate (TectonicPlate, elevationAtGlobal, isBeyondGlacier)
 import World.Material (MaterialId, matGlacier)
 import World.Ocean.Types (OceanMap, OceanDistMap, oceanDistAt)
@@ -216,21 +215,6 @@ computeLocationOverlay seed worldSize plates oceanMap oceanDist lakes rivers def
             h3 = (h2 `xor` (h2 `shiftR` 33)) * 0xff51afd7ed558ccd
             h4 = (h3 `xor` (h3 `shiftR` 33)) * 0xc4ceb9fe1a85ec53
         in  h4 `xor` (h4 `shiftR` 33)
-
--- | Chebyshev distance between two chunk coords under the cylindrical
---   u-wrap (the 'wrapChunkCoordU' topology): the minimum raw Chebyshev
---   distance over the three u-alias images of the first coord. Shifting
---   u by ±w moves a coord by (±w/2, ∓w/2) — v = cx + cy is
---   glacier-bounded and never wraps, so one alias step each way covers
---   every canonical pair. Equals the raw distance for interior pairs
---   and for non-wrapping (arena / zero-size) worlds.
-chunkSeamChebyshev ∷ Int → ChunkCoord → ChunkCoord → Int
-chunkSeamChebyshev worldSize (ChunkCoord ax ay) (ChunkCoord bx by)
-    | halfW ≤ 0 = raw 0
-    | otherwise = minimum [ raw k | k ← [-1, 0, 1] ]
-  where
-    halfW = worldSize `div` 2
-    raw k = max (abs (ax + k * halfW - bx)) (abs (ay - k * halfW - by))
 
 -- | FNV-1a hash of a location id — a fully deterministic salt (no
 --   dependence on hashable's per-run seed) so the overlay is identical

--- a/src/World/Chunk/Types.hs
+++ b/src/World/Chunk/Types.hs
@@ -2,6 +2,7 @@
 module World.Chunk.Types
     ( ChunkCoord(..)
     , wrapChunkCoordU
+    , chunkSeamChebyshev
     , Chunk
     , ColumnIndex
     , columnIndex
@@ -53,6 +54,21 @@ wrapChunkCoordU worldSize cc@(ChunkCoord cx cy)
             cy'      = (v - wrappedU) `div` 2
         in ChunkCoord cx' cy'
   where w = (worldSize `div` 2) * 2
+
+-- | Chebyshev distance between two chunk coords under the cylindrical
+--   u-wrap (the 'wrapChunkCoordU' topology): the minimum raw Chebyshev
+--   distance over the three u-alias images of the first coord. Shifting
+--   u by ±w moves a coord by (±w/2, ∓w/2) — v = cx + cy is
+--   glacier-bounded and never wraps, so one alias step each way covers
+--   every canonical pair. Equals the raw distance for interior pairs
+--   and for non-wrapping (arena / zero-size) worlds.
+chunkSeamChebyshev ∷ Int → ChunkCoord → ChunkCoord → Int
+chunkSeamChebyshev worldSize (ChunkCoord ax ay) (ChunkCoord bx by)
+    | halfW ≤ 0 = raw 0
+    | otherwise = minimum [ raw k | k ← [-1, 0, 1] ]
+  where
+    halfW = worldSize `div` 2
+    raw k = max (abs (ax + k * halfW - bx)) (abs (ay - k * halfW - by))
 
 -- | A single column's tile data: contiguous z-range of non-air tiles.
 --   Tiles from csStartZ to csStartZ + VU.length csMats - 1.

--- a/src/World/Render/Quads.hs
+++ b/src/World/Render/Quads.hs
@@ -2,6 +2,7 @@
 module World.Render.Quads
     ( renderWorldQuads
     , renderWorldCursorQuads
+    , structureFrontWallClear
     ) where
 
 import UPrelude
@@ -13,13 +14,13 @@ import Control.Parallel.Strategies (parListChunk, rdeepseq, using)
 import Engine.Core.State (EngineEnv(..))
 import Engine.Asset.Handle (TextureHandle(..), toInt)
 import Engine.Scene.Types (SortableQuad(..))
-import Engine.Graphics.Camera (Camera2D(..))
+import Engine.Graphics.Camera (Camera2D(..), CameraFacing)
 import World.Types
 import World.Flora.Render (resolveFloraTexture)
 import World.Generate (chunkToGlobal, viewDepth)
 import World.Generate.Coordinates (globalToChunk)
 import World.Grid (gridToScreen, tileSideHeight, applyFacing)
-import Structure.Types (StructureSlot(..), spdGridZ)
+import Structure.Types (StructureSlot(..), ChunkStructures, spdGridZ)
 import World.Mine.Types (MineDesignation(..))
 import World.Construct.Types (ConstructDesignation(..), ConstructTarget(..))
 import World.Chop.Types (ChopDesignation(..))
@@ -143,23 +144,6 @@ renderWorldQuads env worldState zoomAlpha snap = do
             Just lc' → Just (lcTerrainSurfaceMap lc')
             Nothing  → Nothing
 
-        -- #418: a flora/veg billboard sitting in front of a structure's FRONT
-        -- wall must draw over the WHOLE wall, not slice through the wall's
-        -- depth-sorted strips (#417). A single-depth sprite otherwise beats
-        -- the wall's back strips but loses its clamped south strips → the
-        -- "leaf over the wall / frond cut off" straddle. Here we find the
-        -- highest front-wall strip key the sprite at (gx,gy) is spatially IN
-        -- FRONT of, so the caller lifts the sprite's key just above it and it
-        -- clears the entire strip range as one unit. Returns Nothing when no
-        -- such wall is near (the sprite keeps its normal key).
-        --
-        -- The strip-key formula mirrors 'frontWallStrips'/'tieBreak' in
-        -- Structure.Render (SE 0.0006, SW 0.0005; the clamped south strip
-        -- anchors at the S vertex (wgx+1,wgy+1)) — keep them in sync. The
-        -- applyFacing depth test keeps it rotation-correct. Wall lookups cross
-        -- chunks; the per-chunk gate below keeps it free where there are none.
-        seTag = fromIntegral (fromEnum SWallSE) ∷ Word8
-        swTag = fromIntegral (fromEnum SWallSW) ∷ Word8
         -- Chunks that actually carry structures. A sprite is only considered
         -- for the lift when its chunk is within ONE chunk of one of these, so
         -- the check stays a no-op in structure-free areas — but, unlike a
@@ -168,26 +152,7 @@ renderWorldQuads env worldState zoomAlpha snap = do
         -- already resolves that wall cross-chunk).
         structureChunkCoords =
             [ lcCoord lc | lc ← chunks, not (HM.null (lcStructures lc)) ]
-        structureFrontWallClear gx gy =
-            let (fa, fb) = applyFacing facing gx gy
-                spriteDepth = fa + fb
-                wallKeyAt wgx wgy tag tieB = do
-                    let (cc, _) = globalToChunk wgx wgy
-                    lc' ← HM.lookup cc (wtdChunks tileData)
-                    spd ← HM.lookup (wgx, wgy, tag) (lcStructures lc')
-                    let (sa, sb) = applyFacing facing (wgx + 1) (wgy + 1)
-                        scDepth  = sa + sb
-                    if spriteDepth < scDepth   -- sprite is NOT fully in front
-                       then Nothing
-                       else Just (fromIntegral scDepth
-                                  + fromIntegral (spdGridZ spd - zSlice) * 0.001
-                                  + tieB)
-                cands = [ wallKeyAt (gx + dx) (gy + dy) tag tieB
-                        | dx ← [-2 .. 2], dy ← [-2 .. 2], (dx, dy) ≠ (0, 0)
-                        , (tag, tieB) ← [(seTag, 0.0006 ∷ Float), (swTag, 0.0005)] ]
-            in case [ k | Just k ← cands ] of
-                 [] → Nothing
-                 ks → Just (maximum ks)
+        structLookup cc = lcStructures ⊚ HM.lookup cc (wtdChunks tileData)
 
         -- Cached pass: widen the bounds by the pan margin so the camera
         -- can travel that far before cameraChanged forces a rebuild
@@ -216,16 +181,18 @@ renderWorldQuads env worldState zoomAlpha snap = do
                 -- or adjacent to one carrying structures (rooms are localised —
                 -- most chunks are nowhere near one, so this is a no-op there).
                 -- Adjacency (not same-chunk-only) is what lets a sprite across
-                -- a chunk seam from a wall still get lifted. A qualifying sprite
-                -- is raised to sit fully in front of any front wall it overlaps;
+                -- a chunk seam from a wall still get lifted — measured with
+                -- 'chunkSeamChebyshev' so a wall just across the cylindrical
+                -- U seam still qualifies (#423). A qualifying sprite is raised
+                -- to sit fully in front of any front wall it overlaps;
                 -- everything else is untouched.
-                ChunkCoord ccx ccy = coord
                 chunkNearStructures =
-                    any (\(ChunkCoord sx sy) → abs (sx - ccx) ≤ 1 ∧ abs (sy - ccy) ≤ 1)
+                    any (\sc → chunkSeamChebyshev worldSize sc coord ≤ 1)
                         structureChunkCoords
                 bump gx gy q
                     | not chunkNearStructures = q
-                    | otherwise = case structureFrontWallClear gx gy of
+                    | otherwise = case structureFrontWallClear facing worldSize
+                                           zSlice structLookup gx gy of
                         Just c  → q { sqSortKey = max (sqSortKey q) (c + 0.0001) }
                         Nothing → q
 
@@ -431,6 +398,77 @@ renderWorldQuads env worldState zoomAlpha snap = do
             -- low at typical visible-chunk counts (~20–100).
             `using` parListChunk 4 rdeepseq
     return $! V.concat chunkVectors
+
+-- | #418: a flora/veg billboard sitting in front of a structure's FRONT
+--   wall must draw over the WHOLE wall, not slice through the wall's
+--   depth-sorted strips (#417). A single-depth sprite otherwise beats
+--   the wall's back strips but loses its clamped south strips → the
+--   "leaf over the wall / frond cut off" straddle. This finds the
+--   highest front-wall strip key the sprite at (gx,gy) is spatially IN
+--   FRONT of, so the caller lifts the sprite's key just above it and it
+--   clears the entire strip range as one unit. Returns Nothing when no
+--   such wall is near (the sprite keeps its normal key).
+--
+--   The strip-key formula mirrors 'frontWallStrips'/'tieBreak' in
+--   Structure.Render (SE 0.0006, SW 0.0005; the clamped south strip
+--   anchors at the S vertex (wgx+1,wgy+1)) — keep them in sync. The
+--   applyFacing depth test keeps it rotation-correct. Wall lookups cross
+--   chunks; the per-chunk gate at the call site keeps it free where
+--   there are none.
+--
+--   Seam-aware (#423): loaded chunks are keyed by canonical (u-wrapped)
+--   coords ('World.Thread.ChunkLoading'), and a chunk's structures are
+--   keyed by tile coords in that canonical frame. A neighbour probed
+--   just across the cylindrical U seam therefore needs BOTH its chunk
+--   coord canonicalised and its tile key shifted by the same wrap
+--   delta, or the wall on the far side is silently missed.
+structureFrontWallClear
+    ∷ CameraFacing
+    → Int                                   -- ^ world size in chunks
+    → Int                                   -- ^ camera z-slice
+    → (ChunkCoord → Maybe ChunkStructures)  -- ^ loaded-chunk structure lookup
+    → Int → Int                             -- ^ sprite tile (gx, gy)
+    → Maybe Float
+structureFrontWallClear facing worldSize zSlice structLookup gx gy =
+    let (fa, fb) = applyFacing facing gx gy
+        spriteDepth = fa + fb
+        seTag = fromIntegral (fromEnum SWallSE) ∷ Word8
+        swTag = fromIntegral (fromEnum SWallSW) ∷ Word8
+        wallKeyAt wgx wgy tag tieB = do
+            let (ccRaw@(ChunkCoord rcx rcy), _) = globalToChunk wgx wgy
+                cc@(ChunkCoord ccx ccy) = wrapChunkCoordU worldSize ccRaw
+                -- Tile key in the stored (canonical) chunk's frame. The
+                -- chunk wrap shifts u by whole worlds and preserves
+                -- v = cx + cy, so this is the identity away from the seam.
+                sgx = wgx + (ccx - rcx) * chunkSize
+                sgy = wgy + (ccy - rcy) * chunkSize
+            structs ← structLookup cc
+            spd ← HM.lookup (sgx, sgy, tag) structs
+            -- The wall's strips sort at keys computed from its STORED
+            -- coords, while the sprite's own key is in its local frame.
+            -- The u-wrap preserves v = gx + gy, so at north/south facings
+            -- (depth = ±v) the two frames agree and the cross-seam lift
+            -- is exact. At east/west facings depth follows u, which the
+            -- wrap shifts by a whole world width — the wall renders
+            -- nowhere near the sprite on screen there, and lifting
+            -- against its key would only corrupt the sprite's local
+            -- ordering: skip when the frames disagree.
+            let (sa, sb) = applyFacing facing (sgx + 1) (sgy + 1)
+                scDepth  = sa + sb
+                (la, lb) = applyFacing facing (wgx + 1) (wgy + 1)
+                localDepth = la + lb
+            if spriteDepth < localDepth   -- sprite is NOT fully in front
+               ∨ scDepth ≠ localDepth     -- frames disagree (E/W seam)
+               then Nothing
+               else Just (fromIntegral scDepth
+                          + fromIntegral (spdGridZ spd - zSlice) * 0.001
+                          + tieB)
+        cands = [ wallKeyAt (gx + dx) (gy + dy) tag tieB
+                | dx ← [-2 .. 2], dy ← [-2 .. 2], (dx, dy) ≠ (0, 0)
+                , (tag, tieB) ← [(seTag, 0.0006 ∷ Float), (swTag, 0.0005)] ]
+    in case [ k | Just k ← cands ] of
+         [] → Nothing
+         ks → Just (maximum ks)
 
 -- * World Cursor Quads (generated every frame, not cached)
 

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -186,6 +186,7 @@ test-suite synarchy-test-headless
                    Test.Headless.World.Calendar
                    Test.Headless.World.FloraGrowth
                    Test.Headless.River.Graph
+                   Test.Headless.World.Render.FrontWallLift
                    Test.Headless.World.Render.SideFace
                    Test.Headless.World.Render.SlopeBit
                    Test.Headless.Render.ViewportGuard

--- a/test-headless/Spec.hs
+++ b/test-headless/Spec.hs
@@ -46,6 +46,7 @@ import qualified Test.Headless.UI.Tooltip as UITooltip
 import qualified Test.Headless.World.Calendar as Calendar
 import qualified Test.Headless.World.FloraGrowth as FloraGrowth
 import qualified Test.Headless.River.Graph as RiverGraph
+import qualified Test.Headless.World.Render.FrontWallLift as FrontWallLift
 import qualified Test.Headless.World.Render.SideFace as RenderSideFace
 import qualified Test.Headless.World.Render.SlopeBit as RenderSlopeBit
 import qualified Test.Headless.Render.ViewportGuard as ViewportGuard
@@ -104,6 +105,7 @@ main = hspec $ do
     describe "World.Calendar" Calendar.spec
     describe "World.FloraGrowth" FloraGrowth.spec
     describe "River.Graph" RiverGraph.spec
+    describe "World.Render.FrontWallLift" FrontWallLift.spec
     describe "World.Render.SideFace" RenderSideFace.spec
     describe "World.Slope.slopeBit" RenderSlopeBit.spec
     describe "Render.ViewportGuard" ViewportGuard.spec

--- a/test-headless/Test/Headless/World/Render/FrontWallLift.hs
+++ b/test-headless/Test/Headless/World/Render/FrontWallLift.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE Strict, UnicodeSyntax #-}
+-- | Pure tests for 'World.Render.Quads.structureFrontWallClear' — the
+--   #418 flora/vegetation lift over structure front walls.
+--
+--   The regression under test (issue #423): loaded chunks are keyed by
+--   canonical (u-wrapped) coords, and a chunk's structures by tile
+--   coords in that canonical frame. The lift used to probe neighbours
+--   with a raw 'globalToChunk' lookup, so a wall just across the
+--   cylindrical U seam was silently missed and the sprite kept its
+--   unlifted key (the #418 straddle came back at the seam). The fix
+--   canonicalises the probed chunk coord AND shifts the structure tile
+--   key by the same wrap delta.
+--
+--   No engine needed: the function is pure. Structure lookups are fed
+--   from a hand-built @ChunkCoord → ChunkStructures@ map, mirroring how
+--   'renderWorldQuads' backs it with the loaded-chunk map.
+module Test.Headless.World.Render.FrontWallLift (spec) where
+
+import UPrelude
+import Test.Hspec
+import qualified Data.HashMap.Strict as HM
+import Engine.Graphics.Camera (CameraFacing(..))
+import Structure.Types (StructureSlot(..), StructurePieceData(..), ChunkStructures)
+import World.Chunk.Types (ChunkCoord(..), chunkSeamChebyshev)
+import World.Render.Quads (structureFrontWallClear)
+
+seTag ∷ Word8
+seTag = fromIntegral (fromEnum SWallSE)
+
+-- | Lookup backed by a plain map: one 'ChunkStructures' per chunk coord.
+lookupFrom ∷ [(ChunkCoord, [((Int, Int, Word8), StructurePieceData)])]
+           → (ChunkCoord → Maybe ChunkStructures)
+lookupFrom chunks cc = HM.lookup cc (HM.fromList [ (c, HM.fromList ps) | (c, ps) ← chunks ])
+
+-- | A wall piece at world z 5 (palette ids irrelevant to sort keys).
+wallZ5 ∷ StructurePieceData
+wallZ5 = StructurePieceData 0 0 5
+
+-- | worldSize 8 chunks → 128 tiles around the cylinder, canonical chunk
+--   u ∈ [-4, 4). All scenarios use zSlice 5 = the wall z, so the key's
+--   z-term is zero and the expected key is depth + tieBreak alone.
+ws, zSlice ∷ Int
+ws = 8
+zSlice = 5
+
+-- | Interior reference layout: SE wall at (-1,2) in chunk (-1,0), sprite
+--   at (1,2) — two tiles east in grid space, spatially in front of the
+--   wall's south-vertex anchor (0,3) at FaceSouth (depth 3 vs 3).
+interiorLookup ∷ ChunkCoord → Maybe ChunkStructures
+interiorLookup = lookupFrom [ (ChunkCoord (-1) 0, [((-1, 2, seTag), wallZ5)]) ]
+
+-- | Seam layout with the SAME relative geometry: sprite at (-31,34)
+--   (chunk (-2,2), tile u = -65 in its chunk's frame), wall on the
+--   physically adjacent tile two steps east ACROSS the U seam. That
+--   tile's raw coords (-33,34) live in raw chunk (-3,2), u = -5 —
+--   non-canonical; the chunk is loaded as (1,-2) and the wall stored
+--   under the wrapped tile key (31,-30).
+seamLookup ∷ ChunkCoord → Maybe ChunkStructures
+seamLookup = lookupFrom [ (ChunkCoord 1 (-2), [((31, -30, seTag), wallZ5)]) ]
+
+spec ∷ Spec
+spec = do
+    it "lifts a sprite in front of an interior front wall (#418 baseline)" $ do
+        let k = structureFrontWallClear FaceSouth ws zSlice interiorLookup 1 2
+        k `shouldSatisfy` isJust
+        -- Pin the strip-key formula: anchor depth 3, z-term 0 (wall z ≡
+        -- zSlice), SE tieBreak 0.0006.
+        k `shouldSatisfy` maybe False (\v → abs (v - 3.0006) < 1.0e-4)
+
+    it "does not lift a sprite behind the wall" $ do
+        -- depth 1+0 = 1 < wall anchor depth 3 → spatially behind.
+        structureFrontWallClear FaceSouth ws zSlice interiorLookup 1 0
+            `shouldBe` Nothing
+
+    it "does not lift when no wall is near" $ do
+        structureFrontWallClear FaceSouth ws zSlice (const Nothing) 1 2
+            `shouldBe` Nothing
+
+    it "lifts across the U seam exactly like the interior case (#423)" $ do
+        let seamK     = structureFrontWallClear FaceSouth ws zSlice seamLookup (-31) 34
+            interiorK = structureFrontWallClear FaceSouth ws zSlice interiorLookup 1 2
+        seamK `shouldSatisfy` isJust
+        -- The u-wrap preserves v = gx+gy, so the seam pair must produce
+        -- the SAME strip key as the interior pair with identical relative
+        -- geometry: depth 3 + z-term 0 + SE tieBreak.
+        seamK `shouldBe` interiorK
+
+    it "skips the cross-seam wall at east/west facings" $ do
+        -- Depth follows u at FaceEast; the wall's stored frame sits a
+        -- whole world width away, so the lift must not fire.
+        structureFrontWallClear FaceEast ws zSlice seamLookup (-31) 34
+            `shouldBe` Nothing
+
+    it "still lifts at east/west facings away from the seam" $ do
+        -- FaceEast depth = gx - gy: sprite (1,0) depth 1, wall anchor
+        -- (0,3) depth -3 → sprite in front; frames agree (no wrap).
+        structureFrontWallClear FaceEast ws zSlice interiorLookup 1 0
+            `shouldSatisfy` isJust
+
+    it "chunk gate: the seam sprite/wall chunks are wrap-adjacent" $ do
+        -- The per-chunk gate in renderWorldQuads admits sprite chunks
+        -- within seam-aware Chebyshev 1 of a structure-bearing chunk;
+        -- this is the exact pair from the seam scenario above (raw
+        -- distance 4, physical distance 1).
+        chunkSeamChebyshev ws (ChunkCoord 1 (-2)) (ChunkCoord (-2) 2)
+            `shouldBe` 1

--- a/test-headless/Test/Headless/WorldGen.hs
+++ b/test-headless/Test/Headless/WorldGen.hs
@@ -29,9 +29,8 @@ import World.Fluid.Lake.Types (lakesInChunk)
 import World.Fluid.River.Types (riversInChunk)
 import Location.Types (LocationDef(..))
 import Location.Overlay
-    ( computeLocationOverlay, chunkMetricsAt, ChunkMetrics(..)
-    , chunkSeamChebyshev
-    )
+    ( computeLocationOverlay, chunkMetricsAt, ChunkMetrics(..) )
+-- chunkSeamChebyshev comes in via World.Types (World.Chunk.Types, #423)
 
 spec ∷ SpecWith EngineEnv
 spec = do


### PR DESCRIPTION
Closes #423

## Approach

The #418 flora/vegetation lift over structure front walls missed walls across the cylindrical U seam: it probed neighbours with a raw `globalToChunk` lookup and gated per-chunk on raw Chebyshev adjacency, while loaded chunks (and their `lcStructures` tile keys) live under `wrapChunkCoordU`-canonical coords.

- **`structureFrontWallClear`** is hoisted out of `renderWorldQuads` into a pure, exported function (structure lookup via callback, same pattern as `waterSideFaceQuads`), and now canonicalises the probed chunk coord **and** shifts the structure tile key by the same wrap delta — a chunk's structures are keyed in its canonical frame, so both halves are needed.
- **Frame coherence:** the lift key is computed from the wall's *stored* coords (the frame its #417 strips actually sort in); the spatial in-front test stays in the sprite's local frame. The u-wrap preserves `v = gx+gy`, so at north/south facings the two frames agree and the cross-seam lift is exact. At east/west facings depth follows `u`, which the wrap shifts by a whole world width — the wall renders nowhere near the sprite on screen there, so the lift is skipped when the frames disagree (guard: `scDepth ≠ localDepth`) rather than corrupting the sprite's local ordering.
- **Chunk gate:** now measured with `chunkSeamChebyshev`, moved from `Location.Overlay` to `World.Chunk.Types` next to `wrapChunkCoordU` (the documented single source of truth for the seam topology). `Location.Overlay` imports it from there; the #422 placement behavior is unchanged.
- Non-seam behavior is bit-identical: away from the seam the canonicalisation is the identity and the key formula is untouched.

## Testing

- **New pure spec `Test.Headless.World.Render.FrontWallLift`** (7 examples): interior #418 baseline with the strip-key formula pinned (`3.0006`), behind-the-wall and no-wall negatives, the seam regression case (sprite at `(-31,34)`, wall stored in wrapped chunk `(1,-2)` under shifted key `(31,-30)`) asserting the cross-seam lift returns *exactly* the interior key, the east/west seam skip, and the wrap-adjacent gate pair. The seam case is red against the old raw lookup (it resolves raw chunk `(-3,2)`, which is never loaded).
- `cabal test synarchy-test-headless`: 546 examples, 0 failures.
- `python3 tools/test_audit.py`: all 35 groups pass.
- `python3 tools/world_check.py --quick`: 6/6 PASS (no worldgen-output change — `World.Chunk.Types` only gains a function).
- Build warning-clean (the moved helper's old import site in `WorldGen.hs` updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)