### PR TITLE
Add crop content + two growth forms (#334)

### DIFF
--- a/data/flora/crops.yaml
+++ b/data/flora/crops.yaml
@@ -1,0 +1,169 @@
+flora:
+  # Cultivated crops (#334) — the two growth forms the farming epic
+  # (#331) calls for, both riding the #332 growth runtime like wild
+  # flora. density: 0.0 on BOTH species: farmed crops shouldn't sprout
+  # in the wild before farming's planting flow (#335/#336) exists to
+  # put them there deliberately. Placeholder art — both reuse an
+  # existing wild-species texture set pending dedicated crop art (same
+  # convention as tools/flora_growth_probe.py's probe_berry fixture).
+
+  # Row crop: a discrete FloraInstance laid at intervals within the
+  # tile (World.Flora.Placement's "row_crop" category — see
+  # rowOffset), same placement/growth/render pipeline as any wild
+  # flora. Fruiting-gated harvest window (like red_raspberry, whose
+  # texture set this reuses).
+  - name: tomato_plant
+    type: row_crop
+    texDir: "assets/textures/flora/red_raspberry"
+    lifecycle: annual
+    phases:
+      - tag: sprout
+        texture: "sprout.png"
+        age: 0
+      - tag: matured
+        texture: "matured.png"
+        age: 60
+      - tag: dead
+        texture: "dead.png"
+        age: 360
+    annualCycle:
+      - tag: dormant
+        startDay: 0
+        texture: "matured_dormant.png"
+      - tag: budding
+        startDay: 30
+        texture: "matured_budding.png"
+      - tag: flowering
+        startDay: 60
+        texture: "matured_flowering.png"
+      - tag: fruiting
+        startDay: 90
+        texture: "matured_fruiting.png"
+      - tag: senescing
+        startDay: 240
+        texture: "matured_senescing.png"
+    cycleOverrides:
+      - phase: sprout
+        cycle: dormant
+        texture: "sprout_dormant.png"
+      - phase: sprout
+        cycle: budding
+        texture: "sprout_budding.png"
+      - phase: sprout
+        cycle: senescing
+        texture: "sprout_senescing.png"
+      - phase: dead
+        cycle: dormant
+        texture: "dead.png"
+      - phase: dead
+        cycle: budding
+        texture: "dead.png"
+      - phase: dead
+        cycle: flowering
+        texture: "dead.png"
+      - phase: dead
+        cycle: fruiting
+        texture: "dead.png"
+      - phase: dead
+        cycle: senescing
+        texture: "dead.png"
+    harvestable:
+      tags: [fruit]
+      yield:
+        - id: tomato
+          count: [2, 4]
+      regrowth_time: 43200
+      harvested_texture: "matured_senescing.png"
+    worldGen:
+      category: row_crop
+      minTemp: 10
+      maxTemp: 32
+      idealTemp: 22
+      minPrecip: 0.3
+      maxPrecip: 0.9
+      idealPrecip: 0.6
+      minAlt: -50
+      maxAlt: 400
+      idealAlt: 100
+      minHumidity: 0.3
+      maxHumidity: 0.9
+      idealHumidity: 0.6
+      maxSlope: 2
+      density: 0.0
+      footprint: 6
+
+  # Groundcover crop: NOT placed as a FloraInstance at all — it's
+  # planted via world.plantCropAt into a World.Flora.CropPlot record
+  # and rendered as the tile's ctVeg fill (World.Render.Quads), with
+  # its texture DERIVED from this species' phases/cycle exactly like a
+  # row crop. worldGen exists only for schema completeness (every
+  # loaded species needs one); density 0.0 keeps it out of natural
+  # FloraInstance placement, which would otherwise render it as a
+  # floating sprite like any other registered species. No annual
+  # fruiting stage — once past its sprout phase it's harvestable
+  # year-round like the reference white_clover forage, whose texture
+  # set this reuses.
+  - name: wheat
+    type: groundcover_crop
+    texDir: "assets/textures/flora/white_clover"
+    lifecycle: annual
+    phases:
+      - tag: sprout
+        texture: "sprout.png"
+        age: 0
+      - tag: vegetating
+        texture: "budding.png"
+        age: 30
+      - tag: dead
+        texture: "dead.png"
+        age: 360
+    annualCycle:
+      - tag: dormant
+        startDay: 0
+        texture: "dormant.png"
+      - tag: budding
+        startDay: 40
+        texture: "budding.png"
+      - tag: flowering
+        startDay: 90
+        texture: "flowering.png"
+      - tag: senescing
+        startDay: 200
+        texture: "senescing.png"
+    cycleOverrides:
+      - phase: dead
+        cycle: dormant
+        texture: "dead.png"
+      - phase: dead
+        cycle: budding
+        texture: "dead.png"
+      - phase: dead
+        cycle: flowering
+        texture: "dead.png"
+      - phase: dead
+        cycle: senescing
+        texture: "dead.png"
+    harvestable:
+      tags: [grain]
+      yield:
+        - id: wheat_grain
+          count: [1, 2]
+      regrowth_time: 43200
+      harvested_texture: "dead.png"
+    worldGen:
+      category: groundcover_crop
+      minTemp: 5
+      maxTemp: 28
+      idealTemp: 17
+      minPrecip: 0.3
+      maxPrecip: 0.8
+      idealPrecip: 0.55
+      minAlt: -30
+      maxAlt: 600
+      idealAlt: 100
+      minHumidity: 0.3
+      maxHumidity: 0.85
+      idealHumidity: 0.55
+      maxSlope: 3
+      density: 0.0
+      footprint: 0

--- a/data/items/tomato.yaml
+++ b/data/items/tomato.yaml
@@ -1,0 +1,13 @@
+items:
+  # Row-crop harvest yield (#334) — data/flora/crops.yaml's tomato_plant.
+  # DISCRETE food, same shape as the #94 foraged yields (foraged_food.yaml).
+  - name: "tomato"
+    display_name: "Tomato"
+    sprite: "assets/textures/items/supply/wild_berries.png"  # placeholder — reused, no dedicated art yet
+    weight: 0.12
+    category: Supplies
+    food:
+      nutrition:
+        # A single tomato — light next to a ration (250), on par with
+        # a handful of wild berries.
+        calories: 35

--- a/data/items/wheat_grain.yaml
+++ b/data/items/wheat_grain.yaml
@@ -1,0 +1,13 @@
+items:
+  # Groundcover-crop harvest yield (#334) — data/flora/crops.yaml's
+  # wheat. DISCRETE food, same shape as the #94 foraged yields
+  # (foraged_food.yaml) — a bulk sack (like quinoa_sack.yaml) is a
+  # later step once there's a milling/storage use for loose grain.
+  - name: "wheat_grain"
+    display_name: "Wheat Grain"
+    sprite: "assets/textures/items/supply/quinoa_sack.png"  # placeholder — reused, no dedicated art yet
+    weight: 0.3
+    category: Supplies
+    food:
+      nutrition:
+        calories: 80

--- a/src/Engine/Scripting/Lua/API.hs
+++ b/src/Engine/Scripting/Lua/API.hs
@@ -708,6 +708,8 @@ registerLuaAPI lst env backendState = Lua.runWith lst $ do
   registerLuaFunction "harvestFlora" (worldHarvestFloraFn env)
   registerLuaFunction "findHarvestableFlora"
     (worldFindHarvestableFloraFn env)
+  registerLuaFunction "plantCropAt" (worldPlantCropAtFn env)
+  registerLuaFunction "getCropPlotAt" (worldGetCropPlotAtFn env)
 
   Lua.setglobal (Lua.Name "world")
 

--- a/src/Engine/Scripting/Lua/API/Forage.hs
+++ b/src/Engine/Scripting/Lua/API/Forage.hs
@@ -484,6 +484,15 @@ findSpeciesByName name cat =
     listToMaybe [ (FloraId k, sp)
                 | (k, sp) ← HM.toList (fcSpecies cat), fsName sp ≡ name ]
 
+-- | The one YAML worldGen category tag (World.Flora.Placement) that
+--   marks a species as the ctVeg-tile-fill groundcover form (#334) —
+--   the only form world.plantCropAt (a CropPlot) is valid for. A
+--   row_crop species is an ordinary FloraInstance placed by the
+--   worldgen pipeline; planting one as a CropPlot would render it as a
+--   tile-fill (World.Render.Quads), the WRONG form for its species.
+groundcoverCropCategory ∷ Text
+groundcoverCropCategory = "groundcover_crop"
+
 -- | world.plantCropAt(gx, gy, speciesName) → true | nil
 --
 --   Foundation-level planting primitive (#334): plants a groundcover
@@ -491,7 +500,10 @@ findSpeciesByName name cat =
 --   day (the #332 runtime's age-0 baseline for this plot — see
 --   World.Flora.CropPlot). Refuses (nil) unless the tile is plantable
 --   (tilled soil, #333 — same gate as world.isPlantable), speciesName
---   names a registered flora species, and the tile's chunk is loaded.
+--   names a REGISTERED GROUNDCOVER species (worldGen category
+--   "groundcover_crop" — a row_crop species, e.g. tomato_plant, is
+--   refused: it's an ordinary FloraInstance, not a CropPlot, see
+--   groundcoverCropCategory), and the tile's chunk is loaded.
 --
 --   This is a low-level verb with no player-facing tool/AI/UI yet —
 --   #335 (planting tool + suitability) and #336 (farm AI) build the
@@ -530,13 +542,19 @@ worldPlantCropAtFn env = do
                                     cat ← readIORef (floraCatalogRef env)
                                     case findSpeciesByName name cat of
                                         Nothing → pure False
-                                        Just (fid, _) → do
-                                            (_, absDay) ← growthClock ws
-                                            let plot = newCropPlot fid absDay 1.0
-                                            atomicModifyIORef' (wsCropPlotsRef ws) $
-                                                \ps → (HM.insert (gx, gy) plot ps, ())
-                                            bumpQuadCacheGen ws
-                                            pure True
+                                        Just (fid, _) →
+                                            case HM.lookup (unFloraId fid)
+                                                     (fcWorldGen cat) of
+                                                Just wg
+                                                    | fwCategory wg
+                                                        ≡ groundcoverCropCategory → do
+                                                    (_, absDay) ← growthClock ws
+                                                    let plot = newCropPlot fid absDay 1.0
+                                                    atomicModifyIORef' (wsCropPlotsRef ws) $
+                                                        \ps → (HM.insert (gx, gy) plot ps, ())
+                                                    bumpQuadCacheGen ws
+                                                    pure True
+                                                _ → pure False
             Lua.pushboolean ok
             return 1
         _ → Lua.pushnil >> return 1

--- a/src/Engine/Scripting/Lua/API/Forage.hs
+++ b/src/Engine/Scripting/Lua/API/Forage.hs
@@ -14,20 +14,27 @@ module Engine.Scripting.Lua.API.Forage
     , worldHarvestFloraFn
     , worldFindHarvestableFloraFn
     , itemGetFoodFn
+    , worldPlantCropAtFn
+    , worldGetCropPlotAtFn
     ) where
 
 import UPrelude
 import qualified HsLua as Lua
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text.Encoding as TE
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as VU
 import Data.IORef (readIORef, atomicModifyIORef')
 import System.Random (randomR)
 import Engine.Core.State (EngineEnv(..), activeWorldState,
                           freshItemInstanceId)
 import World.Types
+import World.Vegetation (isTilledSoil)
 import World.Flora.Growth (FloraGrowth(..), floraGrowth, harvestOpen,
                            growthPhaseTag, activeStageTag,
                            lifePhaseText, annualStageText)
+import World.Flora.CropPlot (CropPlot(..), newCropPlot,
+                             cropPlotElapsedDays, cropPlotInstance)
 import World.Generate.Coordinates (globalToChunk, chunkToGlobal)
 import Item.Types (ItemDef(..), ItemInstance(..), ItemContainer(..),
                    ItemFood(..), lookupItemDef)
@@ -237,31 +244,65 @@ worldHarvestFloraFn env = do
                 case mWs of
                     Nothing → pure Nothing
                     Just ws → do
-                        insts ← floraAt env ws gx gy
-                        harvests ← readIORef (wsFloraHarvestsRef ws)
+                        -- Planted crop plot (#334): a BARE call only —
+                        -- like chop's tagged flow, a plot isn't a
+                        -- designation target, so a tag skips it
+                        -- straight to the wild-flora path below. A
+                        -- plot never coexists with wild FloraInstances
+                        -- on the same tile (tilled soil excludes
+                        -- natural flora placement), so no precedence
+                        -- question between the two arises.
+                        mPlot ← if isJust tagFilter then pure Nothing
+                                else HM.lookup (gx, gy) ⊚
+                                         readIORef (wsCropPlotsRef ws)
+                        cat ← readIORef (floraCatalogRef env)
                         (doy, absDay) ← growthClock ws
-                        let live = HM.lookupDefault 0 (gx, gy) harvests
-                            -- #332: only the BARE (forage) call checks
-                            -- the growth window; a tagged call is a
-                            -- designation flow (chop "wood") and takes
-                            -- the plant in any growth state.
-                            windowOk i sp = case tagFilter of
-                                Just _  → True
-                                Nothing → harvestOpen sp doy
-                                              (floraGrowth sp absDay i)
-                            mFh = listToMaybe
-                                [ fh | (i, sp) ← insts
-                                     , Just fh ← [fsHarvest sp]
-                                     , maybe True (`elem` fhTags fh) tagFilter
-                                     , windowOk i sp ]
-                        case mFh of
-                            Just fh | live ≤ 0 → do
+                        let mPlotHarvest = do
+                                cp ← mPlot
+                                sp ← lookupSpecies (cpSpecies cp) cat
+                                fh ← fsHarvest sp
+                                let elapsed = cropPlotElapsedDays absDay cp
+                                    g = floraGrowth sp elapsed (cropPlotInstance cp)
+                                if harvestOpen sp elapsed g
+                                    then Just fh else Nothing
+                        case mPlotHarvest of
+                            Just fh → do
                                 spawned ← spawnYields env ws gx gy (fhYield fh)
-                                atomicModifyIORef' (wsFloraHarvestsRef ws) $
-                                    \hs → (HM.insert (gx, gy) (fhRegrowth fh) hs, ())
+                                -- Annual, one-shot: harvesting clears
+                                -- the plot instead of starting a
+                                -- regrowth timer — the tile reverts to
+                                -- bare tilled soil until replanted.
+                                atomicModifyIORef' (wsCropPlotsRef ws) $
+                                    \ps → (HM.delete (gx, gy) ps, ())
                                 bumpQuadCacheGen ws
                                 pure (Just spawned)
-                            _ → pure Nothing
+                            Nothing | isJust mPlot → pure Nothing
+                            Nothing → do
+                              insts ← floraAt env ws gx gy
+                              harvests ← readIORef (wsFloraHarvestsRef ws)
+                              let live = HM.lookupDefault 0 (gx, gy) harvests
+                                  -- #332: only the BARE (forage) call
+                                  -- checks the growth window; a tagged
+                                  -- call is a designation flow (chop
+                                  -- "wood") and takes the plant in any
+                                  -- growth state.
+                                  windowOk i sp = case tagFilter of
+                                      Just _  → True
+                                      Nothing → harvestOpen sp doy
+                                                    (floraGrowth sp absDay i)
+                                  mFh = listToMaybe
+                                      [ fh2 | (i, sp) ← insts
+                                           , Just fh2 ← [fsHarvest sp]
+                                           , maybe True (`elem` fhTags fh2) tagFilter
+                                           , windowOk i sp ]
+                              case mFh of
+                                  Just fh | live ≤ 0 → do
+                                      spawned ← spawnYields env ws gx gy (fhYield fh)
+                                      atomicModifyIORef' (wsFloraHarvestsRef ws) $
+                                          \hs → (HM.insert (gx, gy) (fhRegrowth fh) hs, ())
+                                      bumpQuadCacheGen ws
+                                      pure (Just spawned)
+                                  _ → pure Nothing
             case mSpawned of
                 Nothing → Lua.pushnil
                 Just spawned → do
@@ -435,3 +476,136 @@ itemGetFoodFn env = do
                     Lua.pushnumber (Lua.Number (realToFrac (ifCaloriesPerKg f)))
                     Lua.setfield (-2) "caloriesPerKg"
             return 1
+
+-- | Find a registered flora species by its YAML @name@. Catalogs are
+--   small (tens of species), so a linear scan needs no index.
+findSpeciesByName ∷ Text → FloraCatalog → Maybe (FloraId, FloraSpecies)
+findSpeciesByName name cat =
+    listToMaybe [ (FloraId k, sp)
+                | (k, sp) ← HM.toList (fcSpecies cat), fsName sp ≡ name ]
+
+-- | world.plantCropAt(gx, gy, speciesName) → true | nil
+--
+--   Foundation-level planting primitive (#334): plants a groundcover
+--   crop plot at (gx, gy) at full health, dated to the CURRENT world
+--   day (the #332 runtime's age-0 baseline for this plot — see
+--   World.Flora.CropPlot). Refuses (nil) unless the tile is plantable
+--   (tilled soil, #333 — same gate as world.isPlantable), speciesName
+--   names a registered flora species, and the tile's chunk is loaded.
+--
+--   This is a low-level verb with no player-facing tool/AI/UI yet —
+--   #335 (planting tool + suitability) and #336 (farm AI) build the
+--   real planting flow on top of it, the same foundation-first shape
+--   as #300's unit.repairItem preceding the repair AI/UI. A planted
+--   plot renders as the tile's veg-fill (World.Render.Quads), NOT a
+--   floating sprite.
+worldPlantCropAtFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+worldPlantCropAtFn env = do
+    mGx ← Lua.tointeger 1
+    mGy ← Lua.tointeger 2
+    mName ← Lua.tostring 3
+    case (mGx, mGy, mName) of
+        (Just gx', Just gy', Just nameBS) → do
+            let gx = fromIntegral gx'
+                gy = fromIntegral gy'
+                name = TE.decodeUtf8 nameBS
+            ok ← Lua.liftIO $ do
+                mWs ← activeWorldState env
+                case mWs of
+                    Nothing → pure False
+                    Just ws → do
+                        tileData ← readIORef (wsTilesRef ws)
+                        let (coord, (lx, ly)) = globalToChunk gx gy
+                            idx = ly * chunkSize + lx
+                        case lookupChunk coord tileData of
+                            Nothing → pure False
+                            Just lc → do
+                                let col = lcTiles lc V.! idx
+                                    z    = lcSurfaceMap lc VU.! idx
+                                    i    = z - ctStartZ col
+                                    vg   = if i ≥ 0 ∧ i < VU.length (ctVeg col)
+                                           then ctVeg col VU.! i else 0
+                                if not (isTilledSoil vg) then pure False
+                                else do
+                                    cat ← readIORef (floraCatalogRef env)
+                                    case findSpeciesByName name cat of
+                                        Nothing → pure False
+                                        Just (fid, _) → do
+                                            (_, absDay) ← growthClock ws
+                                            let plot = newCropPlot fid absDay 1.0
+                                            atomicModifyIORef' (wsCropPlotsRef ws) $
+                                                \ps → (HM.insert (gx, gy) plot ps, ())
+                                            bumpQuadCacheGen ws
+                                            pure True
+            Lua.pushboolean ok
+            return 1
+        _ → Lua.pushnil >> return 1
+
+-- | world.getCropPlotAt(gx, gy) → {id, age, health, phase, stage,
+--   generation, dead, harvestable} | nil
+--
+--   The #332 growth-state inspection window for a planted groundcover
+--   crop plot (#334) — mirrors world.getFloraGrowthAt's shape for wild/
+--   row flora, but for a single tile-keyed plot rather than an array of
+--   instances, and with age measured in days ELAPSED SINCE PLANTING
+--   (World.Flora.CropPlot) rather than an absolute placement baseline.
+--   nil when the tile has no planted crop or names an unregistered
+--   species.
+worldGetCropPlotAtFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+worldGetCropPlotAtFn env = do
+    mGx ← Lua.tointeger 1
+    mGy ← Lua.tointeger 2
+    case (mGx, mGy) of
+        (Just gx', Just gy') → do
+            let gx = fromIntegral gx'
+                gy = fromIntegral gy'
+            mResult ← Lua.liftIO $ do
+                mWs ← activeWorldState env
+                case mWs of
+                    Nothing → pure Nothing
+                    Just ws → do
+                        plots ← readIORef (wsCropPlotsRef ws)
+                        case HM.lookup (gx, gy) plots of
+                            Nothing → pure Nothing
+                            Just cp → do
+                                cat ← readIORef (floraCatalogRef env)
+                                (_, absDay) ← growthClock ws
+                                pure $ do
+                                    sp ← lookupSpecies (cpSpecies cp) cat
+                                    let elapsed = cropPlotElapsedDays absDay cp
+                                        g = floraGrowth sp elapsed
+                                                (cropPlotInstance cp)
+                                    Just ( fsName sp, g, cpHealth cp
+                                         , lifePhaseText ⊚ growthPhaseTag sp g
+                                         , annualStageText ⊚
+                                               activeStageTag sp elapsed
+                                         , isJust (fsHarvest sp)
+                                             ∧ harvestOpen sp elapsed g )
+            case mResult of
+                Nothing → Lua.pushnil
+                Just (name, g, health, mPhase, mStage, harvestable) → do
+                    Lua.newtable
+                    Lua.pushstring (TE.encodeUtf8 name)
+                    Lua.setfield (-2) "id"
+                    Lua.pushnumber (Lua.Number (realToFrac (fgAge g)))
+                    Lua.setfield (-2) "age"
+                    Lua.pushnumber (Lua.Number (realToFrac health))
+                    Lua.setfield (-2) "health"
+                    case mPhase of
+                        Just t → do
+                            Lua.pushstring (TE.encodeUtf8 t)
+                            Lua.setfield (-2) "phase"
+                        Nothing → pure ()
+                    case mStage of
+                        Just t → do
+                            Lua.pushstring (TE.encodeUtf8 t)
+                            Lua.setfield (-2) "stage"
+                        Nothing → pure ()
+                    Lua.pushinteger (fromIntegral (fgGeneration g))
+                    Lua.setfield (-2) "generation"
+                    Lua.pushboolean (fgDead g)
+                    Lua.setfield (-2) "dead"
+                    Lua.pushboolean harvestable
+                    Lua.setfield (-2) "harvestable"
+            return 1
+        _ → Lua.pushnil >> return 1

--- a/src/World/Flora/CropPlot.hs
+++ b/src/World/Flora/CropPlot.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE Strict, UnicodeSyntax, DeriveGeneric, DeriveAnyClass #-}
+-- | Planted groundcover-crop state (#334).
+--
+--   A groundcover crop (wheat, barley, ...) draws as the surface
+--   'World.Chunk.Types.ctVeg' tile-fill rather than a floating sprite
+--   (row crops use ordinary 'World.Flora.Types.FloraInstance's for
+--   that instead), so it has no per-instance record in chunk data —
+--   'ctVeg' is just a static byte id with no room for an age. This is
+--   the small world-level record that fills that gap: which species,
+--   and the world day it was planted (the age-0 baseline the #332
+--   runtime measures elapsed growth from), so a planted tile can share
+--   the exact same growth/texture/harvest logic as wild flora instead
+--   of duplicating it as a parallel set of static vegetation ids.
+--
+--   World-level sparse map, same shape as 'World.Flora.Harvest.
+--   FloraHarvests' / 'World.Till.Types.TillDesignations' — tile-keyed,
+--   written by the Lua planting primitive, read by the render pass and
+--   harvest queries. Persisted per page ('wpsCropPlots').
+module World.Flora.CropPlot
+    ( CropPlot(..)
+    , CropPlots
+    , emptyCropPlots
+    , newCropPlot
+    , cropPlotElapsedDays
+    , cropPlotInstance
+    ) where
+
+import UPrelude
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
+import Data.Serialize (Serialize)
+import qualified Data.HashMap.Strict as HM
+import World.Flora.Types (FloraId, FloraInstance(..))
+
+-- | One planted tile. Field order is load-bearing (positional Generic
+--   Serialize — append, don't reorder).
+data CropPlot = CropPlot
+    { cpSpecies    ∷ !FloraId
+    , cpPlantedDay ∷ !Int
+      -- ^ Absolute world day ('World.Time.worldAbsoluteDay') the crop
+      --   was planted — the age-0 baseline. The #332 runtime measures
+      --   this plot's growth as days ELAPSED SINCE PLANTING, not
+      --   calendar day-of-year, so a crop's own lifecycle timeline
+      --   starts fresh regardless of what day of the year it went in.
+    , cpHealth     ∷ !Float
+      -- ^ 0.0 dead … 1.0 full, same meaning as FloraInstance's
+      --   fiHealth — scales growth speed via World.Flora.Growth.
+    } deriving (Show, Eq, Generic, Serialize, NFData)
+
+type CropPlots = HM.HashMap (Int, Int) CropPlot
+
+emptyCropPlots ∷ CropPlots
+emptyCropPlots = HM.empty
+
+newCropPlot ∷ FloraId → Int → Float → CropPlot
+newCropPlot = CropPlot
+
+-- | Days elapsed since planting, clamped to non-negative (a plot can't
+--   have gone negative-age even if queried before its planted day).
+cropPlotElapsedDays ∷ Int → CropPlot → Int
+cropPlotElapsedDays absDay cp = max 0 (absDay - cpPlantedDay cp)
+
+-- | Synthesize a placement-shaped instance so 'World.Flora.Growth' /
+--   'World.Flora.Render' can derive this plot's growth state and
+--   texture without duplicating their logic. Callers pass
+--   'cropPlotElapsedDays' as the runtime's absDay argument (fiAge
+--   stays 0), which is what makes the plot's timeline start at zero on
+--   its planted day rather than being pinned to an absolute placement
+--   baseline like a naturally-placed FloraInstance.
+cropPlotInstance ∷ CropPlot → FloraInstance
+cropPlotInstance cp = FloraInstance
+    { fiSpecies   = cpSpecies cp
+    , fiTileX     = 0
+    , fiTileY     = 0
+    , fiOffU      = 0
+    , fiOffV      = 0
+    , fiZ         = 0
+    , fiAge       = 0
+    , fiHealth    = cpHealth cp
+    , fiVariant   = 0
+    , fiBaseWidth = 0
+    }

--- a/src/World/Flora/Placement.hs
+++ b/src/World/Flora/Placement.hs
@@ -110,8 +110,8 @@ placeTileFlora seed gx gy lx ly surfZ matId slopeId
                     baseW = fwFootprint wg
                     count = instanceCount cat h
                     maxAge = speciesMaxAge fid catalog
-                in [ mkInstance fid lx ly surfZ seed gx gy
-                         (i * 10 + j) count baseW maxAge fitness
+                in [ mkInstance cat fid lx ly surfZ seed gx gy
+                         (i * 10 + j) j count baseW maxAge fitness
                    | j ← [0 .. count - 1]
                    ]
            else []
@@ -156,18 +156,25 @@ instanceCount cat h
     | cat ≡ "shrub"     = 1
     | cat ≡ "bush"      = 1 + fromIntegral ((h `shiftR` 16) .&. 0x01)
     | cat ≡ "cactus"    = 1
+    | cat ≡ "row_crop"  = 3
     | otherwise          = 2 + fromIntegral ((h `shiftR` 16) .&. 0x01)
 
--- | Build one FloraInstance with deterministic sub-tile offset.
---   ALL instances get a random offset (including trees with count=1).
---   The offset is clamped by the footprint so the base stays on the tile.
+-- | Build one FloraInstance with a deterministic sub-tile offset.
+--   ALL instances get an offset (including trees with count=1). The
+--   offset is clamped by the footprint so the base stays on the tile.
 --   Health is the tile's habitat fitness (#332): the same 0–1
 --   'speciesFitness' that gated placement, so a plant in marginal
 --   habitat starts (and stays — climate is static) less healthy, which
 --   slows its derived growth (World.Flora.Growth).
-mkInstance ∷ FloraId → Int → Int → Int → Word64 → Int → Int
-           → Int → Int → Float → Float → Float → FloraInstance
-mkInstance fid lx ly surfZ seed gx gy i _count baseWidth maxAge health =
+--
+--   Every category jitters its offset randomly EXCEPT "row_crop"
+--   (#334): instead of scattering, its instances lay out along a single
+--   evenly-spaced line across the tile ("laid at intervals / in rows"),
+--   using the same offU/offV sub-tile fields every other category
+--   jitters — @j@ is this instance's 0-based position among @count@.
+mkInstance ∷ Text → FloraId → Int → Int → Int → Word64 → Int → Int
+           → Int → Int → Int → Float → Float → Float → FloraInstance
+mkInstance cat fid lx ly surfZ seed gx gy i j count baseWidth maxAge health =
     let h = floraHash seed gx gy (fromIntegral i + 1)
         rawU = fromIntegral ((h `shiftR` 0)  .&. 0xFF) / 255.0 - 0.5
         rawV = fromIntegral ((h `shiftR` 8)  .&. 0xFF) / 255.0 - 0.5
@@ -176,8 +183,11 @@ mkInstance fid lx ly surfZ seed gx gy i _count baseWidth maxAge health =
                    then (baseWidth / 2.0) / 96.0
                    else 0.0
         maxOff = max 0.0 (0.5 - halfBase)
-        offU = clamp (negate maxOff) maxOff (rawU * 0.7)
-        offV = clamp (negate maxOff) maxOff (rawV * 0.7)
+
+        (offU, offV)
+            | cat ≡ "row_crop" = (rowOffset j count maxOff, 0.0)
+            | otherwise        = ( clamp (negate maxOff) maxOff (rawU * 0.7)
+                                  , clamp (negate maxOff) maxOff (rawV * 0.7) )
 
         variant = fromIntegral ((h `shiftR` 16) .&. 0x03)
 
@@ -197,6 +207,17 @@ mkInstance fid lx ly surfZ seed gx gy i _count baseWidth maxAge health =
         , fiVariant   = variant
         , fiBaseWidth = baseWidth
         }
+
+-- | Evenly space @count@ row-crop instances along the U axis, spanning
+--   as much of the tile as @maxOff@ (the footprint clamp) allows. A
+--   single instance sits at tile center, like every other category.
+rowOffset ∷ Int → Int → Float → Float
+rowOffset j count maxOff
+    | count ≤ 1 = 0.0
+    | otherwise =
+        let usable = min maxOff 0.35
+            step = (2.0 * usable) / fromIntegral (count - 1)
+        in negate usable + fromIntegral j * step
 
 -- * Hash
 

--- a/src/World/Render/Quads.hs
+++ b/src/World/Render/Quads.hs
@@ -17,6 +17,7 @@ import Engine.Scene.Types (SortableQuad(..))
 import Engine.Graphics.Camera (Camera2D(..), CameraFacing)
 import World.Types
 import World.Flora.Render (resolveFloraTexture)
+import World.Flora.CropPlot (cropPlotElapsedDays, cropPlotInstance)
 import World.Generate (chunkToGlobal, viewDepth)
 import World.Generate.Coordinates (globalToChunk)
 import World.Grid (gridToScreen, tileSideHeight, applyFacing)
@@ -34,7 +35,7 @@ import World.Render.SideDecoQuads (waterSideFaceQuads)
 import World.Render.TileQuads
     ( tileToQuad, blankTileToQuad, oceanTileToQuad, iceTileToQuad
     , lavaTileToQuad, freshwaterTileToQuad, worldCursorToQuad
-    , worldCursorBgToQuad, vegToQuad
+    , worldCursorBgToQuad, vegToQuad, vegQuadWithTexture
     )
 
 -- * Water Slope Helpers
@@ -109,6 +110,7 @@ renderWorldQuads env worldState zoomAlpha snap = do
     worldDate ← readIORef (wsDateRef worldState)
     texSizes ← readIORef (textureSizeRef env)
     harvests ← readIORef (wsFloraHarvestsRef worldState)
+    cropPlots ← readIORef (wsCropPlotsRef worldState)
 
     let (fbW, fbH) = wcsFbSize snap
         facing = camFacing camera
@@ -228,11 +230,24 @@ renderWorldQuads env worldState zoomAlpha snap = do
                                             -- surface is above the fluid level
                                             vegQ = if z ≡ surfZ ∧ maybe True (\fc → surfZ > fcSurface fc) mFluid
                                                    then let i = z - ctStartZ col
-                                                            vegId = ctVeg col VU.! i
                                                             slopeId = ctSlopes col VU.! i
-                                                        in vegToQuad lookupSlot lookupFmSlot textures facing
-                                                               gx gy z vegId slopeId zSlice effectiveDepth
-                                                               zoomAlpha xOffset
+                                                        in case HM.lookup (gx, gy) cropPlots of
+                                                            -- Planted crop tile (#334): the tile-fill
+                                                            -- texture is DERIVED from the #332 growth
+                                                            -- runtime instead of the static ctVeg id.
+                                                            Just cp →
+                                                                let elapsed = cropPlotElapsedDays absDay cp
+                                                                    tex = resolveFloraTexture floraCat
+                                                                              daysPerYear elapsed
+                                                                              (cropPlotInstance cp)
+                                                                in vegQuadWithTexture lookupSlot lookupFmSlot
+                                                                       textures facing gx gy z tex slopeId
+                                                                       zSlice effectiveDepth zoomAlpha xOffset
+                                                            Nothing →
+                                                                let vegId = ctVeg col VU.! i
+                                                                in vegToQuad lookupSlot lookupFmSlot textures facing
+                                                                       gx gy z vegId slopeId zSlice effectiveDepth
+                                                                       zoomAlpha xOffset
                                                    else Nothing
 
                                         in case vegQ of

--- a/src/World/Render/TileQuads.hs
+++ b/src/World/Render/TileQuads.hs
@@ -9,6 +9,7 @@ module World.Render.TileQuads
     , worldCursorToQuad
     , worldCursorBgToQuad
     , vegToQuad
+    , vegQuadWithTexture
     ) where
 
 import UPrelude
@@ -427,9 +428,29 @@ vegToQuad ∷ (TextureHandle → Int) → (TextureHandle → Float)
           → Float               -- ^ tileAlpha
           → Float               -- ^ xOffset
           → Maybe SortableQuad
-vegToQuad _ _ _ _ _ _ _ 0 _ _ _ _ _ = Nothing
 vegToQuad lookupSlot lookupFmSlot textures facing
           worldX worldY worldZ vegId slopeId zSlice effDepth tileAlpha xOffset =
+    vegQuadWithTexture lookupSlot lookupFmSlot textures facing
+        worldX worldY worldZ (getVegTexture textures vegId) slopeId
+        zSlice effDepth tileAlpha xOffset
+
+-- | Same tile-fill quad as 'vegToQuad', but taking an already-resolved
+--   texture handle directly instead of a vegId → texture lookup. Used
+--   for a planted crop tile (#334): its current texture is DERIVED
+--   from the #332 growth runtime (World.Flora.CropPlot), not looked up
+--   from a fixed vegetation id. Returns Nothing for handle 0.
+vegQuadWithTexture ∷ (TextureHandle → Int) → (TextureHandle → Float)
+                   → WorldTextures → CameraFacing
+                   → Int → Int → Int     -- ^ worldX, worldY, worldZ
+                   → TextureHandle       -- ^ resolved texture
+                   → Word8               -- ^ slopeId (from the terrain tile)
+                   → Int → Int           -- ^ zSlice, effectiveDepth
+                   → Float               -- ^ tileAlpha
+                   → Float               -- ^ xOffset
+                   → Maybe SortableQuad
+vegQuadWithTexture _ _ _ _ _ _ _ (TextureHandle 0) _ _ _ _ _ = Nothing
+vegQuadWithTexture lookupSlot lookupFmSlot textures facing
+          worldX worldY worldZ texHandle slopeId zSlice effDepth tileAlpha xOffset =
     let (rawX, rawY) = gridToScreen facing worldX worldY
         (fa, fb) = applyFacing facing worldX worldY
         relativeZ = worldZ - zSlice
@@ -441,7 +462,6 @@ vegToQuad lookupSlot lookupFmSlot textures facing
                 + fromIntegral relativeZ * 0.001
                 + 0.0002
 
-        texHandle = getVegTexture textures vegId
         actualSlot = lookupSlot texHandle
 
         fmHandle = getVegFaceMapTexture textures slopeId

--- a/src/World/Save/Types.hs
+++ b/src/World/Save/Types.hs
@@ -35,6 +35,7 @@ import World.Chop.Types (ChopDesignations)
 import World.Till.Types (TillDesignations)
 import World.Spoil.Types (SpoilPiles)
 import World.Flora.Harvest (FloraHarvests)
+import World.Flora.CropPlot (CropPlots)
 import Item.Ground (GroundItems)
 import Engine.Graphics.Camera (CameraFacing(..))
 import Building.Types (BuildingId(..), BuildingInstance(..), BuildingDef(..)
@@ -122,7 +123,15 @@ saveMagic = 0x53595241
 --       river carve. Positional Generic Serialize drops the trailing
 --       field, incompatible with v61 (#385).
 currentSaveVersion ∷ Int
-currentSaveVersion = 76  -- v76: WorldPageSave gains trailing
+currentSaveVersion = 77  -- v77: WorldPageSave gains trailing
+                         --      'wpsCropPlots' (#334) — planted
+                         --      groundcover-crop tiles (species +
+                         --      planted day + health). Like the
+                         --      designation layers, restored straight
+                         --      into wsCropPlotsRef; the render pass
+                         --      derives the current growth texture
+                         --      from it with no chunk loading needed.
+                         -- v76: WorldPageSave gains trailing
                          --      'wpsTillDesignations' (#333) — till
                          --      designations (tile → surface z), same
                          --      shape as wpsChopDesignations. ToolMode
@@ -346,6 +355,11 @@ data WorldPageSave = WorldPageSave
         --   designation layers, restored straight into
         --   wsTillDesignationsRef; markers re-render from the stored z.
         --   Appended for save v76.
+    , wpsCropPlots ∷ !CropPlots
+        -- ^ Planted groundcover-crop tiles (#334): tile → (species,
+        --   planted day, health). Restored straight into
+        --   wsCropPlotsRef; render/harvest derive growth state from it
+        --   with no chunk loading needed. Appended for save v77.
     } deriving (Show, Serialize, Generic)
 
 -- | Everything needed to reconstruct the saved game. Per-world state is

--- a/src/World/State/Types.hs
+++ b/src/World/State/Types.hs
@@ -34,6 +34,7 @@ import Craft.Bills (CraftBills, emptyCraftBills)
 import Power.Types (PowerNodes, emptyPowerNodes)
 import World.Spoil.Types (SpoilPiles, emptySpoilPiles)
 import World.Flora.Harvest (FloraHarvests, emptyFloraHarvests)
+import World.Flora.CropPlot (CropPlots, emptyCropPlots)
 import Item.Ground (GroundItems, emptyGroundItems)
 
 data WorldState = WorldState
@@ -143,6 +144,13 @@ data WorldState = WorldState
       --   thread (WorldDesignateTill / cancel commands), read by the
       --   render pass (marker) and the till AI. Persisted in saves
       --   (wpsTillDesignations, v76).
+    , wsCropPlotsRef ∷ IORef CropPlots
+      -- ^ Planted groundcover-crop set (#334): tile (gx, gy) → plot
+      --   (species + planted day + health; see World.Flora.CropPlot).
+      --   World-level (NOT in chunk data, which is transient) so
+      --   eviction can't wipe it; written by world.plantCropAt, read
+      --   by the render pass (tile-fill texture) and world.harvestFlora
+      --   / world.getCropPlotAt. Persisted in saves (wpsCropPlots, v77).
     }
 
 emptyWorldState ∷ IO WorldState
@@ -180,6 +188,7 @@ emptyWorldState = do
     wsCraftBillsRef ← newIORef emptyCraftBills
     wsPowerNodesRef ← newIORef emptyPowerNodes
     wsTillDesignationsRef ← newIORef HM.empty
+    wsCropPlotsRef ← newIORef emptyCropPlots
     return $ WorldState tilesRef cameraRef texturesRef genParamsRef
                         timeRef dateRef timeScaleRef zoomCacheRef
                         quadCacheRef quadCacheGenRef zoomQCRef bgQCRef
@@ -192,6 +201,7 @@ emptyWorldState = do
                         wsConstructDesignationsRef wsFloraHarvestsRef
                         wsChopDesignationsRef wsCraftBillsRef
                         wsPowerNodesRef wsTillDesignationsRef
+                        wsCropPlotsRef
 
 -- | Invalidate a world's cached render quads in a thread-safe way.
 --   Bumps the generation counter atomically rather than nulling

--- a/src/World/Thread/Command/Save.hs
+++ b/src/World/Thread/Command/Save.hs
@@ -183,6 +183,7 @@ handleWorldSaveCommand env logger pageId saveName timestampTxt luaBlobs = do
                                 floraHarvests ← readIORef (wsFloraHarvestsRef ws)
                                 chopDesigs ← readIORef (wsChopDesignationsRef ws)
                                 tillDesigs ← readIORef (wsTillDesignationsRef ws)
+                                cropPlots ← readIORef (wsCropPlotsRef ws)
                                 craftBills ← readIORef (wsCraftBillsRef ws)
                                 powerNodes ← readIORef (wsPowerNodesRef ws)
                                 WorldCamera wcx wcy ← readIORef (wsCameraRef ws)
@@ -233,6 +234,7 @@ handleWorldSaveCommand env logger pageId saveName timestampTxt luaBlobs = do
                                     , wpsCraftBills  = craftBills
                                     , wpsPowerNodes  = powerNodes
                                     , wpsTillDesignations = tillDesigs
+                                    , wpsCropPlots   = cropPlots
                                     }
                     -- UTC ISO 8601 microsecond precision, captured and
                     -- monotonically clamped at the API request time (see
@@ -451,6 +453,9 @@ handleWorldLoadSaveCommand env logger pageId saveData
         -- Till designations (#333): same shape, markers render from the
         -- stored z.
         writeIORef (wsTillDesignationsRef worldState) (wpsTillDesignations wps)
+        -- Planted crop plots (#334): same shape, growth/texture derive
+        -- from the stored species + planted day with no chunk loading.
+        writeIORef (wsCropPlotsRef worldState) (wpsCropPlots wps)
         -- Craft bills (#329): stations restore under their saved
         -- BuildingIds (see 1f), so bills reconnect verbatim; prune the
         -- ones whose station isn't in this page's snapshot (a def

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -641,6 +641,7 @@ library
                      World.Flora.Placement
                      World.Flora.Render
                      World.Flora.Harvest
+                     World.Flora.CropPlot
                      World.Fluids
                      World.Fluid.Types
                      World.Fluid.Internal

--- a/tools/crop_probe.py
+++ b/tools/crop_probe.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Crop content + two growth forms probe (#334).
+
+Boots a headless engine and checks BOTH growth forms the farming epic
+(#331) calls for, sharing the #332 growth runtime like wild flora:
+
+  1. Row crop: an ordinary FloraInstance laid out at intervals within
+     the tile (World.Flora.Placement's "row_crop" category — see
+     rowOffset) via NATURAL worldgen placement, exactly like wild
+     flora. Uses a throwaway `probe_row_crop` species (max-tolerance
+     worldGen, high density) appended AFTER the real data/flora
+     species, mirroring flora_growth_probe.py's probe_berry — the real
+     tomato_plant/wheat species ship with density 0.0 (no wild spawn;
+     #335/#336 own player-driven planting), so a throwaway high-density
+     fixture is how the placement MECHANISM gets exercised headless.
+  2. Groundcover crop: NOT a FloraInstance at all — planted via the new
+     world.plantCropAt primitive into a World.Flora.CropPlot, and
+     rendered as the tile's veg-fill rather than a floating sprite.
+     Tests the REAL shipped `wheat` species + `wheat_grain` item
+     directly (planting doesn't depend on worldGen density).
+
+Checks per form: growth is derived and visibly advances (age/phase),
+a harvest yields the species' item, and (groundcover only) the planted
+state survives save -> load.
+
+Usage: python3 tools/crop_probe.py [--port 9195] [--seed 42]
+       [--size 64] [--plates 3]
+"""
+import argparse, glob, json, socket, subprocess, sys, time
+
+SPROOT = "/tmp"
+
+
+def send(port, lua, timeout=10.0):
+    with socket.create_connection(("localhost", port), timeout=timeout) as s:
+        s.settimeout(timeout)
+        f = s.makefile("rw")
+        f.readline()              # banner
+        f.write(lua + "\n")
+        f.flush()
+        return f.readline().strip().lstrip("> ").strip()
+
+
+def jget(port, lua, timeout=10.0):
+    raw = send(port, lua, timeout)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw.strip('"')
+
+
+def boot(port, log_path):
+    log = open(log_path, "w")
+    proc = subprocess.Popen(
+        ["cabal", "run", "-v0", "exe:synarchy", "--",
+         "--headless", "--port", str(port)],
+        stdout=log, stderr=subprocess.STDOUT)
+    for _ in range(300):
+        time.sleep(0.2)
+        try:
+            if "READY" in open(log_path).read():
+                return proc
+        except FileNotFoundError:
+            pass
+    sys.exit("engine never printed READY")
+
+
+# Throwaway row-crop fixture (mirrors flora_growth_probe.py's
+# probe_berry): max-tolerance worldGen so it places on any seed's
+# geography, high density so it's found quickly, category "row_crop"
+# so it exercises the new deterministic row layout. Same fruiting
+# window shape as probe_berry (dormant@0 / fruiting@180 / senescing@270)
+# so the same set_date calls land in/out of season.
+PROBE_ROW_CROP_YAML = """flora:
+  - name: probe_row_crop
+    type: row_crop
+    texDir: "assets/textures/flora/red_raspberry"
+    lifecycle: annual
+    phases:
+      - {tag: sprout, texture: "sprout.png", age: 0}
+      - {tag: matured, texture: "matured.png", age: 60}
+      - {tag: dead, texture: "dead.png", age: 360}
+    annualCycle:
+      - {tag: dormant, startDay: 0, texture: "matured_dormant.png"}
+      - {tag: fruiting, startDay: 180, texture: "matured_fruiting.png"}
+      - {tag: senescing, startDay: 270, texture: "matured_senescing.png"}
+    harvestable:
+      tags: [fruit]
+      yield:
+        - id: wild_berries
+          count: [1, 3]
+      regrowth_time: 86400
+      harvested_texture: "matured_senescing.png"
+    worldGen:
+      category: row_crop
+      minTemp: -60
+      maxTemp: 60
+      idealTemp: 15
+      minPrecip: 0.0
+      maxPrecip: 5.0
+      idealPrecip: 0.8
+      minAlt: -100
+      maxAlt: 3000
+      idealAlt: 50
+      minHumidity: 0.0
+      maxHumidity: 1.0
+      idealHumidity: 0.5
+      maxSlope: 7
+      density: 1.0
+      footprint: 0
+"""
+
+
+def bootstrap(port):
+    checked = {}
+    for pattern, fn in [
+        ("data/substances/*.yaml", "engine.loadSubstanceYaml"),
+        ("data/items/*.yaml",      "engine.loadItemYaml"),
+        ("data/materials/*.yaml",  "engine.loadMaterialYaml"),
+        ("data/flora/*.yaml",      "engine.loadFloraYaml"),
+    ]:
+        for path in sorted(glob.glob(pattern)):
+            r = jget(port, f"return {fn}('{path}')")
+            if path.endswith("crops.yaml") or path.endswith(
+                    ("tomato.yaml", "wheat_grain.yaml")):
+                checked[path] = r
+    # The probe's own row-crop fixture — appended after the real flora
+    # so their placement hashes (indexed by registration order) are
+    # untouched.
+    path = f"{SPROOT}/probe_row_crop.yaml"
+    with open(path, "w") as f:
+        f.write(PROBE_ROW_CROP_YAML)
+    send(port, f"engine.loadFloraYaml('{path}'); return 'ok'")
+    return checked
+
+
+def set_date(port, page, y, mo, d):
+    """setDate is a queued world command — send, then wait until
+    getDate reflects it."""
+    send(port, f"world.setDate('{page}', {y}, {mo}, {d}); return 'ok'")
+    for _ in range(20):
+        time.sleep(0.2)
+        got = jget(port, f"return world.getDate('{page}')")
+        if isinstance(got, dict) and got.get("year") == y \
+           and got.get("month") == mo and got.get("day") == d:
+            return got
+    sys.exit(f"setDate({y},{mo},{d}) never landed")
+
+
+def find_species_tile(port, species, harvestable=None, lo=-64, hi=64):
+    """Scan the loaded region for the first tile carrying an instance of
+    the given species (optionally requiring its harvestable flag).
+    Returns (gx, gy) or None."""
+    cond = f"e.id=='{species}'"
+    if harvestable is not None:
+        cond += f" and e.harvestable=={'true' if harvestable else 'false'}"
+    r = send(
+        port,
+        f"for gx={lo},{hi} do for gy={lo},{hi} do "
+        f"local t=world.getFloraGrowthAt(gx,gy); "
+        f"if t then for _,e in ipairs(t) do "
+        f"if {cond} then return gx..','..gy end end end "
+        f"end end return 'none'",
+        timeout=60.0)
+    r = r.strip('"')
+    if r == "none":
+        return None
+    gx, gy = r.split(",")
+    return int(gx), int(gy)
+
+
+def find_dry_tile(port, cx, cy, radius=12):
+    """Nearest tile to (cx, cy) with a real surface and no fluid on it —
+    world.getSurfaceAt returns MULTIPLE Lua values (surfaceZ, terrainZ,
+    fluidType, fluidSurface), not a table, so wrap it into one value
+    per call. Returns (gx, gy, surfaceZ) or None."""
+    r = send(
+        port,
+        f"for r=0,{radius} do for dx=-r,r do for dy=-r,r do "
+        f"local gx,gy={cx}+dx,{cy}+dy; "
+        f"local sz,tz,ft=world.getSurfaceAt(gx,gy); "
+        f"if sz and not ft then return gx..','..gy..','..sz end "
+        f"end end end return 'none'",
+        timeout=30.0)
+    r = r.strip('"')
+    if r == "none":
+        return None
+    gx, gy, sz = r.split(",")
+    return int(gx), int(gy), int(sz)
+
+
+def till_and_wait(port, page, gx, gy, z):
+    """world.setVegAt is a queued world command, like world.setDate —
+    send, then poll isPlantable until it lands before planting."""
+    send(port, f"world.setVegAt('{page}', {gx}, {gy}, {z}, 77); return 'ok'")
+    for _ in range(20):
+        if jget(port, f"return world.isPlantable({gx},{gy})") is True:
+            return True
+        time.sleep(0.2)
+    sys.exit(f"setVegAt({gx},{gy}) never landed")
+
+
+def growth_entries(port, gx, gy, species):
+    t = jget(port, f"return world.getFloraGrowthAt({gx},{gy})")
+    if isinstance(t, list):
+        return [e for e in t if e.get("id") == species]
+    return []
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=9195)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--size", type=int, default=64)
+    ap.add_argument("--plates", type=int, default=3)
+    args = ap.parse_args()
+    port = args.port
+    passed = True
+
+    proc = boot(port, f"{SPROOT}/crop_probe_engine.log")
+    try:
+        checked = bootstrap(port)
+        ok0 = all(v not in (0, None, "") for v in checked.values()) \
+            and len(checked) >= 3
+        passed &= ok0
+        print(f"  [{'PASS' if ok0 else 'FAIL'}] shipped crop content loads "
+              f"cleanly: {checked}")
+
+        send(port, f"world.init('probe', {args.seed}, {args.size}, {args.plates}); return 'ok'")
+        send(port, "return world.waitForInit(300)", timeout=310)
+        send(port, "world.show('probe'); return 'ok'")
+        send(port, "return world.loadChunksInRegion(-4, -4, 4, 4)", timeout=30)
+        send(port, "return world.waitForChunks(120)", timeout=125)
+
+        # ============== 1. Row crop (natural placement) ==============
+        set_date(port, "probe", 2, 1, 5)  # dormant season baseline
+        tile = find_species_tile(port, "probe_row_crop")
+        if not tile:
+            print("  [FAIL] probe_row_crop not found in region — try another seed")
+            return 1
+
+        es = growth_entries(port, *tile, "probe_row_crop")
+        ok1a = len(es) == 3
+        passed &= ok1a
+        print(f"  [{'PASS' if ok1a else 'FAIL'}] row-crop category places "
+              f"exactly 3 instances per tile (rowOffset): found {len(es)}")
+
+        ok1b = all(0.0 <= e["health"] <= 1.0 and e["age"] >= 0.0 for e in es)
+        passed &= ok1b
+        print(f"  [{'PASS' if ok1b else 'FAIL'}] row-crop instances report "
+              f"derived growth state: {es}")
+
+        # Season window, same shape as flora_growth_probe.py's raspberry:
+        # dormant now, fruiting once the date moves into its window.
+        ok1c = all(e.get("stage") == "dormant" and not e.get("harvestable")
+                   for e in es)
+        passed &= ok1c
+        print(f"  [{'PASS' if ok1c else 'FAIL'}] row crop not harvestable in "
+              f"the dormant season")
+        set_date(port, "probe", 2, 7, 21)  # day-of-year ~202, in [180,270)
+        es2 = growth_entries(port, *tile, "probe_row_crop")
+        ok1d = any(e.get("stage") == "fruiting" and e.get("harvestable")
+                   for e in es2)
+        passed &= ok1d
+        print(f"  [{'PASS' if ok1d else 'FAIL'}] row crop harvestable in its "
+              f"fruiting window: {es2}")
+
+        y1 = jget(port, f"return world.harvestFlora({tile[0]},{tile[1]})")
+        ok1e = isinstance(y1, list) and len(y1) >= 1 \
+            and all(it.get("id") == "wild_berries" for it in y1)
+        passed &= ok1e
+        print(f"  [{'PASS' if ok1e else 'FAIL'}] row-crop harvest yields: {y1}")
+
+        # ======= 2. Groundcover crop (planted via world.plantCropAt) =======
+        found = find_dry_tile(port, tile[0] + 3, tile[1] + 3)
+        if not found:
+            print("  [FAIL] no dry tile found near the row-crop site")
+            return 1
+        gx0, gy0, z0 = found
+
+        pre = jget(port, f"return world.isPlantable({gx0},{gy0})")
+        ok2a = pre is False
+        passed &= ok2a
+        print(f"  [{'PASS' if ok2a else 'FAIL'}] untilled tile refuses "
+              f"plantCropAt's gate before tilling: isPlantable={pre}")
+        refused = jget(port,
+            f"return world.plantCropAt({gx0},{gy0},'wheat')")
+        ok2b = refused in (None, False)
+        passed &= ok2b
+        print(f"  [{'PASS' if ok2b else 'FAIL'}] plantCropAt refuses on "
+              f"untilled soil: {refused}")
+
+        ok2c = till_and_wait(port, "probe", gx0, gy0, z0)
+        passed &= ok2c
+        print(f"  [{'PASS' if ok2c else 'FAIL'}] tile plantable after tilling "
+              f"(vegTilledSoil): {ok2c}")
+
+        planted = jget(port, f"return world.plantCropAt({gx0},{gy0},'wheat')")
+        ok2d = planted is True
+        passed &= ok2d
+        print(f"  [{'PASS' if ok2d else 'FAIL'}] plantCropAt plants the real "
+              f"'wheat' species: {planted}")
+
+        p0 = jget(port, f"return world.getCropPlotAt({gx0},{gy0})")
+        ok2e = isinstance(p0, dict) and p0.get("id") == "wheat" \
+            and p0.get("phase") == "sprout" and p0.get("age") < 5.0
+        passed &= ok2e
+        print(f"  [{'PASS' if ok2e else 'FAIL'}] freshly planted crop plot "
+              f"starts at age ~0, sprout phase: {p0}")
+
+        # Advance the REAL game clock (not a calendar jump — CropPlot age
+        # is measured relative to its OWN planted day, see
+        # World.Flora.CropPlot) far enough to clear the 30-day vegetating
+        # threshold: ~50000 game-min/real-sec for 4 real-sec ~= 139 game-days.
+        send(port, "world.setTimeScale('probe', 50000); return 'ok'")
+        time.sleep(4.0)
+        send(port, "world.setTimeScale('probe', 1); return 'ok'")
+        p1 = jget(port, f"return world.getCropPlotAt({gx0},{gy0})")
+        ok2f = isinstance(p1, dict) and p1.get("age", 0) > p0.get("age", 0) \
+            and p1.get("phase") != "sprout" and p1.get("harvestable") is True
+        passed &= ok2f
+        print(f"  [{'PASS' if ok2f else 'FAIL'}] groundcover crop visibly "
+              f"advances under the game clock and becomes harvestable: "
+              f"{p0} -> {p1}")
+
+        y2 = jget(port, f"return world.harvestFlora({gx0},{gy0})")
+        ok2g = isinstance(y2, list) and len(y2) >= 1 \
+            and all(it.get("id") == "wheat_grain" for it in y2)
+        passed &= ok2g
+        print(f"  [{'PASS' if ok2g else 'FAIL'}] groundcover-crop harvest "
+              f"yields wheat_grain: {y2}")
+
+        cleared = jget(port, f"return world.getCropPlotAt({gx0},{gy0})")
+        ok2h = cleared is None
+        passed &= ok2h
+        print(f"  [{'PASS' if ok2h else 'FAIL'}] harvest clears the plot "
+              f"(annual, one-shot): {cleared}")
+
+        # ============== 3. Groundcover plot survives save/load ==============
+        found2 = find_dry_tile(port, gx0 + 2, gy0 + 2)
+        if not found2:
+            print("  [FAIL] no dry tile found for the save/load plot")
+            return 1
+        gx1, gy1, z1 = found2
+        till_and_wait(port, "probe", gx1, gy1, z1)
+        jget(port, f"return world.plantCropAt({gx1},{gy1},'wheat')")
+        before = jget(port, f"return world.getCropPlotAt({gx1},{gy1})")
+
+        send(port, "engine.saveWorld('probe', 'crop_plot_check'); return 'ok'")
+        time.sleep(3.0)
+        send(port, "engine.loadSave('crop_plot_check'); return 'ok'")
+        time.sleep(15.0)
+        send(port, "world.show('main_world'); return 'ok'")
+        after = jget(port, f"return world.getCropPlotAt({gx1},{gy1})")
+        ok3 = isinstance(before, dict) and isinstance(after, dict) \
+            and before.get("id") == after.get("id") == "wheat" \
+            and after.get("age", -1) >= 0.0
+        passed &= ok3
+        print(f"  [{'PASS' if ok3 else 'FAIL'}] planted crop plot survives "
+              f"save/load: {before} -> {after}")
+
+        print("\n" + ("ALL CROP CHECKS PASSED" if passed else "SOME FAILED"))
+        return 0 if passed else 1
+    finally:
+        try:
+            send(port, "engine.quit()")
+        except Exception:
+            pass
+        time.sleep(1.0)
+        proc.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/crop_probe.py
+++ b/tools/crop_probe.py
@@ -7,17 +7,23 @@ Boots a headless engine and checks BOTH growth forms the farming epic
   1. Row crop: an ordinary FloraInstance laid out at intervals within
      the tile (World.Flora.Placement's "row_crop" category — see
      rowOffset) via NATURAL worldgen placement, exactly like wild
-     flora. Uses a throwaway `probe_row_crop` species (max-tolerance
-     worldGen, high density) appended AFTER the real data/flora
-     species, mirroring flora_growth_probe.py's probe_berry — the real
-     tomato_plant/wheat species ship with density 0.0 (no wild spawn;
-     #335/#336 own player-driven planting), so a throwaway high-density
-     fixture is how the placement MECHANISM gets exercised headless.
+     flora. The real shipped `tomato_plant` ships with worldGen
+     density 0.0 (no wild spawn; #335/#336 own player-driven planting),
+     so it can never place in an ordinary generated world — to exercise
+     it headless anyway, this probe loads a SECOND copy of its exact
+     YAML entry (parsed straight out of data/flora/crops.yaml, not
+     hand-duplicated) with only the worldGen tolerances relaxed for
+     guaranteed placement, mirroring flora_growth_probe.py's
+     probe_berry pattern but deriving it from the real content so the
+     phases/annualCycle/harvestable data under test is byte-identical
+     to what ships.
   2. Groundcover crop: NOT a FloraInstance at all — planted via the new
      world.plantCropAt primitive into a World.Flora.CropPlot, and
      rendered as the tile's veg-fill rather than a floating sprite.
      Tests the REAL shipped `wheat` species + `wheat_grain` item
-     directly (planting doesn't depend on worldGen density).
+     directly (planting doesn't depend on worldGen density). Also
+     checks world.plantCropAt REFUSES a row_crop species (tomato_plant)
+     — only a groundcover_crop can become a CropPlot.
 
 Checks per form: growth is derived and visibly advances (age/phase),
 a harvest yields the species' item, and (groundcover only) the planted
@@ -26,7 +32,8 @@ state survives save -> load.
 Usage: python3 tools/crop_probe.py [--port 9195] [--seed 42]
        [--size 64] [--plates 3]
 """
-import argparse, glob, json, socket, subprocess, sys, time
+import argparse, copy, glob, json, socket, subprocess, sys, time
+import yaml
 
 SPROOT = "/tmp"
 
@@ -66,49 +73,17 @@ def boot(port, log_path):
 
 
 # Throwaway row-crop fixture (mirrors flora_growth_probe.py's
-# probe_berry): max-tolerance worldGen so it places on any seed's
-# geography, high density so it's found quickly, category "row_crop"
-# so it exercises the new deterministic row layout. Same fruiting
-# window shape as probe_berry (dormant@0 / fruiting@180 / senescing@270)
-# so the same set_date calls land in/out of season.
-PROBE_ROW_CROP_YAML = """flora:
-  - name: probe_row_crop
-    type: row_crop
-    texDir: "assets/textures/flora/red_raspberry"
-    lifecycle: annual
-    phases:
-      - {tag: sprout, texture: "sprout.png", age: 0}
-      - {tag: matured, texture: "matured.png", age: 60}
-      - {tag: dead, texture: "dead.png", age: 360}
-    annualCycle:
-      - {tag: dormant, startDay: 0, texture: "matured_dormant.png"}
-      - {tag: fruiting, startDay: 180, texture: "matured_fruiting.png"}
-      - {tag: senescing, startDay: 270, texture: "matured_senescing.png"}
-    harvestable:
-      tags: [fruit]
-      yield:
-        - id: wild_berries
-          count: [1, 3]
-      regrowth_time: 86400
-      harvested_texture: "matured_senescing.png"
-    worldGen:
-      category: row_crop
-      minTemp: -60
-      maxTemp: 60
-      idealTemp: 15
-      minPrecip: 0.0
-      maxPrecip: 5.0
-      idealPrecip: 0.8
-      minAlt: -100
-      maxAlt: 3000
-      idealAlt: 50
-      minHumidity: 0.0
-      maxHumidity: 1.0
-      idealHumidity: 0.5
-      maxSlope: 7
-      density: 1.0
-      footprint: 0
-"""
+# Max-tolerance worldGen override for the placement-tolerant tomato_plant
+# double below — same numbers flora_growth_probe.py's probe_berry uses,
+# just relaxed so it places on any seed's geography regardless of the
+# shipped species' real (narrower) climate gate.
+RELAXED_WORLDGEN = {
+    "minTemp": -60, "maxTemp": 60, "idealTemp": 15,
+    "minPrecip": 0.0, "maxPrecip": 5.0, "idealPrecip": 0.8,
+    "minAlt": -100, "maxAlt": 3000, "idealAlt": 50,
+    "minHumidity": 0.0, "maxHumidity": 1.0, "idealHumidity": 0.5,
+    "maxSlope": 7, "density": 1.0,
+}
 
 
 def bootstrap(port):
@@ -124,12 +99,28 @@ def bootstrap(port):
             if path.endswith("crops.yaml") or path.endswith(
                     ("tomato.yaml", "wheat_grain.yaml")):
                 checked[path] = r
-    # The probe's own row-crop fixture — appended after the real flora
-    # so their placement hashes (indexed by registration order) are
-    # untouched.
-    path = f"{SPROOT}/probe_row_crop.yaml"
+
+    # tomato_plant ships with worldGen density 0.0 (#334: farmed crops
+    # shouldn't wild-spawn), so it can never place in an ordinary
+    # generated world. To exercise the REAL shipped row-crop content
+    # (not a hand-written proxy), parse its exact entry back out of
+    # data/flora/crops.yaml and reload it under the SAME name with only
+    # worldGen relaxed — phases/annualCycle/cycleOverrides/harvestable
+    # (and so the "tomato" yield item) are byte-identical to what ships.
+    # Appended after the real flora so THEIR placement hashes (indexed
+    # by registration order) are untouched; the two same-named
+    # registrations don't collide (World.Flora.Placement keys placement
+    # by FloraId, not name — see Engine.Scripting.Lua.API.Forage's
+    # findSpeciesByName docstring for the one place name matters, which
+    # this doesn't affect since both copies share the same category).
+    with open("data/flora/crops.yaml") as f:
+        crops = yaml.safe_load(f)
+    tomato = copy.deepcopy(
+        next(e for e in crops["flora"] if e["name"] == "tomato_plant"))
+    tomato["worldGen"] = {**tomato["worldGen"], **RELAXED_WORLDGEN}
+    path = f"{SPROOT}/probe_tomato_plant.yaml"
     with open(path, "w") as f:
-        f.write(PROBE_ROW_CROP_YAML)
+        yaml.safe_dump({"flora": [tomato]}, f)
     send(port, f"engine.loadFloraYaml('{path}'); return 'ok'")
     return checked
 
@@ -233,13 +224,13 @@ def main():
         send(port, "return world.waitForChunks(120)", timeout=125)
 
         # ============== 1. Row crop (natural placement) ==============
-        set_date(port, "probe", 2, 1, 5)  # dormant season baseline
-        tile = find_species_tile(port, "probe_row_crop")
+        set_date(port, "probe", 2, 1, 5)  # dormant/budding season baseline
+        tile = find_species_tile(port, "tomato_plant")
         if not tile:
-            print("  [FAIL] probe_row_crop not found in region — try another seed")
+            print("  [FAIL] tomato_plant not found in region — try another seed")
             return 1
 
-        es = growth_entries(port, *tile, "probe_row_crop")
+        es = growth_entries(port, *tile, "tomato_plant")
         ok1a = len(es) == 3
         passed &= ok1a
         print(f"  [{'PASS' if ok1a else 'FAIL'}] row-crop category places "
@@ -250,15 +241,16 @@ def main():
         print(f"  [{'PASS' if ok1b else 'FAIL'}] row-crop instances report "
               f"derived growth state: {es}")
 
-        # Season window, same shape as flora_growth_probe.py's raspberry:
-        # dormant now, fruiting once the date moves into its window.
-        ok1c = all(e.get("stage") == "dormant" and not e.get("harvestable")
-                   for e in es)
+        # Season window (tomato_plant's real annualCycle: dormant@0 /
+        # budding@30 / flowering@60 / fruiting@90 / senescing@240):
+        # dormant/budding now, fruiting once the date moves into its window.
+        ok1c = all(e.get("stage") in ("dormant", "budding")
+                   and not e.get("harvestable") for e in es)
         passed &= ok1c
-        print(f"  [{'PASS' if ok1c else 'FAIL'}] row crop not harvestable in "
-              f"the dormant season")
-        set_date(port, "probe", 2, 7, 21)  # day-of-year ~202, in [180,270)
-        es2 = growth_entries(port, *tile, "probe_row_crop")
+        print(f"  [{'PASS' if ok1c else 'FAIL'}] row crop not harvestable "
+              f"before its fruiting window: {es}")
+        set_date(port, "probe", 2, 7, 21)  # day-of-year ~202, in [90,240)
+        es2 = growth_entries(port, *tile, "tomato_plant")
         ok1d = any(e.get("stage") == "fruiting" and e.get("harvestable")
                    for e in es2)
         passed &= ok1d
@@ -267,9 +259,10 @@ def main():
 
         y1 = jget(port, f"return world.harvestFlora({tile[0]},{tile[1]})")
         ok1e = isinstance(y1, list) and len(y1) >= 1 \
-            and all(it.get("id") == "wild_berries" for it in y1)
+            and all(it.get("id") == "tomato" for it in y1)
         passed &= ok1e
-        print(f"  [{'PASS' if ok1e else 'FAIL'}] row-crop harvest yields: {y1}")
+        print(f"  [{'PASS' if ok1e else 'FAIL'}] row-crop harvest yields "
+              f"tomato: {y1}")
 
         # ======= 2. Groundcover crop (planted via world.plantCropAt) =======
         found = find_dry_tile(port, tile[0] + 3, tile[1] + 3)
@@ -294,6 +287,21 @@ def main():
         passed &= ok2c
         print(f"  [{'PASS' if ok2c else 'FAIL'}] tile plantable after tilling "
               f"(vegTilledSoil): {ok2c}")
+
+        # plantCropAt is a CropPlot-only primitive: a row_crop species
+        # (tomato_plant is an ordinary FloraInstance, not a CropPlot) must
+        # be refused even on tilled, otherwise-plantable soil.
+        row_refused = jget(port,
+            f"return world.plantCropAt({gx0},{gy0},'tomato_plant')")
+        ok2r = row_refused in (None, False)
+        passed &= ok2r
+        print(f"  [{'PASS' if ok2r else 'FAIL'}] plantCropAt refuses a "
+              f"row_crop species (tomato_plant) on tilled soil: {row_refused}")
+        cleared_row = jget(port, f"return world.getCropPlotAt({gx0},{gy0})")
+        ok2s = cleared_row is None
+        passed &= ok2s
+        print(f"  [{'PASS' if ok2s else 'FAIL'}] the refused tomato_plant "
+              f"plant left no crop plot behind: {cleared_row}")
 
         planted = jget(port, f"return world.plantCropAt({gx0},{gy0},'wheat')")
         ok2d = planted is True


### PR DESCRIPTION
## Summary
- Row crops (`tomato_plant`) place as ordinary `FloraInstance`s through the existing worldgen pipeline, using a new `row_crop` placement category (`World.Flora.Placement`) that lays instances out at deterministic intervals instead of random jitter.
- Groundcover crops (`wheat`) are the genuinely new mechanism the issue calls out: a small world-level `CropPlot` record (species + planted day + health — `World.Flora.CropPlot`, save v77) lets a planted tile share the #332 growth runtime and render as the tile's veg-fill instead of a floating sprite, without needing `ctVeg` itself to carry any growth state.
- `world.plantCropAt` / `world.getCropPlotAt` are new foundation-level Lua primitives (no player-facing tool/AI yet — #335/#336 build the real planting flow on top, mirroring how #300's `unit.repairItem` preceded the repair AI/UI). `world.harvestFlora` now checks a tile's crop plot first, falling back to wild `FloraInstance`s.
- Both shipped species ship with `worldGen.density: 0.0` so they don't wild-spawn ahead of real planting (#335/#336); placeholder art reuses existing wild-species textures (`red_raspberry`, `white_clover`) per the established "reuse until real art" convention, and new food items (`tomato`, `wheat_grain`) reuse existing supply sprites.

## Test plan
- [x] `cabal build all` — clean, no warnings
- [x] `cabal build synarchy-test-headless` — clean
- [x] `cabal test synarchy-test-headless` — 666 examples, 0 failures
- [x] `python3 tools/world_check.py --quick` — 6/6 (no worldgen-output change; new flora isn't a dumped layer)
- [x] `python3 tools/test_audit.py` — 35/35
- [x] New `tools/crop_probe.py` (mirrors `flora_growth_probe.py`'s pattern) — boots a headless engine and exercises both forms end to end: row-crop natural placement (3 instances/tile via `rowOffset`), season-gated growth/harvest; groundcover plant/grow-under-the-real-clock/harvest/clear, plus a save → load round-trip for the planted plot.

Closes #334