### PR TITLE
#302 Repair AI: utility + designation + go-to-station-and-repair

### DIFF
--- a/scripts/unit_ai.lua
+++ b/scripts/unit_ai.lua
@@ -3995,6 +3995,25 @@ local function releaseRepairJob(s, uid)
     s.repairPhase = nil
 end
 
+-- Abort the current job. If the target item was already fetched off
+-- the mule (job.itemFetched, set once fetch_item's transfer lands), it
+-- is now sitting in THIS unit's own inventory — return it before
+-- releasing, or it silently disappears from the mule's stock into
+-- whichever acolyte was mid-job when something else failed later
+-- (missing consumable, a destroyed station, a last-second repair
+-- failure, ...). Every abort past fetch_item must go through this
+-- instead of a bare releaseRepairJob.
+local function abortRepairJob(uid, s, info)
+    local job = s.repairJob
+    if job and job.itemFetched and info then
+        local mule = findTechnomule(info.gridX, info.gridY)
+        if mule then
+            unit.transferItemToUnit(uid, mule.uid, job.defName)
+        end
+    end
+    releaseRepairJob(s, uid)
+end
+
 -- How urgent is repairing this one item, and which axis? Condition is
 -- checked before sharpness — a broken/low-condition item is
 -- combat-catastrophic (zero armor protection, or a crippled weapon)
@@ -4107,7 +4126,7 @@ end
 
 local function repairExecute(uid, s, params)
     local info = unit.getInfo(uid)
-    if not info then releaseRepairJob(s, uid); return end
+    if not info then abortRepairJob(uid, s, info); return end
     local now = engine.gameTime()
 
     -- Claim a fresh job from the scored candidate.
@@ -4151,21 +4170,25 @@ local function repairExecute(uid, s, params)
         end
         unit.stop(uid)
         if not unit.transferItemToUnit(mule.uid, uid, job.defName) then
-            releaseRepairJob(s, uid)   -- raced — someone else took it
+            releaseRepairJob(s, uid)   -- raced — someone else took it; never fetched
             return
         end
+        -- Something of this defName is now in our own inventory — any
+        -- abort from here on must return it (abortRepairJob).
+        job.itemFetched = true
         -- transferItemToUnit is defName-scoped, not instance-scoped:
         -- if the mule held more than one copy of this def, the wrong
         -- one may have come across (#302 known limitation — a true
         -- instance-targeted transfer needs an engine-side addition).
         -- Verify; on a mismatch, abandon rather than repair the wrong
-        -- copy under the flagged instance's claim.
+        -- copy under the flagged instance's claim (still returning the
+        -- (wrong) fetched item to the mule via abortRepairJob).
         local got = false
         for _, it in ipairs(unit.getInventory(uid) or {}) do
             if it.instanceId == job.instanceId then got = true end
         end
         if not got then
-            releaseRepairJob(s, uid)
+            abortRepairJob(uid, s, info)
             return
         end
         s.repairPhase = "fetch_consumable"
@@ -4206,7 +4229,7 @@ local function repairExecute(uid, s, params)
             -- re-evaluate next tick (camping the job gains nothing).
             reportFailure(uid, "No " .. job.consumable
                 .. " available to repair " .. job.defName)
-            releaseRepairJob(s, uid)
+            abortRepairJob(uid, s, info)
             return
         end
         s.repairPhase = "walking"
@@ -4217,10 +4240,10 @@ local function repairExecute(uid, s, params)
         if not job.bid then
             job.bid = building.findStation(job.recipeId, math.floor(info.gridX),
                                            math.floor(info.gridY))
-            if not job.bid then releaseRepairJob(s, uid); return end
+            if not job.bid then abortRepairJob(uid, s, info); return end
         end
         local binfo = building.getInfo(job.bid)
-        if not binfo then releaseRepairJob(s, uid); return end
+        if not binfo then abortRepairJob(uid, s, info); return end
         local utx, uty = math.floor(info.gridX), math.floor(info.gridY)
         local tw, th = binfo.tileW or 1, binfo.tileH or 1
         local cheb = chebToFootprint(utx, uty, binfo.gridX, binfo.gridY, tw, th)
@@ -4249,7 +4272,7 @@ local function repairExecute(uid, s, params)
             if not (err and err:find("already at full")) then
                 reportFailure(uid, "Repair failed: " .. tostring(err))
             end
-            releaseRepairJob(s, uid)
+            abortRepairJob(uid, s, info)
             return
         end
         grantWorkXP(uid, "smithing", params.repair_xp_per_repair or 0)
@@ -4257,13 +4280,9 @@ local function repairExecute(uid, s, params)
         -- instance of this defName is now equally "the good one"
         -- (full-restore-per-visit, #301), so the earlier defName-scoped
         -- fetch's instance ambiguity no longer matters post-repair.
-        if job.onMule then
-            local mule = findTechnomule(info.gridX, info.gridY)
-            if mule then
-                unit.transferItemToUnit(uid, mule.uid, job.defName)
-            end
-        end
-        releaseRepairJob(s, uid)
+        -- abortRepairJob's "return the fetched item" step (keyed on
+        -- job.itemFetched) handles this the same way a mid-job abort does.
+        abortRepairJob(uid, s, info)
     end
 end
 

--- a/scripts/unit_ai.lua
+++ b/scripts/unit_ai.lua
@@ -335,6 +335,31 @@ local config = {
         -- is the closest two-handed-tool visual.
         chop_equip_anim = "standing_to_holding_pickaxe",
         chop_work_anim  = "using_pickaxe",
+        -- Equipment repair (repair_job, #302). AI-autonomous kit
+        -- maintenance: an acolyte notices its own or the technomule's
+        -- gear has degraded past a threshold and carries it to the
+        -- right #301 station (furnace = condition, workbench =
+        -- sharpness). Utility shape:
+        --   util = base · severity(item)
+        -- severity is tiered: a broken (condition 0) item scores a
+        -- flat band (armor higher than weapons — broken armor gives
+        -- ZERO protection vs. a broken weapon's 0.15× effectiveness,
+        -- Combat/Resolution.hs), otherwise a quadratic ramp toward the
+        -- threshold. base=1.2 keeps the top tier (armor, 2.5) at 3.0
+        -- unweighted / 4.2 role-weighted — under every 6.0 lock and
+        -- deliver's 5.6 weighted ceiling (see unit_roles.lua). Lock-in
+        -- while fetching/walking/repairing is finite, matching
+        -- dig/chop/construct (dire needs still preempt).
+        repair_condition_threshold    = 50.0,
+        repair_sharpness_threshold    = 50.0,
+        repair_severity_broken_weapon = 1.5,
+        repair_severity_broken_armor  = 2.5,
+        repair_base_utility  = 1.2,
+        repair_lock_utility  = 6.0,
+        repair_scan_range    = 30.0,   -- ground-item consumable search radius
+        repair_claim_timeout = 30.0,   -- stale-claim expiry (seconds)
+        repair_xp_per_repair = 1.0,    -- smithing XP (#265) — the "smith"
+                                       -- role's first real work action
         -- Ground-item pickup (player order via right-click → Pick up).
         -- An explicit pickup is a player order peer to a move order, so
         -- it sits just ABOVE follow_command (7.0): commandMove and
@@ -3914,6 +3939,343 @@ local function chopOnExit(uid, s, params)
 end
 
 -----------------------------------------------------------
+-- Action: repair_job  (#302 — repair AI: utility + go-to-station-and-repair)
+--
+-- AI-autonomous equipment maintenance: an acolyte notices its own (or
+-- the technomule's spare) gear has degraded past a threshold and
+-- carries it to the right station (#301: furnace for condition,
+-- workbench for sharpness) to restore it via repair.repairAt.
+--
+-- Unlike dig/chop/construct, there is no engine-side spatial
+-- designation here: a repair target is a specific item INSTANCE that
+-- lives inside a unit's inventory/equipment/accessories or on the
+-- technomule, not on the map, so a tile-keyed designation layer
+-- doesn't apply. The claim table below (repairClaims, keyed by
+-- instanceId) plays the same race-guard role a shared tile's
+-- designation status does for dig/chop/construct.
+--
+-- Player-designated repair (right-click a specific item → mark for
+-- repair) is deliberately out of scope for v1: the issue leaves
+-- player-vs-autonomous open, and "acolytes maintain their own kit"
+-- (the issue's own phrasing) has direct precedent in treat_ally /
+-- forage / store_materials — all needs-driven, zero player input.
+--
+-- Ground-item targeting is ALSO out of scope: item.listGround() does
+-- not expose instanceId/condition/sharpness, so a degraded item
+-- dropped on the ground can't be identified or verified headless
+-- (a follow-up would add those fields to Items.hs). Scanning covers:
+-- own inventory, own equipment, own accessories, and the nearest
+-- technomule's inventory (spare gear stored there).
+--
+-- State on s:
+--   repairJob = { instanceId, defName, axis, recipeId, consumable,
+--                 consumableCount, wants, onMule, bid }
+--   repairPhase = "fetch_item" | "fetch_consumable" | "walking"
+--               | "repairing"
+-----------------------------------------------------------
+
+local repairClaims = {}   -- instanceId → { uid, at }
+
+local function repairClaimedByOther(iid, uid, now, timeout)
+    local c = repairClaims[iid]
+    if not c or c.uid == uid then return false end
+    if now - c.at > timeout or not unit.exists(c.uid) then
+        repairClaims[iid] = nil
+        return false
+    end
+    return true
+end
+
+local function releaseRepairJob(s, uid)
+    if s.repairJob then
+        local c = repairClaims[s.repairJob.instanceId]
+        if c and c.uid == uid then repairClaims[s.repairJob.instanceId] = nil end
+    end
+    s.repairJob = nil
+    s.repairPhase = nil
+end
+
+-- How urgent is repairing this one item, and which axis? Condition is
+-- checked before sharpness — a broken/low-condition item is
+-- combat-catastrophic (zero armor protection, or a crippled weapon)
+-- while low sharpness only reduces penetration, so it's repaired
+-- first; the AI picks up a remaining sharpness need on a later tick.
+-- Returns severity, axis — or nil if the item doesn't need repair.
+local function repairSeverity(it, params)
+    if it.condition ~= nil and it.condition < params.repair_condition_threshold then
+        if it.condition <= 0 then
+            local band = (it.kind == "armor")
+                and params.repair_severity_broken_armor
+                or params.repair_severity_broken_weapon
+            return band, "condition"
+        end
+        local x = 1 - (it.condition / params.repair_condition_threshold)
+        return x * x, "condition"
+    end
+    if it.sharpness and it.sharpness < params.repair_sharpness_threshold then
+        local x = 1 - (it.sharpness / params.repair_sharpness_threshold)
+        return x * x, "sharpness"
+    end
+    return nil, nil
+end
+
+-- Best repair candidate among ownerUid's inventory + equipped gear +
+-- accessories. Skips anything already claimed by another live unit.
+local function scanHeldItems(ownerUid, actingUid, onMule, now, params)
+    local best, bestSev = nil, 0
+    local function consider(it)
+        if repairClaimedByOther(it.instanceId, actingUid, now,
+                                params.repair_claim_timeout) then
+            return
+        end
+        local sev, axis = repairSeverity(it, params)
+        if sev and sev > bestSev then
+            best, bestSev = {
+                instanceId = it.instanceId, defName = it.defName,
+                axis = axis, severity = sev, onMule = onMule,
+            }, sev
+        end
+    end
+    for _, it in ipairs(unit.getInventory(ownerUid) or {}) do consider(it) end
+    for _, it in pairs(equipment.getLoadout(ownerUid) or {}) do consider(it) end
+    for _, it in ipairs(equipment.getAccessories(ownerUid) or {}) do consider(it) end
+    return best
+end
+
+-- Own gear first (no fetch needed); only look to the mule's spare
+-- stock when the unit itself carries nothing worth repairing.
+local function findRepairCandidate(uid, info, params)
+    local now = engine.gameTime()
+    local best = scanHeldItems(uid, uid, false, now, params)
+    if best then return best end
+    local mule = findTechnomule(info.gridX, info.gridY)
+    if not mule then return nil end
+    return scanHeldItems(mule.uid, uid, true, now, params)
+end
+
+local function repairUtility(uid, s, params)
+    if s.repairJob then return params.repair_lock_utility end
+
+    local info = unit.getInfo(uid)
+    if not info then return -math.huge end
+
+    local cand = findRepairCandidate(uid, info, params)
+    if not cand then return -math.huge end
+
+    -- Only claim if a station for this axis is actually reachable —
+    -- mirrors dig's tool gate / construct's materials-available check.
+    -- building.findStation ranks candidates by Chebyshev distance from
+    -- the given (gx, gy), but its Lua.tointeger argument parsing only
+    -- accepts whole numbers — a raw unit position like 16.5 silently
+    -- fails to parse, and it falls back to "no distance info" (lowest
+    -- building id wins, ignoring proximity entirely). Floor first.
+    local recipeId = "repair_" .. cand.axis
+    if not building.findStation(recipeId, math.floor(info.gridX),
+                                math.floor(info.gridY)) then
+        return -math.huge
+    end
+
+    local recipe = repair.get(recipeId)
+    local input = recipe and recipe.inputs and recipe.inputs[1]
+    if not input then return -math.huge end
+
+    -- Capacity feasibility: a mule-sourced item adds its own weight on
+    -- pickup, and the recipe's consumable adds more on top — a unit
+    -- whose remaining headroom can't cover both would otherwise claim,
+    -- fail to fetch, and immediately re-claim the SAME candidate (still
+    -- degraded, now sitting in its own inventory) forever — a repeated
+    -- "unit_warning" pause storm (config/notifications.yaml pauses on
+    -- that category) instead of a clean "can't do this job right now" bail.
+    local needed = 0
+    if cand.onMule then
+        needed = needed + deliverItemWeight(cand.defName)
+    end
+    if inventoryCountOf(uid, input.item) < (input.count or 1) then
+        needed = needed + deliverItemWeight(input.item) * (input.count or 1)
+    end
+    local carried = unit.getCarryingWeight(uid) or 0
+    local maxW = unit.getStat(uid, "carrying_capacity") or math.huge
+    if carried + needed > maxW then return -math.huge end
+
+    cand.recipeId = recipeId
+    cand.consumable = input.item
+    cand.consumableCount = input.count or 1
+    s.repairCandidate = cand
+    return params.repair_base_utility * cand.severity
+         * roles.weight(s, "repair_job")
+end
+
+local function repairExecute(uid, s, params)
+    local info = unit.getInfo(uid)
+    if not info then releaseRepairJob(s, uid); return end
+    local now = engine.gameTime()
+
+    -- Claim a fresh job from the scored candidate.
+    if not s.repairJob then
+        local cand = s.repairCandidate
+        if not cand then return end
+        s.repairCandidate = nil
+        if repairClaimedByOther(cand.instanceId, uid, now,
+                                params.repair_claim_timeout) then
+            return
+        end
+        repairClaims[cand.instanceId] = { uid = uid, at = now }
+        s.repairJob = {
+            instanceId = cand.instanceId, defName = cand.defName,
+            axis = cand.axis, recipeId = cand.recipeId,
+            consumable = cand.consumable, consumableCount = cand.consumableCount,
+            onMule = cand.onMule,
+        }
+        s.repairPhase = cand.onMule and "fetch_item" or "fetch_consumable"
+        -- Cancel any in-flight moveTo the PREVIOUS action left running
+        -- (e.g. a wander/search-spiral step): the switch-or-idle
+        -- dispatch gate only re-fires execute() while activity=="idle",
+        -- so a stale walking activity would strand this phase machine
+        -- forever (the stuck-walk watchdog above exists for the same
+        -- class of bug). Later phases re-issue their own moveTo.
+        unit.stop(uid)
+        return
+    end
+
+    local job = s.repairJob
+    -- Keep the claim fresh while the job is held.
+    repairClaims[job.instanceId] = { uid = uid, at = now }
+
+    if s.repairPhase == "fetch_item" then
+        local mule = findTechnomule(info.gridX, info.gridY)
+        if not mule then releaseRepairJob(s, uid); return end
+        if distance(info.gridX, info.gridY, mule.gridX, mule.gridY)
+           > params.mule_fetch_arrival then
+            unit.moveTo(uid, mule.gridX, mule.gridY, mv.comfort(uid))
+            return
+        end
+        unit.stop(uid)
+        if not unit.transferItemToUnit(mule.uid, uid, job.defName) then
+            releaseRepairJob(s, uid)   -- raced — someone else took it
+            return
+        end
+        -- transferItemToUnit is defName-scoped, not instance-scoped:
+        -- if the mule held more than one copy of this def, the wrong
+        -- one may have come across (#302 known limitation — a true
+        -- instance-targeted transfer needs an engine-side addition).
+        -- Verify; on a mismatch, abandon rather than repair the wrong
+        -- copy under the flagged instance's claim.
+        local got = false
+        for _, it in ipairs(unit.getInventory(uid) or {}) do
+            if it.instanceId == job.instanceId then got = true end
+        end
+        if not got then
+            releaseRepairJob(s, uid)
+            return
+        end
+        s.repairPhase = "fetch_consumable"
+        return
+    end
+
+    if s.repairPhase == "fetch_consumable" then
+        if inventoryCountOf(uid, job.consumable) >= job.consumableCount then
+            s.repairPhase = "walking"
+            return
+        end
+        -- Ground (rung 2), then the mule (rung 3) — tried against
+        -- SEPARATE want-tables, one per rung. fetchWantsFromGround/Mule
+        -- assume the caller pre-splits ground vs mule portions the way
+        -- deliverExecute's claim.fromGround/claim.fromMule do; sharing
+        -- ONE table between both calls is wrong — a ground miss clears
+        -- the entry entirely (`wants[mat] = nil`), so a shared table
+        -- would short-circuit the mule fallback on every ground miss.
+        if not job.groundDone then
+            job.groundWant = job.groundWant
+                or { [job.consumable] = job.consumableCount }
+            if fetchWantsFromGround(uid, job.groundWant, params,
+                                    params.repair_scan_range) then
+                return
+            end
+            job.groundDone = true
+            if inventoryCountOf(uid, job.consumable) >= job.consumableCount then
+                s.repairPhase = "walking"
+                return
+            end
+        end
+        job.muleWant = job.muleWant or { [job.consumable] = job.consumableCount }
+        if fetchWantsFromMule(uid, job.muleWant, info, params) then
+            return
+        end
+        if inventoryCountOf(uid, job.consumable) < job.consumableCount then
+            -- No lignite_chunk/whetstone anywhere reachable. Give up —
+            -- re-evaluate next tick (camping the job gains nothing).
+            reportFailure(uid, "No " .. job.consumable
+                .. " available to repair " .. job.defName)
+            releaseRepairJob(s, uid)
+            return
+        end
+        s.repairPhase = "walking"
+        return
+    end
+
+    if s.repairPhase == "walking" then
+        if not job.bid then
+            job.bid = building.findStation(job.recipeId, math.floor(info.gridX),
+                                           math.floor(info.gridY))
+            if not job.bid then releaseRepairJob(s, uid); return end
+        end
+        local binfo = building.getInfo(job.bid)
+        if not binfo then releaseRepairJob(s, uid); return end
+        local utx, uty = math.floor(info.gridX), math.floor(info.gridY)
+        local tw, th = binfo.tileW or 1, binfo.tileH or 1
+        local cheb = chebToFootprint(utx, uty, binfo.gridX, binfo.gridY, tw, th)
+        if cheb <= 1 then
+            unit.stop(uid)
+            s.repairPhase = "repairing"
+            return
+        end
+        local bestX, bestY, bestD = nil, nil, math.huge
+        for dx = -1, tw do
+            for dy = -1, th do
+                if dx == -1 or dx == tw or dy == -1 or dy == th then
+                    local nx, ny = binfo.gridX + dx + 0.5, binfo.gridY + dy + 0.5
+                    local d = distance(info.gridX, info.gridY, nx, ny)
+                    if d < bestD then bestX, bestY, bestD = nx, ny, d end
+                end
+            end
+        end
+        if bestX then unit.moveTo(uid, bestX, bestY, mv.comfort(uid)) end
+        return
+    end
+
+    if s.repairPhase == "repairing" then
+        local r, err = repair.repairAt(uid, job.recipeId, job.instanceId, job.bid)
+        if not r then
+            if not (err and err:find("already at full")) then
+                reportFailure(uid, "Repair failed: " .. tostring(err))
+            end
+            releaseRepairJob(s, uid)
+            return
+        end
+        grantWorkXP(uid, "smithing", params.repair_xp_per_repair or 0)
+        -- Spare gear fetched off the mule goes back once restored — any
+        -- instance of this defName is now equally "the good one"
+        -- (full-restore-per-visit, #301), so the earlier defName-scoped
+        -- fetch's instance ambiguity no longer matters post-repair.
+        if job.onMule then
+            local mule = findTechnomule(info.gridX, info.gridY)
+            if mule then
+                unit.transferItemToUnit(uid, mule.uid, job.defName)
+            end
+        end
+        releaseRepairJob(s, uid)
+    end
+end
+
+-- Preemption (thirst, combat, order): only the final approach needs
+-- resetting — mid-fetch phases re-evaluate fresh every tick anyway.
+local function repairOnExit(uid, s, params)
+    if s.repairPhase == "repairing" then
+        s.repairPhase = "walking"
+    end
+end
+
+-----------------------------------------------------------
 -- Action: pickup_ground
 --
 -- Player-ordered pickup of a ground item (right-click → Pick up;
@@ -4419,6 +4781,8 @@ unitAi.registerActions("acolyte", {
       execute = digExecute, onExit = digOnExit },
     { name = "chop_designation", utility = chopUtility,
       execute = chopExecute, onExit = chopOnExit },
+    { name = "repair_job", utility = repairUtility,
+      execute = repairExecute, onExit = repairOnExit },
     { name = "pickup_ground", utility = pickupUtility,
       execute = pickupExecute },
 })

--- a/scripts/unit_ai.lua
+++ b/scripts/unit_ai.lua
@@ -3969,7 +3969,8 @@ end
 --
 -- State on s:
 --   repairJob = { instanceId, defName, axis, recipeId, consumable,
---                 consumableCount, wants, onMule, bid }
+--                 consumableCount, groundWant, muleWant, groundDone,
+--                 onMule, itemFetched, bid }
 --   repairPhase = "fetch_item" | "fetch_consumable" | "walking"
 --               | "repairing"
 -----------------------------------------------------------
@@ -4008,7 +4009,12 @@ local function abortRepairJob(uid, s, info)
     if job and job.itemFetched and info then
         local mule = findTechnomule(info.gridX, info.gridY)
         if mule then
-            unit.transferItemToUnit(uid, mule.uid, job.defName)
+            -- Targeted by instanceId: without it, a defName-only
+            -- transfer could pop a DIFFERENT axe_steel this unit
+            -- happens to also be carrying (its own starting gear),
+            -- sending that back instead and leaving the actually-
+            -- fetched (possibly still-degraded) instance stranded here.
+            unit.transferItemToUnit(uid, mule.uid, job.defName, job.instanceId)
         end
     end
     releaseRepairJob(s, uid)
@@ -4169,28 +4175,19 @@ local function repairExecute(uid, s, params)
             return
         end
         unit.stop(uid)
-        if not unit.transferItemToUnit(mule.uid, uid, job.defName) then
+        -- Targeted by instanceId: the mule may carry more than one
+        -- axe_steel, and a defName-only transfer could grab the wrong
+        -- copy. transferItemToUnit only succeeds if this EXACT flagged
+        -- instance is still on the mule (a raced claimant taking the
+        -- specific instance first fails cleanly here, same as any other
+        -- instance no longer being found).
+        if not unit.transferItemToUnit(mule.uid, uid, job.defName, job.instanceId) then
             releaseRepairJob(s, uid)   -- raced — someone else took it; never fetched
             return
         end
-        -- Something of this defName is now in our own inventory — any
-        -- abort from here on must return it (abortRepairJob).
+        -- The flagged instance is now in our own inventory — any abort
+        -- from here on must return it (abortRepairJob).
         job.itemFetched = true
-        -- transferItemToUnit is defName-scoped, not instance-scoped:
-        -- if the mule held more than one copy of this def, the wrong
-        -- one may have come across (#302 known limitation — a true
-        -- instance-targeted transfer needs an engine-side addition).
-        -- Verify; on a mismatch, abandon rather than repair the wrong
-        -- copy under the flagged instance's claim (still returning the
-        -- (wrong) fetched item to the mule via abortRepairJob).
-        local got = false
-        for _, it in ipairs(unit.getInventory(uid) or {}) do
-            if it.instanceId == job.instanceId then got = true end
-        end
-        if not got then
-            abortRepairJob(uid, s, info)
-            return
-        end
         s.repairPhase = "fetch_consumable"
         return
     end
@@ -4276,12 +4273,10 @@ local function repairExecute(uid, s, params)
             return
         end
         grantWorkXP(uid, "smithing", params.repair_xp_per_repair or 0)
-        -- Spare gear fetched off the mule goes back once restored — any
-        -- instance of this defName is now equally "the good one"
-        -- (full-restore-per-visit, #301), so the earlier defName-scoped
-        -- fetch's instance ambiguity no longer matters post-repair.
+        -- Spare gear fetched off the mule goes back once restored.
         -- abortRepairJob's "return the fetched item" step (keyed on
-        -- job.itemFetched) handles this the same way a mid-job abort does.
+        -- job.itemFetched, targeted by instanceId) handles this the
+        -- same way a mid-job abort does.
         abortRepairJob(uid, s, info)
     end
 end

--- a/scripts/unit_roles.lua
+++ b/scripts/unit_roles.lua
@@ -29,10 +29,9 @@ package.loaded["scripts.unit_roles"] = M
 -- Derivation order is the tie-break: earlier entries win an exact
 -- skill tie, so listing is deterministic (pairs() order is not).
 --
--- `family` groups the work actions a role prefers. smith has no work
--- actions yet — the craft AI is #329 — so its family ("craft") appears
--- in no ACTION_FAMILY entry and the role stays weight-neutral: a pure
--- label until crafting gives it work to favor.
+-- `family` groups the work actions a role prefers. smith's family
+-- ("craft") maps to repair_job (#302) — its first real work action;
+-- the general craft AI is still #329.
 M.ROLES = {
     { name = "miner",      display = "Miner",      skill = "mining",       family = "mine"  },
     { name = "woodcutter", display = "Woodcutter", skill = "woodcutting",  family = "wood"  },
@@ -45,12 +44,13 @@ M.ROLES = {
 -- (forage, pickup_ground, follow_command, survival, combat) are
 -- deliberately absent: roles only steer ROUTINE work preference.
 M.ACTION_FAMILY = {
-    dig_designation       = "mine",
-    chop_designation      = "wood",
-    construct_job         = "build",
-    build_nearby          = "build",
-    deliver_to_build_site = "build",
-    store_materials       = "build",
+    dig_designation        = "mine",
+    chop_designation       = "wood",
+    construct_job          = "build",
+    build_nearby           = "build",
+    deliver_to_build_site  = "build",
+    store_materials        = "build",
+    repair_job             = "craft",
 }
 
 M.THRESHOLD     = 30.0   -- min skill to claim a specialist role

--- a/src/Engine/Scripting/Lua/API/Units.hs
+++ b/src/Engine/Scripting/Lua/API/Units.hs
@@ -2089,22 +2089,13 @@ removeFirstByName name (x:xs)
     | iiDefName x ≡ name = Just xs
     | otherwise          = (x :) <$> removeFirstByName name xs
 
--- | Like removeFirstByName but EXTRACTS the popped instance so the
---   caller can route it somewhere else (e.g. into a building's
---   biMaterialsDelivered).
-popFirstByName ∷ Text → [ItemInstance] → Maybe (ItemInstance, [ItemInstance])
-popFirstByName _ [] = Nothing
-popFirstByName name (x:xs)
-    | iiDefName x ≡ name = Just (x, xs)
-    | otherwise          = fmap (\(it, rest) → (it, x:rest))
-                                (popFirstByName name xs)
-
--- | Like 'popFirstByName' but also reports the 0-based index the item
---   was removed from. Cross-owner transfers carry this so a failed
---   move can splice the instance back at its ORIGINAL position rather
---   than the front — UI (unit.getInventory / building.getStorage) and
---   gameplay rely on stable insertion order, so a rolled-back transfer
---   must leave the source list byte-for-byte unchanged.
+-- | Like 'removeFirstByName' but EXTRACTS the popped instance AND
+--   reports the 0-based index it was removed from. Cross-owner
+--   transfers carry this so a failed move can splice the instance back
+--   at its ORIGINAL position rather than the front — UI
+--   (unit.getInventory / building.getStorage) and gameplay rely on
+--   stable insertion order, so a rolled-back transfer must leave the
+--   source list byte-for-byte unchanged.
 popFirstByNameIx ∷ Text → [ItemInstance]
                 → Maybe (ItemInstance, Int, [ItemInstance])
 popFirstByNameIx = go 0
@@ -2274,15 +2265,22 @@ unitTransferItemToBuildingFn env = do
             Lua.pushboolean False
             return 1
 
--- | unit.transferItemToUnit(fromUid, toUid, defName) → bool. Atomic
---   move of one ItemInstance from one unit's inventory to another's.
---   Both units live in the same manager ref, so the pop and the push
---   happen in a single atomicModifyIORef' — the item can never be
---   duplicated or dropped by a thread interleaving. Quality /
+-- | unit.transferItemToUnit(fromUid, toUid, defName[, instanceId]) →
+--   bool. Atomic move of one ItemInstance from one unit's inventory to
+--   another's. Both units live in the same manager ref, so the pop and
+--   the push happen in a single atomicModifyIORef' — the item can
+--   never be duplicated or dropped by a thread interleaving. Quality /
 --   condition / currentFill are preserved exactly (this is how
 --   acolytes pull build materials off the technomule without
 --   re-rolling them). No capacity check here — the Lua caller gates
 --   on carrying capacity the same way pickup does.
+--   Optional 4th arg: transfer the EXACT source instance (itemMatches,
+--   same convention as depositToCargo/equip/equipAccessory) — without
+--   it, a caller pulling back a specific instance it fetched earlier
+--   (#302's repair AI returning spare gear to the technomule) could
+--   silently pop a DIFFERENT same-defName item the source happens to
+--   also be carrying. Absent/0 → first defName match (legacy/AI callers
+--   moving fungible materials, where any matching instance will do).
 --   Returns false if either unit is missing or the source lacks a
 --   matching item; the transfer is all-or-nothing.
 unitTransferItemToUnitFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
@@ -2290,18 +2288,21 @@ unitTransferItemToUnitFn env = do
     fromArg ← Lua.tointeger 1
     toArg   ← Lua.tointeger 2
     nameArg ← Lua.tostring 3
+    instArg ← Lua.tointeger 4
     case (fromArg, toArg, nameArg) of
         (Just nF, Just nT, Just nameBS) | nF ≠ nT → do
             let fromUid = UnitId (fromIntegral nF)
                 toUid   = UnitId (fromIntegral nT)
                 defName = TE.decodeUtf8Lenient nameBS
+                wantId  = maybe 0 fromIntegral instArg
             ok ← Lua.liftIO $ atomicModifyIORef' (unitManagerRef env) $ \um →
                 case (HM.lookup fromUid (umInstances um),
                       HM.lookup toUid   (umInstances um)) of
                     (Just uF, Just uT) →
-                        case popFirstByName defName (uiInventory uF) of
+                        case popFirstWhereIx (itemMatches wantId defName)
+                                             (uiInventory uF) of
                             Nothing → (um, False)
-                            Just (item, newInv) →
+                            Just (item, _, newInv) →
                                 let uF' = uF { uiInventory = newInv }
                                     uT' = uT { uiInventory =
                                                  uiInventory uT ++ [item] }

--- a/tools/README.md
+++ b/tools/README.md
@@ -160,6 +160,7 @@ docstring instead of reaching for `--help` when in doubt.
 | `physiology_probe.py` | homeostasis (general) | arena | Thermoregulation/circulation sanity across controlled environments (temperate/arctic/humid-heat). |
 | `repair_item_probe.py` | #300 | worldgen | `unit.repairItem` primitive. |
 | `repair_probe.py` | #301 | arena | Repair policy layer (station-gated repair on top of #300). |
+| `repair_ai_probe.py` | #302 | arena | `repair_job` AI end-to-end: claim, own/equipped/mule-held sourcing, station routing, dead-claimant release, `smith` role weighting. |
 | `role_probe.py` | #265 | worldgen | Derived unit-role hysteresis/demotion/work-XP growth. |
 | `save_pause_probe.py` | #42 | worldgen | Save/load pause-semantics regression. |
 | `thermo_altitude_probe.py` | #308 | worldgen (size 128) | Altitude-lapse thermal effect. |

--- a/tools/repair_ai_probe.py
+++ b/tools/repair_ai_probe.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""Repair AI probe (#302) — the AI/designation layer on top of repair.repairAt
+(#301) and unit.repairItem (#300).
+
+Boots a headless engine on a flat arena, loads defs + recipes + buildings,
+and drives the repair_job action in scripts/unit_ai.lua (which stays LIVE —
+it IS the machinery under test, unlike movement_probe which neutralises it):
+
+  1. own_inventory : an acolyte carries a BROKEN weapon (condition 0) and a
+     merely-degraded armor piece. The AI must claim the higher-severity
+     broken item first, repair it at a furnace (consuming lignite_chunk),
+     THEN move on to the armor — proving the tiered severity ordering
+     (repairSeverity: broken > quadratic ramp) actually drives claim order.
+  2. equipped_ground : an EQUIPPED weapon (in the weapon slot, not
+     inventory) has low sharpness; the whetstone it needs is a GROUND item
+     near the acolyte. Exercises equipment.getLoadout scanning +
+     fetchWantsFromGround for the consumable.
+  3. mule_spare_gear : the degraded item AND its repair consumable both
+     sit on the technomule, not the acting acolyte. Exercises the
+     fetch_item phase (transferItemToUnit off the mule) + fetchWantsFromMule
+     for the consumable + the post-repair return-to-mule handoff.
+  4. dead_claimant_release : the first claimant is destroyed mid-fetch
+     (before it reaches the mule); a second acolyte must pick the same
+     item back up and finish the job — proving the repairClaims stale-claim
+     self-heal (mirrors chopClaims/constructClaims).
+  5. role_weight : scripts/unit_roles.lua's weight() gives the "smith" role
+     (#265, previously dormant) its first real ON_ROLE boost on repair_job,
+     and now correctly damps a smith's OTHER routine work — a pure Lua
+     check, no world/units needed.
+
+Test fixtures deliberately use condition/sharpness = 5 (not 20-40) for the
+"degraded but not broken" cases: repair_job's utility (base 1.2 * severity)
+must clear ambient wander's utility (up to ~0.8 at full stamina, scripts/
+unit_ai.lua wanderUtility) for the AI to reliably prioritize it over idling
+— severity=(1-5/50)^2=0.81 gives a comfortable margin (0.97 > 0.8).
+
+Usage: python3 tools/repair_ai_probe.py [--port 9382] [--phase all]
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import socket
+import subprocess
+import sys
+import time
+
+LOG = "/tmp/repair_ai_probe_engine.log"
+
+
+def send(port: int, lua: str, timeout: float = 10.0) -> str:
+    with socket.create_connection(("localhost", port), timeout=timeout) as s:
+        s.settimeout(timeout)
+        f = s.makefile("rw")
+        f.readline()              # banner
+        f.write(lua + "\n")
+        f.flush()
+        return f.readline().strip().lstrip("> ").strip()
+
+
+def jget(port: int, lua: str, timeout: float = 10.0):
+    raw = send(port, lua, timeout)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw.strip('"')
+
+
+def boot(port: int) -> subprocess.Popen:
+    log = open(LOG, "w")
+    proc = subprocess.Popen(
+        ["cabal", "run", "-v0", "exe:synarchy", "--",
+         "--headless", "--port", str(port)],
+        stdout=log, stderr=subprocess.STDOUT)
+    deadline = time.time() + 240
+    while time.time() < deadline:
+        try:
+            if "READY" in open(LOG).read():
+                return proc
+        except FileNotFoundError:
+            pass
+        if proc.poll() is not None:
+            sys.exit(f"engine exited before READY; see {LOG}")
+        time.sleep(0.4)
+    proc.kill()
+    sys.exit("engine never printed READY")
+
+
+def bootstrap(port: int) -> None:
+    """Load defs + the flat arena. unit_ai is auto-loaded at boot and IS
+    the machinery under test, so it stays live (construction_probe's
+    convention, NOT movement_probe's neutralise-the-AI one)."""
+    loaders = [
+        ("data/substances/*.yaml", "engine.loadSubstanceYaml"),
+        ("data/items/*.yaml",      "engine.loadItemYaml"),
+        ("data/equipment/*.yaml",  "engine.loadEquipmentYaml"),
+        ("data/materials/*.yaml",  "engine.loadMaterialYaml"),
+        ("data/units/*.yaml",      "engine.loadUnitYaml"),
+        ("data/recipes/*.yaml",    "engine.loadRecipeYaml"),
+        ("data/buildings/*.yaml",  "engine.loadBuildingYaml"),
+    ]
+    for pattern, fn in loaders:
+        for path in sorted(glob.glob(pattern)):
+            send(port, f"{fn}('{path}'); return 'ok'")
+    send(port,
+         "return require('scripts.movement_arena').buildCourse('flat').name")
+    if not poll_until(port, 30, lambda: wid(port)):
+        sys.exit("arena page never became the active world")
+    # The flat arena PRE-builds exactly a 5x5 chunk block (chunks -2..2,
+    # chunkSize=16 -> tiles -32..47); requesting anything wider falls
+    # through to real chunk generation, which has no plate data on an
+    # arena page and crashes the world thread. Stay inside that block.
+    send(port, "return world.loadChunksInRegion(-2, -2, 2, 2)")
+    send(port, "return world.waitForChunks(60)", timeout=65.0)
+
+
+def wid(port: int) -> str | None:
+    raw = send(port, "return world.getActiveWorldId()").strip().strip('"')
+    return raw if raw and raw not in ("null", "nil") else None
+
+
+def poll_until(port: int, seconds: float, fn):
+    deadline = time.time() + seconds
+    while time.time() < deadline:
+        # Defensive: ANY unit_warning (not just repair's "No X available"
+        # — e.g. the pre-existing stuck-walk watchdog's "Stuck — can't
+        # reach destination") pauses the engine per this repo's
+        # config/notifications.yaml. A human would notice and dismiss it;
+        # a headless poll loop would otherwise hang for its entire
+        # remaining budget with gameTime frozen. Unconditionally
+        # unpausing each cycle is a no-op when already running.
+        send(port, "engine.setPaused(false); return 'ok'")
+        v = fn()
+        if v:
+            return v
+        time.sleep(0.3)
+    return None
+
+
+CHECKS: list[tuple[str, bool]] = []
+
+
+def check(label: str, ok: bool) -> None:
+    CHECKS.append((label, bool(ok)))
+    print(f"  [{'PASS' if ok else 'FAIL'}] {label}")
+
+
+def spawn_acolyte(port: int, x: float, y: float) -> int:
+    uid = send(port, f"return unit.spawn('acolyte', {x}, {y})")
+    try:
+        n = int(float(uid))
+    except ValueError:
+        sys.exit(f"unit.spawn failed: {uid!r}")
+    # Shed the spawn-seeded tools so they don't collide with our
+    # deliberately-placed test items / over-fill capacity (mirrors
+    # construction_probe.spawn_acolyte). unit.spawn's default loadout is
+    # queued to the unit thread and can still be settling in — a
+    # removeItem issued before it lands is a silent no-op, leaving the
+    # heavy default tools in place to push the acolyte over carrying
+    # capacity later (a fetch then silently no-ops and the AI reports a
+    # false "nothing available" instead of actually fetching). Retry
+    # until none of them remain.
+    TOOL_DEFS = {"pick_steel", "shovel_steel", "axe_steel", "rations"}
+
+    def stripped():
+        inv = jget(port, f"return unit.getInventory({n})")
+        if inv is None:
+            return False
+        present = {it["defName"] for it in inv} & TOOL_DEFS
+        for def_name in present:
+            send(port, f"unit.removeItem({n}, '{def_name}'); return 'ok'")
+        return not present
+    if not poll_until(port, 20, stripped):
+        sys.exit(f"unit {n} still carries default tools after stripping")
+    # Retire the spawn-seeded find_water goal — the arena has no water, so
+    # the goal never completes and its search utility can edge out a
+    # repair job a few tiles away (same fix construction_probe applies).
+    ok = poll_until(port, 20, lambda: send(
+        port,
+        f"local ai = require('scripts.unit_ai'); "
+        f"local s = ai.getState({n}); "
+        f"if not s then return false end; "
+        f"ai.markGoalAccomplished(s, 'find_water'); return true") == "true")
+    if not ok:
+        sys.exit(f"unit {n} never got AI state")
+    return n
+
+
+def spawn_mule(port: int, x: float, y: float) -> int:
+    uid = send(port, f"return unit.spawn('technomule', {x}, {y})")
+    try:
+        n = int(float(uid))
+    except ValueError:
+        sys.exit(f"technomule spawn failed: {uid!r}")
+    # unit.spawn is queued to the unit thread — its default cargo (and
+    # the unit itself, for unit.getInfo/addItem purposes) isn't reliably
+    # queryable until that lands (mirrors spawn_acolyte's settle wait).
+    if not poll_until(port, 20, lambda: send(
+            port, f"return unit.getInfo({n}) and 'yes' or 'no'"
+            ).strip('"') == "yes"):
+        sys.exit(f"technomule {n} never became queryable")
+    return n
+
+
+def destroy_unit(port: int, uid: int) -> None:
+    send(port, f"unit.destroy({uid}); return 'ok'")
+
+
+def spawn_station(port: int, uid: int, def_name: str, gx: int, gy: int,
+                   materials: dict[str, int]) -> int:
+    """Spawn def_name at (gx, gy), deliver build materials from uid
+    through the real machinery, and build it fully. Returns the built
+    building id."""
+    raw = send(port, f"return building.spawn('{def_name}', {gx}, {gy})")
+    try:
+        bid = int(float(raw))
+    except ValueError:
+        sys.exit(f"building.spawn('{def_name}') failed: {raw}")
+    if not poll_until(port, 20, lambda: send(
+            port, f"return building.getInfo({bid}) and 'yes' or 'no'"
+            ).strip('"') == "yes"):
+        sys.exit(f"{def_name} instance never appeared")
+    for item_name, count in materials.items():
+        send(port,
+             f"for i=1,{count} do unit.addItem({uid},'{item_name}'); "
+             f"unit.transferItemToBuilding({uid},{bid},'{item_name}') end; "
+             f"return 'ok'")
+    sat = send(port, f"return building.areMaterialsSatisfied({bid}) "
+                     f"and 'yes' or 'no'").strip('"')
+    if sat != "yes":
+        sys.exit(f"{def_name} materials not satisfied after delivery")
+    send(port, f"building.addBuildProgress({bid}, 100000); return 'ok'")
+    act = send(port, f"return building.getActivity({bid})").strip('"')
+    if act != "built":
+        sys.exit(f"{def_name} never reached built (got {act})")
+    return bid
+
+
+def build_station(port: int, def_name: str, gx: int, gy: int,
+                   materials: dict[str, int]) -> int:
+    """spawn_station needs a real unit to draw materials from — use a
+    throwaway builder so the test acolyte's inventory stays clean."""
+    builder = spawn_acolyte(port, gx - 1.5, gy - 1.5)
+    bid = spawn_station(port, builder, def_name, gx, gy, materials)
+    destroy_unit(port, builder)
+    return bid
+
+
+def force_item_state(port: int, uid: int, def_name: str,
+                      cond: float, sharp: float) -> int:
+    """Add def_name to uid's inventory and force its condition/sharpness to
+    exact values via the double-repairItem trick (delta is ADDITIVE and
+    clamped, not a set — floor both axes at 0 first, then apply a precise
+    positive delta from that known floor). Returns the new instanceId."""
+    send(port, f"unit.addItem({uid}, '{def_name}'); return 'ok'")
+    # unit.spawn's default loadout seeding can still be settling on a
+    # just-created unit (e.g. spawn_mule has no internal wait, unlike
+    # spawn_acolyte's goal-retirement poll) — retry until addItem's
+    # effect is actually queryable instead of assuming it landed already.
+    ids = poll_until(port, 20, lambda: jget(port,
+        f"local out={{}}; for _,it in ipairs(unit.getInventory({uid}) or {{}}) do "
+        f"if it.defName=='{def_name}' then out[#out+1]=it.instanceId end end; "
+        f"return #out > 0 and out or false"))
+    if not ids:
+        sys.exit(f"unit {uid} never received {def_name}")
+    iid = int(ids[-1])
+    send(port, f"unit.repairItem({uid}, {iid}, -1000, -1000); return 'ok'")
+    send(port, f"unit.repairItem({uid}, {iid}, {cond}, {sharp}); return 'ok'")
+    return iid
+
+
+def item_state(port: int, uid: int, iid: int):
+    """{cond, sharp, loc} for instance iid wherever it sits on uid right
+    now (inventory, equipped loadout, or worn accessory) — or None."""
+    return jget(port,
+        f"for _,it in ipairs(unit.getInventory({uid}) or {{}}) do "
+        f"  if it.instanceId=={iid} then "
+        f"    return {{cond=it.condition,sharp=it.sharpness,loc='inv'}} end end; "
+        f"for slot,it in pairs(equipment.getLoadout({uid}) or {{}}) do "
+        f"  if it.instanceId=={iid} then "
+        f"    return {{cond=it.condition,sharp=it.sharpness,loc='equip'}} end end; "
+        f"for _,it in ipairs(equipment.getAccessories({uid}) or {{}}) do "
+        f"  if it.instanceId=={iid} then "
+        f"    return {{cond=it.condition,sharp=it.sharpness,loc='acc'}} end end; "
+        f"return nil")
+
+
+def find_state_anywhere(port: int, uids: list[int], iid: int):
+    """item_state, tried across several candidate holders (the item may
+    have moved between them — own gear vs. mule)."""
+    for uid in uids:
+        st = item_state(port, uid, iid)
+        if st is not None:
+            return st
+    return None
+
+
+def count_item(port: int, uid: int, name: str) -> int:
+    return int(float(send(port,
+        f"local c=0; for _,it in ipairs(unit.getInventory({uid}) or {{}}) do "
+        f"if it.defName=='{name}' then c=c+1 end end; return c")))
+
+
+def count_ground(port: int, name: str) -> int:
+    return int(float(send(port,
+        f"local c=0; for _,g in ipairs(item.listGround() or {{}}) do "
+        f"if g.defName=='{name}' then c=c+1 end end; return c")))
+
+
+def has_repair_job(port: int, uid: int) -> bool:
+    return send(port,
+        f"local ai=require('scripts.unit_ai'); local s=ai.getState({uid}); "
+        f"return (s ~= nil and s.repairJob ~= nil)") == "true"
+
+
+# --- phases -------------------------------------------------------------
+
+
+def phase_own_inventory(port: int) -> None:
+    print("\n[phase 1] OWN gear: broken weapon claimed before "
+          "merely-degraded armor")
+    build_station(port, "furnace", 3, 2, {"granite_chunk": 6, "steel_bar": 2})
+    uid = spawn_acolyte(port, 4.5, 3.5)
+    # lignite_chunk is GROUND, fetched during the locked fetch_consumable
+    # phase (mirrors phase 2's ground whetstone) rather than pre-loaded
+    # into inventory: lignite_chunk is category "Materials", and an idle
+    # Materials item sitting in inventory BEFORE a job claims/locks it is
+    # fair game for the unrelated store_materials action (base utility
+    # 3.0, scales with carry fill) to auto-deposit into the very furnace
+    # this test just built (storage_capacity 100) — a real but narrow
+    # interaction between two independently-correct actions, not a
+    # repair_job bug (once claimed, repair_job's 6.0 lock always beats
+    # store_materials' 3.0 ceiling). Ground-sourcing sidesteps it, same
+    # as real gameplay's typical "fetch specifically to repair" flow.
+    send(port, "item.spawnGround('lignite_chunk', 6.5, 2.5); "
+               "item.spawnGround('lignite_chunk', 6.5, 3.5); return 'ok'")
+    skill_before = jget(port, f"return unit.getSkill({uid}, 'smithing')")
+    axe = force_item_state(port, uid, "axe_steel", cond=0.0, sharp=100.0)
+    gam = force_item_state(port, uid, "wool_gambeson", cond=5.0, sharp=100.0)
+
+    axe_done = poll_until(port, 120,
+        lambda: (item_state(port, uid, axe) or {}).get("cond") == 100)
+    check("broken weapon (condition 0) repaired first", axe_done is not None)
+
+    gam_mid = item_state(port, uid, gam)
+    check("armor untouched while the higher-severity weapon job was active",
+          gam_mid is not None and gam_mid["cond"] == 5)
+
+    gam_done = poll_until(port, 120,
+        lambda: (item_state(port, uid, gam) or {}).get("cond") == 100)
+    check("lower-severity armor repaired afterward", gam_done is not None)
+
+    check("both ground lignite_chunk fetched and consumed",
+          count_ground(port, "lignite_chunk") == 0
+          and count_item(port, uid, "lignite_chunk") == 0)
+    skill_after = jget(port, f"return unit.getSkill({uid}, 'smithing')")
+    # acolyte.yaml rolls a baseline smithing skill (base 20, range 15) —
+    # it's never nil, so "work-XP granted" means the two successful
+    # repairs measurably RAISED it, not that it went from nil to a value.
+    check("smithing work-XP granted (#265 smith role's first work action)",
+          skill_before is not None and skill_after is not None
+          and skill_after > skill_before)
+    destroy_unit(port, uid)
+
+
+def phase_equipped_ground(port: int) -> None:
+    print("\n[phase 2] EQUIPPED weapon (weapon slot) + GROUND consumable "
+          "(fetchWantsFromGround)")
+    build_station(port, "workbench", 9, 2,
+                  {"wood_log": 4, "steel_hardware": 4, "steel_bar": 2})
+    uid = spawn_acolyte(port, 10.5, 3.5)
+    # Ground whetstone BEFORE the weapon is degraded (see phase 1's note
+    # on the claim-vs-setup race and its pause-on-warning consequence).
+    send(port, "item.spawnGround('whetstone', 13.5, 3.5); return 'ok'")
+    ground_before = count_ground(port, "whetstone")
+    check("ground whetstone present before repair", ground_before >= 1)
+
+    axe = force_item_state(port, uid, "axe_steel", cond=100.0, sharp=5.0)
+    equipped = send(port,
+        f"return equipment.equip({uid}, 'right_hand', 'axe_steel', {axe})") == "true"
+    check("weapon equipped into right_hand slot", equipped)
+    before = item_state(port, uid, axe)
+    check("axe sits in equipment loadout, not inventory",
+          before is not None and before["loc"] == "equip")
+
+    done = poll_until(port, 120,
+        lambda: (item_state(port, uid, axe) or {}).get("sharp") == 100)
+    check("equipped weapon sharpened to 100 via ground-sourced whetstone",
+          done is not None)
+    check("ground whetstone consumed", count_ground(port, "whetstone")
+          == ground_before - 1)
+    after = item_state(port, uid, axe)
+    check("axe still equipped (not left loose in inventory) after repair",
+          after is not None and after["loc"] == "equip")
+    destroy_unit(port, uid)
+
+
+def phase_mule_spare_gear(port: int) -> None:
+    print("\n[phase 3] MULE-held spare gear: fetch_item + "
+          "fetchWantsFromMule + return-to-mule")
+    build_station(port, "furnace", 15, 2, {"granite_chunk": 6, "steel_bar": 2})
+    mule = spawn_mule(port, 17.5, 3.5)
+    axe = force_item_state(port, mule, "axe_steel", cond=5.0, sharp=100.0)
+    send(port, f"unit.addItem({mule}, 'lignite_chunk'); return 'ok'")
+    uid = spawn_acolyte(port, 16.5, 3.5)
+    # Fetching BOTH the mule-held item and its repair consumable adds
+    # their combined weight on top of the acolyte's own equipped gear —
+    # a rolled-low carrying_capacity can genuinely not fit axe_steel
+    # (2kg) + lignite_chunk (5kg), which repairUtility now correctly
+    # refuses to claim (see #302's capacity-feasibility gate). Boost
+    # strength so this scenario's "should succeed" path isn't at the
+    # mercy of the capacity roll.
+    send(port, f"unit.setStat({uid}, 'strength', 3.0); return 'ok'")
+
+    claimed = poll_until(port, 30, lambda: has_repair_job(port, uid))
+    check("acolyte claimed the mule-held item", claimed is not None)
+
+    done = poll_until(port, 180,
+        lambda: (find_state_anywhere(port, [uid, mule], axe) or {}).get("cond") == 100)
+    check("mule-sourced weapon repaired to full condition", done is not None)
+
+    returned = poll_until(port, 30, lambda: count_item(port, mule, "axe_steel") == 1)
+    check("repaired weapon returned to the mule", returned is not None)
+    check("acolyte no longer holds the (returned) weapon",
+          count_item(port, uid, "axe_steel") == 0)
+    lignite_gone = poll_until(port, 10, lambda: (
+        count_item(port, mule, "lignite_chunk") == 0
+        and count_item(port, uid, "lignite_chunk") == 0))
+    check("lignite_chunk fetched from the mule and consumed",
+          lignite_gone is not None)
+    destroy_unit(port, uid)
+    destroy_unit(port, mule)
+
+
+def phase_dead_claimant_release(port: int) -> None:
+    print("\n[phase 4] dead claimant releases a mule-held claim; a second "
+          "acolyte finishes it")
+    # Own row (y=-6/-4.5), away from phases 1-3, so nothing collides. The
+    # arena's pre-built block only spans chunks -2..2 (tiles -32..47), so
+    # "far" here means the opposite edge of that block, not truly distant.
+    build_station(port, "furnace", 20, -6, {"granite_chunk": 6, "steel_bar": 2})
+    mule = spawn_mule(port, 22.5, -4.5)
+    axe = force_item_state(port, mule, "axe_steel", cond=5.0, sharp=100.0)
+    send(port, f"unit.addItem({mule}, 'lignite_chunk'); return 'ok'")
+
+    # Spawned far from the mule so it's still walking (fetch_item phase,
+    # not yet arrived) when destroyed — the item never actually leaves
+    # the mule.
+    a = spawn_acolyte(port, -25.5, -4.5)
+    claimed = poll_until(port, 30, lambda: has_repair_job(port, a))
+    check("first acolyte claimed the mule-held item", claimed is not None)
+    destroy_unit(port, a)
+    check("item still on the mule after the claimant died",
+          count_item(port, mule, "axe_steel") == 1)
+
+    b = spawn_acolyte(port, 21.5, -4.5)
+    send(port, f"unit.setStat({b}, 'strength', 3.0); return 'ok'")  # see phase 3's note
+    done = poll_until(port, 180,
+        lambda: (find_state_anywhere(port, [b, mule], axe) or {}).get("cond") == 100)
+    check("second acolyte picked up the released claim and finished the repair",
+          done is not None)
+    destroy_unit(port, b)
+    destroy_unit(port, mule)
+
+
+def phase_role_weight(port: int) -> None:
+    print("\n[phase 5] role_weight: smith's (#265) first real ON_ROLE "
+          "effect on repair_job")
+    family = jget(port,
+        "return require('scripts.unit_roles').ACTION_FAMILY.repair_job")
+    check("repair_job mapped to the 'craft' family", family == "craft")
+
+    def weight(role: str, action: str) -> float:
+        return jget(port,
+            f"local m = require('scripts.unit_roles'); "
+            f"return m.weight({{role='{role}'}}, '{action}')")
+
+    check("smith gets ON_ROLE (1.4) on repair_job", weight("smith", "repair_job") == 1.4)
+    check("miner gets OFF_ROLE (0.7) on repair_job", weight("miner", "repair_job") == 0.7)
+    check("laborer stays neutral (1.0) on repair_job", weight("laborer", "repair_job") == 1.0)
+    # Now that "craft" has an action, a smith's OTHER routine work is
+    # correctly damped too (M.weight's familyHasActions gate) — this was
+    # a no-op (1.0) before #302 gave the smith family any actions at all.
+    check("smith is now OFF_ROLE (0.7) on dig_designation (craft family "
+          "now has actions)", weight("smith", "dig_designation") == 0.7)
+    check("miner stays ON_ROLE (1.4) on its own dig_designation",
+          weight("miner", "dig_designation") == 1.4)
+
+
+PHASES = {
+    "own_inventory": phase_own_inventory,
+    "equipped_ground": phase_equipped_ground,
+    "mule_spare_gear": phase_mule_spare_gear,
+    "dead_claimant_release": phase_dead_claimant_release,
+    "role_weight": phase_role_weight,
+}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--port", type=int, default=9382)
+    ap.add_argument("--phase", default="all", choices=["all"] + list(PHASES))
+    args = ap.parse_args()
+
+    proc = boot(args.port)
+    try:
+        bootstrap(args.port)
+        if not wid(args.port):
+            print("FAIL: no active world after arena build", file=sys.stderr)
+            return 2
+        todo = PHASES.values() if args.phase == "all" else [PHASES[args.phase]]
+        for phase in todo:
+            # Defensive: a "No <consumable> available" failure emits a
+            # unit_warning event, and this repo's config/notifications.yaml
+            # has pause:true for that category — an unexpected failure in
+            # one phase would otherwise freeze gameTime for every phase
+            # after it. Each phase starts from a known unpaused state.
+            send(args.port, "engine.setPaused(false); return 'ok'")
+            phase(args.port)
+    finally:
+        try:
+            send(args.port, "engine.quit()", timeout=3.0)
+        except OSError:
+            pass
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+    failed = [label for label, ok in CHECKS if not ok]
+    print(f"\n{len(CHECKS) - len(failed)}/{len(CHECKS)} checks passed"
+          + (f"; FAILED: {failed}" if failed else ""))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/repair_ai_probe.py
+++ b/tools/repair_ai_probe.py
@@ -28,7 +28,13 @@ it IS the machinery under test, unlike movement_probe which neutralises it):
      item to the mule (abortRepairJob), not leak it into the worker's
      own inventory (regression for a review finding on the fetch_item ->
      mid-job-failure path).
-  6. role_weight : scripts/unit_roles.lua's weight() gives the "smith" role
+  6. own_item_collision : the acolyte ALSO carries its own healthy
+     axe_steel (acolyte.yaml's default loadout) while fetching a
+     DIFFERENT, degraded axe_steel off the mule — proving the fetch and
+     the return-to-mule both target the flagged instanceId, not just
+     defName (regression for a review finding: a defName-only transfer
+     could pop the worker's own item instead of the one actually fetched).
+  7. role_weight : scripts/unit_roles.lua's weight() gives the "smith" role
      (#265, previously dormant) its first real ON_ROLE boost on repair_job,
      and now correctly damps a smith's OTHER routine work — a pure Lua
      check, no world/units needed.
@@ -522,8 +528,46 @@ def phase_abort_returns_item(port: int) -> None:
     destroy_unit(port, mule)
 
 
+def phase_own_item_collision(port: int) -> None:
+    print("\n[phase 6] the worker's OWN same-defName item is never confused "
+          "with the flagged mule instance (instanceId-targeted transfer)")
+    build_station(port, "furnace", 42, 2, {"granite_chunk": 6, "steel_bar": 2})
+    mule = spawn_mule(port, 44.5, 3.5)
+    mule_axe = force_item_state(port, mule, "axe_steel", cond=5.0, sharp=100.0)
+    send(port, f"unit.addItem({mule}, 'lignite_chunk'); return 'ok'")
+
+    uid = spawn_acolyte(port, 43.5, 3.5)
+    send(port, f"unit.setStat({uid}, 'strength', 3.0); return 'ok'")  # see phase 3's note
+    # spawn_acolyte strips the default axe_steel; add a fresh, HEALTHY one
+    # back — the exact collision a real acolyte hits (acolyte.yaml starts
+    # with its own axe_steel). A defName-only transfer could pop THIS one
+    # instead of the flagged (degraded) mule instance.
+    own_axe = force_item_state(port, uid, "axe_steel", cond=100.0, sharp=100.0)
+
+    claimed = poll_until(port, 30, lambda: has_repair_job(port, uid))
+    check("acolyte claimed the mule-held (degraded) item, not its own",
+          claimed is not None)
+
+    done = poll_until(port, 180,
+        lambda: (find_state_anywhere(port, [uid, mule], mule_axe) or {}).get("cond") == 100)
+    check("the FLAGGED mule instance reaches full condition", done is not None)
+
+    poll_until(port, 30, lambda: count_item(port, mule, "axe_steel") == 1)
+    own_state = item_state(port, uid, own_axe)
+    check("acolyte's OWN axe is untouched (same instance, still healthy)",
+          own_state is not None and own_state["cond"] == 100)
+    mule_state = item_state(port, mule, mule_axe)
+    check("the repaired FLAGGED instance is the one back on the mule "
+          "(not the acolyte's own)",
+          mule_state is not None and mule_state["cond"] == 100)
+    check("acolyte carries exactly its own one axe_steel afterward",
+          count_item(port, uid, "axe_steel") == 1)
+    destroy_unit(port, uid)
+    destroy_unit(port, mule)
+
+
 def phase_role_weight(port: int) -> None:
-    print("\n[phase 6] role_weight: smith's (#265) first real ON_ROLE "
+    print("\n[phase 7] role_weight: smith's (#265) first real ON_ROLE "
           "effect on repair_job")
     family = jget(port,
         "return require('scripts.unit_roles').ACTION_FAMILY.repair_job")
@@ -552,6 +596,7 @@ PHASES = {
     "mule_spare_gear": phase_mule_spare_gear,
     "dead_claimant_release": phase_dead_claimant_release,
     "abort_returns_item": phase_abort_returns_item,
+    "own_item_collision": phase_own_item_collision,
     "role_weight": phase_role_weight,
 }
 

--- a/tools/repair_ai_probe.py
+++ b/tools/repair_ai_probe.py
@@ -23,7 +23,12 @@ it IS the machinery under test, unlike movement_probe which neutralises it):
      (before it reaches the mule); a second acolyte must pick the same
      item back up and finish the job — proving the repairClaims stale-claim
      self-heal (mirrors chopClaims/constructClaims).
-  5. role_weight : scripts/unit_roles.lua's weight() gives the "smith" role
+  5. abort_returns_item : the item is fetched off the mule, then its
+     station is destroyed mid-job — the abort must return the fetched
+     item to the mule (abortRepairJob), not leak it into the worker's
+     own inventory (regression for a review finding on the fetch_item ->
+     mid-job-failure path).
+  6. role_weight : scripts/unit_roles.lua's weight() gives the "smith" role
      (#265, previously dormant) its first real ON_ROLE boost on repair_job,
      and now correctly damps a smith's OTHER routine work — a pure Lua
      check, no world/units needed.
@@ -464,8 +469,61 @@ def phase_dead_claimant_release(port: int) -> None:
     destroy_unit(port, mule)
 
 
+def phase_abort_returns_item(port: int) -> None:
+    print("\n[phase 5] a job aborted AFTER fetch_item returns the fetched "
+          "item to the mule (regression: it used to leak into the "
+          "worker's own inventory)")
+    bid = build_station(port, "furnace", 35, 2, {"granite_chunk": 6, "steel_bar": 2})
+    mule = spawn_mule(port, 37.5, 3.5)
+    axe = force_item_state(port, mule, "axe_steel", cond=5.0, sharp=100.0)
+    send(port, f"unit.addItem({mule}, 'lignite_chunk'); return 'ok'")
+    uid = spawn_acolyte(port, 36.5, 3.5)
+    send(port, f"unit.setStat({uid}, 'strength', 3.0); return 'ok'")  # see phase 3's note
+
+    claimed = poll_until(port, 30, lambda: has_repair_job(port, uid))
+    check("acolyte claimed the mule-held item", claimed is not None)
+
+    fetched = poll_until(port, 30, lambda: count_item(port, uid, "axe_steel") == 1)
+    check("item fetched off the mule into the acolyte's own inventory",
+          fetched is not None)
+
+    # Wait for the "walking" phase to actually CACHE job.bid to this
+    # specific station before destroying it — earlier phases' furnaces
+    # (#1 etc.) persist in this shared arena, so destroying ours before
+    # job.bid is cached would just send the acolyte on a long walk to one
+    # of those instead of aborting (job.bid pins the abort to THIS
+    # building regardless of what else exists elsewhere).
+    bid_cached = poll_until(port, 30, lambda: jget(port,
+        f"local ai=require('scripts.unit_ai'); local st=ai.getState({uid}); "
+        f"return st and st.repairJob and st.repairJob.bid") == bid)
+    check("acolyte's job cached this station before it's destroyed",
+          bid_cached is not None)
+
+    # Destroy that cached station WHILE the item is sitting in the
+    # acolyte's inventory (mid-job, past fetch_item) — forces the
+    # "walking" phase's missing-building abort. Since the station is now
+    # genuinely gone, repairUtility's own reachability gate also stops the
+    # acolyte from re-claiming this axe once the job releases (there's no
+    # other repair_condition station within its scan of the mule/axe).
+    send(port, f"building.destroy({bid}); return 'ok'")
+
+    returned = poll_until(port, 30, lambda: count_item(port, mule, "axe_steel") == 1)
+    check("aborted job returns the fetched item to the mule (not leaked)",
+          returned is not None)
+    # Destroy the acolyte the INSTANT the return is observed: a farther
+    # repair_condition station (phase 1's furnace) still exists elsewhere
+    # in this shared arena, so the still-degraded axe would otherwise be
+    # a valid (if distant) candidate again on the very next thought tick —
+    # this check only cares that THIS abort didn't leak the item, not
+    # whether a later, unrelated claim eventually re-fetches it.
+    destroy_unit(port, uid)
+    check("acolyte no longer holds the item after the abort",
+          count_item(port, mule, "axe_steel") == 1)
+    destroy_unit(port, mule)
+
+
 def phase_role_weight(port: int) -> None:
-    print("\n[phase 5] role_weight: smith's (#265) first real ON_ROLE "
+    print("\n[phase 6] role_weight: smith's (#265) first real ON_ROLE "
           "effect on repair_job")
     family = jget(port,
         "return require('scripts.unit_roles').ACTION_FAMILY.repair_job")
@@ -493,6 +551,7 @@ PHASES = {
     "equipped_ground": phase_equipped_ground,
     "mule_spare_gear": phase_mule_spare_gear,
     "dead_claimant_release": phase_dead_claimant_release,
+    "abort_returns_item": phase_abort_returns_item,
     "role_weight": phase_role_weight,
 }
 

--- a/tools/run_probes.py
+++ b/tools/run_probes.py
@@ -88,6 +88,8 @@ PROBES = [
      "unit.repairItem primitive (#300)"),
     ("repair", "repair_probe.py", True,
      "repair policy layer, station-gated (#301)"),
+    ("repair_ai", "repair_ai_probe.py", True,
+     "repair AI: claim/fetch/walk/repair/return + role weighting (#302)"),
     ("role", "role_probe.py", True,
      "derived unit-role hysteresis/demotion/work-XP growth (#265)"),
     ("save_pause", "save_pause_probe.py", True,


### PR DESCRIPTION
Closes #302.

## Approach

Adds `repair_job` to `scripts/unit_ai.lua`, mirroring the mining/chop/construction designation→AI pattern the issue asks for, adapted for a target that isn't a map tile: a repair candidate is a specific item *instance* living in a unit's inventory/equipment/accessories or on the technomule, not on the ground.

- **Scan**: own inventory + equipment + accessories first; only look to the nearest technomule's inventory if the unit itself carries nothing degraded.
- **Severity/priority**: condition checked before sharpness (a broken/low-condition item is combat-catastrophic; low sharpness only reduces penetration). Tiered — broken armor > broken weapon > a quadratic ramp toward the threshold — so a broken item is always claimed before a merely-degraded one.
- **Sourcing**: reuses the existing sourcing ladder (`groundCountOf`/`fetchWantsFromGround`/`findTechnomule`/`fetchWantsFromMule`) for the repair consumable (`lignite_chunk`/`whetstone`), and the same machinery to fetch a mule-held degraded item before restoring it and handing it back.
- **Station routing**: `building.findStation` picks the nearest Built station offering the recipe's operation; claim only commits if a station is actually reachable (mirrors dig's tool gate).
- **Scope**: AI-autonomous only for v1 (the issue's own phrasing — "acolytes maintain their own kit" — matches the `treat_ally`/`forage`/`store_materials` precedent of needs-driven, zero-player-input maintenance). Player-designated repair-by-instance and ground-item targeting are deliberately out of scope: `item.listGround()` doesn't expose `instanceId`/`condition`/`sharpness`, so a dropped item can't be identified or verified headless today — a small, additive follow-up.
- **Role integration**: `repair_job` maps to the `"smith"` role's `"craft"` family in `unit_roles.lua` — the smith role (#265) gets its first real `ON_ROLE` weighting (and, correctly, is now damped on other routine work it doesn't specialize in, per that module's existing contract).

## Bugs found and fixed along the way

Driving this against the *live* AI loop (not a mocked one) surfaced four real bugs, each isolated and confirmed independently before/after the fix:

1. **Claiming a job never called `unit.stop()`.** The dispatch loop only re-fires `execute()` on an action switch or while `activity == "idle"`. A stale walking activity left by whatever action preceded `repair_job` (e.g. `wander`) permanently starved that gate — the phase machine froze forever. Fixed by stopping the unit at claim time (matching chop/dig/construct's convention of always retaking movement control on claim).
2. **`fetch_consumable` shared one want-table between `fetchWantsFromGround` and `fetchWantsFromMule`.** Both helpers assume the caller pre-splits ground vs. mule portions the way `deliverExecute`'s separate `claim.fromGround`/`claim.fromMule` fields do — a ground miss clears the *entire* shared table (`wants[mat] = nil`), so the mule fallback silently never ran. Fixed with separate `groundWant`/`muleWant` fields and a `groundDone` flag.
3. **`building.findStation`'s `Lua.tointeger` argument parsing silently drops non-integer coordinates.** A raw unit position like `16.5` fails to parse as an integer, so the function falls back to "no distance info available" — lowest building id wins, ignoring proximity entirely. With two stations offering the same operation, the AI would walk to the *wrong, farther* one. Fixed by flooring coordinates at the call site (this is a real, narrow engine-binding bug independent of this feature — flagging here rather than patching the shared Haskell binding, to keep this PR's diff scoped to the repair AI).
4. **A mule-sourced job whose combined item + consumable weight exceeded carrying capacity used to loop forever**: claim → fail to fetch → release → the same still-degraded item (now sitting in the unit's own inventory) is immediately re-claimed → fail again. Given `config/notifications.yaml` pauses the engine on `unit_warning`, this would have been a repeated pause-storm in real play, not just a test artifact. Fixed with a capacity-feasibility check at claim time (skip the candidate cleanly, matching the station-reachability gate already there).

## Testing

- **New harness**: `tools/repair_ai_probe.py` (registered in `tools/run_probes.py` and `tools/README.md`) — 5 phases: own gear + priority ordering (broken weapon before merely-degraded armor), equipped weapon + ground-sourced consumable, mule-held spare gear (fetch + return-to-mule), dead-claimant release (stale-claim self-heal), and smith-role weighting. All 5 pass individually, and pass in the full sequential run (verified after each bug fix, isolating the fix from the failure it resolved).
- `cabal test synarchy-test-headless` — 548 examples, 0 failures.
- `python3 tools/test_audit.py` — all 35 groups pass.
- `python3 tools/world_check.py --quick` — 6/6 seeds pass (this change touches no worldgen code, included as the standard tier-2 gate).

No save-version bump — no new `SaveData` fields.