### PR TITLE
Power-network simulation: connected components + energy balance (#360)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,7 +413,7 @@ persists per-world (`wpsPowerNodes`, v73) keyed by the `BuildingId` it
 rides on, reconnecting on load like `Craft.Bills`. Wire adjacency /
 network energy balance are #359/#360, not this.
 
-Turnkey harness: **`python3 tools/power_probe.py`** — the #358 gate.
+Turnkey harness: **`python3 tools/power_probe.py`** — the #358/#360 gate.
 Boots headless on a flat arena, confirms the technomule's starting kit
 carries the new items, and drives `buildTool.commitPlacement` (not just
 the raw Lua verb) end to end: refusal with no unit selected (an ordinary
@@ -422,6 +422,47 @@ a source and a storage node once a carrying unit is selected, no node
 leaking onto an ordinary building, refusal once the carrying unit's
 stock is exhausted, and a full save → quit → fresh-restart → load
 round-trip reconnecting every node to its building.
+
+### Testing power network connectivity + balance headless (#360)
+
+`Power.Network` is the connected-components + energy-balance sim on top
+of #358's nodes and #359's wire (`Structure.Types.SWire`, placed via
+`scripts/wire.lua`'s `M.place(gx,gy)`). A "network" is a 4-dir-adjacent
+run of wire tiles plus whichever nodes sit on or beside it — connectivity
+and a network's generation/drain numbers are recomputed fresh on every
+tick/query (nothing about network membership is persisted); only a
+battery's own accumulated charge (`pnStoredWh`, save v75) survives a
+save. It ticks on the WORLD thread beside `tickWorldTime` (not the
+fluid-specific `Sim.Thread`, which mirrors per-chunk cell data for a much
+higher-throughput problem than power needs), in the same game-scaled
+`dtGame` clock flora/item-temperature already follow — so `world.
+setTimeScale` fast-forwards a network's charge exactly like it does a
+crop's growth. Solar generation scales by `World.Time.Types.
+worldTimeToSunAngle` through a cosine curve (`Power.Network.
+solarIntensity`: 1 at noon, 0 at dawn/dusk/midnight). `power.
+listNetworks()` / `power.getNetworkForNode(nodeId)` report each network's
+`nodeIds`/`generationW`/`drainW`/`storedWh`/`capacityWh`/`powered`;
+`power.getNode`/`getNodeForBuilding`/`listNodes` also gained a `storedWh`
+field on each node.
+
+Consumer drain (#361 — `requires_power` workshops) isn't wired up yet:
+the tick's drain-by-node map is always empty in production today. The
+balance math itself (charging, holding, brownout under a deficit) is
+proven with a synthetic drain in the pure hspec suite, not against a
+real consumer.
+
+Turnkey harnesses:
+- **`python3 tools/power_probe.py`** (extended for #360) — wires a
+  placed solar panel + battery together, confirms they land on one
+  network (and an unwired panel doesn't), fast-forwards the clock and
+  confirms the battery's `storedWh` actually rises, then confirms the
+  charge survives a save → quit → fresh-restart → load round-trip.
+- **`Test.Headless.Power.Network`** (hspec, no engine needed) — the
+  #360 gate for the algorithm itself: flood-fill connectivity (incl. the
+  4-dir-only / no-wire-no-network cases), instantaneous status
+  (Powered/Brownout independent of `dtHours`), charging + capacity
+  clamping, and discharge/brownout under a synthetic drain incl.
+  proportional multi-battery split.
 
 ### Flora growth runtime (#332)
 

--- a/src/Engine/Scripting/Lua/API.hs
+++ b/src/Engine/Scripting/Lua/API.hs
@@ -542,13 +542,17 @@ registerLuaAPI lst env backendState = Lua.runWith lst $ do
   -- pops a solar_panel/high_voltage_battery item out of a unit's
   -- inventory and turns it into a persistent power node; getNode /
   -- getNodeForBuilding / listNodes are read-only queries reporting each
-  -- node's role + parameters. Network attachment (#359/#360) isn't here.
+  -- node's role + parameters. listNetworks / getNetworkForNode (#360)
+  -- report the live wire-connectivity view: which nodes share a network
+  -- and its current generation/drain/stored/capacity/powered status.
   Lua.newtable
   registerLuaFunction "isPlaceable"       (powerIsPlaceableFn env)
   registerLuaFunction "placeNode"         (powerPlaceNodeFn env)
   registerLuaFunction "getNode"           (powerGetNodeFn env)
   registerLuaFunction "getNodeForBuilding" (powerGetNodeForBuildingFn env)
   registerLuaFunction "listNodes"         (powerListNodesFn env)
+  registerLuaFunction "listNetworks"       (powerListNetworksFn env)
+  registerLuaFunction "getNetworkForNode"  (powerGetNetworkForNodeFn env)
   Lua.setglobal (Lua.Name "power")
 
   -- Repair global (#301) — the policy layer on top of unit.repairItem

--- a/src/Engine/Scripting/Lua/API/Power.hs
+++ b/src/Engine/Scripting/Lua/API/Power.hs
@@ -1,27 +1,34 @@
 {-# LANGUAGE Strict, UnicodeSyntax, OverloadedStrings #-}
--- | Lua surface for the power-node registry (#358). power.placeNode
---   pops a solar_panel/high_voltage_battery item out of a unit's
---   inventory and turns it into a placed, persistent power node —
---   mirroring the portal's instant-build path (building.spawn with
---   bdBuildWork = 0) but sourced from an item instead of being free.
---   The read-only queries (getNode / getNodeForBuilding / listNodes)
---   are the #358 "reports its role + parameters" surface. Network
---   attachment / energy balance are #359/#360, not here.
+-- | Lua surface for the power-node registry (#358) and its connectivity
+--   + energy balance (#360). power.placeNode pops a solar_panel/
+--   high_voltage_battery item out of a unit's inventory and turns it
+--   into a placed, persistent power node — mirroring the portal's
+--   instant-build path (building.spawn with bdBuildWork = 0) but sourced
+--   from an item instead of being free. getNode / getNodeForBuilding /
+--   listNodes report each node's own role + parameters (+ current charge
+--   for storage nodes); listNetworks / getNetworkForNode report the live
+--   connected-component view — which nodes share a wired network and
+--   that network's current generation/drain/stored/capacity/powered
+--   status (Power.Network).
 module Engine.Scripting.Lua.API.Power
     ( powerIsPlaceableFn
     , powerPlaceNodeFn
     , powerGetNodeFn
     , powerGetNodeForBuildingFn
     , powerListNodesFn
+    , powerListNetworksFn
+    , powerGetNetworkForNodeFn
     ) where
 
 import UPrelude
+import Data.List (find)
 import qualified Data.Text.Encoding as TE
 import qualified Data.HashMap.Strict as HM
 import qualified HsLua as Lua
 import Data.IORef (readIORef, atomicModifyIORef')
 import Engine.Core.State (EngineEnv(..), activeWorldPage)
 import World.Page.Types (WorldPageId(..))
+import World.Time.Types (worldTimeToSunAngle)
 import World.Types (WorldManager(..), WorldState(..))
 import World.Tile.Types (WorldTileData)
 import qualified Engine.Core.Queue as Q
@@ -32,6 +39,8 @@ import Unit.Types (UnitId(..), UnitManager(..), UnitInstance(..))
 import Unit.Pathing.Cost (lookupTerrainZ)
 import Item.Types (ItemInstance(..))
 import Power.Types
+import Power.Network (wireTilesOn, positionsOf, computeSnapshots)
+import qualified Power.Network as PN
 
 -- | power.isPlaceable(itemDefName) → bool. Lets a caller (the build
 --   tool's placement click) decide whether a def routes through
@@ -226,7 +235,8 @@ powerListNodesFn env = do
     return 1
 
 -- | Push one node as a Lua table: { id, building, role, peakWatts,
---   capacityWh }. role is "source" | "storage".
+--   capacityWh, storedWh }. role is "source" | "storage". storedWh
+--   (#360) is always 0 for a source node.
 pushNode ∷ PowerNode → Lua.LuaE Lua.Exception ()
 pushNode node = do
     Lua.newtable
@@ -239,6 +249,74 @@ pushNode node = do
     Lua.setfield (-2) "role"
     putN "peakWatts"  (pnPeakWatts node)
     putN "capacityWh" (pnCapacityWh node)
+    putN "storedWh"   (pnStoredWh node)
   where
     roleText PowerSource  = "source"
     roleText PowerStorage = "storage"
+
+-- | Gather the active world's current network snapshots (#360):
+--   connectivity + generation/drain/stored/capacity/status, recomputed
+--   live from this instant's sun angle. No consumers are wired up yet
+--   (#361), so every network's drainW is 0 today — the balance math
+--   itself (incl. brownout under a synthetic drain) is covered by
+--   Test.Headless.Power.Network, not this live path.
+activeNetworkSnapshots ∷ EngineEnv → IO [PN.PowerNetworkSnapshot]
+activeNetworkSnapshots env = do
+    mPage ← activeWorldPage env
+    case mPage of
+        Nothing → pure []
+        Just (pageId, ws) → do
+            nodes ← readIORef (wsPowerNodesRef ws)
+            wt    ← readIORef (wsTimeRef ws)
+            td    ← readIORef (wsTilesRef ws)
+            bm    ← readIORef (buildingManagerRef env)
+            let sunAngle   = worldTimeToSunAngle wt
+                wireTiles  = wireTilesOn td
+                positions  = positionsOf pageId bm nodes
+            pure (computeSnapshots sunAngle HM.empty wireTiles nodes positions)
+
+-- | power.listNetworks() → array of network tables on the active world.
+--   Order is incidental (component discovery order) — callers key off
+--   nodeIds/building ids, not array position.
+powerListNetworksFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+powerListNetworksFn env = do
+    nets ← Lua.liftIO $ activeNetworkSnapshots env
+    Lua.newtable
+    forM_ (zip [1 ∷ Int ..] nets) $ \(i, net) → do
+        pushNetwork net
+        Lua.rawseti (-2) (fromIntegral i)
+    return 1
+
+-- | power.getNetworkForNode(nodeId) → table | nil — the network the
+--   given node currently attaches to (nil if it isn't wired into one:
+--   not adjacent to any wire tile).
+powerGetNetworkForNodeFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+powerGetNetworkForNodeFn env = do
+    idArg ← Lua.tointeger 1
+    case idArg of
+        Nothing → Lua.pushnil >> return 1
+        Just n  → do
+            let nid = PowerNodeId (fromIntegral n)
+            nets ← Lua.liftIO $ activeNetworkSnapshots env
+            case find (elem nid . PN.pnwNodeIds) nets of
+                Just net → pushNetwork net >> return 1
+                Nothing  → Lua.pushnil >> return 1
+
+-- | Push one network snapshot: { nodeIds = {...}, generationW, drainW,
+--   storedWh, capacityWh, powered }.
+pushNetwork ∷ PN.PowerNetworkSnapshot → Lua.LuaE Lua.Exception ()
+pushNetwork net = do
+    Lua.newtable
+    let putN k v = Lua.pushnumber (Lua.Number (realToFrac v))
+                   >> Lua.setfield (-2) k
+    Lua.newtable
+    forM_ (zip [1 ∷ Int ..] (PN.pnwNodeIds net)) $ \(i, nid) → do
+        Lua.pushinteger (fromIntegral (unPowerNodeId nid))
+        Lua.rawseti (-2) (fromIntegral i)
+    Lua.setfield (-2) "nodeIds"
+    putN "generationW" (PN.pnwGenerationW net)
+    putN "drainW"      (PN.pnwDrainW net)
+    putN "storedWh"    (PN.pnwStoredWh net)
+    putN "capacityWh"  (PN.pnwCapacityWh net)
+    Lua.pushboolean (PN.pnwStatus net ≡ PN.Powered)
+    Lua.setfield (-2) "powered"

--- a/src/Power/Network.hs
+++ b/src/Power/Network.hs
@@ -5,7 +5,11 @@
 --   scripts/wire.lua's autotile shape) plus whichever power nodes sit on
 --   or orthogonally beside it — two nodes that don't share a wire path
 --   are NOT on the same network even if their tiles happen to be
---   adjacent to each other directly.
+--   adjacent to each other directly. A node touching two otherwise-
+--   disconnected wire stubs bridges them into ONE merged network
+--   ('groupByComponent') rather than attaching to both independently —
+--   a proper connected-components partition can't put one node in two
+--   groups at once.
 --
 --   Connectivity and a network's generation/drain numbers are recomputed
 --   fresh every call — nothing about network MEMBERSHIP is persisted,
@@ -40,6 +44,7 @@ module Power.Network
     ) where
 
 import UPrelude
+import Data.List (nub)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
 import Building.Types (BuildingInstance(..), BuildingManager(..))
@@ -95,26 +100,72 @@ wireComponents tiles = go (HS.toList tiles) HS.empty []
                          , not (HS.member n visited) ]
         in bfs (foldl' (flip HS.insert) visited fresh) (rest ++ fresh)
 
--- | A tile attaches to a wire component if it sits ON the wire (rare — a
---   building could share a tile with a wire overlay) or orthogonally
---   beside it.
-attachedTo ∷ (Int, Int) → HS.HashSet (Int, Int) → Bool
-attachedTo tile comp = HS.member tile comp ∨ any (`HS.member` comp) (neighborsOf tile)
+-- | Which wire components (by index into @comps@) a tile touches — the
+--   tile itself (rare — a building could share a tile with a wire
+--   overlay) or any of its 4 orthogonal neighbours. A tile that only
+--   ever touches wire is attached to at most one component (BFS already
+--   guarantees that); a NODE's tile can legitimately touch two or more
+--   otherwise-disconnected wire stubs at once (e.g. a panel sitting
+--   between two separate short runs) — that's the case 'mergedRoots'
+--   below resolves.
+touchedComponents ∷ HM.HashMap (Int, Int) Int → (Int, Int) → [Int]
+touchedComponents tileToIdx tile =
+    nub [ i | t ← tile : neighborsOf tile, Just i ← [HM.lookup t tileToIdx] ]
 
--- | Group a world's nodes by which wire component they attach to,
---   looking each one up in @nodes@ (the single source of truth for its
---   current role/wattage/capacity/charge) by id. Bare wire runs with no
---   attached node produce no group, and a position with no matching node
---   (or a node with no position) is silently skipped — both are
---   defensive, not expected in practice.
+-- | Bare-bones union-find over component indices @[0 .. n-1]@: 'ufFind'
+--   walks parent pointers to the representative; 'ufUnion' points one
+--   root at the other. No path compression / union-by-rank — @n@ is the
+--   wire-component count, expected small, so the naive walk is cheap.
+newtype UnionFind = UnionFind (HM.HashMap Int Int)
+
+ufNew ∷ Int → UnionFind
+ufNew n = UnionFind (HM.fromList [ (i, i) | i ← [0 .. n - 1] ])
+
+ufFind ∷ UnionFind → Int → Int
+ufFind uf@(UnionFind m) i = case HM.lookup i m of
+    Just p | p ≡ i     → i
+           | otherwise → ufFind uf p
+    Nothing            → i
+
+ufUnion ∷ UnionFind → Int → Int → UnionFind
+ufUnion uf@(UnionFind m) a b =
+    let ra = ufFind uf a
+        rb = ufFind uf b
+    in if ra ≡ rb then uf else UnionFind (HM.insert ra rb m)
+
+-- | Group a world's nodes by which (possibly node-merged) wire network
+--   they attach to, looking each one up in @nodes@ (the single source of
+--   truth for its current role/wattage/capacity/charge) by id. A node
+--   touching two or more otherwise-disconnected wire components BRIDGES
+--   them into one network via union-find, rather than being attached to
+--   several components at once (a proper connected-components partition
+--   can't put one vertex in two groups — a node bridging two stubs
+--   physically joins them, it doesn't pick one arbitrarily or generate
+--   into both). A node touching NO wire component at all — including two
+--   nodes directly adjacent to each other with no wire tile between them
+--   — attaches to nothing. Bare wire runs with no attached node produce
+--   no group; a position with no matching node is silently skipped
+--   (defensive, not expected in practice).
 groupByComponent ∷ [HS.HashSet (Int, Int)] → PowerNodes
                  → HM.HashMap PowerNodeId (Int, Int) → [[PowerNode]]
 groupByComponent comps nodes positions =
-    [ grp | comp ← comps
-          , let grp = [ n | (nid, tile) ← HM.toList positions
-                           , attachedTo tile comp
-                           , Just n ← [lookupPowerNode nid nodes] ]
-          , not (null grp) ]
+    let tileToIdx = HM.fromList [ (t, i) | (i, comp) ← zip [0 ..] comps
+                                          , t ← HS.toList comp ]
+        nodeList  = HM.toList positions
+        uf0       = ufNew (length comps)
+        -- Every node that touches 2+ components unions them together.
+        mergedUf  = foldl' (\uf (_, tile) → case touchedComponents tileToIdx tile of
+                        (i : is@(_ : _)) → foldl' (\u j → ufUnion u i j) uf is
+                        _                → uf
+                    ) uf0 nodeList
+        rootFor tile = case touchedComponents tileToIdx tile of
+            (i : _) → Just (ufFind mergedUf i)
+            []      → Nothing
+        byRoot = HM.fromListWith (++)
+                   [ (root, [nid]) | (nid, tile) ← nodeList, Just root ← [rootFor tile] ]
+    in [ grp | nids ← HM.elems byRoot
+             , let grp = [ n | nid ← nids, Just n ← [lookupPowerNode nid nodes] ]
+             , not (null grp) ]
 
 -- | Distribute a charge (non-negative Wh) across batteries proportional
 --   to each one's remaining headroom, so a fuller battery takes less.

--- a/src/Power/Network.hs
+++ b/src/Power/Network.hs
@@ -1,0 +1,234 @@
+{-# LANGUAGE Strict, UnicodeSyntax #-}
+-- | Power-grid connectivity + energy balance (#360): the core sim on top
+--   of #358's placed nodes and #359's wire tiles. A "network" is a
+--   connected component of wire tiles (4-dir cardinal adjacency, matching
+--   scripts/wire.lua's autotile shape) plus whichever power nodes sit on
+--   or orthogonally beside it — two nodes that don't share a wire path
+--   are NOT on the same network even if their tiles happen to be
+--   adjacent to each other directly.
+--
+--   Connectivity and a network's generation/drain numbers are recomputed
+--   fresh every call — nothing about network MEMBERSHIP is persisted,
+--   only a battery's own accumulated charge ('pnStoredWh', Power.Types)
+--   survives a save. Recomputing every tick is simpler than maintaining
+--   incremental connectivity and cheap at the node/wire counts a
+--   colony's grid is expected to reach; the issue's own "recompute only
+--   when wire/nodes change" note is a future perf tuning knob, not a
+--   correctness requirement — nothing here would need to change shape to
+--   add that cache later.
+--
+--   'PowerNodes' is always the single source of truth for node data
+--   (role, wattage, capacity, current charge) — every function here
+--   takes it plus a separate tile-position lookup, rather than a list of
+--   caller-constructed node copies that could drift out of sync with the
+--   registry.
+--
+--   Consumer drain (#361 — "requires_power" workshops) isn't wired up
+--   yet: 'tickPowerNodes' takes a @drain-by-node@ map as a parameter so
+--   the balance math (charge, hold, brownout-under-load) is fully
+--   exercised and tested now; the production call site passes an empty
+--   map until #361 has real consumers to populate it from.
+module Power.Network
+    ( PowerNetworkStatus(..)
+    , PowerNetworkSnapshot(..)
+    , solarIntensity
+    , wireComponents
+    , computeSnapshots
+    , tickPowerNodes
+    , wireTilesOn
+    , positionsOf
+    ) where
+
+import UPrelude
+import qualified Data.HashMap.Strict as HM
+import qualified Data.HashSet as HS
+import Building.Types (BuildingInstance(..), BuildingManager(..))
+import Structure.Types (StructureSlot(..))
+import World.Chunk.Types (LoadedChunk(..))
+import World.Page.Types (WorldPageId)
+import World.Tile.Types (WorldTileData(..))
+import Power.Types
+
+-- | Whether a network's demand was fully met this instant.
+data PowerNetworkStatus = Powered | Brownout
+    deriving (Show, Eq)
+
+-- | A read-only view of one connected component's current numbers — the
+--   Lua query surface (power.listNetworks / getNetworkForNode) reports
+--   exactly this. Never persisted; recomputed live on every query.
+data PowerNetworkSnapshot = PowerNetworkSnapshot
+    { pnwNodeIds     ∷ ![PowerNodeId]  -- ^ every node on this network, oldest id first
+    , pnwGenerationW ∷ !Float          -- ^ Σ source output this instant
+    , pnwDrainW      ∷ !Float          -- ^ Σ registered consumer draw this instant
+    , pnwStoredWh    ∷ !Float          -- ^ Σ storage node charge
+    , pnwCapacityWh  ∷ !Float          -- ^ Σ storage node capacity
+    , pnwStatus      ∷ !PowerNetworkStatus
+    } deriving (Show, Eq)
+
+-- | Solar output as a fraction of peak, from a raw sun angle
+--   ('World.Time.Types.worldTimeToSunAngle': 0 = midnight, 0.25 = dawn,
+--   0.5 = noon, 0.75 = dusk). Cosine of the sun's elevation — 1 at noon,
+--   0 at dawn/dusk, clamped to 0 overnight — one of the two curve shapes
+--   the issue leaves open, chosen for being smooth rather than a flat
+--   day/night step.
+solarIntensity ∷ Float → Float
+solarIntensity sunAngle = max 0 (negate (cos (2 * pi * sunAngle)))
+
+neighborsOf ∷ (Int, Int) → [(Int, Int)]
+neighborsOf (x, y) = [(x, y - 1), (x + 1, y), (x, y + 1), (x - 1, y)]
+
+-- | Flood-fill connected components of a set of wire tiles (4-dir
+--   cardinal adjacency).
+wireComponents ∷ HS.HashSet (Int, Int) → [HS.HashSet (Int, Int)]
+wireComponents tiles = go (HS.toList tiles) HS.empty []
+  where
+    go [] _ acc = acc
+    go (t : ts) seen acc
+        | HS.member t seen = go ts seen acc
+        | otherwise =
+            let comp = bfs (HS.singleton t) [t]
+            in go ts (HS.union seen comp) (comp : acc)
+    bfs visited [] = visited
+    bfs visited (cur : rest) =
+        let fresh = [ n | n ← neighborsOf cur
+                         , HS.member n tiles
+                         , not (HS.member n visited) ]
+        in bfs (foldl' (flip HS.insert) visited fresh) (rest ++ fresh)
+
+-- | A tile attaches to a wire component if it sits ON the wire (rare — a
+--   building could share a tile with a wire overlay) or orthogonally
+--   beside it.
+attachedTo ∷ (Int, Int) → HS.HashSet (Int, Int) → Bool
+attachedTo tile comp = HS.member tile comp ∨ any (`HS.member` comp) (neighborsOf tile)
+
+-- | Group a world's nodes by which wire component they attach to,
+--   looking each one up in @nodes@ (the single source of truth for its
+--   current role/wattage/capacity/charge) by id. Bare wire runs with no
+--   attached node produce no group, and a position with no matching node
+--   (or a node with no position) is silently skipped — both are
+--   defensive, not expected in practice.
+groupByComponent ∷ [HS.HashSet (Int, Int)] → PowerNodes
+                 → HM.HashMap PowerNodeId (Int, Int) → [[PowerNode]]
+groupByComponent comps nodes positions =
+    [ grp | comp ← comps
+          , let grp = [ n | (nid, tile) ← HM.toList positions
+                           , attachedTo tile comp
+                           , Just n ← [lookupPowerNode nid nodes] ]
+          , not (null grp) ]
+
+-- | Distribute a charge (non-negative Wh) across batteries proportional
+--   to each one's remaining headroom, so a fuller battery takes less.
+--   Surplus beyond total capacity is curtailed (lost), like a full bank
+--   spilling excess solar.
+chargeBatteries ∷ Float → [PowerNode] → [PowerNode]
+chargeBatteries wh batteries =
+    let headrooms     = [ max 0 (pnCapacityWh b - pnStoredWh b) | b ← batteries ]
+        totalHeadroom = sum headrooms
+    in if totalHeadroom ≤ 0
+       then batteries
+       else [ b { pnStoredWh = pnStoredWh b + min hr (wh * (hr / totalHeadroom)) }
+            | (b, hr) ← zip batteries headrooms ]
+              -- clamp each share at its OWN headroom: when wh exceeds
+              -- totalHeadroom every share would otherwise overshoot its
+              -- battery's capacity by the same ratio — clamping fills
+              -- each exactly full instead (the curtailed-surplus case).
+
+-- | Distribute a discharge (non-negative Wh demand) across batteries
+--   proportional to each one's current stored charge. When the demand
+--   exceeds total stored, every battery's share exceeds what it holds
+--   and all drain to exactly 0 (full depletion, not a favored survivor).
+dischargeBatteries ∷ Float → [PowerNode] → [PowerNode]
+dischargeBatteries wh batteries =
+    let stores      = map pnStoredWh batteries
+        totalStored = sum stores
+    in if totalStored ≤ 0
+       then batteries
+       else [ b { pnStoredWh = max 0 (pnStoredWh b - wh * (s / totalStored)) }
+            | (b, s) ← zip batteries stores ]
+
+-- | One network's aggregate numbers plus its batteries' updated charge
+--   after @dtHours@ of the given solar intensity vs. registered drain.
+--   @dtHours = 0@ is a pure read — no mutation, current numbers only
+--   (what 'computeSnapshots' uses for a live query between ticks).
+tickGroup ∷ Float → HM.HashMap PowerNodeId Float → Float
+          → [PowerNode] → ([PowerNode], PowerNetworkSnapshot)
+tickGroup intensity drainByNode dtHours nodes =
+    let generationW      = sum [ pnPeakWatts n * intensity
+                                | n ← nodes, pnRole n ≡ PowerSource ]
+        drainW           = sum [ HM.lookupDefault 0 (pnId n) drainByNode | n ← nodes ]
+        batteries        = [ n | n ← nodes, pnRole n ≡ PowerStorage ]
+        totalCap         = sum (map pnCapacityWh batteries)
+        deltaWh          = (generationW - drainW) * dtHours
+        batteries'       = if deltaWh ≥ 0
+                            then chargeBatteries deltaWh batteries
+                            else dischargeBatteries (negate deltaWh) batteries
+        byId             = HM.fromList [ (pnId b, b) | b ← batteries' ]
+        updated          = [ HM.lookupDefault n (pnId n) byId | n ← nodes ]
+        totalStoredAfter = sum (map pnStoredWh batteries')
+        -- Rate-based, not energy-based: browned out only when CURRENT
+        -- demand exceeds CURRENT supply and there's no stored charge
+        -- left to cover the gap. Independent of dtHours so a live query
+        -- (computeSnapshots, dtHours = 0) reports the same status a
+        -- tick would — "would this network keep the lights on right
+        -- now", not "did energy actually move this call".
+        status           = if generationW ≥ drainW ∨ totalStoredAfter > 1.0e-6
+                            then Powered else Brownout
+    in ( updated
+       , PowerNetworkSnapshot (map pnId nodes) generationW drainW
+                              totalStoredAfter totalCap status )
+
+-- | Every connected network's current numbers, read-only (no charge
+--   mutation) — what a Lua query reports at any instant between ticks.
+computeSnapshots ∷ Float → HM.HashMap PowerNodeId Float → HS.HashSet (Int, Int)
+                 → PowerNodes → HM.HashMap PowerNodeId (Int, Int)
+                 → [PowerNetworkSnapshot]
+computeSnapshots sunAngle drainByNode wireTiles nodes positions =
+    [ snd (tickGroup (solarIntensity sunAngle) drainByNode 0 grp)
+    | grp ← groupByComponent (wireComponents wireTiles) nodes positions ]
+
+-- | Advance every network on a page by @dtGameSeconds@ of generation vs.
+--   registered drain, folding each network's updated battery charge back
+--   into the node registry. Nodes not attached to any wire network are
+--   untouched. A no-op for @dtGameSeconds ≤ 0@ (paused / no time passed).
+tickPowerNodes ∷ Float → HM.HashMap PowerNodeId Float → Float
+              → HS.HashSet (Int, Int) → HM.HashMap PowerNodeId (Int, Int)
+              → PowerNodes → PowerNodes
+tickPowerNodes sunAngle drainByNode dtGameSeconds wireTiles positions nodes
+    | dtGameSeconds ≤ 0 = nodes
+    | otherwise =
+        let intensity = solarIntensity sunAngle
+            dtHours   = dtGameSeconds / 3600
+            groups    = groupByComponent (wireComponents wireTiles) nodes positions
+            updates   = concatMap (fst . tickGroup intensity drainByNode dtHours) groups
+        in nodes { pnsNodes = foldl' (\m n → HM.insert (pnId n) n m)
+                                     (pnsNodes nodes) updates }
+
+wireSlotTag ∷ Word8
+wireSlotTag = fromIntegral (fromEnum SWire)
+
+-- | Every (gx, gy) carrying a wire piece across a page's LOADED chunks —
+--   the shared glue between the world-thread tick ('World.Thread.Power')
+--   and a live Lua query, so both see identically-defined connectivity.
+--   A chunk that hasn't loaded contributes no wire, matching how
+--   scripts/wire.lua itself only ever sees loaded-chunk state.
+wireTilesOn ∷ WorldTileData → HS.HashSet (Int, Int)
+wireTilesOn td = HS.fromList
+    [ (gx, gy)
+    | lc ← HM.elems (wtdChunks td)
+    , ((gx, gy, slotTag), _) ← HM.toList (lcStructures lc)
+    , slotTag ≡ wireSlotTag
+    ]
+
+-- | Every node's tile, resolved via the building it rides on and
+--   restricted to one page. A node whose building isn't on this page is
+--   dropped (shouldn't happen — a node only exists riding an
+--   already-placed building on its own page — but cheap to filter
+--   defensively rather than assume).
+positionsOf ∷ WorldPageId → BuildingManager → PowerNodes
+           → HM.HashMap PowerNodeId (Int, Int)
+positionsOf pageId bm nodes = HM.fromList
+    [ (pnId n, (biAnchorX bi, biAnchorY bi))
+    | n ← allNodes nodes
+    , Just bi ← [HM.lookup (pnBuilding n) (bmInstances bm)]
+    , biPage bi ≡ pageId
+    ]

--- a/src/Power/Types.hs
+++ b/src/Power/Types.hs
@@ -8,11 +8,12 @@
 --   persisted as its own 'WorldPageSave' field, pruned to live buildings
 --   on load.
 --
---   Deliberately NOT here: wire adjacency / network membership (#359),
---   connected-components + energy balance (#360), and consumer drain
---   (#361) — this registry only needs to expose a stable id + building +
---   role + parameters for those to query later, per #358's "network-
---   attachment-ready without implementing attachment" scope.
+--   Wire adjacency / connected-components + energy balance live in
+--   'Power.Network' (#360); consumer drain (#361) is still deferred.
+--   This registry additionally carries each storage node's own charge
+--   ('pnStoredWh'), the one piece of #360 state that must survive save/
+--   load — connectivity and the tick's generation/drain numbers are all
+--   recomputed fresh from wire + node positions, never persisted.
 module Power.Types
     ( PowerRole(..)
     , PowerNodeId(..)
@@ -62,6 +63,10 @@ data PowerNode = PowerNode
       --   Meaningful for 'PowerSource'; 0 for storage nodes.
     , pnCapacityWh ∷ !Float
       -- ^ Meaningful for 'PowerStorage'; 0 for source nodes.
+    , pnStoredWh   ∷ !Float
+      -- ^ Current charge (#360). Meaningful for 'PowerStorage'; always 0
+      --   for source nodes (a panel has no charge of its own to report).
+      --   Appended field — save v75.
     } deriving (Show, Eq, Generic, Serialize)
 
 -- | The per-world node set. The id counter lives inside so it persists
@@ -84,7 +89,10 @@ powerNodeSpecFor "solar_panel"          = Just (PowerSource,  400)
 powerNodeSpecFor "high_voltage_battery" = Just (PowerStorage, 5000)
 powerNodeSpecFor _                      = Nothing
 
--- | Register a new node riding an already-placed building.
+-- | Register a new node riding an already-placed building. A freshly
+--   placed battery starts empty (pnStoredWh = 0) — it charges up from
+--   the network like any other newly-wired storage, rather than
+--   starting pre-filled.
 addPowerNode ∷ BuildingId → PowerRole → Float → PowerNodes
              → (PowerNodes, PowerNodeId)
 addPowerNode bid role param nodes =
@@ -95,6 +103,7 @@ addPowerNode bid role param nodes =
             , pnRole       = role
             , pnPeakWatts  = if role ≡ PowerSource  then param else 0
             , pnCapacityWh = if role ≡ PowerStorage then param else 0
+            , pnStoredWh   = 0
             }
     in ( nodes { pnsNodes  = HM.insert nid node (pnsNodes nodes)
                , pnsNextId = pnsNextId nodes + 1 }

--- a/src/World/Save/Types.hs
+++ b/src/World/Save/Types.hs
@@ -121,7 +121,15 @@ saveMagic = 0x53595241
 --       river carve. Positional Generic Serialize drops the trailing
 --       field, incompatible with v61 (#385).
 currentSaveVersion ∷ Int
-currentSaveVersion = 74  -- v74: CraftBill (nested in WorldPageSave's
+currentSaveVersion = 75  -- v75: PowerNode (nested in WorldPageSave's
+                         --      wpsPowerNodes) gains trailing
+                         --      'pnStoredWh' (#360) — a storage node's
+                         --      current charge, the one piece of the
+                         --      network energy balance that must
+                         --      survive save/load (connectivity +
+                         --      generation/drain are recomputed fresh
+                         --      from wire + node positions).
+                         -- v74: CraftBill (nested in WorldPageSave's
                          --      wpsCraftBills) gains trailing 'cbSeq'
                          --      and 'cbPaused' (#330's manual-reorder
                          --      + pause bill controls).
@@ -321,10 +329,12 @@ data WorldPageSave = WorldPageSave
         --   whose station was orphaned. Appended for save v72.
     , wpsPowerNodes ∷ !PowerNodes
         -- ^ Power-node registry (#358): placed solar-panel/battery
-        --   source + storage nodes (role + parameters). Like craft
-        --   bills, references a BuildingId that restores verbatim (see
-        --   wpsBuildings); restore prunes nodes whose building was
-        --   orphaned. Appended for save v73.
+        --   source + storage nodes (role + parameters), plus each
+        --   storage node's current charge (pnStoredWh, #360). Like
+        --   craft bills, references a BuildingId that restores
+        --   verbatim (see wpsBuildings); restore prunes nodes whose
+        --   building was orphaned. Appended for save v73, pnStoredWh
+        --   for v75.
     } deriving (Show, Serialize, Generic)
 
 -- | Everything needed to reconstruct the saved game. Per-world state is

--- a/src/World/Thread/Power.hs
+++ b/src/World/Thread/Power.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE Strict, UnicodeSyntax #-}
+-- | Per-page power-network tick (#360).
+--
+--   Runs beside the world clock ('World.Thread.Time.tickWorldTime'), once
+--   per visible page per world-thread iteration, in GAME-seconds — the
+--   same clock flora regrowth and item cooling follow, so a network's
+--   charge tracks a "simulated day" under a time-scale fast-forward and
+--   freezes with the pause flag. The issue's own text calls out living
+--   "on the sim thread beside the fluid sim", but that thread
+--   ('Sim.Thread') mirrors per-chunk terrain/fluid CELL data into its own
+--   state specifically for fluid's per-cell throughput needs — power only
+--   needs the sparse, already-authoritative wire-tile set and the small
+--   node registry the world thread already owns, so ticking here avoids
+--   rebuilding that mirroring machinery for a much smaller problem.
+--
+--   Every tracked power node lives on exactly one page (see
+--   Building.Types.biPage), so the wire tiles + nodes gathered here are
+--   already page-scoped — no cross-page filtering needed beyond that.
+module World.Thread.Power
+    ( tickPowerNetworks
+    ) where
+
+import UPrelude
+import qualified Data.HashMap.Strict as HM
+import Data.IORef (readIORef, atomicModifyIORef')
+import Engine.Core.State (EngineEnv(..))
+import Power.Types (PowerNodes(..))
+import Power.Network (tickPowerNodes, wireTilesOn, positionsOf)
+import World.Time.Types (WorldTime, worldTimeToSunAngle)
+import World.Types (WorldPageId, WorldState(..))
+
+-- | Advance one page's power networks by @dtGame@ game-seconds. No-op
+--   when the page has no power nodes at all (the common case while the
+--   power epic is unused) — cheap enough to check every tick without a
+--   full wire-tile scan.
+tickPowerNetworks ∷ EngineEnv → WorldPageId → WorldState → Float → IO ()
+tickPowerNetworks env pageId ws dtGame = do
+    nodes ← readIORef (wsPowerNodesRef ws)
+    when (not (HM.null (pnsNodes nodes))) $ do
+        wt  ← readIORef (wsTimeRef ws)
+        td  ← readIORef (wsTilesRef ws)
+        bm  ← readIORef (buildingManagerRef env)
+        let sunAngle    = worldTimeToSunAngle (wt ∷ WorldTime)
+            wireTiles   = wireTilesOn td
+            positions   = positionsOf pageId bm nodes
+            drainByNode = HM.empty
+              -- ^ #361's real requires_power consumers aren't wired up
+              --   yet; tickPowerNodes already accepts this map so the
+              --   balance math (charge/hold/brownout) is fully covered
+              --   by Test.Headless.Power.Network today.
+            nodes'      = tickPowerNodes sunAngle drainByNode dtGame
+                                          wireTiles positions nodes
+        atomicModifyIORef' (wsPowerNodesRef ws) (const (nodes', ()))

--- a/src/World/Thread/Power.hs
+++ b/src/World/Thread/Power.hs
@@ -35,19 +35,26 @@ import World.Types (WorldPageId, WorldState(..))
 --   full wire-tile scan.
 tickPowerNetworks ∷ EngineEnv → WorldPageId → WorldState → Float → IO ()
 tickPowerNetworks env pageId ws dtGame = do
-    nodes ← readIORef (wsPowerNodesRef ws)
-    when (not (HM.null (pnsNodes nodes))) $ do
-        wt  ← readIORef (wsTimeRef ws)
-        td  ← readIORef (wsTilesRef ws)
-        bm  ← readIORef (buildingManagerRef env)
+    nodes0 ← readIORef (wsPowerNodesRef ws)
+    when (not (HM.null (pnsNodes nodes0))) $ do
+        wt ← readIORef (wsTimeRef ws)
+        td ← readIORef (wsTilesRef ws)
+        bm ← readIORef (buildingManagerRef env)
         let sunAngle    = worldTimeToSunAngle (wt ∷ WorldTime)
             wireTiles   = wireTilesOn td
-            positions   = positionsOf pageId bm nodes
             drainByNode = HM.empty
               -- ^ #361's real requires_power consumers aren't wired up
               --   yet; tickPowerNodes already accepts this map so the
               --   balance math (charge/hold/brownout) is fully covered
               --   by Test.Headless.Power.Network today.
-            nodes'      = tickPowerNodes sunAngle drainByNode dtGame
-                                          wireTiles positions nodes
-        atomicModifyIORef' (wsPowerNodesRef ws) (const (nodes', ()))
+        -- Snapshot-and-clobber would lose any node power.placeNode
+        -- registers between the read above and the write below (both
+        -- this tick and placeNode hit wsPowerNodesRef). Recompute
+        -- positions from and fold the tick into whatever the CURRENT
+        -- registry is inside the atomic update instead — same pattern
+        -- as Combat.Wounds.tickAllWounds / Unit.Thread.publishToRender.
+        atomicModifyIORef' (wsPowerNodesRef ws) $ \current →
+            let positions = positionsOf pageId bm current
+            in ( tickPowerNodes sunAngle drainByNode dtGame
+                                 wireTiles positions current
+               , () )

--- a/src/World/Thread/Time.hs
+++ b/src/World/Thread/Time.hs
@@ -9,6 +9,7 @@ import Engine.Core.State (EngineEnv(..))
 import World.Types
 import World.Flora.Harvest (tickFloraHarvests)
 import World.Thread.ItemTemp (tickItemTemperatures)
+import World.Thread.Power (tickPowerNetworks)
 
 -- | Advance time for all visible worlds, write sun angle to the shared ref.
 tickWorldTime ∷ EngineEnv → Float → IO ()
@@ -63,6 +64,11 @@ tickWorldTime env dt = do
                     -- game-second clock: tracked (hot/cold) items on
                     -- this page relax toward their tile's ambient.
                     tickItemTemperatures env pageId worldState dtGame
+                    -- Power networks (#360) follow it too: solar
+                    -- generation (scaled by this page's own sun angle)
+                    -- charges wired batteries over the same simulated
+                    -- day/night cycle.
+                    tickPowerNetworks env pageId worldState dtGame
 
     case wmVisible manager of
         (pageId:_) → case lookup pageId (wmWorlds manager) of

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -186,6 +186,7 @@ test-suite synarchy-test-headless
                    Test.Headless.Craft.Execute
                    Test.Headless.Craft.Bills
                    Test.Headless.Power.Types
+                   Test.Headless.Power.Network
                    Test.Headless.UI.Tooltip
                    Test.Headless.World.Calendar
                    Test.Headless.World.TimeLocal
@@ -487,6 +488,7 @@ library
                      Engine.Asset.YamlRecipes
                      Engine.Scripting.Lua.API.Craft
                      Power.Types
+                     Power.Network
                      Engine.Scripting.Lua.API.Power
                      Engine.Scripting.Lua.API.Repair
                      Location.Types
@@ -520,6 +522,7 @@ library
                      World.Thread.Cursor
                      World.Thread.Time
                      World.Thread.ItemTemp
+                     World.Thread.Power
                      World.Thread.ChunkLoading
                      World.Thread.Command
                      World.Thread.Command.Basic

--- a/test-headless/Spec.hs
+++ b/test-headless/Spec.hs
@@ -47,6 +47,7 @@ import qualified Test.Headless.Construct.Corners as ConstructCorners
 import qualified Test.Headless.Craft.Execute as CraftExecute
 import qualified Test.Headless.Craft.Bills as CraftBills
 import qualified Test.Headless.Power.Types as PowerTypes
+import qualified Test.Headless.Power.Network as PowerNetwork
 import qualified Test.Headless.UI.Tooltip as UITooltip
 import qualified Test.Headless.World.Calendar as Calendar
 import qualified Test.Headless.World.FloraGrowth as FloraGrowth
@@ -112,6 +113,7 @@ main = hspec $ do
     describe "Craft.Execute" CraftExecute.spec
     describe "Craft.Bills" CraftBills.spec
     describe "Power.Types" PowerTypes.spec
+    describe "Power.Network" PowerNetwork.spec
     describe "UI.Tooltip" UITooltip.spec
     describe "World.Calendar" Calendar.spec
     describe "World.FloraGrowth" FloraGrowth.spec

--- a/test-headless/Test/Headless/Power/Network.hs
+++ b/test-headless/Test/Headless/Power/Network.hs
@@ -89,6 +89,41 @@ spec = do
                 [net] → pnwNodeIds net `shouldBe` [srcId]
                 _     → expectationFailure ("expected exactly one network, got " <> show nets)
 
+        it "a node bridging two otherwise-disconnected wire stubs merges them into one network" $ do
+            -- Two 1-tile wire stubs, (4,5) and (6,5), NOT adjacent to each
+            -- other (2 apart in x) — wireComponents sees them as separate
+            -- components. A battery at (5,5) is orthogonally adjacent to
+            -- BOTH: it must bridge them into one network, not attach to
+            -- each independently.
+            let (n1, srcAId) = addPowerNode panel PowerSource 100 emptyPowerNodes
+                (n2, srcBId) = addPowerNode farPanel PowerSource 100 n1
+                (n3, batId)  = addPowerNode battery PowerStorage 5000 n2
+                positions = HM.fromList [ (srcAId, (4, 4))
+                                        , (batId,  (5, 5))
+                                        , (srcBId, (7, 5)) ]
+                wire = HS.fromList [(4, 5), (6, 5)]
+                nets = computeSnapshots noon HM.empty wire n3 positions
+            case nets of
+                [net] → HS.fromList (pnwNodeIds net)
+                            `shouldBe` HS.fromList [srcAId, batId, srcBId]
+                _     → expectationFailure
+                            ("expected exactly one merged network, got " <> show nets)
+
+        it "the bridged network's battery is charged by BOTH sources, not overwritten" $ do
+            let (n1, srcAId) = addPowerNode panel PowerSource 100 emptyPowerNodes
+                (n2, srcBId) = addPowerNode farPanel PowerSource 100 n1
+                (n3, batId)  = addPowerNode battery PowerStorage 5000 n2
+                positions = HM.fromList [ (srcAId, (4, 4))
+                                        , (batId,  (5, 5))
+                                        , (srcBId, (7, 5)) ]
+                wire = HS.fromList [(4, 5), (6, 5)]
+                -- noon (full intensity), 1 hour: 100W + 100W = 200 Wh into
+                -- the one shared battery. A regression here (the battery
+                -- ending up at 100, or split across two spurious networks)
+                -- would mean one source's contribution was silently lost.
+                ticked = tickPowerNodes noon HM.empty 3600 wire positions n3
+            pnStoredWh ⊚ lookupPowerNode batId ticked `shouldBe` Just 200
+
     describe "computeSnapshots — instantaneous status" $ do
         it "generation covering drain reads Powered even with no storage" $ do
             let (n1, srcId) = addPowerNode panel PowerSource 400 emptyPowerNodes

--- a/test-headless/Test/Headless/Power/Network.hs
+++ b/test-headless/Test/Headless/Power/Network.hs
@@ -1,0 +1,181 @@
+{-# LANGUAGE UnicodeSyntax, OverloadedStrings #-}
+-- | Power-network connectivity + energy balance tests (#360): the pure
+--   flood-fill + tick math in Power.Network. No engine/Lua needed — the
+--   connectivity + brownout math is fully exercised here with synthetic
+--   drain, since #361's real consumers don't exist yet (see
+--   Power.Network's module haddock).
+module Test.Headless.Power.Network (spec) where
+
+import UPrelude
+import Test.Hspec
+import qualified Data.HashMap.Strict as HM
+import qualified Data.HashSet as HS
+import Power.Types
+import Power.Network
+import Building.Types (BuildingId(..))
+
+panel, battery, battery2, farPanel ∷ BuildingId
+panel    = BuildingId 1
+battery  = BuildingId 2
+battery2 = BuildingId 3
+farPanel = BuildingId 4
+
+-- | Seed a battery's stored charge directly (bypassing the tick), for
+--   scenarios that start mid-charge/mid-discharge.
+seedStored ∷ PowerNodeId → Float → PowerNodes → PowerNodes
+seedStored nid wh nodes =
+    nodes { pnsNodes = HM.adjust (\n → n { pnStoredWh = wh }) nid (pnsNodes nodes) }
+
+noon, midnight, dawn, dusk ∷ Float
+noon     = 0.5
+midnight = 0.0
+dawn     = 0.25
+dusk     = 0.75
+
+spec ∷ Spec
+spec = do
+    describe "solarIntensity" $ do
+        it "peaks at 1 at noon" $
+            solarIntensity noon `shouldBe` 1.0
+
+        it "is 0 at midnight" $
+            solarIntensity midnight `shouldBe` 0.0
+
+        it "is 0 at dawn and dusk" $ do
+            solarIntensity dawn `shouldSatisfy` (< 1.0e-6)
+            solarIntensity dusk `shouldSatisfy` (< 1.0e-6)
+
+    describe "wireComponents" $ do
+        it "an empty tile set has no components" $
+            wireComponents HS.empty `shouldBe` []
+
+        it "a straight run of wire is one component" $
+            wireComponents (HS.fromList [(0,0), (1,0), (2,0)])
+                `shouldBe` [HS.fromList [(0,0), (1,0), (2,0)]]
+
+        it "two disjoint runs are two components" $
+            length (wireComponents (HS.fromList [(0,0), (1,0), (10,10), (11,10)]))
+                `shouldBe` 2
+
+        it "diagonal-only tiles do NOT connect (4-dir adjacency only)" $
+            length (wireComponents (HS.fromList [(0,0), (1,1)])) `shouldBe` 2
+
+    describe "computeSnapshots — connectivity" $ do
+        it "a source and a battery joined by ONE wire tile share a network" $ do
+            let (n1, srcId) = addPowerNode panel PowerSource 400 emptyPowerNodes
+                (n2, batId) = addPowerNode battery PowerStorage 5000 n1
+                positions   = HM.fromList [(srcId, (0, 0)), (batId, (2, 0))]
+                wire        = HS.singleton (1, 0)
+                nets        = computeSnapshots noon HM.empty wire n2 positions
+            case nets of
+                [net] → HS.fromList (pnwNodeIds net) `shouldBe` HS.fromList [srcId, batId]
+                _     → expectationFailure ("expected exactly one network, got " <> show nets)
+
+        it "two nodes with no wire at all attach to no network" $ do
+            let (n1, srcId) = addPowerNode panel PowerSource 400 emptyPowerNodes
+                (n2, batId) = addPowerNode battery PowerStorage 5000 n1
+                positions   = HM.fromList [(srcId, (0, 0)), (batId, (1, 0))]
+                nets        = computeSnapshots noon HM.empty HS.empty n2 positions
+            nets `shouldBe` []
+              -- adjacent tiles, but NO wire tile between them => not networked
+
+        it "a node with no wire adjacent to it isn't networked, even if another node is" $ do
+            let (n1, srcId) = addPowerNode panel PowerSource 400 emptyPowerNodes
+                (n2, farId) = addPowerNode farPanel PowerSource 400 n1
+                positions   = HM.fromList [(srcId, (0, 0)), (farId, (50, 50))]
+                wire        = HS.singleton (1, 0)
+                nets        = computeSnapshots noon HM.empty wire n2 positions
+            case nets of
+                [net] → pnwNodeIds net `shouldBe` [srcId]
+                _     → expectationFailure ("expected exactly one network, got " <> show nets)
+
+    describe "computeSnapshots — instantaneous status" $ do
+        it "generation covering drain reads Powered even with no storage" $ do
+            let (n1, srcId) = addPowerNode panel PowerSource 400 emptyPowerNodes
+                positions   = HM.singleton srcId (0, 0)
+                wire        = HS.singleton (1, 0)
+                drain       = HM.singleton srcId 100
+                nets        = computeSnapshots noon drain wire n1 positions
+            map pnwStatus nets `shouldBe` [Powered]
+
+        it "drain exceeding generation with no storage reads Brownout" $ do
+            let (n1, srcId) = addPowerNode panel PowerSource 400 emptyPowerNodes
+                positions   = HM.singleton srcId (0, 0)
+                wire        = HS.singleton (1, 0)
+                drain       = HM.singleton srcId 500
+                nets        = computeSnapshots noon drain wire n1 positions
+            map pnwStatus nets `shouldBe` [Brownout]
+
+        it "a deficit is Powered as long as the battery still holds charge" $ do
+            let (n1, srcId) = addPowerNode panel PowerSource 100 emptyPowerNodes
+                (n2, batId) = addPowerNode battery PowerStorage 5000 n1
+                seeded      = seedStored batId 10 n2
+                positions   = HM.fromList [(srcId, (0, 0)), (batId, (2, 0))]
+                wire        = HS.singleton (1, 0)
+                drain       = HM.singleton srcId 1000
+                nets        = computeSnapshots midnight drain wire seeded positions
+            map pnwStatus nets `shouldBe` [Powered]
+
+    describe "tickPowerNodes — charging" $ do
+        it "a full hour at noon charges the battery by peakWatts Wh" $ do
+            let (n1, srcId) = addPowerNode panel PowerSource 400 emptyPowerNodes
+                (n2, batId) = addPowerNode battery PowerStorage 5000 n1
+                positions   = HM.fromList [(srcId, (0, 0)), (batId, (2, 0))]
+                wire        = HS.singleton (1, 0)
+                n3          = tickPowerNodes noon HM.empty 3600 wire positions n2
+            pnStoredWh ⊚ lookupPowerNode batId n3 `shouldBe` Just 400
+
+        it "charging never exceeds capacity — surplus is curtailed" $ do
+            let (n1, srcId) = addPowerNode panel PowerSource 400 emptyPowerNodes
+                (n2, batId) = addPowerNode battery PowerStorage 500 n1
+                seeded      = seedStored batId 400 n2
+                positions   = HM.fromList [(srcId, (0, 0)), (batId, (2, 0))]
+                wire        = HS.singleton (1, 0)
+                n3          = tickPowerNodes noon HM.empty 3600 wire positions seeded
+            pnStoredWh ⊚ lookupPowerNode batId n3 `shouldBe` Just 500
+
+        it "no time passing (dtGameSeconds <= 0) is a no-op" $ do
+            let (n1, srcId) = addPowerNode panel PowerSource 400 emptyPowerNodes
+                (n2, batId) = addPowerNode battery PowerStorage 5000 n1
+                positions   = HM.fromList [(srcId, (0, 0)), (batId, (2, 0))]
+                wire        = HS.singleton (1, 0)
+                n3          = tickPowerNodes noon HM.empty 0 wire positions n2
+            pnStoredWh ⊚ lookupPowerNode batId n3 `shouldBe` Just 0
+
+    describe "tickPowerNodes — discharging + brownout" $ do
+        it "a synthetic drain at night discharges the battery" $ do
+            let (n1, srcId) = addPowerNode panel PowerSource 400 emptyPowerNodes
+                (n2, batId) = addPowerNode battery PowerStorage 5000 n1
+                seeded      = seedStored batId 50 n2
+                positions   = HM.fromList [(srcId, (0, 0)), (batId, (2, 0))]
+                wire        = HS.singleton (1, 0)
+                drain       = HM.singleton srcId 100
+                -- midnight: 0 generation, 100W drain, 1h => -100Wh from
+                -- 50Wh stored => clamped to 0
+                n3          = tickPowerNodes midnight drain 3600 wire positions seeded
+            pnStoredWh ⊚ lookupPowerNode batId n3 `shouldBe` Just 0
+
+        it "depleting the battery reports Brownout on the next query" $ do
+            let (n1, srcId) = addPowerNode panel PowerSource 400 emptyPowerNodes
+                (n2, batId) = addPowerNode battery PowerStorage 5000 n1
+                positions   = HM.fromList [(srcId, (0, 0)), (batId, (2, 0))]
+                wire        = HS.singleton (1, 0)
+                drain       = HM.singleton srcId 100
+                nets        = computeSnapshots midnight drain wire n2 positions
+            map pnwStatus nets `shouldBe` [Brownout]
+
+        it "two batteries discharge proportionally to their own charge" $ do
+            let (n1, srcId)  = addPowerNode panel PowerSource 0 emptyPowerNodes
+                (n2, batId1) = addPowerNode battery PowerStorage 5000 n1
+                (n3, batId2) = addPowerNode battery2 PowerStorage 5000 n2
+                seeded = seedStored batId1 100 (seedStored batId2 200 n3)
+                positions = HM.fromList [ (srcId, (0, 0))
+                                        , (batId1, (2, 0)), (batId2, (2, 1)) ]
+                wire  = HS.fromList [(1, 0), (1, 1)]
+                drain = HM.singleton srcId 300
+                -- 300W drain for 1h = 300Wh demand, split 1:2 by current
+                -- charge (100 vs 200) => battery1 loses 100 (empty),
+                -- battery2 loses 200 (empty) — both exactly drained.
+                ticked = tickPowerNodes midnight drain 3600 wire positions seeded
+            pnStoredWh ⊚ lookupPowerNode batId1 ticked `shouldBe` Just 0
+            pnStoredWh ⊚ lookupPowerNode batId2 ticked `shouldBe` Just 0

--- a/tools/power_probe.py
+++ b/tools/power_probe.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Power-node placement probe (#358) — the build-tool-driven path, not
-just the raw Lua API.
+"""Power-node placement + network probe (#358/#360) — the build-tool-
+driven path, not just the raw Lua API.
 
 #358 ships the power-node registry (Power.Types), the power.* Lua verbs
 (isPlaceable / placeNode / getNode / getNodeForBuilding / listNodes), and
@@ -9,13 +9,23 @@ buildTool.commitPlacement routes a solar_panel / high_voltage_battery
 placement through power.placeNode against the currently-selected unit
 (consuming the item). Ordinary non-power buildings are handled by the
 normal build-tool paths (starting-building spawn or construction
-designation), not by this power placement helper. This probe exercises
-the routed power path end-to-end, not just the underlying Haskell API,
-then proves the result through a save -> quit -> fresh-restart -> load
-round-trip (the gold-standard save check, mirroring
-multiworld_save_probe.py) since a power node is only
-"network-attachment-ready" if it actually reconnects to its building
-after a reload.
+designation), not by this power placement helper. #360 adds wire
+connectivity + the energy balance tick (Power.Network): this probe wires
+the placed nodes together with scripts/wire.lua's M.place (the same verb
+the chop/construct-style wire designation job calls), confirms
+power.listNetworks/getNetworkForNode report the connected component, and
+fast-forwards the world clock to show a wired battery's storedWh actually
+rise under real daylight generation. It then proves everything (nodes AND
+their charge) through a save -> quit -> fresh-restart -> load round-trip
+(the gold-standard save check, mirroring multiworld_save_probe.py) since a
+power node is only "network-attachment-ready" if it actually reconnects to
+its building after a reload.
+
+Brownout-under-load isn't probed here: #361 (the generic requires_power
+consumer) doesn't exist yet, so there's no real drain to attach to a
+network. That side of the balance math (charge, hold, brownout under a
+synthetic drain) is covered by the pure hspec suite
+(Test.Headless.Power.Network), which needs no real consumer to exercise it.
 
 What it does:
   1. Boots a headless engine, loads defs, builds a flat arena, spawns a
@@ -30,8 +40,14 @@ What it does:
      (power.getNode / getNodeForBuilding).
   5. Exhausting the mule's remaining solar panels makes the next
      commitPlacement refuse (inventory unaffected).
-  6. Save -> quit -> fresh restart -> reload defs -> load: every placed
-     building AND its power node survive, reconnected by BuildingId.
+  6. Wire connects the panel + battery: power.listNetworks/
+     getNetworkForNode report them on ONE network; the unwired second
+     panel reports no network at all.
+  7. Fast-forwarding the world clock (world.setTimeScale) over real
+     daylight hours shows the wired battery's storedWh actually rise.
+  8. Save -> quit -> fresh restart -> reload defs -> load: every placed
+     building, its power node, AND the battery's charged storedWh survive,
+     reconnected by BuildingId.
 
 Usage: python3 tools/power_probe.py [--port 9358]
 Exit 0 = every check passed.
@@ -283,7 +299,48 @@ def main() -> int:
         passed = check(passed, node_count == expected_nodes,
                        f"listNodes reports {expected_nodes} nodes", node_count)
 
-        # --- 6. Save -> quit -> fresh restart -> load ---
+        # --- 6. Wire connectivity (#360): join the panel (7,5) and the
+        # battery (8,5) with a two-tile wire run just south of them, and
+        # confirm both land on ONE network. M.place is the same verb the
+        # wire designation job calls (scripts/unit_ai.lua) — calling it
+        # directly here skips the job/AI machinery, matching how other
+        # probes call a tool module's placement function directly.
+        for gx, gy in [(7, 6), (8, 6)]:
+            send(port, f"require('scripts.wire').place({gx}, {gy}); return 'ok'")
+
+        panel_node = jget(port, f"return power.getNodeForBuilding({panel_bid})")
+        batt_node = jget(port, f"return power.getNodeForBuilding({batt_bid})")
+        panel_net = jget(port, f"return power.getNetworkForNode({panel_node['id']})")
+        batt_net = jget(port, f"return power.getNetworkForNode({batt_node['id']})")
+        passed = check(passed,
+            isinstance(panel_net, dict) and isinstance(batt_net, dict)
+            and sorted(panel_net.get("nodeIds", [])) == sorted(batt_net.get("nodeIds", []))
+            and len(panel_net.get("nodeIds", [])) == 2,
+            "solar panel + battery share one network after wiring",
+            {"panel_net": panel_net, "battery_net": batt_net})
+
+        second_panel_node = jget(port,
+            f"return power.getNodeForBuilding({second_panel_bid})")
+        lone_net = jget(port,
+            f"return power.getNetworkForNode({second_panel_node['id']})")
+        passed = check(passed, lone_net is None,
+                       "the unwired second solar panel has no network", lone_net)
+
+        # --- 7. Charging over a simulated few hours of daylight ---
+        stored_before = jget(port,
+            f"return power.getNodeForBuilding({batt_bid}).storedWh")
+        send(port, "world.setTimeScale('power_probe', 120); return 'ok'")
+        time.sleep(2.5)
+        send(port, "world.setTimeScale('power_probe', 0); return 'ok'")
+        stored_after = jget(port, f"return power.getNodeForBuilding({batt_bid}).storedWh")
+        passed = check(passed,
+            isinstance(stored_before, (int, float))
+            and isinstance(stored_after, (int, float))
+            and stored_after > stored_before,
+            "battery storedWh rose over simulated daylight "
+            f"({stored_before} -> {stored_after})")
+
+        # --- 8. Save -> quit -> fresh restart -> load ---
         saved = send(port, f"return engine.saveWorld('power_probe', '{save_name}')")
         passed = check(passed, saved.strip() == "true",
                        "engine.saveWorld returned true", saved)
@@ -326,6 +383,13 @@ def main() -> int:
                 and node.get("capacityWh") == want_cap,
                 f"building #{bid}'s power node survived with role/params intact",
                 node)
+            if bid == batt_bid:
+                stored_reloaded = node.get("storedWh") if isinstance(node, dict) else None
+                passed = check(passed,
+                    isinstance(stored_reloaded, (int, float))
+                    and abs(stored_reloaded - stored_after) < 1e-3,
+                    "battery's charged storedWh survived the reload "
+                    f"({stored_after} -> {stored_reloaded})")
 
         node_count_after = as_int(send(port, "local ns=power.listNodes(); return #ns"))
         passed = check(passed, node_count_after == expected_nodes,


### PR DESCRIPTION
## Summary

Core sim for the Power / electrical grid epic (#357), the next unblocked piece after #358 (nodes) and #359 (wire), both merged.

- **`Power.Network`** (new, pure): a "network" is a 4-dir-adjacent connected component of wire tiles (`Structure.Types.SWire`) plus whichever source/storage nodes (`Power.Types.PowerNode`) sit on or orthogonally beside it — two nodes with no wire path between them are never on the same network, even if directly adjacent. Connectivity and a network's generation/drain numbers are recomputed fresh on every tick/query rather than persisted; `PowerNodes` stays the single source of truth for node data (role/wattage/capacity/charge), with a separate tile-position lookup passed alongside it so there's no risk of a caller's copy drifting out of sync with the registry.
- **Solar generation** scales by `World.Time.Types.worldTimeToSunAngle` through a cosine curve (`solarIntensity`: 1 at noon, 0 at dawn/dusk/midnight) — one of the two curve shapes the issue left open.
- **Energy balance**: charging distributes surplus Wh across a network's batteries proportional to remaining headroom (curtailed once every battery is full); discharging distributes proportional to current charge (all batteries drain to exactly 0 together if demand exceeds total stored). A network's status is `Powered`/`Brownout` based on current generation vs. drain and remaining stored charge — rate-based rather than energy-based, so a live query between ticks reports the same thing a tick would.
- **Ticks on the world thread** (`World.Thread.Power`, wired into `tickWorldTime` beside item-temperature/flora) rather than the fluid-specific `Sim.Thread` the issue's text suggested — that thread mirrors per-chunk terrain/fluid *cell* data specifically for fluid's per-cell throughput needs; power only needs the already-authoritative sparse wire-tile set and small node registry the world thread already owns, so ticking there avoids rebuilding that mirroring machinery for a much smaller problem. It follows the same game-scaled `dtGame` clock flora/item-temp use, so `world.setTimeScale` fast-forwards a network's charge exactly like it does a crop's growth.
- **Lua API**: `power.listNetworks()` / `power.getNetworkForNode(nodeId)` report `{nodeIds, generationW, drainW, storedWh, capacityWh, powered}`; `power.getNode`/`getNodeForBuilding`/`listNodes` also gained a `storedWh` field per node.
- **Persistence**: `PowerNode` gains a trailing `pnStoredWh` field (save v75) — the one piece of state that must survive a save, since connectivity and generation/drain are always recomputed fresh.

### Consumer drain (#361) is still out of scope
`tickPowerNodes` takes a `drain-by-node` map parameter so the balance math (charging, holding, brownout under a deficit) is fully exercised and tested *now*; the production call site passes an empty map until #361 has real `requires_power` consumers to populate it from.

## Test plan
- [x] `cabal build all` — clean, no warnings
- [x] `cabal test synarchy-test-headless` — 657 examples, 0 failures (new `Test.Headless.Power.Network`: 21 examples covering flood-fill connectivity incl. 4-dir-only/no-wire-no-network edge cases, instantaneous Powered/Brownout status independent of `dtHours`, charging + capacity clamping, and discharge/brownout under a synthetic drain incl. proportional multi-battery split)
- [x] `python3 tools/world_check.py` — 21/21 seeds pass (no worldgen-output change)
- [x] `python3 tools/test_audit.py` — all 35 groups pass
- [x] Extended `tools/power_probe.py` (the #358/#360 gate) end-to-end over the debug console: placed a solar panel + battery via the real build-tool path, wired them together with `scripts/wire.lua`'s `M.place` (the same verb the wire designation job calls), confirmed `power.listNetworks`/`getNetworkForNode` report them on one network while an unwired second panel reports none, fast-forwarded the world clock and confirmed the battery's `storedWh` actually rose under real daylight generation, then confirmed the charge survives a save → quit → fresh-restart → load round-trip

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)