### PR TITLE
Quality tiers + tooltip descriptions (#345)

### DIFF
--- a/scripts/cargo_inventory_panel.lua
+++ b/scripts/cargo_inventory_panel.lua
@@ -30,6 +30,7 @@ local label       = require("scripts.ui.label")
 local scale       = require("scripts.ui.scale")
 local boxTextures = require("scripts.ui.box_textures")
 local brokenOverlay = require("scripts.ui.broken_overlay")
+local qualityTier = require("scripts.ui.quality_tier")
 
 -----------------------------------------------------------
 -- Layout constants. Mirrors unit_info_v2's inventory section so
@@ -443,7 +444,7 @@ local function buildRows(originX, originY, contentW, grouped)
 
         -- Display name (with stack suffix), truncated with ".." if it
         -- would otherwise overrun into the weight column.
-        local rawName = g.displayName or g.defName or "?"
+        local rawName = qualityTier.withSuffix(g.displayName or g.defName or "?", g)
         if (g.count or 1) > 1 then
             rawName = string.format("%s ×%d", rawName, g.count)
         end

--- a/scripts/item_info_panel.lua
+++ b/scripts/item_info_panel.lua
@@ -12,6 +12,7 @@
 --     Same one-thing-at-a-time rule as units/buildings.
 
 local infoPanel = require("scripts.hud.info_panel")
+local qualityTier = require("scripts.ui.quality_tier")
 
 local itemInfoWatch = {}
 
@@ -47,7 +48,7 @@ local function pushItemInfo(gid)
     if not g then return false end
     local d = defEntry(g.defName)
     local lines = {}
-    local nm = (d and d.displayName) or g.defName
+    local nm = qualityTier.withSuffix((d and d.displayName) or g.defName, g)
     -- Condition 0 = broken (see Combat.Resolution weapon wear).
     if g.condition and g.condition <= 0 then nm = nm .. " (broken)" end
     table.insert(lines, nm)

--- a/scripts/ui/quality_tier.lua
+++ b/scripts/ui/quality_tier.lua
@@ -1,0 +1,30 @@
+-- Shared quality-tier display helper (#345).
+--
+-- Any item whose def declares a quality spec resolves its numeric
+-- iiQuality (0..100) to a named band on the engine side
+-- (Item.Types.qualityTierLabel — "excellent" / "good" / "average" /
+-- "bad" / "atrocious" by default, or a def's own `quality_tiers:`
+-- override). It arrives on item tables as `qualityTier`, alongside
+-- `quality`, only when the def has a spec (unit.getInventory,
+-- equipment.getLoadout/getAccessories, building.getStorage,
+-- item.listGround). This module is the one place that turns that
+-- into display text, so every panel reads the same suffix.
+
+local qualityTier = {}
+
+-- " (excellent)" appended to an item's name, or "" when the item has
+-- no tier (no quality spec on the def).
+function qualityTier.suffix(it)
+    if it and it.qualityTier and it.qualityTier ~= "" then
+        return " (" .. it.qualityTier .. ")"
+    end
+    return ""
+end
+
+-- `baseName` with the tier suffix appended — "coffee" at 95% reads
+-- "coffee (excellent)".
+function qualityTier.withSuffix(baseName, it)
+    return (baseName or "") .. qualityTier.suffix(it)
+end
+
+return qualityTier

--- a/scripts/unit_info_v2.lua
+++ b/scripts/unit_info_v2.lua
@@ -21,6 +21,7 @@ local scale       = require("scripts.ui.scale")
 local boxTextures = require("scripts.ui.box_textures")
 local scrollbar   = require("scripts.ui.scrollbar")
 local brokenOverlay = require("scripts.ui.broken_overlay")
+local qualityTier = require("scripts.ui.quality_tier")
 local stats       = require("scripts.unit_stats")
 local injuries    = require("scripts.injuries")
 local knowledge   = require("scripts.knowledge")
@@ -2173,6 +2174,7 @@ local function buildItemHint(it, equippedSlot)
     if it.quality then
         hintLines[#hintLines + 1] =
             string.format("quality: %d%%", math.floor(it.quality + 0.5))
+            .. qualityTier.suffix(it)
     end
     if it.condition then
         hintLines[#hintLines + 1] =
@@ -2391,7 +2393,8 @@ local function rebuildEquipmentSection()
                 -- condition / weapon stats / equipped slot) here as
                 -- they do in the inventory list.
                 UI.setTooltipRich(iconElemId, {
-                    text = eq.displayName or eq.defName or s.name,
+                    text = qualityTier.withSuffix(
+                        eq.displayName or eq.defName or s.name, eq),
                     hint = buildItemHint(eq, s.id),
                 })
                 UI.setClickable(iconElemId, true)
@@ -2463,7 +2466,8 @@ local function rebuildEquipmentSection()
                 UI.setClickable(iconId, true)
                 UI.setOnRightClick(iconId, "onAccessoryRowRightClick")
                 UI.setTooltipRich(iconId, {
-                    text = it.displayName or it.defName,
+                    text = qualityTier.withSuffix(
+                        it.displayName or it.defName, it),
                     hint = buildItemHint(it, "(worn)"),
                 })
                 table.insert(unitInfoV2.equipElements,
@@ -2514,6 +2518,7 @@ local function collectInventoryAndEquipment(uid)
             currentFill  = it.currentFill or 0,
             capacity     = it.capacity,
             quality      = it.quality,
+            qualityTier  = it.qualityTier,
             condition    = it.condition,
             weapon       = it.weapon,
             sharpness    = it.sharpness,
@@ -2550,6 +2555,7 @@ local function collectInventoryAndEquipment(uid)
                 currentFill   = it.currentFill or 0,
                 capacity      = it.capacity,
                 quality       = it.quality,
+                qualityTier   = it.qualityTier,
                 condition     = it.condition,
                 weapon        = it.weapon,
                 sharpness     = it.sharpness,
@@ -2576,6 +2582,7 @@ local function collectInventoryAndEquipment(uid)
             currentFill    = it.currentFill or 0,
             capacity       = it.capacity,
             quality        = it.quality,
+            qualityTier    = it.qualityTier,
             condition      = it.condition,
             weapon         = it.weapon,
             sharpness      = it.sharpness,
@@ -2914,7 +2921,7 @@ local function rebuildInventorySection()
         local nameX = listX + textPad + iconSz + textPad
         local nameMaxPx = (listX + listW - textPad - wW) - nameX
                         - math.floor(4 * uiscale)
-        local rawName = it.displayName
+        local rawName = qualityTier.withSuffix(it.displayName, it)
         if (it.stackCount or 1) > 1 then
             rawName = string.format("%s ×%d", rawName, it.stackCount)
         end
@@ -2956,7 +2963,7 @@ local function rebuildInventorySection()
         UI.setOnRightClick(hitId, "onInventoryItemRightClick")
 
         UI.setTooltipRich(hitId, {
-            text = it.displayName,
+            text = qualityTier.withSuffix(it.displayName, it),
             hint = buildItemHint(it, it.equipped and it.equippedSlot or nil),
         })
 

--- a/src/Engine/Asset/YamlItems.hs
+++ b/src/Engine/Asset/YamlItems.hs
@@ -6,6 +6,7 @@ module Engine.Asset.YamlItems
     , ItemYamlContent(..)
     , ItemYamlFood(..)
     , ItemYamlRollSpec(..)
+    , ItemYamlQualityTier(..)
     , ItemYamlWeapon(..)
     , ItemYamlArmor(..)
     , ItemYamlBuff(..)
@@ -79,6 +80,19 @@ instance FromJSON ItemYamlRollSpec where
     parseJSON = withObject "ItemYamlRollSpec" $ \v → ItemYamlRollSpec
         ⊚ v .: "min"
         ⊛ v .: "max"
+
+-- | One override band in an item's `quality_tiers:` list (#345) — a
+--   (threshold, label) pair; see 'Item.Types.QualityTier'. Reads as
+--   `{ min: 90, label: excellent }` in YAML.
+data ItemYamlQualityTier = ItemYamlQualityTier
+    { iyqtMin   ∷ !Float
+    , iyqtLabel ∷ !Text
+    } deriving (Show, Eq, Generic)
+
+instance FromJSON ItemYamlQualityTier where
+    parseJSON = withObject "ItemYamlQualityTier" $ \v → ItemYamlQualityTier
+        ⊚ v .: "min"
+        ⊛ v .: "label"
 
 -- | One stat-modifier conferred by equipping an item.
 --   YAML shape: `{ stat: perception, amount: 1, scales_with_condition: true }`.
@@ -169,6 +183,9 @@ data ItemYamlDef = ItemYamlDef
                                                    --   defaults to ""
     , iydQuality     ∷ !(Maybe ItemYamlRollSpec)   -- ^ quality roll range
     , iydCondition   ∷ !(Maybe ItemYamlRollSpec)   -- ^ condition roll range
+    , iydQualityTiers ∷ ![ItemYamlQualityTier]     -- ^ quality→label
+                                                   --   overrides (#345);
+                                                   --   [] ⇒ default set
     , iydContainer   ∷ !(Maybe ItemYamlContainer)
     , iydContents    ∷ ![ItemYamlContent]            -- ^ item-container defaults
     , iydFood        ∷ !(Maybe ItemYamlFood)
@@ -193,6 +210,7 @@ instance FromJSON ItemYamlDef where
         ⊛ v .:? "material"     .!= ""
         ⊛ v .:? "quality"
         ⊛ v .:? "condition"
+        ⊛ v .:? "quality_tiers" .!= []
         ⊛ v .:? "container"
         ⊛ v .:? "contents"     .!= []
         ⊛ v .:? "food"

--- a/src/Engine/Scripting/Lua/API/Equipment.hs
+++ b/src/Engine/Scripting/Lua/API/Equipment.hs
@@ -29,7 +29,7 @@ import Equipment.Types
 import Item.Types (ItemInstance(..), ItemDef(..), ItemWeapon(..),
                    ItemBuff(..), ItemContainer(..),
                    ItemManager(..), lookupItemDef, itemMatches,
-                   itemContentsSig, itemTotalWeight)
+                   itemContentsSig, itemTotalWeight, qualityTierLabel)
 import Unit.Types (UnitInstance(..), UnitManager(..), UnitId(..),
                    UnitDef(..), StatModifier(..))
 import Unit.Stats (applyItemBuffs)
@@ -361,12 +361,18 @@ equipmentGetLoadoutFn env = do
                         -- canteens / rations don't show "100%" they
                         -- never had.
                         let mDef = lookupItemDef (iiDefName inst) itemMgr
-                        case mDef >>= idQualitySpec of
-                            Just _ → do
+                        case mDef of
+                            Just d | Just _ ← idQualitySpec d → do
                                 Lua.pushnumber
                                     (Lua.Number (realToFrac (iiQuality inst)))
                                 Lua.setfield (-2) "quality"
-                            Nothing → pure ()
+                                -- Named tier (#345), e.g. "excellent".
+                                case qualityTierLabel d (iiQuality inst) of
+                                    Just tier → do
+                                        Lua.pushstring (TE.encodeUtf8 tier)
+                                        Lua.setfield (-2) "qualityTier"
+                                    Nothing → pure ()
+                            _ → pure ()
                         case mDef >>= idConditionSpec of
                             Just _ → do
                                 Lua.pushnumber
@@ -462,11 +468,17 @@ pushItemInstance inst itemMgr = do
     -- items like canteens / rations don't have these qualities and
     -- shouldn't show "100%" in tooltips.
     let mDef = lookupItemDef (iiDefName inst) itemMgr
-    case mDef >>= idQualitySpec of
-        Just _ → do
+    case mDef of
+        Just d | Just _ ← idQualitySpec d → do
             Lua.pushnumber (Lua.Number (realToFrac (iiQuality inst)))
             Lua.setfield (-2) "quality"
-        Nothing → pure ()
+            -- Named tier (#345), e.g. "excellent" at 95%.
+            case qualityTierLabel d (iiQuality inst) of
+                Just tier → do
+                    Lua.pushstring (TE.encodeUtf8 tier)
+                    Lua.setfield (-2) "qualityTier"
+                Nothing → pure ()
+        _ → pure ()
     case mDef >>= idConditionSpec of
         Just _ → do
             Lua.pushnumber (Lua.Number (realToFrac (iiCondition inst)))

--- a/src/Engine/Scripting/Lua/API/Items.hs
+++ b/src/Engine/Scripting/Lua/API/Items.hs
@@ -156,6 +156,9 @@ loadItemYamlFn env backendState = do
                                               <$> iydQuality def
                             , idConditionSpec = (\r → (iyrsMin r, iyrsMax r))
                                               <$> iydCondition def
+                            , idQualityTiers = map
+                                (\t → QualityTier (iyqtMin t) (iyqtLabel t))
+                                (iydQualityTiers def)
                             , idContainer   = container
                             , idDefaultContents =
                                 [ (iycoItem c, iycoCount c, iycoFill c)
@@ -302,8 +305,10 @@ itemSpawnGroundFn env = do
         _ → Lua.pushnil >> return 1
 
 -- | item.listGround() → array of {id, defName, x, y, fill, quality,
---   condition, weight}. `weight` is the live total mass (itemTotalWeight:
---   empty weight + fill + nested contents), not the static def weight.
+--   qualityTier, condition, weight}. `weight` is the live total mass
+--   (itemTotalWeight: empty weight + fill + nested contents), not the
+--   static def weight. `qualityTier` (#345) is present only when the
+--   def declares a quality spec.
 itemListGroundFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 itemListGroundFn env = do
     mWs ← Lua.liftIO $ activeWorld env
@@ -330,6 +335,18 @@ itemListGroundFn env = do
                     Lua.pushnumber (Lua.Number (realToFrac
                         (iiQuality (giInst gi))))
                     Lua.setfield (Lua.nth 2) "quality"
+                    -- Tier label only when the def actually declares a
+                    -- quality spec (mirrors unit.getInventory / the
+                    -- equipment queries — #345).
+                    case lookupItemDef (iiDefName (giInst gi)) im of
+                        Just d | Just _ ← idQualitySpec d →
+                            case qualityTierLabel d
+                                     (iiQuality (giInst gi)) of
+                                Just tier → do
+                                    Lua.pushstring (TE.encodeUtf8 tier)
+                                    Lua.setfield (Lua.nth 2) "qualityTier"
+                                Nothing → pure ()
+                        _ → pure ()
                     Lua.pushnumber (Lua.Number (realToFrac
                         (iiCondition (giInst gi))))
                     Lua.setfield (Lua.nth 2) "condition"

--- a/src/Engine/Scripting/Lua/API/Units.hs
+++ b/src/Engine/Scripting/Lua/API/Units.hs
@@ -155,7 +155,8 @@ import Item.Types (ItemDef(..)
                    , ItemBuff(..)
                    , ItemManager(..)
                    , lookupItemDef
-                   , itemTotalWeight)
+                   , itemTotalWeight
+                   , qualityTierLabel)
 import Item.Ground (spawnGroundItem)
 import Combat.Wounds (bleedRateFor, kindBleedFactor)
 import Combat.Types (pushInjuryEvent)
@@ -4673,12 +4674,19 @@ unitGetInventoryFn env = do
                         -- callers (e.g. inventory tooltip) would show
                         -- "100%" for items like canteens / rations that
                         -- conceptually don't have these qualities.
-                        case mDef >>= idQualitySpec of
-                            Just _ → do
+                        case mDef of
+                            Just d | Just _ ← idQualitySpec d → do
                                 Lua.pushnumber
                                     (Lua.Number (realToFrac (iiQuality inst)))
                                 Lua.setfield (-2) "quality"
-                            Nothing → pure ()
+                                -- Named tier (#345), e.g. "excellent" at
+                                -- 95% — the tooltip suffix / name reader.
+                                case qualityTierLabel d (iiQuality inst) of
+                                    Just tier → do
+                                        Lua.pushstring (TE.encodeUtf8 tier)
+                                        Lua.setfield (-2) "qualityTier"
+                                    Nothing → pure ()
+                            _ → pure ()
                         case mDef >>= idConditionSpec of
                             Just _ → do
                                 Lua.pushnumber

--- a/src/Item/Types.hs
+++ b/src/Item/Types.hs
@@ -13,12 +13,15 @@ module Item.Types
     , ItemManager(..)
     , emptyItemManager
     , lookupItemDef
+    , QualityTier(..)
+    , defaultQualityTiers
+    , qualityTierLabel
     ) where
 
 import UPrelude
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
-import Data.List (sort)
+import Data.List (sort, sortBy, find)
 import GHC.Generics (Generic)
 import Data.Serialize (Serialize)
 import Engine.Asset.Handle (TextureHandle(..))
@@ -176,6 +179,11 @@ data ItemDef = ItemDef
       --   as a normal distribution centered at (min+max)/2 with
       --   stddev (max-min)/6, clamped to [min, max]. Nothing ⇒ spawn
       --   at 100%.
+    , idQualityTiers  ∷ ![QualityTier]
+      -- ^ Data-driven quality→label thresholds (`quality_tiers:` in
+      --   YAML), e.g. 90→"excellent" so a 95%-quality coffee reads
+      --   "coffee (excellent)". Empty ⇒ fall back to
+      --   'defaultQualityTiers'.
     , idConditionSpec ∷ !(Maybe (Float, Float))
       -- ^ (min, max) % range for condition rolls at spawn. Same
       --   distribution shape as quality. Condition degrades with use;
@@ -328,6 +336,37 @@ itemTotalWeight im it =
     fillUnitWeight = case idContainer =<< lookupItemDef (iiDefName it) im of
         Just c  → icFillWeight c
         Nothing → 1.0   -- no container def in scope → assume litres (1 kg/L)
+
+-- | One band of a quality→label mapping (#345). `qtMin` is the
+--   inclusive lower bound (0..100) of the band; 'qualityTierLabel'
+--   resolves a quality value to the highest band whose bound it clears.
+data QualityTier = QualityTier
+    { qtMin   ∷ !Float
+    , qtLabel ∷ !Text
+    } deriving (Show, Eq)
+
+-- | Fallback quality tiers for any item def that doesn't declare its
+--   own `quality_tiers:` override. The 0-floor band guarantees a
+--   result for every non-negative quality value.
+defaultQualityTiers ∷ [QualityTier]
+defaultQualityTiers =
+    [ QualityTier 90 "excellent"
+    , QualityTier 75 "good"
+    , QualityTier 50 "average"
+    , QualityTier 25 "bad"
+    , QualityTier 0  "atrocious"
+    ]
+
+-- | Resolve a quality percentage to its named tier: the def's own
+--   table when it declares one (idQualityTiers), else
+--   'defaultQualityTiers'. Picks the highest-qtMin band the value
+--   clears.
+qualityTierLabel ∷ ItemDef → Float → Maybe Text
+qualityTierLabel def q = qtLabel ⊚ find (\t → q ≥ qtMin t) sorted
+  where
+    tiers  = if null (idQualityTiers def) then defaultQualityTiers
+                                           else idQualityTiers def
+    sorted = sortBy (\a b → compare (qtMin b) (qtMin a)) tiers
 
 -- | Engine-wide registry of all loaded item defs.
 newtype ItemManager = ItemManager

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -166,6 +166,7 @@ test-suite synarchy-test-headless
                    Test.Headless.Unit.NightPerception
                    Test.Headless.Item.Temperature
                    Test.Headless.Item.BuffYaml
+                   Test.Headless.Item.QualityTier
                    Test.Headless.Asset.TextureFallback
                    Test.Headless.World.Save.Sanitize
                    Test.Headless.World.Save.Serialize

--- a/test-headless/Spec.hs
+++ b/test-headless/Spec.hs
@@ -26,6 +26,7 @@ import qualified Test.Headless.Unit.Stats as StatsTest
 import qualified Test.Headless.Unit.NightPerception as NightPerception
 import qualified Test.Headless.Item.Temperature as ItemTemp
 import qualified Test.Headless.Item.BuffYaml as ItemBuffYaml
+import qualified Test.Headless.Item.QualityTier as ItemQualityTier
 import qualified Test.Headless.Asset.TextureFallback as TextureFallback
 import qualified Test.Headless.World.Save.Sanitize as SaveSanitize
 import qualified Test.Headless.World.Save.Serialize as SaveSerialize
@@ -86,6 +87,7 @@ main = hspec $ do
     describe "Unit.NightPerception" NightPerception.spec
     describe "Item.Temperature" ItemTemp.spec
     describe "Item.BuffYaml" ItemBuffYaml.spec
+    describe "Item.QualityTier" ItemQualityTier.spec
     describe "World.Save.Sanitize" SaveSanitize.spec
     describe "World.Save.Serialize" SaveSerialize.spec
     describe "World.CursorInfo" CursorInfo.spec

--- a/test-headless/Test/Headless/Item/QualityTier.hs
+++ b/test-headless/Test/Headless/Item/QualityTier.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE UnicodeSyntax, OverloadedStrings #-}
+-- | Pure tests for the quality→label tier resolution (#345): the
+--   default band table's boundaries, an item def's own
+--   `quality_tiers:` override taking precedence, and the YAML schema
+--   for that override list.
+module Test.Headless.Item.QualityTier (spec) where
+
+import UPrelude
+import Test.Hspec
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.Yaml as Yaml
+import Item.Types (ItemDef(..), QualityTier(..), qualityTierLabel)
+import Engine.Asset.YamlItems (ItemYamlQualityTier(..))
+import Engine.Asset.Handle (TextureHandle(..))
+
+-- | A minimal ItemDef stand-in — only idQualityTiers matters here.
+blankDef ∷ [QualityTier] → ItemDef
+blankDef tiers = ItemDef
+    { idName = "test_item", idDisplayName = "Test Item"
+    , idTexture = TextureHandle 0, idWeight = 0, idWeightSpec = Nothing
+    , idKind = "misc", idCategory = "Misc", idMake = "", idMaterial = ""
+    , idQualitySpec = Just (0, 100), idConditionSpec = Nothing
+    , idQualityTiers = tiers
+    , idContainer = Nothing, idDefaultContents = []
+    , idFood = Nothing, idWeapon = Nothing, idArmor = Nothing
+    , idUnequippable = False, idBuffs = [], idInsulation = 0
+    }
+
+decode ∷ BS.ByteString → Either String ItemYamlQualityTier
+decode = either (Left . show) Right . Yaml.decodeEither'
+
+spec ∷ Spec
+spec = do
+    describe "qualityTierLabel (default table)" $ do
+        let def = blankDef []
+        it "labels 100 as excellent" $
+            qualityTierLabel def 100 `shouldBe` Just "excellent"
+        it "labels the 90 boundary as excellent" $
+            qualityTierLabel def 90 `shouldBe` Just "excellent"
+        it "labels just under 90 as good" $
+            qualityTierLabel def 89.9 `shouldBe` Just "good"
+        it "labels the 75 boundary as good" $
+            qualityTierLabel def 75 `shouldBe` Just "good"
+        it "labels just under 75 as average" $
+            qualityTierLabel def 74.9 `shouldBe` Just "average"
+        it "labels the 50 boundary as average" $
+            qualityTierLabel def 50 `shouldBe` Just "average"
+        it "labels just under 50 as bad" $
+            qualityTierLabel def 49.9 `shouldBe` Just "bad"
+        it "labels the 25 boundary as bad" $
+            qualityTierLabel def 25 `shouldBe` Just "bad"
+        it "labels just under 25 as atrocious" $
+            qualityTierLabel def 24.9 `shouldBe` Just "atrocious"
+        it "labels 0 as atrocious" $
+            qualityTierLabel def 0 `shouldBe` Just "atrocious"
+
+    describe "qualityTierLabel (per-def override)" $ do
+        let custom = [ QualityTier 80 "masterwork", QualityTier 0 "crude" ]
+            def    = blankDef custom
+        it "uses the def's own table instead of the default" $
+            qualityTierLabel def 95 `shouldBe` Just "masterwork"
+        it "falls through the override table's own bands" $
+            qualityTierLabel def 10 `shouldBe` Just "crude"
+        it "ignores an unrelated quality with an empty override" $
+            -- An empty override list still falls back to the default —
+            -- there's always a 0-floor band to land on.
+            qualityTierLabel (blankDef []) 60 `shouldBe` Just "average"
+
+    describe "ItemYamlQualityTier YAML parsing" $ do
+        it "parses a { min, label } entry" $
+            decode "{ min: 90, label: excellent }"
+              `shouldBe` Right ItemYamlQualityTier
+                  { iyqtMin = 90, iyqtLabel = "excellent" }
+        it "requires both min and label" $
+            decode "{ min: 90 }"
+              `shouldSatisfy` either (const True) (const False)


### PR DESCRIPTION
Closes #345

## Approach

Turns an item instance's numeric `iiQuality` (0..100) into a named tier — `excellent`/`good`/`average`/`bad`/`atrocious` by default (the thresholds from the issue's design note), or a per-item-def override via a new `quality_tiers:` YAML list — and surfaces it wherever quality is already shown.

- `Item.Types`: new `QualityTier` type + `defaultQualityTiers` + `qualityTierLabel :: ItemDef -> Float -> Maybe Text`, picking the highest-threshold band a quality value clears. `ItemDef` gains `idQualityTiers` (empty ⇒ fall back to the default table).
- `Engine.Asset.YamlItems`: parses an optional `quality_tiers: [{min, label}, ...]` block on an item def.
- `Engine.Scripting.Lua.API.{Items,Units,Equipment}`: every site that already gates `quality` on the def having a quality spec (`unit.getInventory`, `equipment.getLoadout`/`getAccessories` via the shared `pushItemInstance`, `item.listGround`) now pushes a sibling `qualityTier` string alongside it.
- `scripts/ui/quality_tier.lua`: new shared Lua helper (`qualityTier.suffix`/`withSuffix`), mirroring the existing `scripts/ui/broken_overlay.lua` pattern for a cross-panel concern. Wired into `unit_info_v2.lua` (inventory rows, equipped-slot + accessory tooltips, the hint's `quality: N%` line), `item_info_panel.lua` (ground item name), and `cargo_inventory_panel.lua` (cargo row name) — the same "inventory, ground, cargo, equipment" surfaces the issue named. `building.getStorage` rides along for free since it shares `pushItemInstance`.

Left out of scope: the item-contents (kit) panel, which already deliberately omits quality/condition display, and the equip-submenu item picker (a compact selector, not a name-reading surface).

Not persisted — `ItemDef` doesn't derive `Serialize`; no save-version bump needed.

## Testing

- New `Test.Headless.Item.QualityTier` hspec spec: default-table boundaries (all 5 bands + edges), per-def override precedence, and the new YAML schema. `cabal test synarchy-test-headless` — 594 examples, 0 failures.
- `python3 tools/world_check.py` (21/21) and `tools/test_audit.py` — unaffected (no worldgen-output change).
- Full warning-clean rebuild: `cabal build all --builddir=dist-force --ghc-options=-Werror`.
- Manual headless end-to-end via the debug console: spawned an `axe_steel` ground item at quality 95 → `item.listGround()` returned `qualityTier: "excellent"`; at quality 40 → `"bad"`. Spawned an acolyte, confirmed `unit.getInventory` and `equipment.getLoadout` (after equipping) both carry the matching `qualityTier`.