### PR TITLE
Remove dead scsGenFluid field (unused save-diff baseline)

### DIFF
--- a/src/Sim/Fluid/Active.hs
+++ b/src/Sim/Fluid/Active.hs
@@ -66,7 +66,6 @@ deactivateInPlace scs =
     in scs { scsActive      = False
            , scsActiveFluid = V.replicate sz Nothing
            , scsFluid       = bakedFluid
-           , scsGenFluid    = bakedFluid
            , scsEquilTicks  = 0
            }
 

--- a/src/Sim/State/Types.hs
+++ b/src/Sim/State/Types.hs
@@ -42,7 +42,6 @@ data SimWorldState = SimWorldState
 data SimChunkState = SimChunkState
     { scsFluid       ∷ !FluidMap          -- ^ Live fluid state
     , scsTerrain     ∷ !(VU.Vector Int)   -- ^ Terrain surface (read-only until modified)
-    , scsGenFluid    ∷ !FluidMap          -- ^ Original generated fluid (for diff on save)
     , scsSettleTicks ∷ !Int               -- ^ Remaining fast settle ticks (0 = settled)
     , scsActive      ∷ !Bool              -- ^ True when volume sim is running
     , scsActiveFluid ∷ !(V.Vector (Maybe ActiveFluidCell))  -- ^ Volume-tracked fluid (active only)

--- a/src/Sim/Thread.hs
+++ b/src/Sim/Thread.hs
@@ -184,7 +184,6 @@ handleSimCommand env logger simStateRef cmd = do
                 scs = SimChunkState
                     { scsFluid       = fluidMap
                     , scsTerrain     = terrainMap
-                    , scsGenFluid    = fluidMap
                     , scsSettleTicks = newChunkSettleTicks
                     , scsActive      = False
                     , scsActiveFluid = V.replicate sz Nothing
@@ -209,13 +208,11 @@ handleSimCommand env logger simStateRef cmd = do
                 base = case HM.lookup coord (swsChunks sws) of
                     Just scs → scs { scsFluid       = fluidMap
                                    , scsTerrain     = terrainMap
-                                   , scsGenFluid    = fluidMap
                                    , scsSettleTicks = reactivateSettleTicks
                                    }
                     Nothing  → SimChunkState
                         { scsFluid       = fluidMap
                         , scsTerrain     = terrainMap
-                        , scsGenFluid    = fluidMap
                         , scsSettleTicks = reactivateSettleTicks
                         , scsActive      = False
                         , scsActiveFluid = V.replicate sz Nothing

--- a/test-headless/Test/Headless/Sim/Seam.hs
+++ b/test-headless/Test/Headless/Sim/Seam.hs
@@ -30,7 +30,6 @@ mkChunk ∷ V.Vector (Maybe ActiveFluidCell) → SimChunkState
 mkChunk active = SimChunkState
     { scsFluid       = V.replicate n Nothing
     , scsTerrain     = VU.replicate n 0
-    , scsGenFluid    = V.replicate n Nothing
     , scsSettleTicks = 0
     , scsActive      = True
     , scsActiveFluid = active


### PR DESCRIPTION
Closes #394

## Approach

`scsGenFluid` (`Sim/State/Types.hs`) was documented as "original generated fluid (for diff on save)" but:
- `deactivateInPlace` (`Sim/Fluid/Active.hs`) immediately overwrote it with the post-settle baked fluid, so it never actually held the pristine generated state.
- No code anywhere reads it.

The save-diff feature it was meant to feed was never built, and the field only ever carried the wrong data — a corrupted placeholder for a feature with no consumer. Per the issue's own scoping, removed the field and its three write sites (`Sim/Thread.hs` × 3, `Sim/Fluid/Active.hs` × 1) rather than fixing a baseline nothing reads.

`SimChunkState` is in-memory sim-thread state only, not part of save serialization, so there's no save-version bump.

## Testing

- `cabal build all` — clean build.
- `cabal build synarchy-test-headless` — needed one more fixup: a test fixture in `test-headless/Test/Headless/Sim/Seam.hs` also constructed `SimChunkState` with `scsGenFluid`.
- `cabal test synarchy-test-headless` — 666 examples, 0 failures.
- `python3 tools/world_check.py` — 21/21 seeds PASS (no worldgen-output change expected or observed).
- `python3 tools/test_audit.py` — all 35 test groups passed.