### PR TITLE
Add farm AI: plant + skill-gated auto-harvest + rot (#336)

### DIFF
--- a/data/units/acolyte.yaml
+++ b/data/units/acolyte.yaml
@@ -76,6 +76,11 @@ units:
       # placed (construct_xp_per_piece). Feeds the derived Builder
       # role (#265).
       construction: { base: 25.0, range: 30.0 }
+      # Farming: scales the plant AI's planting rate and the harvest AI's
+      # auto-harvest rate the same way — factor = 0.5 + farming/100. Gains
+      # XP per completed plant/harvest action. Feeds the derived Farmer
+      # role (#265/#336). Same novice spread as mining/woodcutting.
+      farming: { base: 25.0, range: 30.0 }
       # Cooking: sets crafted-output quality for the cooking recipe tier
       # (craft.execute, #343/#346), the same convention as smithing.
       # Acolytes arrive as novice cooks — the portal kit is rations and

--- a/scripts/unit_ai.lua
+++ b/scripts/unit_ai.lua
@@ -4731,10 +4731,15 @@ function unitAi.plant.utility(uid, s, params)
     if not wid then return -math.huge end
 
     -- Active job: finite lock-in, released the moment the designation
-    -- disappears (this check runs BEFORE execute each tick).
+    -- disappears OR changes crop (this check runs BEFORE execute each
+    -- tick). plant.designate replaces in place (HM.insert) rather than
+    -- refusing a re-designate, so a player can swap the crop on this
+    -- tile while we're mid-job; matching only on d's existence would
+    -- plant the STALE crop we originally claimed and then cancel the
+    -- player's newer designation out from under them.
     if s.plantJob then
         local d = plant.getDesignationAt(wid, s.plantJob.x, s.plantJob.y)
-        if d then return params.plant_lock_utility end
+        if d and d.crop == s.plantJob.crop then return params.plant_lock_utility end
         unitAi.plant.complete(uid, s)
     end
 
@@ -4827,8 +4832,11 @@ function unitAi.plant.execute(uid, s, params)
     end
 
     if s.plantPhase == "planting" then
-        if not plant.getDesignationAt(wid, job.x, job.y) then
-            -- Player cancelled (or raced) out from under us.
+        local d = plant.getDesignationAt(wid, job.x, job.y)
+        if not d or d.crop ~= job.crop then
+            -- Player cancelled, or re-designated this tile with a
+            -- different crop, out from under us — drop the stale job
+            -- rather than plant it and cancel the newer designation.
             unitAi.plant.complete(uid, s)
             return
         end

--- a/scripts/unit_ai.lua
+++ b/scripts/unit_ai.lua
@@ -341,7 +341,9 @@ local config = {
         -- (no tool table at all here, unlike dig/chop). Lock-in while
         -- tilling is finite (dire needs still preempt; never
         -- math.huge). Claims mirror chopClaims (module-local, expire on
-        -- till_claim_timeout or claimant death).
+        -- till_claim_timeout or claimant death). Rate scaling + XP grant
+        -- by the farming skill (#265) landed with #336, alongside the
+        -- rest of the farm loop.
         till_scan_range    = 30.0,
         till_base_utility  = 2.0,
         till_lock_utility  = 6.0,
@@ -349,11 +351,42 @@ local config = {
                                     -- (a tile is 1.0 total — 5s bare-handed)
         till_equip_seconds = 1.0,
         till_claim_timeout = 30.0,  -- stale-claim expiry (seconds)
+        till_xp_per_till   = 1.0,   -- farming XP (#265/#336) per tilled tile
         -- No dedicated push/tiller animation exists yet — the shovel
         -- work set is the closest hand-tool-on-ground visual (same
         -- reuse-until-real-art convention as chop_equip_anim above).
         till_equip_anim = "standing_to_holding_shovel",
         till_work_anim  = "shoveling",
+        -- Planting (plant_designation, #336). Structure mirrors till
+        -- exactly (claim/walk/equip/work-progress), skill-scaled by the
+        -- new farming skill (#265) like chop/mining. Completion
+        -- dispatches to world.plantCropAt (groundcover) or
+        -- world.plantRowCropAt (row_crop) by the designation's category.
+        plant_scan_range    = 30.0,
+        plant_base_utility  = 2.0,
+        plant_lock_utility  = 6.0,
+        plant_rate          = 0.2,   -- planting progress/sec at strength
+                                     -- 1.0 and farming 50 (a tile is 1.0
+                                     -- total — mirrors till_rate)
+        plant_equip_seconds = 1.0,
+        plant_claim_timeout = 30.0,  -- stale-claim expiry (seconds)
+        plant_xp_per_plant  = 1.0,   -- farming XP (#265) per planted tile
+        -- No dedicated planting animation exists yet — the shovel work
+        -- set is the closest hand-tool-on-ground visual (same
+        -- reuse-until-real-art convention as till_equip_anim above).
+        plant_equip_anim = "standing_to_holding_shovel",
+        plant_work_anim  = "shoveling",
+        -- Auto-harvest (auto_harvest, #336). Instant harvest — mirrors
+        -- forage's shape (#94), not till/chop's progress accumulator,
+        -- since picking ripe fruit is quick. NOT hunger-gated like
+        -- forage: this is routine farm-tending work, weighted by the
+        -- farming skill/role (#265) instead of scaled by need. Reuses
+        -- world.findHarvestableFlora/world.harvestFlora, which cover
+        -- planted crops AND wild flora alike (a diligent farmer keeps
+        -- the whole area picked, not just the tilled fields).
+        harvest_scan_range     = 24.0,
+        harvest_base_utility   = 2.0,
+        harvest_xp_per_harvest = 1.0,  -- farming XP (#265) per harvest
         -- Equipment repair (repair_job, #302). AI-autonomous kit
         -- maintenance: an acolyte notices its own or the technomule's
         -- gear has degraded past a threshold and carries it to the
@@ -4611,14 +4644,21 @@ function unitAi.till.execute(uid, s, params)
         unit.setAnimOverride(uid, params.till_work_anim)
         local dt = math.min(now - (s.lastTillAt or now), 2.0)
         s.lastTillAt = now
+        -- Farming skill (#265/#336) rides along like mining/woodcutting
+        -- do for dig/chop: level 50 ≈ baseline, level 0 half rate.
+        -- Legacy-save units without the key till at the yaml novice base.
         local strength = unit.getStat(uid, "strength") or 1.0
-        s.tillProgress = (s.tillProgress or 0) + params.till_rate * strength * dt
+        local fSkill = unit.getSkill(uid, "farming") or 25.0
+        s.tillProgress = (s.tillProgress or 0)
+                       + params.till_rate * strength
+                       * (0.5 + fSkill / 100.0) * dt
         if s.tillProgress >= 1.0 then
             -- Tilled: flip the tile's ground cover, then drop the
             -- designation (mirrors chop's harvestFlora → cancelDesignation
             -- order — the world edit lands before the marker clears).
             world.setVegAt(wid, job.x, job.y, job.z, unitAi.till.VEG_ID)
             till.cancelDesignation(job.x, job.y)
+            grantWorkXP(uid, "farming", params.till_xp_per_till or 0)
             unitAi.till.complete(uid, s)
         end
         return
@@ -4633,6 +4673,278 @@ function unitAi.till.onExit(uid, s, params)
     if s.tillPhase == "tilling" or s.tillPhase == "equipping" then
         s.tillPhase = "walking"
     end
+end
+
+-----------------------------------------------------------
+-- Action: plant_designation (#336)
+--
+-- Player-directed planting: claim the nearest plant-designated tile
+-- (#335), walk to it, and work until done — dispatches to
+-- world.plantCropAt (groundcover crops, a CropPlot) or
+-- world.plantRowCropAt (row crops, a FloraInstance) by the
+-- designation's category, then the designation is removed. Structure
+-- mirrors unitAi.till exactly: module-local claims keyed by tile,
+-- finite lock-in, walking → equipping → planting phases with the same
+-- anim-override discipline. Planting progress lives HERE
+-- (s.plantProgress), not in the designation — an interrupted plant
+-- restarts, there is no mid-plant visual to persist.
+--
+-- Grouped under unitAi.plant (the unitAi.till convention, #333's
+-- 200-local-ceiling workaround) — plain field assignments, no new
+-- top-level locals.
+-----------------------------------------------------------
+unitAi.plant = { claims = {} }   -- claims: "x,y" → { uid = ..., at = gameTime }
+
+function unitAi.plant.key(x, y) return x .. "," .. y end
+
+function unitAi.plant.claimedByOther(key, uid, now, timeout)
+    local c = unitAi.plant.claims[key]
+    if not c or c.uid == uid then return false end
+    if now - c.at > timeout or not unit.exists(c.uid) then
+        unitAi.plant.claims[key] = nil
+        return false
+    end
+    return true
+end
+
+function unitAi.plant.releaseJob(s, uid)
+    if s.plantJob then
+        local key = unitAi.plant.key(s.plantJob.x, s.plantJob.y)
+        local c = unitAi.plant.claims[key]
+        if c and c.uid == uid then unitAi.plant.claims[key] = nil end
+    end
+    s.plantJob = nil
+    s.plantPhase = nil
+    s.plantProgress = nil
+end
+
+-- The designation vanished (tile planted — possibly by us — or player
+-- cancel). BOTH the utility check and the execute loop can be first
+-- to notice, so completion lives in one helper.
+function unitAi.plant.complete(uid, s)
+    unit.clearAnimOverride(uid)
+    unitAi.plant.releaseJob(s, uid)
+end
+
+function unitAi.plant.utility(uid, s, params)
+    local wid = world.getActiveWorldId()
+    if not wid then return -math.huge end
+
+    -- Active job: finite lock-in, released the moment the designation
+    -- disappears (this check runs BEFORE execute each tick).
+    if s.plantJob then
+        local d = plant.getDesignationAt(wid, s.plantJob.x, s.plantJob.y)
+        if d then return params.plant_lock_utility end
+        unitAi.plant.complete(uid, s)
+    end
+
+    local info = unit.getInfo(uid)
+    if not info then return -math.huge end
+    local gx, gy, dist =
+        plant.nearestDesignation(wid, info.gridX, info.gridY)
+    if not gx then return -math.huge end
+    if dist > params.plant_scan_range then return -math.huge end
+
+    local now = engine.gameTime()
+    if unitAi.plant.claimedByOther(unitAi.plant.key(gx, gy), uid, now,
+                                   params.plant_claim_timeout) then
+        return -math.huge
+    end
+
+    -- Stash the scored candidate so execute doesn't re-scan.
+    s.plantCandidate = { x = gx, y = gy }
+
+    local distFactor = math.max(0, 1 - dist / params.plant_scan_range)
+    return params.plant_base_utility * distFactor
+         * roles.weight(s, "plant_designation")
+end
+
+function unitAi.plant.execute(uid, s, params)
+    local wid = world.getActiveWorldId()
+    if not wid then return end
+    local info = unit.getInfo(uid)
+    if not info then return end
+    local now = engine.gameTime()
+
+    -- Claim a fresh job and head for the tile.
+    if not s.plantJob then
+        local cand = s.plantCandidate
+        if not cand then return end
+        local key = unitAi.plant.key(cand.x, cand.y)
+        if unitAi.plant.claimedByOther(key, uid, now, params.plant_claim_timeout) then
+            return
+        end
+        local d = plant.getDesignationAt(wid, cand.x, cand.y)
+        if not d then return end
+        unitAi.plant.claims[key] = { uid = uid, at = now }
+        s.plantCandidate = nil
+        s.plantJob = { x = cand.x, y = cand.y, z = d.z,
+                       crop = d.crop, category = d.category }
+        s.plantProgress = 0
+        s.plantEquipped = false
+        s.plantPhase = "walking"
+        unit.moveTo(uid, cand.x + 0.5, cand.y + 0.5, mv.comfort(uid))
+        return
+    end
+
+    local job = s.plantJob
+    -- Keep the claim fresh while we hold the job.
+    unitAi.plant.claims[unitAi.plant.key(job.x, job.y)] = { uid = uid, at = now }
+
+    if s.plantPhase == "walking" then
+        local utx = math.floor(info.gridX)
+        local uty = math.floor(info.gridY)
+        local cheb = math.max(math.abs(utx - job.x), math.abs(uty - job.y))
+        if cheb <= 1 then
+            unit.stop(uid)
+            if not s.plantEquipped then
+                -- setAnimOverride wins over the engine's state-driven
+                -- anim resolution (same as dig/chop/till).
+                unit.setAnimOverride(uid, params.plant_equip_anim)
+                s.plantPhase = "equipping"
+                s.plantEquipUntil = now + params.plant_equip_seconds
+            else
+                unit.setAnimOverride(uid, params.plant_work_anim)
+                s.plantPhase = "planting"
+                s.lastPlantAt = now
+            end
+        else
+            -- Execute only fires when idle, so this re-issue means
+            -- the previous walk arrived short or failed.
+            unit.moveTo(uid, job.x + 0.5, job.y + 0.5, mv.comfort(uid))
+        end
+        return
+    end
+
+    if s.plantPhase == "equipping" then
+        if now >= (s.plantEquipUntil or 0) then
+            s.plantEquipped = true
+            unit.setAnimOverride(uid, params.plant_work_anim)
+            s.plantPhase = "planting"
+            s.lastPlantAt = now
+        end
+        return
+    end
+
+    if s.plantPhase == "planting" then
+        if not plant.getDesignationAt(wid, job.x, job.y) then
+            -- Player cancelled (or raced) out from under us.
+            unitAi.plant.complete(uid, s)
+            return
+        end
+        -- Idempotent: re-asserts the work anim after preemption.
+        unit.setAnimOverride(uid, params.plant_work_anim)
+        local dt = math.min(now - (s.lastPlantAt or now), 2.0)
+        s.lastPlantAt = now
+        -- Farming skill (#265) rides along like mining/woodcutting do
+        -- for dig/chop: level 50 ≈ baseline, level 0 half rate.
+        local strength = unit.getStat(uid, "strength") or 1.0
+        local fSkill = unit.getSkill(uid, "farming") or 25.0
+        s.plantProgress = (s.plantProgress or 0)
+                        + params.plant_rate * strength
+                        * (0.5 + fSkill / 100.0) * dt
+        if s.plantProgress >= 1.0 then
+            -- Planted: dispatch by category (row crops are a
+            -- FloraInstance, groundcover crops a CropPlot), then drop
+            -- the designation (mirrors till's world-edit-before-marker-
+            -- clears order).
+            if job.category == "groundcover_crop" then
+                world.plantCropAt(job.x, job.y, job.crop)
+            else
+                world.plantRowCropAt(wid, job.x, job.y, job.crop)
+            end
+            plant.cancelDesignation(job.x, job.y)
+            grantWorkXP(uid, "farming", params.plant_xp_per_plant or 0)
+            unitAi.plant.complete(uid, s)
+        end
+        return
+    end
+end
+
+-- Preemption (thirst, combat, player order): drop the tool VISUAL
+-- only — claim, job, and progress survive so the plant resumes
+-- afterwards, re-entered through the walking phase.
+function unitAi.plant.onExit(uid, s, params)
+    unit.clearAnimOverride(uid)
+    if s.plantPhase == "planting" or s.plantPhase == "equipping" then
+        s.plantPhase = "walking"
+    end
+end
+
+-----------------------------------------------------------
+-- Action: auto_harvest (#336)
+--
+-- Skill-gated colony farm-tending: pick up any ripe harvestable flora
+-- in range — planted crops AND wild flora alike (world.
+-- findHarvestableFlora / world.harvestFlora, #94, don't distinguish the
+-- two; #334's crop species carry worldGen.density 0.0, so any crop
+-- instance found here was deliberately planted, never a wild spawn).
+-- Instant harvest, mirroring forage's shape rather than till/plant's
+-- progress accumulator — picking ripe fruit is quick. NOT hunger-gated
+-- like forage: this is routine farm-tending work, weighted by the
+-- farming skill/role (#265) instead of scaled by need.
+--
+-- Grouped under unitAi.harvest (the unitAi.till convention, #333's
+-- 200-local-ceiling workaround) — plain field assignments, no new
+-- top-level locals.
+-----------------------------------------------------------
+unitAi.harvest = {}
+
+function unitAi.harvest.utility(uid, s, params)
+    if not world.findHarvestableFlora then return -math.huge end
+    local info = unit.getInfo(uid)
+    if not info then return -math.huge end
+    local ux = math.floor(info.gridX)
+    local uy = math.floor(info.gridY)
+    local spot = world.findHarvestableFlora(ux, uy, params.harvest_scan_range)
+    if not spot then
+        s.harvestTarget = nil
+        return -math.huge
+    end
+    s.harvestTarget = { x = spot.gx, y = spot.gy }
+    local distFactor = math.max(0, 1 - spot.dist / params.harvest_scan_range)
+    return params.harvest_base_utility * distFactor
+         * roles.weight(s, "auto_harvest")
+end
+
+function unitAi.harvest.execute(uid, s, params)
+    -- Collecting: pull the harvested yield off the ground, one item
+    -- per tick (mirrors forageExecute's collecting phase).
+    if s.harvestPhase == "collecting" then
+        local loot = s.harvestLoot or {}
+        local nextGid = table.remove(loot)
+        if not nextGid or not item.pickupGround(uid, nextGid) then
+            s.harvestPhase = nil
+            s.harvestLoot  = nil
+        end
+        return
+    end
+
+    local tgt = s.harvestTarget
+    if not tgt then return end
+    local info = unit.getInfo(uid)
+    if not info then return end
+    local utx = math.floor(info.gridX)
+    local uty = math.floor(info.gridY)
+    local cheb = math.max(math.abs(utx - tgt.x), math.abs(uty - tgt.y))
+
+    if cheb <= 1 then
+        local yields = world.harvestFlora(tgt.x, tgt.y)
+        if yields and #yields > 0 then
+            unit.pickup(uid)   -- bend-down anim over the plant
+            local gids = {}
+            for _, yi in ipairs(yields) do gids[#gids + 1] = yi.gid end
+            s.harvestLoot  = gids
+            s.harvestPhase = "collecting"
+            grantWorkXP(uid, "farming", params.harvest_xp_per_harvest or 0)
+        end
+        -- Raced / regrowing after all, or a completed harvest either
+        -- way: forget the target; the next decision re-finds.
+        s.harvestTarget = nil
+        return
+    end
+
+    unit.moveTo(uid, tgt.x + 0.5, tgt.y + 0.5, mv.comfort(uid))
 end
 
 -----------------------------------------------------------
@@ -5559,6 +5871,10 @@ unitAi.registerActions("acolyte", {
       execute = chopExecute, onExit = chopOnExit },
     { name = "till_designation", utility = unitAi.till.utility,
       execute = unitAi.till.execute, onExit = unitAi.till.onExit },
+    { name = "plant_designation", utility = unitAi.plant.utility,
+      execute = unitAi.plant.execute, onExit = unitAi.plant.onExit },
+    { name = "auto_harvest", utility = unitAi.harvest.utility,
+      execute = unitAi.harvest.execute },
     { name = "repair_job", utility = repairUtility,
       execute = repairExecute, onExit = repairOnExit },
     { name = "pickup_ground", utility = pickupUtility,

--- a/scripts/unit_roles.lua
+++ b/scripts/unit_roles.lua
@@ -37,12 +37,18 @@ M.ROLES = {
     { name = "woodcutter", display = "Woodcutter", skill = "woodcutting",  family = "wood"  },
     { name = "builder",    display = "Builder",    skill = "construction", family = "build" },
     { name = "smith",      display = "Smith",      skill = "smithing",     family = "craft" },
+    { name = "farmer",     display = "Farmer",     skill = "farming",      family = "farm"  },
 }
 
 -- Work action → family. deliver/store/build_nearby serve build sites,
 -- so they ride with the Builder. Need- and order-driven actions
 -- (forage, pickup_ground, follow_command, survival, combat) are
 -- deliberately absent: roles only steer ROUTINE work preference.
+--
+-- till/plant/auto_harvest (#336) all ride the "farm" family together —
+-- a Farmer tends the whole till→plant→harvest loop, not just one leg
+-- of it (till_designation shipped with #333 unmapped; #336 is the farm
+-- AI + skill/role landing this issue's own text deferred that decision to).
 M.ACTION_FAMILY = {
     dig_designation        = "mine",
     chop_designation       = "wood",
@@ -52,6 +58,9 @@ M.ACTION_FAMILY = {
     store_materials        = "build",
     repair_job             = "craft",
     craft_job              = "craft",
+    till_designation       = "farm",
+    plant_designation      = "farm",
+    auto_harvest           = "farm",
 }
 
 M.THRESHOLD     = 30.0   -- min skill to claim a specialist role

--- a/src/Engine/Scripting/Lua/API.hs
+++ b/src/Engine/Scripting/Lua/API.hs
@@ -725,6 +725,7 @@ registerLuaAPI lst env backendState = Lua.runWith lst $ do
   registerLuaFunction "plantCropAt" (worldPlantCropAtFn env)
   registerLuaFunction "getCropPlotAt" (worldGetCropPlotAtFn env)
   registerLuaFunction "getPlantSuitability" (worldGetPlantSuitabilityFn env)
+  registerLuaFunction "plantRowCropAt" (worldPlantRowCropAtFn env)
 
   Lua.setglobal (Lua.Name "world")
 

--- a/src/Engine/Scripting/Lua/API/Forage.hs
+++ b/src/Engine/Scripting/Lua/API/Forage.hs
@@ -263,7 +263,15 @@ worldHarvestFloraFn env = do
                                 fh ← fsHarvest sp
                                 let elapsed = cropPlotElapsedDays absDay cp
                                     g = floraGrowth sp elapsed (cropPlotInstance cp)
-                                if harvestOpen sp elapsed g
+                                -- elapsed is the plot's own age clock; the
+                                -- fruiting-window gate reads the real
+                                -- calendar day (doy), matching
+                                -- world.findHarvestableFlora's crop-plot
+                                -- scan and world.getCropPlotAt below — a
+                                -- future fruiting-stage groundcover species
+                                -- must agree across all three query/action
+                                -- entry points.
+                                if harvestOpen sp doy g
                                     then Just fh else Nothing
                         case mPlotHarvest of
                             Just fh → do
@@ -455,7 +463,17 @@ worldFindHarvestableFloraFn env = do
                                     , let elapsed = cropPlotElapsedDays absDay cp
                                           g = floraGrowth sp elapsed
                                                   (cropPlotInstance cp)
-                                    , harvestOpen sp elapsed g
+                                    -- elapsed (days since planting) is the
+                                    -- plot's own AGE clock (#334 — a plot's
+                                    -- growth/phase timeline starts fresh at
+                                    -- planting, not at the calendar epoch),
+                                    -- but the fruiting-window annual-cycle
+                                    -- gate must read the REAL calendar day
+                                    -- (doy) — a future fruiting-stage
+                                    -- groundcover species must ripen in
+                                    -- season, not on an elapsed-day clock
+                                    -- that drifts away from the calendar.
+                                    , harvestOpen sp doy g
                                     , let d2 = (tgx - gx) * (tgx - gx)
                                              + (tgy - gy) * (tgy - gy)
                                     , d2 ≤ r2
@@ -607,18 +625,24 @@ worldGetCropPlotAtFn env = do
                             Nothing → pure Nothing
                             Just cp → do
                                 cat ← readIORef (floraCatalogRef env)
-                                (_, absDay) ← growthClock ws
+                                (doy, absDay) ← growthClock ws
                                 pure $ do
                                     sp ← lookupSpecies (cpSpecies cp) cat
                                     let elapsed = cropPlotElapsedDays absDay cp
                                         g = floraGrowth sp elapsed
                                                 (cropPlotInstance cp)
+                                    -- elapsed is the plot's own age clock
+                                    -- (fine for fgAge/phase); the annual
+                                    -- cycle stage and fruiting-window gate
+                                    -- read the real calendar day (doy), to
+                                    -- agree with world.harvestFlora /
+                                    -- findHarvestableFlora above.
                                     Just ( fsName sp, g, cpHealth cp
                                          , lifePhaseText ⊚ growthPhaseTag sp g
                                          , annualStageText ⊚
-                                               activeStageTag sp elapsed
+                                               activeStageTag sp doy
                                          , isJust (fsHarvest sp)
-                                             ∧ harvestOpen sp elapsed g )
+                                             ∧ harvestOpen sp doy g )
             case mResult of
                 Nothing → Lua.pushnil
                 Just (name, g, health, mPhase, mStage, harvestable) → do

--- a/src/Engine/Scripting/Lua/API/Forage.hs
+++ b/src/Engine/Scripting/Lua/API/Forage.hs
@@ -396,6 +396,7 @@ worldFindHarvestableFloraFn env = do
                         tileData ← readIORef (wsTilesRef ws)
                         cat ← readIORef (floraCatalogRef env)
                         harvests ← readIORef (wsFloraHarvestsRef ws)
+                        cropPlots ← readIORef (wsCropPlotsRef ws)
                         (doy, absDay) ← growthClock ws
                         itemMgr ← readIORef (itemManagerRef env)
                         let (cLo, _) = globalToChunk (gx - radius) (gy - radius)
@@ -433,7 +434,33 @@ worldFindHarvestableFloraFn env = do
                                 , d2 ≤ r2
                                 , not (HM.member (tgx, tgy) harvests)
                                 ]
-                        pure $ case candidates of
+                            -- Planted groundcover crop plots (#334) are a
+                            -- world-level flat map, not chunk-embedded
+                            -- FloraInstances, so they need their own scan
+                            -- (never covered by the fcdInstances sweep
+                            -- above). Mirrors worldHarvestFloraFn's plot
+                            -- branch: BARE calls only (a tag is a
+                            -- designation flow — chop's "wood" — and a
+                            -- plot is never a designation target), no
+                            -- regrowth-timer check (harvesting a plot
+                            -- clears it outright instead of starting one).
+                            cropCandidates = case tagFilter of
+                                Just _  → []
+                                Nothing →
+                                    [ (d2, tgx, tgy, fsName sp)
+                                    | ((tgx, tgy), cp) ← HM.toList cropPlots
+                                    , Just sp ← [lookupSpecies (cpSpecies cp) cat]
+                                    , Just fh ← [fsHarvest sp]
+                                    , wanted fh
+                                    , let elapsed = cropPlotElapsedDays absDay cp
+                                          g = floraGrowth sp elapsed
+                                                  (cropPlotInstance cp)
+                                    , harvestOpen sp elapsed g
+                                    , let d2 = (tgx - gx) * (tgx - gx)
+                                             + (tgy - gy) * (tgy - gy)
+                                    , d2 ≤ r2
+                                    ]
+                        pure $ case candidates ⧺ cropCandidates of
                             [] → Nothing
                             cs → Just (minimum cs)
             case mBest of

--- a/src/Engine/Scripting/Lua/API/Forage.hs
+++ b/src/Engine/Scripting/Lua/API/Forage.hs
@@ -575,7 +575,23 @@ worldPlantCropAtFn env = do
                                     i    = z - ctStartZ col
                                     vg   = if i ≥ 0 ∧ i < VU.length (ctVeg col)
                                            then ctVeg col VU.! i else 0
-                                if not (isTilledSoil vg) then pure False
+                                    -- A tile already carrying a flora
+                                    -- instance (e.g. a row crop planted
+                                    -- via world.plantRowCropAt) must
+                                    -- refuse — otherwise a groundcover
+                                    -- plot lands underneath/on top of it
+                                    -- (world.isPlantable is tilled-soil
+                                    -- only, so it stays "plantable" after
+                                    -- either form is already planted).
+                                    hasExistingFlora = any
+                                        (\fi → fromIntegral (fiTileX fi) ≡ lx
+                                             ∧ fromIntegral (fiTileY fi) ≡ ly)
+                                        (fcdInstances (lcFlora lc))
+                                plots ← readIORef (wsCropPlotsRef ws)
+                                let hasExistingPlot = HM.member (gx, gy) plots
+                                if not (isTilledSoil vg)
+                                   ∨ hasExistingFlora ∨ hasExistingPlot
+                                then pure False
                                 else do
                                     cat ← readIORef (floraCatalogRef env)
                                     case findSpeciesByName name cat of

--- a/src/Engine/Scripting/Lua/API/Plant.hs
+++ b/src/Engine/Scripting/Lua/API/Plant.hs
@@ -74,7 +74,12 @@ plantCancelDesignationFn env = do
         _ → pure ()
     return 0
 
--- | plant.getDesignationAt(pageId, gx, gy) → {x, y, z, crop} | nil.
+-- | plant.getDesignationAt(pageId, gx, gy) → {x, y, z, crop, category} | nil.
+--   @category@ is the crop's worldGen category ("row_crop" |
+--   "groundcover_crop") — the farm AI (#336) needs it to pick which
+--   planting primitive to call (world.plantRowCropAt vs
+--   world.plantCropAt) without a second round-trip through
+--   world.getPlantSuitability.
 plantGetDesignationAtFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
 plantGetDesignationAtFn env = do
     pageIdArg ← Lua.tostring 1
@@ -95,6 +100,9 @@ plantGetDesignationAtFn env = do
                             cat ← Lua.liftIO $ readIORef (floraCatalogRef env)
                             let cropName =
                                     maybe "" fsName (lookupSpecies (ptCrop pd) cat)
+                                category = maybe "" fwCategory
+                                    (HM.lookup (unFloraId (ptCrop pd))
+                                               (fcWorldGen cat))
                             Lua.newtable
                             Lua.pushinteger (fromIntegral gx)
                             Lua.setfield (Lua.nth 2) "x"
@@ -104,6 +112,8 @@ plantGetDesignationAtFn env = do
                             Lua.setfield (Lua.nth 2) "z"
                             Lua.pushstring (TE.encodeUtf8 cropName)
                             Lua.setfield (Lua.nth 2) "crop"
+                            Lua.pushstring (TE.encodeUtf8 category)
+                            Lua.setfield (Lua.nth 2) "category"
                             return 1
                         Nothing → Lua.pushnil >> return 1
         _ → Lua.pushnil >> return 1

--- a/src/Engine/Scripting/Lua/API/World.hs
+++ b/src/Engine/Scripting/Lua/API/World.hs
@@ -55,6 +55,7 @@ module Engine.Scripting.Lua.API.World
     , worldSetFluidTileFn
     , worldSetSlopeFn
     , worldSetVegFn
+    , worldPlantRowCropAtFn
     , worldSetCellFn
     , worldMarkLocationContentsSpawnedFn
     , worldMarkLocationStampedFn
@@ -1482,6 +1483,34 @@ worldSetSlopeFn env = do
                         (fromIntegral gx) (fromIntegral gy)
                         (fromIntegral z)
                         (fromIntegral bits)  -- → Word8 truncates to low 8 bits
+            Lua.pushboolean True
+            return 1
+        _ → do
+            Lua.pushboolean False
+            return 1
+
+-- | world.plantRowCropAt(pageId, gx, gy, cropName) → bool
+--   Plant a single row-crop FloraInstance at (gx,gy) via the WePlaceFlora
+--   edit path (queued, same fire-and-forget shape as world.setVegAt) —
+--   the farm AI's (#336) row-crop planting completion, the FloraInstance
+--   counterpart to world.plantCropAt's CropPlot for groundcover crops.
+--   Refused world-thread-side unless the tile is tilled soil and
+--   cropName names a registered row_crop species; poll
+--   world.getFloraGrowthAt afterward to confirm it landed.
+worldPlantRowCropAtFn ∷ EngineEnv → Lua.LuaE Lua.Exception Lua.NumResults
+worldPlantRowCropAtFn env = do
+    pageIdArg ← Lua.tostring 1
+    gxArg     ← Lua.tointeger 2
+    gyArg     ← Lua.tointeger 3
+    cropArg   ← Lua.tostring 4
+    case (pageIdArg, gxArg, gyArg, cropArg) of
+        (Just pageIdBS, Just gx, Just gy, Just cropBS) → do
+            Lua.liftIO $ do
+                let pageId = WorldPageId (TE.decodeUtf8 pageIdBS)
+                Q.writeQueue (worldQueue env) $
+                    WorldPlantRowCropAt pageId
+                        (fromIntegral gx) (fromIntegral gy)
+                        (TE.decodeUtf8 cropBS)
             Lua.pushboolean True
             return 1
         _ → do

--- a/src/World/Command/Types.hs
+++ b/src/World/Command/Types.hs
@@ -180,6 +180,14 @@ data WorldCommand
         -- ^ Set the vegetation id of the tile at (gx,gy,z) via the
         --   WeSetVeg edit path (world.setVegAt) — the till AI's
         --   completion primitive (#333), same shape as world.setSlope.
+    | WorldPlantRowCropAt WorldPageId Int Int Text
+        -- ^ worldId, gx, gy, cropName. Plant a single row-crop
+        --   FloraInstance at (gx,gy) via the WePlaceFlora edit path
+        --   (world.plantRowCropAt) — the farm AI's (#336) row-crop
+        --   planting completion, the FloraInstance counterpart to
+        --   world.plantCropAt's CropPlot for groundcover crops. Refused
+        --   world-thread-side unless the tile is tilled soil and
+        --   cropName names a registered row_crop species.
     | WorldDigTile WorldPageId Int Int Float Float Float Float Float
         -- ^ Apply dig progress to the designated tile at (gx, gy):
         --   pageId gx gy uxPos uyPos amount minerSkill perception.

--- a/src/World/Edit/Apply.hs
+++ b/src/World/Edit/Apply.hs
@@ -182,6 +182,31 @@ applyEdit (WeSetVeg gx gy z vegId) lc
            else
                let col' = col { ctVeg = ctVeg col VU.// [(i, vegId)] }
                in lc { lcTiles = lcTiles lc V.// [(idx, col')] }
+applyEdit (WePlaceFlora gx gy fid plantedDay baseWidth) lc
+    | not (edgeBelongsTo gx gy lc) = lc
+    | otherwise =
+        let (_, (lx, ly)) = globalToChunk gx gy
+            idx = columnIndex lx ly
+            z   = lcSurfaceMap lc VU.! idx
+            -- age(day) = fiAge + day · growthRate(fiHealth) (World.Flora.
+            -- Growth). Full health (rate 1.0) + a negative fiAge baseline
+            -- of -plantedDay makes the instance read as age 0 on its own
+            -- planted day and grow from there, exactly like a CropPlot's
+            -- cpPlantedDay does for groundcover crops.
+            inst = FloraInstance
+                { fiSpecies   = fid
+                , fiTileX     = fromIntegral lx
+                , fiTileY     = fromIntegral ly
+                , fiOffU      = 0.0
+                , fiOffV      = 0.0
+                , fiZ         = z
+                , fiAge       = negate (fromIntegral plantedDay)
+                , fiHealth    = 1.0
+                , fiVariant   = 0
+                , fiBaseWidth = baseWidth
+                }
+        in lc { lcFlora = FloraChunkData
+                    (inst : fcdInstances (lcFlora lc)) }
 applyEdit (WeSetCell gx gy z mat) lc
     | not (edgeBelongsTo gx gy lc) = lc
     | otherwise =

--- a/src/World/Edit/Types.hs
+++ b/src/World/Edit/Types.hs
@@ -21,6 +21,7 @@ import GHC.Generics (Generic)
 import qualified Data.HashMap.Strict as HM
 import World.Chunk.Types (ChunkCoord(..))
 import World.Fluid.Types (FluidType(..))
+import World.Flora.Types (FloraId)
 import World.Material.Id (MaterialId(..))
 
 -- | One tile-scale edit, keyed by global (gx, gy). Replay order
@@ -75,6 +76,24 @@ data WorldEdit
                                            --   and have it survive chunk
                                            --   eviction + save/load like every
                                            --   other edit.
+    | WePlaceFlora !Int !Int !FloraId !Int !Float
+                                           -- ^ Plant a single new row-crop
+                                           --   'World.Flora.Types.FloraInstance'
+                                           --   at (gx,gy): species id, the
+                                           --   absolute world day it was
+                                           --   planted (the age-0 baseline —
+                                           --   mirrors 'World.Flora.CropPlot's
+                                           --   cpPlantedDay), and the species'
+                                           --   worldgen footprint (baked in so
+                                           --   replay never needs a catalog
+                                           --   lookup). No generator path emits
+                                           --   this — 'World.Flora.Placement'
+                                           --   only places row crops once, at
+                                           --   worldgen time; this exists so
+                                           --   the farm AI's (#336)
+                                           --   world.plantRowCropAt survives
+                                           --   chunk eviction + save/load like
+                                           --   every other edit.
     deriving (Show, Eq, Generic, Serialize)
 
 -- | All edits in a world, keyed by the chunk that contains them.

--- a/src/World/Save/Types.hs
+++ b/src/World/Save/Types.hs
@@ -124,7 +124,14 @@ saveMagic = 0x53595241
 --       river carve. Positional Generic Serialize drops the trailing
 --       field, incompatible with v61 (#385).
 currentSaveVersion ∷ Int
-currentSaveVersion = 78  -- v78: WorldPageSave gains trailing
+currentSaveVersion = 79  -- v79: WorldEdit gains a new trailing
+                         --      'WePlaceFlora' constructor (#336) — the
+                         --      farm AI's row-crop planting completion
+                         --      (world.plantRowCropAt). Order-preserving
+                         --      (appended at the end), but per this
+                         --      module's own policy any new WorldEdit
+                         --      variant bumps the version.
+                         -- v78: WorldPageSave gains trailing
                          --      'wpsPlantDesignations' (#335) — plant
                          --      designations (tile → surface z + chosen
                          --      crop species). Like the other

--- a/src/World/Thread/Command.hs
+++ b/src/World/Thread/Command.hs
@@ -74,7 +74,8 @@ import World.Thread.Command.Edit (handleWorldDeleteTileCommand
                                  , handleWorldClearStructureCommand
                                  , handleWorldClearAllStructuresCommand
                                  , handleWorldDigTileCommand
-                                 , handleWorldAddTileCommand)
+                                 , handleWorldAddTileCommand
+                                 , handleWorldPlantRowCropAtCommand)
 import World.Thread.Command.Location
     (handleWorldMarkLocationContentsSpawnedCommand
     ,handleWorldMarkLocationStampedCommand)
@@ -178,6 +179,8 @@ handleWorldCommand env logger (WorldSetPlantDesignateTexture pageId texHandle)
   = handleWorldSetPlantDesignateTextureCommand env logger pageId texHandle
 handleWorldCommand env logger (WorldSetVeg pageId gx gy z vegId)
   = handleWorldSetVegCommand env logger pageId gx gy z vegId
+handleWorldCommand env logger (WorldPlantRowCropAt pageId gx gy cropName)
+  = handleWorldPlantRowCropAtCommand env logger pageId gx gy cropName
 handleWorldCommand env logger (WorldDigTile pageId gx gy ux uy amount skill percep)
   = handleWorldDigTileCommand env logger pageId gx gy ux uy amount skill percep
 handleWorldCommand env logger (WorldAddTile pageId gx gy mat)

--- a/src/World/Thread/Command/Cursor.hs
+++ b/src/World/Thread/Command/Cursor.hs
@@ -683,8 +683,15 @@ handleWorldSetTillDesignateTextureCommand env _logger pageId tid = do
 
 -- | Commit a plant designation at (gx, gy) for the named crop. Refused
 --   (silently — the caller polls plant.getDesignationAt to confirm) if
---   the chunk isn't loaded, the tile isn't tilled soil, or cropName
---   doesn't name a registered plantable-crop species.
+--   the chunk isn't loaded, the tile isn't tilled soil, the tile is
+--   already occupied (an existing flora instance or crop plot — #336's
+--   plantCropAt/plantRowCropAt both refuse to plant over one, and
+--   world.isPlantable is tilled-soil-only so it can't tell the
+--   difference on its own; excluding an occupied tile HERE, same as
+--   till's own designation excludes flora-carrying tiles, keeps a farm
+--   AI from spending a full walk-and-work cycle on a designation that
+--   was always going to fail), or cropName doesn't name a registered
+--   plantable-crop species.
 handleWorldDesignatePlantCommand ∷ EngineEnv → LoggerState → WorldPageId
     → Int → Int → Text → IO ()
 handleWorldDesignatePlantCommand env logger pageId gx gy cropName = do
@@ -694,8 +701,10 @@ handleWorldDesignatePlantCommand env logger pageId gx gy cropName = do
         Just worldState → do
             tileData ← readIORef (wsTilesRef worldState)
             cat ← readIORef (floraCatalogRef env)
+            plots ← readIORef (wsCropPlotsRef worldState)
             let (coord, (lx, ly)) = globalToChunk gx gy
                 idx = columnIndex lx ly
+                hasExistingPlot = HM.member (gx, gy) plots
                 resolvedCrop = case findSpeciesByName cropName cat of
                     Just (fid, _sp)
                         | Just wg ← HM.lookup (unFloraId fid) (fcWorldGen cat)
@@ -708,7 +717,13 @@ handleWorldDesignatePlantCommand env logger pageId gx gy cropName = do
                         i   = z - ctStartZ col
                         vg  = if i ≥ 0 ∧ i < VU.length (ctVeg col)
                               then ctVeg col VU.! i else 0
-                    if isTilledSoil vg then Just z else Nothing
+                        hasExistingFlora = any
+                            (\fi → fromIntegral (fiTileX fi) ≡ lx
+                                 ∧ fromIntegral (fiTileY fi) ≡ ly)
+                            (fcdInstances (lcFlora lc))
+                    if isTilledSoil vg ∧ not hasExistingFlora
+                       ∧ not hasExistingPlot
+                    then Just z else Nothing
             case (tileZ, resolvedCrop) of
                 (Just z, Just fid) → do
                     atomicModifyIORef' (wsPlantDesignationsRef worldState) $

--- a/src/World/Thread/Command/Edit.hs
+++ b/src/World/Thread/Command/Edit.hs
@@ -394,6 +394,19 @@ handleWorldPlantRowCropAtCommand env logger pageId gx gy cropName = do
                         i   = z - ctStartZ col
                         vg  = if i ≥ 0 ∧ i < VU.length (ctVeg col)
                               then ctVeg col VU.! i else 0
+                        -- A tile already carrying a flora instance
+                        -- (a prior plantRowCropAt, or in principle any
+                        -- other rooted flora) must refuse a second
+                        -- planting — otherwise repeated calls (a
+                        -- re-designate + re-plant, or the primitive
+                        -- called twice) stack overlapping FloraInstances
+                        -- that all persist via the edit log.
+                        hasExistingFlora = any
+                            (\fi → fromIntegral (fiTileX fi) ≡ lx
+                                 ∧ fromIntegral (fiTileY fi) ≡ ly)
+                            (fcdInstances (lcFlora lc))
+                    plots ← readIORef (wsCropPlotsRef ws)
+                    let hasExistingPlot = HM.member (gx, gy) plots
                     case resolved of
                         Nothing →
                             logWarn logger CatWorld $
@@ -404,6 +417,11 @@ handleWorldPlantRowCropAtCommand env logger pageId gx gy cropName = do
                             logWarn logger CatWorld $
                                 "Plant row crop refused (not tilled soil) at "
                                   <> T.pack (show gx) <> "," <> T.pack (show gy)
+                        Just _ | hasExistingFlora ∨ hasExistingPlot →
+                            logWarn logger CatWorld $
+                                "Plant row crop refused (tile already "
+                                  <> "planted) at " <> T.pack (show gx) <> ","
+                                  <> T.pack (show gy)
                         Just (fid, baseWidth) → do
                             paramsM ← readIORef (wsGenParamsRef ws)
                             date ← readIORef (wsDateRef ws)

--- a/src/World/Thread/Command/Edit.hs
+++ b/src/World/Thread/Command/Edit.hs
@@ -10,6 +10,7 @@ module World.Thread.Command.Edit
     , handleWorldClearStructureCommand
     , handleWorldClearAllStructuresCommand
     , handleWorldDigTileCommand
+    , handleWorldPlantRowCropAtCommand
     ) where
 
 import UPrelude
@@ -27,6 +28,7 @@ import World.Types
 import World.Generate.Coordinates (globalToChunk)
 import World.Edit.Types (WorldEdit(..), appendEdit)
 import World.Edit.Apply (applyEdit)
+import World.Vegetation (isTilledSoil)
 import Structure.Types (emptyChunkStructures)
 import World.Material (MaterialProps(..), getMaterialProps
                       , materialIdByName)
@@ -355,6 +357,72 @@ handleWorldSetVegCommand env logger pageId gx gy z vegId = do
                             "Set veg at " <> T.pack (show gx) <> ","
                               <> T.pack (show gy) <> " z=" <> T.pack (show z)
                               <> " vegId=" <> T.pack (show vegId)
+
+-- | Plant a single row-crop FloraInstance at (gx, gy) via the
+--   WePlaceFlora edit path — the farm AI's (#336) row-crop planting
+--   completion, the FloraInstance counterpart to world.plantCropAt's
+--   CropPlot for groundcover crops. Refused (a warn, no mutation) unless
+--   the chunk is loaded, the tile is tilled soil, and cropName names a
+--   registered row_crop species — mirrors handleWorldDesignatePlantCommand's
+--   validation.
+handleWorldPlantRowCropAtCommand ∷ EngineEnv → LoggerState → WorldPageId
+    → Int → Int → Text → IO ()
+handleWorldPlantRowCropAtCommand env logger pageId gx gy cropName = do
+    mgr ← readIORef (worldManagerRef env)
+    case lookup pageId (wmWorlds mgr) of
+        Nothing →
+            logWarn logger CatWorld $
+                "World not found for plant row crop: " <> unWorldPageId pageId
+        Just ws → do
+            let (coord, (lx, ly)) = globalToChunk gx gy
+                idx  = columnIndex lx ly
+            td ← readIORef (wsTilesRef ws)
+            cat ← readIORef (floraCatalogRef env)
+            let resolved = do
+                    (fid, _sp) ← findSpeciesByName cropName cat
+                    wg ← HM.lookup (unFloraId fid) (fcWorldGen cat)
+                    if fwCategory wg ≡ "row_crop"
+                        then Just (fid, fwFootprint wg) else Nothing
+            case lookupChunk coord td of
+                Nothing →
+                    logWarn logger CatWorld $
+                        "Chunk not loaded for plant row crop at "
+                          <> T.pack (show gx) <> "," <> T.pack (show gy)
+                Just lc → do
+                    let col = lcTiles lc V.! idx
+                        z   = lcSurfaceMap lc VU.! idx
+                        i   = z - ctStartZ col
+                        vg  = if i ≥ 0 ∧ i < VU.length (ctVeg col)
+                              then ctVeg col VU.! i else 0
+                    case resolved of
+                        Nothing →
+                            logWarn logger CatWorld $
+                                "Plant row crop refused (unknown/non-row-crop"
+                                  <> " species) at " <> T.pack (show gx) <> ","
+                                  <> T.pack (show gy) <> " crop=" <> cropName
+                        Just _ | not (isTilledSoil vg) →
+                            logWarn logger CatWorld $
+                                "Plant row crop refused (not tilled soil) at "
+                                  <> T.pack (show gx) <> "," <> T.pack (show gy)
+                        Just (fid, baseWidth) → do
+                            paramsM ← readIORef (wsGenParamsRef ws)
+                            date ← readIORef (wsDateRef ws)
+                            let calendar = maybe defaultCalendarConfig
+                                               wgpCalender paramsM
+                                absDay = worldAbsoluteDay calendar date
+                                edit = WePlaceFlora gx gy fid absDay baseWidth
+                                lc'  = applyEdit edit lc
+                            atomicModifyIORef' (wsTilesRef ws) $ \w →
+                                (insertChunk lc' w, ())
+                            atomicModifyIORef' (wsEditsRef ws) $ \es →
+                                (appendEdit coord edit es, ())
+                            bumpQuadCacheGen ws
+                            writeIORef (wsZoomQuadCacheRef ws) Nothing
+                            writeIORef (wsBgQuadCacheRef ws)   Nothing
+                            logDebug logger CatWorld $
+                                "Planted row crop " <> cropName <> " at "
+                                  <> T.pack (show gx) <> ","
+                                  <> T.pack (show gy)
 
 -- | Set a single 3D cell at (gx, gy, z) to a material (id 0 = air) via
 --   the WeSetCell edit path — the locations primitive for carving

--- a/tools/crop_probe.py
+++ b/tools/crop_probe.py
@@ -161,16 +161,22 @@ def find_species_tile(port, species, harvestable=None, lo=-64, hi=64):
 
 
 def find_dry_tile(port, cx, cy, radius=12):
-    """Nearest tile to (cx, cy) with a real surface and no fluid on it —
-    world.getSurfaceAt returns MULTIPLE Lua values (surfaceZ, terrainZ,
-    fluidType, fluidSurface), not a table, so wrap it into one value
-    per call. Returns (gx, gy, surfaceZ) or None."""
+    """Nearest tile to (cx, cy) with a real surface, no fluid, and no
+    existing flora on it — world.getSurfaceAt returns MULTIPLE Lua
+    values (surfaceZ, terrainZ, fluidType, fluidSurface), not a table,
+    so wrap it into one value per call. The flora exclusion matters
+    since #336: world.plantCropAt now refuses a tile that already
+    carries a flora instance (no planting underneath/on top of an
+    existing plant), so a wild bush here would make the subsequent
+    plantCropAt call spuriously refuse. Returns (gx, gy, surfaceZ) or
+    None."""
     r = send(
         port,
         f"for r=0,{radius} do for dx=-r,r do for dy=-r,r do "
         f"local gx,gy={cx}+dx,{cy}+dy; "
         f"local sz,tz,ft=world.getSurfaceAt(gx,gy); "
-        f"if sz and not ft then return gx..','..gy..','..sz end "
+        f"if sz and not ft and not world.getFloraAt(gx,gy) then "
+        f"return gx..','..gy..','..sz end "
         f"end end end return 'none'",
         timeout=30.0)
     r = r.strip('"')

--- a/tools/farm_ai_probe.py
+++ b/tools/farm_ai_probe.py
@@ -19,10 +19,12 @@ Checks:
   2. plantRowCropAt refused for a groundcover_crop name (wheat) — mirrors
      plantCropAt's reciprocal refusal of a row_crop name.
   3. plantRowCropAt places a real row-crop instance (tomato_plant) on
-     tilled soil, at full health, age ~0.
-  4. Rot: the freshly-planted row crop becomes harvestable in its
-     fruiting window and NOT harvestable once the calendar rolls into
-     senescing without being picked — the #332 mechanic, exercised
+     tilled soil, at full health, age ~0. A tile already carrying an
+     instance then refuses a second planting (no duplicate/overlapping
+     instances stacking from a re-plant).
+  4. Rot: a freshly-planted row crop (its own tile) becomes harvestable
+     in its fruiting window and NOT harvestable once the calendar rolls
+     into senescing without being picked — the #332 mechanic, exercised
      through THIS issue's own planting primitive.
   5. plant.getDesignationAt's new "category" field reports row_crop /
      groundcover_crop correctly (the farm AI's dispatch key).
@@ -39,7 +41,10 @@ Checks:
      autonomously finds and harvests it — NOT hunger-gated, reuses
      #94's yield path — clearing the plot and dropping wheat_grain on
      the ground, growing farming XP further.
- 10. Save/load: the row-crop instance (WePlaceFlora, save v79) survives
+ 10. Re-designating a tile the AI has already claimed with a DIFFERENT
+     crop makes it plant the NEW crop, not the stale one it originally
+     walked over for (plant.designate replaces in place, HM.insert).
+ 11. Save/load: the row-crop instance (WePlaceFlora, save v79) survives
      save → loadSave.
 
 Usage: python3 tools/farm_ai_probe.py [--port 9336] [--seed 42]
@@ -216,12 +221,14 @@ def main():
         send(port, "return world.loadChunksInRegion(-4, -4, 4, 4)", timeout=30)
         send(port, "return world.waitForChunks(120)", timeout=125)
 
-        # Three distinct tiles: A (groundcover, full till+plant+harvest
-        # AI loop) and B (row crop, AI-planted) near the origin; C (row
-        # crop, direct-primitive refusal + rot checks) far enough away
-        # (>24 tiles, past harvest_scan_range) that the acolyte working
-        # A/B can never stumble onto it and confound the "ignored crop
-        # rots" check.
+        # Four distinct tiles: A (groundcover, full till+plant+harvest AI
+        # loop) and B (row crop, AI-planted) near the origin; C and D
+        # (direct-primitive checks: refusal + a single real plant, and
+        # the rot timeline, respectively — a planted tile now refuses a
+        # second planting, so the rot check needs its OWN fresh tile
+        # rather than replanting C) far enough away (>24 tiles, past
+        # harvest_scan_range) that the acolyte working A/B can never
+        # stumble onto them and confound the "ignored crop rots" check.
         used = set()
         tA = find_tillable(port)
         if not tA:
@@ -237,10 +244,17 @@ def main():
         if not tC:
             print("  [FAIL] no tillable tile found for site C (try another seed)")
             return 1
+        used.add(tC)
+        tD = find_tillable(port, cx=-60, cy=-60, exclude=used)
+        if not tD:
+            print("  [FAIL] no tillable tile found for site D (try another seed)")
+            return 1
         ax, ay = tA
         bx, by = tB
         cx, cy = tC
-        print(f"  site A={tA} (groundcover) B={tB} (row, AI) C={tC} (row, direct)")
+        dx, dy = tD
+        print(f"  site A={tA} (groundcover) B={tB} (row, AI) C={tC} (row, direct) "
+              f"D={tD} (row, rot)")
 
         # --- 1/2/3. Direct-primitive plantRowCropAt checks (tile C) ---
         refused0 = growth_entries(port, cx, cy, "tomato_plant")
@@ -280,23 +294,39 @@ def main():
         #     window to auto-harvest it first. Recipe: land the SECOND
         #     setDate ~197 days after whatever moment this was planted
         #     at (mirrors crop_probe.py's proven day5->day202 jump for
-        #     tomato_plant's real annualCycle: fruiting@90..240). ---
+        #     tomato_plant's real annualCycle: fruiting@90..240). Its OWN
+        #     tile (D) — a planted tile now refuses a second planting
+        #     (see check 3b below), so this can't reuse C. ---
+        dz = jget(port, f"local sz=world.getSurfaceAt({dx},{dy}); return sz")
+        till_and_wait(port, "probe", dx, dy, dz)
         set_date(port, "probe", 2, 1, 5)
-        send(port, f"world.plantRowCropAt('probe',{cx},{cy},'tomato_plant'); "
+        send(port, f"world.plantRowCropAt('probe',{dx},{dy},'tomato_plant'); "
                    f"return 'ok'")
         set_date(port, "probe", 2, 7, 21)
-        ripe = growth_entries(port, cx, cy, "tomato_plant")
+        ripe = growth_entries(port, dx, dy, "tomato_plant")
         ok4a = any(e.get("stage") == "fruiting" and e.get("harvestable")
                    for e in ripe)
         passed &= ok4a
         print(f"  [{'PASS' if ok4a else 'FAIL'}] planted row crop reaches "
               f"its fruiting window: {ripe}")
         set_date(port, "probe", 2, 9, 15)
-        rotten = growth_entries(port, cx, cy, "tomato_plant")
+        rotten = growth_entries(port, dx, dy, "tomato_plant")
         ok4b = ok4a and not any(e.get("harvestable") for e in rotten)
         passed &= ok4b
         print(f"  [{'PASS' if ok4b else 'FAIL'}] ignored ripe crop rots past "
               f"senescing: {rotten}")
+
+        # --- 3b. A tile that's already been planted refuses a second
+        #     planting (guards against overlapping/duplicate instances
+        #     stacking from a re-designate or a repeated direct call). ---
+        send(port, f"world.plantRowCropAt('probe',{cx},{cy},'tomato_plant'); "
+                   f"return 'ok'")
+        time.sleep(0.5)
+        es_dup = growth_entries(port, cx, cy, "tomato_plant")
+        ok3b = len(es_dup) == 1
+        passed &= ok3b
+        print(f"  [{'PASS' if ok3b else 'FAIL'}] plantRowCropAt refuses an "
+              f"already-planted tile (no duplicate instance): {es_dup}")
 
         # --- 5. plant.getDesignationAt's category field ---
         send(port, f"plant.designate('probe',{cx},{cy},'tomato_plant'); "
@@ -457,7 +487,57 @@ def main():
               f"from auto-harvest: {farming_after_plant} -> "
               f"{farming_after_harvest}")
 
-        # --- 10. Save/load: the AI-planted row crop (WePlaceFlora, v79)
+        # --- 10. Re-designating a claimed tile with a DIFFERENT crop
+        #     must not plant the stale crop the unit originally claimed.
+        #     plant.designate replaces in place (HM.insert), so a player
+        #     can swap the crop mid-job; the AI must notice and plant
+        #     whatever's there NOW, not what it walked over for. ---
+        tE = find_tillable(port, exclude=used)
+        if not tE:
+            print("  [FAIL] no tillable tile found for site E (try another seed)")
+            return 1
+        used.add(tE)
+        ex, ey = tE
+        ez = jget(port, f"local sz=world.getSurfaceAt({ex},{ey}); return sz")
+        till_and_wait(port, "probe", ex, ey, ez)
+        send(port, f"plant.designate('probe',{ex},{ey},'wheat'); return 'ok'")
+
+        deadline = time.time() + 30.0
+        claimed = False
+        while time.time() < deadline:
+            time.sleep(0.5)
+            job = send(port,
+                       f"local ai=require('scripts.unit_ai'); "
+                       f"local s=ai.getState({uid}); "
+                       f"if s and s.plantJob then return s.plantJob.x..','.."
+                       f"s.plantJob.y else return 'none' end").strip('"')
+            if job == f"{ex},{ey}":
+                claimed = True
+                break
+        if not claimed:
+            print("  [FAIL] acolyte never claimed the re-designation test job")
+            return 1
+        send(port, f"plant.designate('probe',{ex},{ey},'tomato_plant'); "
+                   f"return 'ok'")
+
+        deadline = time.time() + 90.0
+        redesignated_done = False
+        while time.time() < deadline:
+            time.sleep(2.0)
+            de = jget(port, f"return plant.getDesignationAt('probe',{ex},{ey})")
+            if not isinstance(de, dict):
+                redesignated_done = True
+                break
+        planted_new = growth_entries(port, ex, ey, "tomato_plant")
+        planted_stale = jget(port, f"return world.getCropPlotAt({ex},{ey})")
+        ok10 = (redesignated_done and len(planted_new) >= 1
+                and planted_stale is None)
+        passed &= ok10
+        print(f"  [{'PASS' if ok10 else 'FAIL'}] re-designating a claimed tile "
+              f"plants the NEW crop, not the stale one: "
+              f"new={planted_new} stale_plot={planted_stale}")
+
+        # --- 11. Save/load: the AI-planted row crop (WePlaceFlora, v79)
         #     survives save -> loadSave. ---
         send(port, "engine.saveWorld('probe', 'farm_ai_v79_check'); "
                    "return 'ok'")

--- a/tools/farm_ai_probe.py
+++ b/tools/farm_ai_probe.py
@@ -27,7 +27,12 @@ Checks:
   4. Rot: a freshly-planted row crop (its own tile) becomes harvestable
      in its fruiting window and NOT harvestable once the calendar rolls
      into senescing without being picked — the #332 mechanic, exercised
-     through THIS issue's own planting primitive.
+     through THIS issue's own planting primitive. The rotten-but-still-
+     standing plant then makes plant.designate itself refuse that tile
+     (the designation path is the occupancy gate, not just the two
+     planting primitives — a farm AI should never walk a full
+     claim-and-work cycle toward a designation that was always going to
+     fail the primitive's own occupancy guard).
   5. plant.getDesignationAt's new "category" field reports row_crop /
      groundcover_crop correctly (the farm AI's dispatch key).
   6. Full loop, tile A (groundcover): till.designate → AI tills
@@ -251,12 +256,18 @@ def main():
         if not tD:
             print("  [FAIL] no tillable tile found for site D (try another seed)")
             return 1
+        used.add(tD)
+        tF = find_tillable(port, cx=-60, cy=-60, exclude=used)
+        if not tF:
+            print("  [FAIL] no tillable tile found for site F (try another seed)")
+            return 1
         ax, ay = tA
         bx, by = tB
         cx, cy = tC
         dx, dy = tD
+        fx, fy = tF
         print(f"  site A={tA} (groundcover) B={tB} (row, AI) C={tC} (row, direct) "
-              f"D={tD} (row, rot)")
+              f"D={tD} (row, rot) F={tF} (category field)")
 
         # --- 1/2/3. Direct-primitive plantRowCropAt checks (tile C) ---
         refused0 = growth_entries(port, cx, cy, "tomato_plant")
@@ -318,6 +329,19 @@ def main():
         print(f"  [{'PASS' if ok4b else 'FAIL'}] ignored ripe crop rots past "
               f"senescing: {rotten}")
 
+        # --- 4b. plant.designate itself refuses an occupied tile (the
+        #     rotten-but-still-standing tomato at D) — the designation
+        #     path is the actual gate now, not just the two planting
+        #     primitives, so a farm AI never spends a full walk-and-work
+        #     cycle on a designation that was always going to fail. ---
+        send(port, f"plant.designate('probe',{dx},{dy},'wheat'); return 'ok'")
+        time.sleep(0.5)
+        d4c = jget(port, f"return plant.getDesignationAt('probe',{dx},{dy})")
+        ok4c = not isinstance(d4c, dict)
+        passed &= ok4c
+        print(f"  [{'PASS' if ok4c else 'FAIL'}] plant.designate refuses an "
+              f"already-occupied tile: {d4c}")
+
         # --- 3b. A tile that's already been planted refuses a second
         #     planting (guards against overlapping/duplicate instances
         #     stacking from a re-designate or a repeated direct call). ---
@@ -343,21 +367,25 @@ def main():
               f"already carrying a row-crop instance: planted={cross_plant} "
               f"plot={cross_plot}")
 
-        # --- 5. plant.getDesignationAt's category field ---
-        send(port, f"plant.designate('probe',{cx},{cy},'tomato_plant'); "
+        # --- 5. plant.getDesignationAt's category field (its own fresh,
+        #     unoccupied tile F — C is already planted by this point,
+        #     and an occupied tile now refuses designation, check 4b). ---
+        fz = jget(port, f"local sz=world.getSurfaceAt({fx},{fy}); return sz")
+        till_and_wait(port, "probe", fx, fy, fz)
+        send(port, f"plant.designate('probe',{fx},{fy},'tomato_plant'); "
                    f"return 'ok'")
         time.sleep(0.5)
-        dcat_row = jget(port, f"return plant.getDesignationAt('probe',{cx},{cy})")
-        send(port, f"plant.designate('probe',{cx},{cy},'wheat'); return 'ok'")
+        dcat_row = jget(port, f"return plant.getDesignationAt('probe',{fx},{fy})")
+        send(port, f"plant.designate('probe',{fx},{fy},'wheat'); return 'ok'")
         time.sleep(0.5)
-        dcat_ground = jget(port, f"return plant.getDesignationAt('probe',{cx},{cy})")
+        dcat_ground = jget(port, f"return plant.getDesignationAt('probe',{fx},{fy})")
         ok5 = (isinstance(dcat_row, dict) and dcat_row.get("category") == "row_crop"
                and isinstance(dcat_ground, dict)
                and dcat_ground.get("category") == "groundcover_crop")
         passed &= ok5
         print(f"  [{'PASS' if ok5 else 'FAIL'}] getDesignationAt reports "
               f"category: row={dcat_row} ground={dcat_ground}")
-        send(port, f"plant.cancelDesignation({cx},{cy}); return 'ok'")
+        send(port, f"plant.cancelDesignation({fx},{fy}); return 'ok'")
 
         # --- 6/7/8. Full AI loop: till (A) -> plant (A, wheat) ->
         #     plant (B, tomato_plant, pre-tilled) ---

--- a/tools/farm_ai_probe.py
+++ b/tools/farm_ai_probe.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+"""Farm AI probe (#336): plant + skill-gated auto-harvest + rot.
+
+Boots a headless engine on a real generated world and drives the
+capstone of the farming epic (#331) — till → plant → grow → auto-harvest
+— end to end through the real acolyte AI stack, plus the two new
+primitives this issue adds:
+
+  - world.plantRowCropAt: runtime placement of a row-crop FloraInstance
+    (the WePlaceFlora edit path, save v79) — #334 only ever placed row
+    crops at worldgen time; #336 needs to place one when a unit finishes
+    planting a row-crop designation.
+  - world.findHarvestableFlora's new CropPlot scan — so auto-harvest can
+    discover a ripe PLANTED groundcover crop, not just wild FloraInstances.
+
+Checks:
+
+  1. plantRowCropAt refused on untilled soil (no instance appears).
+  2. plantRowCropAt refused for a groundcover_crop name (wheat) — mirrors
+     plantCropAt's reciprocal refusal of a row_crop name.
+  3. plantRowCropAt places a real row-crop instance (tomato_plant) on
+     tilled soil, at full health, age ~0.
+  4. Rot: the freshly-planted row crop becomes harvestable in its
+     fruiting window and NOT harvestable once the calendar rolls into
+     senescing without being picked — the #332 mechanic, exercised
+     through THIS issue's own planting primitive.
+  5. plant.getDesignationAt's new "category" field reports row_crop /
+     groundcover_crop correctly (the farm AI's dispatch key).
+  6. Full loop, tile A (groundcover): till.designate → AI tills
+     autonomously (farming-skill-scaled, #265) → plant.designate(wheat)
+     → AI plants autonomously (world.plantCropAt) → getCropPlotAt shows
+     it planted, at full health.
+  7. Full loop, tile B (row crop): pre-tilled, plant.designate
+     (tomato_plant) → AI plants autonomously (world.plantRowCropAt) →
+     getFloraGrowthAt shows the new instance.
+  8. Farming skill (#265) grows from these actions.
+  9. Auto-harvest: fast-forward tile A's wheat past its 30-day
+     vegetating threshold, then the same (now idle) acolyte
+     autonomously finds and harvests it — NOT hunger-gated, reuses
+     #94's yield path — clearing the plot and dropping wheat_grain on
+     the ground, growing farming XP further.
+ 10. Save/load: the row-crop instance (WePlaceFlora, save v79) survives
+     save → loadSave.
+
+Usage: python3 tools/farm_ai_probe.py [--port 9336] [--seed 42]
+       [--size 64] [--plates 3]
+"""
+import argparse, glob, json, socket, subprocess, sys, time
+
+SPROOT = "/tmp"
+
+
+def send(port, lua, timeout=10.0):
+    with socket.create_connection(("localhost", port), timeout=timeout) as s:
+        s.settimeout(timeout)
+        f = s.makefile("rw")
+        f.readline()              # banner
+        f.write(lua + "\n")
+        f.flush()
+        return f.readline().strip().lstrip("> ").strip()
+
+
+def jget(port, lua, timeout=10.0):
+    raw = send(port, lua, timeout)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw.strip('"')
+
+
+def boot(port, log_path):
+    log = open(log_path, "w")
+    proc = subprocess.Popen(
+        ["cabal", "run", "-v0", "exe:synarchy", "--",
+         "--headless", "--port", str(port)],
+        stdout=log, stderr=subprocess.STDOUT)
+    for _ in range(300):
+        time.sleep(0.2)
+        try:
+            if "READY" in open(log_path).read():
+                return proc
+        except FileNotFoundError:
+            pass
+    sys.exit("engine never printed READY")
+
+
+def bootstrap(port):
+    for pattern, fn in [
+        ("data/substances/*.yaml", "engine.loadSubstanceYaml"),
+        ("data/infections/*.yaml", "engine.loadInfectionYaml"),
+        ("data/items/*.yaml",      "engine.loadItemYaml"),
+        ("data/equipment/*.yaml",  "engine.loadEquipmentYaml"),
+        ("data/materials/*.yaml",  "engine.loadMaterialYaml"),
+        ("data/flora/*.yaml",      "engine.loadFloraYaml"),
+        ("data/units/*.yaml",      "engine.loadUnitYaml"),
+    ]:
+        for path in sorted(glob.glob(pattern)):
+            send(port, f"{fn}('{path}'); return 'ok'")
+
+
+def find_tillable(port, cx=0, cy=0, span=4, exclude=None):
+    """Scan sample points around (cx,cy) for a flat, dry, flora-free
+    tile not already in `exclude`; returns (gx, gy) or None."""
+    exclude = exclude or set()
+    for sx in range(cx - span * 16, cx + span * 16 + 1, 4):
+        for sy in range(cy - span * 16, cy + span * 16 + 1, 4):
+            if (sx, sy) in exclude:
+                continue
+            slope = jget(port, f"return world.getSlopeAt({sx},{sy})")
+            if slope != 0:
+                continue
+            fluid = jget(port, f"return world.getFluidAt({sx},{sy})")
+            if isinstance(fluid, dict) and fluid.get("type"):
+                continue
+            flora = jget(port, f"return world.getFloraAt({sx},{sy})")
+            if isinstance(flora, dict):
+                continue
+            return sx, sy
+    return None
+
+
+def till_and_wait(port, page, gx, gy, z):
+    """world.setVegAt is a queued world command — send, then poll
+    isPlantable until it lands before designating/planting."""
+    send(port, f"world.setVegAt('{page}', {gx}, {gy}, {z}, 77); return 'ok'")
+    for _ in range(20):
+        if jget(port, f"return world.isPlantable({gx},{gy})") is True:
+            return True
+        time.sleep(0.2)
+    sys.exit(f"setVegAt({gx},{gy}) never landed")
+
+
+def set_date(port, page, y, mo, d):
+    """setDate is a queued world command — send, then wait until
+    getDate reflects it."""
+    send(port, f"world.setDate('{page}', {y}, {mo}, {d}); return 'ok'")
+    for _ in range(20):
+        time.sleep(0.2)
+        got = jget(port, f"return world.getDate('{page}')")
+        if isinstance(got, dict) and got.get("year") == y \
+           and got.get("month") == mo and got.get("day") == d:
+            return got
+    sys.exit(f"setDate({y},{mo},{d}) never landed")
+
+
+def growth_entries(port, gx, gy, species):
+    t = jget(port, f"return world.getFloraGrowthAt({gx},{gy})")
+    if isinstance(t, list):
+        return [e for e in t if e.get("id") == species]
+    return []
+
+
+def spawn_worker(port, x, y):
+    """Spawn an acolyte and quiet its find_water goal (the water-search
+    spiral outranks menial work and can walk a fresh spawn off cliffs) —
+    the till_probe.py / role_probe.py convention."""
+    uid_s = send(port, f"local u=unit.spawn('acolyte',{x},{y}); return u")
+    try:
+        uid = int(float(uid_s.strip('"')))
+    except ValueError:
+        return -1
+    time.sleep(2.0)
+    quiet = send(port,
+                 f"local ai=require('scripts.unit_ai'); "
+                 f"local s=ai.getState({uid}); "
+                 f"if s then ai.markGoalAccomplished(s,'find_water'); "
+                 f"unit.stop({uid}); return 'ok' "
+                 f"else return 'nostate' end").strip('"')
+    if quiet != "ok":
+        return -1
+    return uid
+
+
+def clear_wild_forage(port, cx, cy, radius=30, keep=None):
+    """Harvest away any currently-ripe wild flora within `radius` of
+    (cx,cy) so the auto-harvest AI check below can't get distracted by
+    incidental wild forage racing it to a nearer bush instead of the
+    planted crop plot under test. `keep` (gx,gy) is the crop plot under
+    test itself — findHarvestableFlora covers crop plots too now, so
+    without this the direct harvestFlora call here would harvest the
+    plot itself before the unit ever gets a turn."""
+    cleared = []
+    for _ in range(50):
+        spot = jget(port, f"return world.findHarvestableFlora({cx},{cy},{radius})")
+        if not isinstance(spot, dict):
+            return cleared
+        if keep and (spot.get("gx"), spot.get("gy")) == tuple(keep):
+            return cleared
+        jget(port, f"return world.harvestFlora({spot['gx']},{spot['gy']})")
+        cleared.append((spot.get("gx"), spot.get("gy"), spot.get("id")))
+    return cleared
+
+
+def get_skill(port, uid, name):
+    v = jget(port, f"return unit.getSkill({uid},'{name}') or -1")
+    return float(v) if isinstance(v, (int, float)) else -1.0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=9336)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--size", type=int, default=64)
+    ap.add_argument("--plates", type=int, default=3)
+    args = ap.parse_args()
+    port = args.port
+    passed = True
+
+    proc = boot(port, f"{SPROOT}/farm_ai_probe_engine.log")
+    try:
+        bootstrap(port)
+        send(port, f"world.init('probe', {args.seed}, {args.size}, "
+                   f"{args.plates}); return 'ok'")
+        send(port, "return world.waitForInit(300)", timeout=310)
+        send(port, "world.show('probe'); return 'ok'")
+        send(port, "return world.loadChunksInRegion(-4, -4, 4, 4)", timeout=30)
+        send(port, "return world.waitForChunks(120)", timeout=125)
+
+        # Three distinct tiles: A (groundcover, full till+plant+harvest
+        # AI loop) and B (row crop, AI-planted) near the origin; C (row
+        # crop, direct-primitive refusal + rot checks) far enough away
+        # (>24 tiles, past harvest_scan_range) that the acolyte working
+        # A/B can never stumble onto it and confound the "ignored crop
+        # rots" check.
+        used = set()
+        tA = find_tillable(port)
+        if not tA:
+            print("  [FAIL] no tillable tile found for site A (try another seed)")
+            return 1
+        used.add(tA)
+        tB = find_tillable(port, exclude=used)
+        if not tB:
+            print("  [FAIL] no tillable tile found for site B (try another seed)")
+            return 1
+        used.add(tB)
+        tC = find_tillable(port, cx=-60, cy=-60, exclude=used)
+        if not tC:
+            print("  [FAIL] no tillable tile found for site C (try another seed)")
+            return 1
+        ax, ay = tA
+        bx, by = tB
+        cx, cy = tC
+        print(f"  site A={tA} (groundcover) B={tB} (row, AI) C={tC} (row, direct)")
+
+        # --- 1/2/3. Direct-primitive plantRowCropAt checks (tile C) ---
+        refused0 = growth_entries(port, cx, cy, "tomato_plant")
+        send(port, f"world.plantRowCropAt('probe',{cx},{cy},'tomato_plant'); "
+                   f"return 'ok'")
+        time.sleep(0.5)
+        after_refused = growth_entries(port, cx, cy, "tomato_plant")
+        ok1 = not refused0 and not after_refused
+        passed &= ok1
+        print(f"  [{'PASS' if ok1 else 'FAIL'}] plantRowCropAt refused on "
+              f"untilled soil: {after_refused}")
+
+        cz = jget(port, f"local sz=world.getSurfaceAt({cx},{cy}); return sz")
+        till_and_wait(port, "probe", cx, cy, cz)
+
+        send(port, f"world.plantRowCropAt('probe',{cx},{cy},'wheat'); "
+                   f"return 'ok'")
+        time.sleep(0.5)
+        wheat_refused = growth_entries(port, cx, cy, "wheat")
+        ok2 = not wheat_refused
+        passed &= ok2
+        print(f"  [{'PASS' if ok2 else 'FAIL'}] plantRowCropAt refuses a "
+              f"groundcover_crop name (wheat): {wheat_refused}")
+
+        send(port, f"world.plantRowCropAt('probe',{cx},{cy},'tomato_plant'); "
+                   f"return 'ok'")
+        time.sleep(0.5)
+        es = growth_entries(port, cx, cy, "tomato_plant")
+        ok3 = (len(es) == 1 and es[0].get("health") == 1.0
+               and es[0].get("age", 99) < 2.0)
+        passed &= ok3
+        print(f"  [{'PASS' if ok3 else 'FAIL'}] plantRowCropAt places a real "
+              f"row-crop instance at full health, age~0: {es}")
+
+        # --- 4. Rot: fruiting window then senescing, back-to-back with
+        #     no sleep so the (still-elsewhere) acolyte gets no wall-clock
+        #     window to auto-harvest it first. Recipe: land the SECOND
+        #     setDate ~197 days after whatever moment this was planted
+        #     at (mirrors crop_probe.py's proven day5->day202 jump for
+        #     tomato_plant's real annualCycle: fruiting@90..240). ---
+        set_date(port, "probe", 2, 1, 5)
+        send(port, f"world.plantRowCropAt('probe',{cx},{cy},'tomato_plant'); "
+                   f"return 'ok'")
+        set_date(port, "probe", 2, 7, 21)
+        ripe = growth_entries(port, cx, cy, "tomato_plant")
+        ok4a = any(e.get("stage") == "fruiting" and e.get("harvestable")
+                   for e in ripe)
+        passed &= ok4a
+        print(f"  [{'PASS' if ok4a else 'FAIL'}] planted row crop reaches "
+              f"its fruiting window: {ripe}")
+        set_date(port, "probe", 2, 9, 15)
+        rotten = growth_entries(port, cx, cy, "tomato_plant")
+        ok4b = ok4a and not any(e.get("harvestable") for e in rotten)
+        passed &= ok4b
+        print(f"  [{'PASS' if ok4b else 'FAIL'}] ignored ripe crop rots past "
+              f"senescing: {rotten}")
+
+        # --- 5. plant.getDesignationAt's category field ---
+        send(port, f"plant.designate('probe',{cx},{cy},'tomato_plant'); "
+                   f"return 'ok'")
+        time.sleep(0.5)
+        dcat_row = jget(port, f"return plant.getDesignationAt('probe',{cx},{cy})")
+        send(port, f"plant.designate('probe',{cx},{cy},'wheat'); return 'ok'")
+        time.sleep(0.5)
+        dcat_ground = jget(port, f"return plant.getDesignationAt('probe',{cx},{cy})")
+        ok5 = (isinstance(dcat_row, dict) and dcat_row.get("category") == "row_crop"
+               and isinstance(dcat_ground, dict)
+               and dcat_ground.get("category") == "groundcover_crop")
+        passed &= ok5
+        print(f"  [{'PASS' if ok5 else 'FAIL'}] getDesignationAt reports "
+              f"category: row={dcat_row} ground={dcat_ground}")
+        send(port, f"plant.cancelDesignation({cx},{cy}); return 'ok'")
+
+        # --- 6/7/8. Full AI loop: till (A) -> plant (A, wheat) ->
+        #     plant (B, tomato_plant, pre-tilled) ---
+        send(port, "engine.loadScript('scripts/unit_stats.lua', 0.1); "
+                   "return 'ok'")
+        send(port, "engine.loadScript('scripts/unit_resources.lua', 0.2); "
+                   "return 'ok'")
+        send(port, "engine.loadScript('scripts/unit_ai.lua', 0.1); "
+                   "return 'ok'")
+        bz = jget(port, f"local sz=world.getSurfaceAt({bx},{by}); return sz")
+        till_and_wait(port, "probe", bx, by, bz)
+
+        uid = spawn_worker(port, ax + 2, ay)
+        if uid < 0:
+            print(f"  [FAIL] could not spawn farm worker")
+            return 1
+        farming_before = get_skill(port, uid, "farming")
+
+        send(port, f"till.designate('probe',{ax},{ay},{ax},{ay}); return 'ok'")
+        send(port, f"plant.designate('probe',{bx},{by},'tomato_plant'); "
+                   f"return 'ok'")
+
+        deadline = time.time() + 90.0
+        tilled = False
+        while time.time() < deadline:
+            time.sleep(2.0)
+            if jget(port, f"return world.isPlantable({ax},{ay})") is True:
+                tilled = True
+                break
+        ok6a = tilled
+        passed &= ok6a
+        print(f"  [{'PASS' if ok6a else 'FAIL'}] acolyte tills site A "
+              f"autonomously: {tilled}")
+        if not ok6a:
+            print("\nSOME FAILED")
+            return 1
+
+        send(port, f"plant.designate('probe',{ax},{ay},'wheat'); return 'ok'")
+
+        deadline = time.time() + 120.0
+        planted_a = planted_b = False
+        while time.time() < deadline:
+            time.sleep(2.0)
+            if not planted_a:
+                pa = jget(port, f"return world.getCropPlotAt({ax},{ay})")
+                if isinstance(pa, dict) and pa.get("id") == "wheat":
+                    planted_a = True
+            if not planted_b:
+                eb = growth_entries(port, bx, by, "tomato_plant")
+                if eb:
+                    planted_b = True
+            if planted_a and planted_b:
+                break
+        ok6 = planted_a
+        passed &= ok6
+        print(f"  [{'PASS' if ok6 else 'FAIL'}] acolyte plants wheat at site A "
+              f"(world.plantCropAt): planted={planted_a}")
+        ok7 = planted_b
+        passed &= ok7
+        print(f"  [{'PASS' if ok7 else 'FAIL'}] acolyte plants tomato_plant at "
+              f"site B (world.plantRowCropAt): planted={planted_b}")
+
+        da = jget(port, f"return plant.getDesignationAt('probe',{ax},{ay})")
+        db = jget(port, f"return plant.getDesignationAt('probe',{bx},{by})")
+        ok7b = not isinstance(da, dict) and not isinstance(db, dict)
+        passed &= ok7b
+        print(f"  [{'PASS' if ok7b else 'FAIL'}] both plant designations "
+              f"cleared on completion: A={da} B={db}")
+
+        farming_after_plant = get_skill(port, uid, "farming")
+        ok8 = farming_after_plant > farming_before
+        passed &= ok8
+        print(f"  [{'PASS' if ok8 else 'FAIL'}] farming skill grows from "
+              f"till+plant: {farming_before} -> {farming_after_plant}")
+
+        # --- 9. Auto-harvest: fast-forward wheat past its 30-day
+        #     vegetating threshold, then let the same idle acolyte find
+        #     and harvest it on its own (not hunger-gated). A real
+        #     generated world has plenty of ambient wild forage, which
+        #     the same world.findHarvestableFlora search also covers —
+        #     left unchecked the unit happily wanders off picking wild
+        #     bushes instead of the plot under test, forever finding a
+        #     nearer distraction before it ever arrives. Two mitigations,
+        #     confirmed sufficient by an isolated repro: station the
+        #     unit adjacent to the plot first (a raw moveTo, bypassing
+        #     the AI decision this once), and sweep wild forage away
+        #     from the site frequently.
+        clear_wild_forage(port, ax, ay)
+        send(port, "world.setTimeScale('probe', 50000); return 'ok'")
+        deadline = time.time() + 15.0
+        ripe_wheat = False
+        while time.time() < deadline:
+            time.sleep(1.0)
+            pw = jget(port, f"return world.getCropPlotAt({ax},{ay})")
+            if isinstance(pw, dict) and pw.get("harvestable") is True:
+                ripe_wheat = True
+                break
+        send(port, "world.setTimeScale('probe', 1); return 'ok'")
+        ok9a = ripe_wheat
+        passed &= ok9a
+        print(f"  [{'PASS' if ok9a else 'FAIL'}] wheat becomes harvestable "
+              f"under the game clock: {ripe_wheat}")
+
+        send(port, f"unit.moveTo({uid}, {ax + 0.5}, {ay + 1.5}, 1.0); return 'ok'")
+        deadline = time.time() + 20.0
+        while time.time() < deadline:
+            time.sleep(1.0)
+            info = jget(port, f"return unit.getInfo({uid})")
+            if isinstance(info, dict):
+                dx = info.get("gridX", 0) - ax
+                dy = info.get("gridY", 0) - ay
+                if dx * dx + dy * dy <= 4.0:
+                    break
+        clear_wild_forage(port, ax, ay, radius=60, keep=(ax, ay))
+
+        # The big time-jump above can ripen a lot of ambient wild flora
+        # at once, not just the wheat plot — keep sweeping it away each
+        # poll, tightly, so the plot stays the ONLY harvestable thing in
+        # range and the now-nearby unit can't get waylaid en route by a
+        # regrowing wild bush.
+        deadline = time.time() + 60.0
+        harvested = False
+        while time.time() < deadline:
+            time.sleep(0.5)
+            clear_wild_forage(port, ax, ay, radius=60, keep=(ax, ay))
+            pw2 = jget(port, f"return world.getCropPlotAt({ax},{ay})")
+            if pw2 is None:
+                harvested = True
+                break
+        ground = jget(port, "return item.listGround()")
+        has_grain = isinstance(ground, list) and any(
+            g.get("defName") == "wheat_grain" for g in ground)
+        ok9 = harvested and has_grain
+        passed &= ok9
+        print(f"  [{'PASS' if ok9 else 'FAIL'}] acolyte auto-harvests the ripe "
+              f"wheat: plot_cleared={harvested} grain_on_ground={has_grain}")
+
+        farming_after_harvest = get_skill(port, uid, "farming")
+        ok9b = farming_after_harvest > farming_after_plant
+        passed &= ok9b
+        print(f"  [{'PASS' if ok9b else 'FAIL'}] farming skill grows further "
+              f"from auto-harvest: {farming_after_plant} -> "
+              f"{farming_after_harvest}")
+
+        # --- 10. Save/load: the AI-planted row crop (WePlaceFlora, v79)
+        #     survives save -> loadSave. ---
+        send(port, "engine.saveWorld('probe', 'farm_ai_v79_check'); "
+                   "return 'ok'")
+        time.sleep(3.0)
+        send(port, "engine.loadSave('farm_ai_v79_check'); return 'ok'")
+        time.sleep(15.0)
+        send(port, "world.show('main_world'); return 'ok'")
+        send(port, "engine.setPaused(false); return 'ok'")
+        send(port, "return world.loadChunksInRegion(-4, -4, 4, 4)", timeout=30)
+        send(port, "return world.waitForChunks(120)", timeout=125)
+        eb2 = growth_entries(port, bx, by, "tomato_plant")
+        ok10 = len(eb2) >= 1
+        passed &= ok10
+        print(f"  [{'PASS' if ok10 else 'FAIL'}] AI-planted row crop survives "
+              f"save/load: {eb2}")
+
+        print("\n" + ("ALL FARM AI CHECKS PASSED" if passed else "SOME FAILED"))
+        return 0 if passed else 1
+    finally:
+        try:
+            send(port, "engine.quit()")
+        except Exception:
+            pass
+        time.sleep(1.0)
+        proc.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/farm_ai_probe.py
+++ b/tools/farm_ai_probe.py
@@ -21,7 +21,9 @@ Checks:
   3. plantRowCropAt places a real row-crop instance (tomato_plant) on
      tilled soil, at full health, age ~0. A tile already carrying an
      instance then refuses a second planting (no duplicate/overlapping
-     instances stacking from a re-plant).
+     instances stacking from a re-plant), and the reciprocal cross-form
+     guard holds too: plantCropAt (groundcover) refuses a tile already
+     carrying a row-crop instance.
   4. Rot: a freshly-planted row crop (its own tile) becomes harvestable
      in its fruiting window and NOT harvestable once the calendar rolls
      into senescing without being picked — the #332 mechanic, exercised
@@ -327,6 +329,19 @@ def main():
         passed &= ok3b
         print(f"  [{'PASS' if ok3b else 'FAIL'}] plantRowCropAt refuses an "
               f"already-planted tile (no duplicate instance): {es_dup}")
+
+        # --- 3c. The reciprocal cross-form guard: plantCropAt (the
+        #     groundcover primitive) refuses a tile that already has a
+        #     row-crop FloraInstance on it (tile C, above) — otherwise a
+        #     CropPlot lands underneath the existing plant since
+        #     isPlantable is tilled-soil-only and stays true either way. ---
+        cross_plant = jget(port, f"return world.plantCropAt({cx},{cy},'wheat')")
+        cross_plot = jget(port, f"return world.getCropPlotAt({cx},{cy})")
+        ok3c = cross_plant in (None, False) and cross_plot is None
+        passed &= ok3c
+        print(f"  [{'PASS' if ok3c else 'FAIL'}] plantCropAt refuses a tile "
+              f"already carrying a row-crop instance: planted={cross_plant} "
+              f"plot={cross_plot}")
 
         # --- 5. plant.getDesignationAt's category field ---
         send(port, f"plant.designate('probe',{cx},{cy},'tomato_plant'); "


### PR DESCRIPTION
## Summary

The capstone of the farming epic (#331): till → plant → grow → auto-harvest, end to end through the acolyte AI, closing the loop from designation to food on the ground. Dependencies (#332 growth runtime, #333 tilling, #334 crop content, #335 plant designation) were already shipped; this issue ties them together with the actual AI + two primitives that were still missing.

- **New `unitAi.plant` action** (mirrors `unitAi.till` exactly — claim/walk/equip/work-progress) claims a plant designation (#335), walks over, and dispatches to `world.plantCropAt` (groundcover crop, a `CropPlot`) or the new `world.plantRowCropAt` (row crop, a `FloraInstance`) by the designation's category.
- **`world.plantRowCropAt` is a genuinely new primitive.** Runtime row-crop placement didn't exist before this — #334 only ever placed row crops once, at worldgen time (`World.Flora.Placement`). This adds a new `WePlaceFlora` edit-log entry (**save v79**) so a planted row crop survives chunk eviction and save/load like every other edit, with a negative `fiAge` baseline (`-plantedDay`, full health) so it reads as age 0 on its planted day and grows from there — the `FloraInstance` counterpart to `CropPlot`'s `cpPlantedDay` trick.
- **New `unitAi.harvest` (`auto_harvest`) action**: instant harvest (mirrors `forage`'s shape, not till/plant's progress accumulator), but skill/role-weighted instead of hunger-gated — routine farm-tending, not an emergency need. Reuses `world.harvestFlora`/`findHarvestableFlora` (#94) end to end.
- **Extended `world.findHarvestableFlora`** to also scan planted `CropPlot`s (previously it only ever scanned chunk-embedded `FloraInstance`s), so a ripe groundcover crop is actually discoverable by the harvest AI.
- **New `farming` skill + `Farmer` role** (#265), folding `till_designation`/`plant_designation`/`auto_harvest` into one `"farm"` family. `till_designation` also gains farming-skill-scaled rate + an XP grant — #333 explicitly deferred this ("no new work skill/role — that's farm AI's job") to this issue.
- **Rot needed zero new code.** `World.Flora.Growth.harvestOpen`'s fruiting-window gate (#332) already causes an unharvested fruiting-stage crop to lose its yield at senescing; this PR's probe exercises it through the new planting primitive to confirm the wiring.
- `plant.getDesignationAt` gains a `category` field (`"row_crop"` | `"groundcover_crop"`) so the AI can dispatch without a second round-trip through `getPlantSuitability`.

## Save version

Bumped `currentSaveVersion` 78 → **79**: `WorldEdit` gains a new trailing `WePlaceFlora` constructor. Order-preserving (appended at the end), but per that module's own documented policy, any new `WorldEdit` variant bumps the version regardless.

## Test plan

- [x] `cabal build all` — clean, no warnings
- [x] `cabal test synarchy-test-headless` — 666 examples, 0 failures
- [x] `python3 tools/world_check.py` — 21/21 (no worldgen-output change — the new edit only ever fires from an explicit player/AI action, never from the generator)
- [x] `python3 tools/test_audit.py` — 35/35
- [x] New `tools/farm_ai_probe.py` (the #336 gate):
  - `plantRowCropAt` refused on untilled soil, and refused for a groundcover_crop name (mirrors `plantCropAt`'s reciprocal refusal of a row_crop name)
  - `plantRowCropAt` places a real row-crop instance at full health, age ~0
  - the planted row crop reaches its fruiting window and becomes harvestable, then **rots** (unharvestable again) once the calendar rolls into senescing without being picked
  - `plant.getDesignationAt`'s new `category` field is correct for both crop forms
  - full AI loop: an acolyte tills a tile autonomously (farming-skill-scaled), then plants wheat (groundcover) there and tomato_plant (row crop) on a second tile, both via designations
  - farming skill visibly grows from till + plant
  - the same idle acolyte autonomously auto-harvests the now-ripe wheat (not hunger-gated) — plot clears, `wheat_grain` lands on the ground, farming skill grows further
  - the AI-planted row crop survives save → loadSave (the new `WePlaceFlora` edit, v79)

One test-methodology note worth flagging for reviewers: the auto-harvest check needed the probe to explicitly clear ambient wild forage near the test site and reposition the unit, because a real generated world has enough wild edible flora nearby that the unit would happily go pick a wild bush instead of the planted crop before ever reaching it — confirmed via an isolated repro that the underlying mechanism harvests the target crop within ~1 second once that contention is removed. This is a probe-robustness detail, not an engine behavior change (a farmer harvesting whatever's ripest and nearest, planted or wild, is the intended behavior).

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)