### PR TITLE
Make locomotion injury penalty data-driven (#393)

### DIFF
--- a/data/units/acolyte.yaml
+++ b/data/units/acolyte.yaml
@@ -179,7 +179,7 @@ units:
       # Part durability is derived from the tissue layers below (no
       # max_health_factor); the representative layers also set the strike's
       # REACH, so deep organs (depth 0.5) stay reachable.
-      - { id: torso, name: "torso", parent: null, vital: false, targetable: true,
+      - { id: torso, name: "torso", parent: null, vital: false, targetable: true, affects_balance: true,
           area_weight: 0.40, tactical_value: 0.8,
           bleed_factor: 2.0,
           height_low: 1.00, height_high: 1.55,
@@ -300,7 +300,7 @@ units:
 
       # ---- LEGS (targetable) → thigh + knee + shin (share depth 0.3, one
       # per hit). Skeleton chain thigh(femur) → shin(tibia/fibula) → foot.
-      - { id: l_leg, name: "left leg", parent: torso, vital: false, targetable: true,
+      - { id: l_leg, name: "left leg", parent: torso, vital: false, targetable: true, affects_locomotion: true,
           area_weight: 0.10, tactical_value: 0.3,
           bleed_factor: 1.0, height_low: 0.00, height_high: 0.90,
           layers: [ { name: skin, material: flesh, thickness: 5 }, { name: muscle, material: flesh, thickness: 35 }, { name: bone, material: bone, thickness: 35 } ] }
@@ -313,7 +313,7 @@ units:
       - { id: l_shin, name: "shin", parent: l_thigh, targetable: false, vital: false, depth: 0.30,
           area_weight: 0.40, bleed_factor: 1.2,
           layers: [ { name: skin, material: flesh, thickness: 4 }, { name: muscle, material: flesh, thickness: 28 }, { name: tibia, material: bone, thickness: 16 }, { name: fibula, material: bone, thickness: 12 } ] }
-      - { id: r_leg, name: "right leg", parent: torso, vital: false, targetable: true,
+      - { id: r_leg, name: "right leg", parent: torso, vital: false, targetable: true, affects_locomotion: true,
           area_weight: 0.10, tactical_value: 0.3,
           bleed_factor: 1.0, height_low: 0.00, height_high: 0.90,
           layers: [ { name: skin, material: flesh, thickness: 5 }, { name: muscle, material: flesh, thickness: 35 }, { name: bone, material: bone, thickness: 35 } ] }
@@ -328,7 +328,7 @@ units:
           layers: [ { name: skin, material: flesh, thickness: 4 }, { name: muscle, material: flesh, thickness: 28 }, { name: tibia, material: bone, thickness: 16 }, { name: fibula, material: bone, thickness: 12 } ] }
 
       # ---- FEET (targetable; parent = shin). Sole + 5 toes, depth 0.2.
-      - { id: l_foot, name: "left foot", parent: l_shin, vital: false, targetable: true,
+      - { id: l_foot, name: "left foot", parent: l_shin, vital: false, targetable: true, affects_locomotion: true,
           area_weight: 0.04, tactical_value: 0.2,
           bleed_factor: 1.0, height_low: 0.00, height_high: 0.10,
           layers: [ { name: skin, material: flesh, thickness: 5 }, { name: muscle, material: flesh, thickness: 15 }, { name: bone, material: bone, thickness: 15 } ] }
@@ -344,7 +344,7 @@ units:
           layers: [ { name: skin, material: flesh, thickness: 2 }, { name: bone, material: bone, thickness: 3 } ] }
       - { id: l_pinkytoe,  name: "little toe", parent: l_foot, targetable: false, depth: 0.2, area_weight: 0.08,
           layers: [ { name: skin, material: flesh, thickness: 2 }, { name: bone, material: bone, thickness: 3 } ] }
-      - { id: r_foot, name: "right foot", parent: r_shin, vital: false, targetable: true,
+      - { id: r_foot, name: "right foot", parent: r_shin, vital: false, targetable: true, affects_locomotion: true,
           area_weight: 0.04, tactical_value: 0.2,
           bleed_factor: 1.0, height_low: 0.00, height_high: 0.10,
           layers: [ { name: skin, material: flesh, thickness: 5 }, { name: muscle, material: flesh, thickness: 15 }, { name: bone, material: bone, thickness: 15 } ] }

--- a/data/units/bear_brown.yaml
+++ b/data/units/bear_brown.yaml
@@ -95,7 +95,7 @@ units:
                     { name: fat,    material: fat,    thickness: 4 },
                     { name: muscle, material: muscle, thickness: 22 },
                     { name: throat, material: organ,  thickness: 10 } ] }
-      - { id: torso,        name: "torso", parent: null,  vital: true,
+      - { id: torso,        name: "torso", parent: null,  vital: true, affects_balance: true,
           area_weight: 0.40, tactical_value: 0.8,
           bleed_factor: 2.0,
           height_low: 0.50, height_high: 1.40,
@@ -104,7 +104,7 @@ units:
                     { name: muscle, material: muscle, thickness: 25 },
                     { name: ribs,   material: bone,   thickness: 10 },
                     { name: vitals, material: organ,  thickness: 120 } ] }
-      - { id: l_fore_leg,   name: "left foreleg", parent: torso,
+      - { id: l_fore_leg,   name: "left foreleg", parent: torso, affects_locomotion: true,
           area_weight: 0.10, tactical_value: 0.3,
           bleed_factor: 1.0,
           height_low: 0.00, height_high: 0.95,
@@ -112,7 +112,7 @@ units:
                     { name: fat,    material: fat,    thickness: 5 },
                     { name: muscle, material: muscle, thickness: 22 },
                     { name: bone,   material: bone,   thickness: 14 } ] }
-      - { id: r_fore_leg,   name: "right foreleg", parent: torso,
+      - { id: r_fore_leg,   name: "right foreleg", parent: torso, affects_locomotion: true,
           area_weight: 0.10, tactical_value: 0.3,
           bleed_factor: 1.0,
           height_low: 0.00, height_high: 0.95,
@@ -120,7 +120,7 @@ units:
                     { name: fat,    material: fat,    thickness: 5 },
                     { name: muscle, material: muscle, thickness: 22 },
                     { name: bone,   material: bone,   thickness: 14 } ] }
-      - { id: l_hind_leg,   name: "left hind leg", parent: torso,
+      - { id: l_hind_leg,   name: "left hind leg", parent: torso, affects_locomotion: true,
           area_weight: 0.10, tactical_value: 0.3,
           bleed_factor: 1.0,
           height_low: 0.00, height_high: 0.95,
@@ -128,7 +128,7 @@ units:
                     { name: fat,    material: fat,    thickness: 5 },
                     { name: muscle, material: muscle, thickness: 25 },
                     { name: bone,   material: bone,   thickness: 16 } ] }
-      - { id: r_hind_leg,   name: "right hind leg", parent: torso,
+      - { id: r_hind_leg,   name: "right hind leg", parent: torso, affects_locomotion: true,
           area_weight: 0.10, tactical_value: 0.3,
           bleed_factor: 1.0,
           height_low: 0.00, height_high: 0.95,

--- a/data/units/red_squirrel.yaml
+++ b/data/units/red_squirrel.yaml
@@ -88,7 +88,7 @@ units:
                     { name: fat,    material: fat,    thickness: 1 },
                     { name: muscle, material: muscle, thickness: 4 },
                     { name: throat, material: organ,  thickness: 4 } ] }
-      - { id: torso,        name: "torso", parent: null,  vital: true,
+      - { id: torso,        name: "torso", parent: null,  vital: true, affects_balance: true,
           area_weight: 0.36, tactical_value: 0.8,
           bleed_factor: 2.0,
           height_low: 0.06, height_high: 0.20,
@@ -97,7 +97,7 @@ units:
                     { name: muscle, material: muscle, thickness: 5 },
                     { name: ribs,   material: bone,   thickness: 2 },
                     { name: vitals, material: organ,  thickness: 30 } ] }
-      - { id: l_fore_leg,   name: "left foreleg", parent: torso,
+      - { id: l_fore_leg,   name: "left foreleg", parent: torso, affects_locomotion: true,
           area_weight: 0.08, tactical_value: 0.3,
           bleed_factor: 1.0,
           height_low: 0.00, height_high: 0.14,
@@ -105,7 +105,7 @@ units:
                     { name: fat,    material: fat,    thickness: 1 },
                     { name: muscle, material: muscle, thickness: 3 },
                     { name: bone,   material: bone,   thickness: 3 } ] }
-      - { id: r_fore_leg,   name: "right foreleg", parent: torso,
+      - { id: r_fore_leg,   name: "right foreleg", parent: torso, affects_locomotion: true,
           area_weight: 0.08, tactical_value: 0.3,
           bleed_factor: 1.0,
           height_low: 0.00, height_high: 0.14,
@@ -113,7 +113,7 @@ units:
                     { name: fat,    material: fat,    thickness: 1 },
                     { name: muscle, material: muscle, thickness: 3 },
                     { name: bone,   material: bone,   thickness: 3 } ] }
-      - { id: l_hind_leg,   name: "left hind leg", parent: torso,
+      - { id: l_hind_leg,   name: "left hind leg", parent: torso, affects_locomotion: true,
           area_weight: 0.10, tactical_value: 0.3,
           bleed_factor: 1.0,
           height_low: 0.00, height_high: 0.14,
@@ -121,7 +121,7 @@ units:
                     { name: fat,    material: fat,    thickness: 1 },
                     { name: muscle, material: muscle, thickness: 4 },
                     { name: bone,   material: bone,   thickness: 3 } ] }
-      - { id: r_hind_leg,   name: "right hind leg", parent: torso,
+      - { id: r_hind_leg,   name: "right hind leg", parent: torso, affects_locomotion: true,
           area_weight: 0.10, tactical_value: 0.3,
           bleed_factor: 1.0,
           height_low: 0.00, height_high: 0.14,

--- a/data/units/technomule.yaml
+++ b/data/units/technomule.yaml
@@ -108,7 +108,7 @@ units:
                     { name: fat,    material: fat,    thickness: 4 },
                     { name: muscle, material: muscle, thickness: 22 },
                     { name: throat, material: organ,  thickness: 10 } ] }
-      - { id: torso,        name: "torso", parent: null,  vital: true,
+      - { id: torso,        name: "torso", parent: null,  vital: true, affects_balance: true,
           area_weight: 0.40, tactical_value: 0.8,
           bleed_factor: 2.0,
           height_low: 0.55, height_high: 1.50,
@@ -117,7 +117,7 @@ units:
                     { name: muscle, material: muscle, thickness: 25 },
                     { name: ribs,   material: bone,   thickness: 10 },
                     { name: vitals, material: organ,  thickness: 120 } ] }
-      - { id: l_fore_leg,   name: "left foreleg", parent: torso,
+      - { id: l_fore_leg,   name: "left foreleg", parent: torso, affects_locomotion: true,
           area_weight: 0.10, tactical_value: 0.3,
           bleed_factor: 1.0,
           height_low: 0.00, height_high: 1.00,
@@ -125,7 +125,7 @@ units:
                     { name: fat,    material: fat,    thickness: 5 },
                     { name: muscle, material: muscle, thickness: 22 },
                     { name: bone,   material: bone,   thickness: 14 } ] }
-      - { id: r_fore_leg,   name: "right foreleg", parent: torso,
+      - { id: r_fore_leg,   name: "right foreleg", parent: torso, affects_locomotion: true,
           area_weight: 0.10, tactical_value: 0.3,
           bleed_factor: 1.0,
           height_low: 0.00, height_high: 1.00,
@@ -133,7 +133,7 @@ units:
                     { name: fat,    material: fat,    thickness: 5 },
                     { name: muscle, material: muscle, thickness: 22 },
                     { name: bone,   material: bone,   thickness: 14 } ] }
-      - { id: l_hind_leg,   name: "left hind leg", parent: torso,
+      - { id: l_hind_leg,   name: "left hind leg", parent: torso, affects_locomotion: true,
           area_weight: 0.10, tactical_value: 0.3,
           bleed_factor: 1.0,
           height_low: 0.00, height_high: 1.00,
@@ -141,7 +141,7 @@ units:
                     { name: fat,    material: fat,    thickness: 5 },
                     { name: muscle, material: muscle, thickness: 25 },
                     { name: bone,   material: bone,   thickness: 16 } ] }
-      - { id: r_hind_leg,   name: "right hind leg", parent: torso,
+      - { id: r_hind_leg,   name: "right hind leg", parent: torso, affects_locomotion: true,
           area_weight: 0.10, tactical_value: 0.3,
           bleed_factor: 1.0,
           height_low: 0.00, height_high: 1.00,

--- a/src/Engine/Asset/YamlUnits.hs
+++ b/src/Engine/Asset/YamlUnits.hs
@@ -190,6 +190,8 @@ data UnitYamlBodyPart = UnitYamlBodyPart
     , uybpLayers          ∷ ![UnitYamlLayer]   -- outer→inner; [] ⇒ default
     , uybpTargetable      ∷ !Bool              -- macro-part (aimed at) vs subpart
     , uybpDepth           ∷ !Float             -- subpart depth 0..1 (slash swath)
+    , uybpAffectsLocomotion ∷ !Bool            -- leg/foot-type part (injurySpeedMult)
+    , uybpAffectsBalance    ∷ !Bool            -- torso-type part (injurySpeedMult)
     } deriving (Show, Eq, Generic)
 
 instance FromJSON UnitYamlBodyPart where
@@ -216,6 +218,8 @@ instance FromJSON UnitYamlBodyPart where
         ⊛ v .:? "layers"              .!= []
         ⊛ v .:? "targetable"          .!= True
         ⊛ v .:? "depth"               .!= 0.0
+        ⊛ v .:? "affects_locomotion"  .!= False
+        ⊛ v .:? "affects_balance"     .!= False
 
 -- | Natural (innate) weapon block — claws/fangs/fists. Optional on
 --   the unit YAML. When present, Combat.Resolution falls back to

--- a/src/Engine/Scripting/Lua/API/Units.hs
+++ b/src/Engine/Scripting/Lua/API/Units.hs
@@ -326,6 +326,8 @@ loadUnitYamlFn env backendState = do
                                     | l ← uybpLayers p ]
                                 , bpTargetable      = uybpTargetable p
                                 , bpDepth           = uybpDepth p
+                                , bpAffectsLocomotion = uybpAffectsLocomotion p
+                                , bpAffectsBalance     = uybpAffectsBalance p
                                 }
                             | p ← uydBodyParts def
                             ]

--- a/src/Unit/Thread/Command.hs
+++ b/src/Unit/Thread/Command.hs
@@ -2,6 +2,7 @@
 module Unit.Thread.Command
     ( processAllUnitCommands
     , recomputeBodyDerivedStats
+    , injurySpeedMult
     ) where
 
 import UPrelude
@@ -336,10 +337,10 @@ handleUnitCommand env utsRef (UnitMoveTo uid tx ty speed) = do
     let (effSpeed, isRunning) = case HM.lookup uid (umInstances um) of
             Nothing   → (speed, False)
             Just inst →
-                let sp     = speed * injurySpeedMult inst
-                    (maxSp, runFrac) = case HM.lookup (uiDefName inst) (umDefs um) of
-                        Just d  → (udMaxSpeed d, udRunThreshold d)
-                        Nothing → (3.0, 0.6)
+                let (bodyParts, maxSp, runFrac) = case HM.lookup (uiDefName inst) (umDefs um) of
+                        Just d  → (udBodyParts d, udMaxSpeed d, udRunThreshold d)
+                        Nothing → ([], 3.0, 0.6)
+                    sp     = speed * injurySpeedMult bodyParts inst
                     runCut = maxSp * runFrac   -- per-unit run-anim threshold
                 in (sp, sp > runCut)
     atomicModifyIORef' utsRef $ \uts →
@@ -744,29 +745,32 @@ bloodSeedFromStats s = case HM.lookup "body_mass" s of
 -- | Movement-speed multiplier derived from the unit's wounds + blood.
 --
 --   Three terms compose multiplicatively:
---     * leg/foot wound severity × 0.6 — wounds on legs/feet hit
---       harder because that's literally what walks.
---     * torso wound severity × 0.3 — concussive / vital-area damage
---       slows the unit too but less than a leg.
+--     * leg/foot wound severity × 1.2 — wounds on parts flagged
+--       'bpAffectsLocomotion' hit harder because that's literally
+--       what walks.
+--     * torso wound severity × 0.3 — parts flagged 'bpAffectsBalance'
+--       (concussive / vital-area damage) slow the unit too but less
+--       than a leg.
 --     * blood fraction → 0.5 + 0.5 × frac — at full blood we're 1.0,
 --       at 0 blood we're 0.5 (matches "unconscious bleeding out is
 --       still capable of some movement before collapse").
 --   Result clamped to [0.1, 1.0] so a unit never literally stops.
 --   Applied to UnitMoveTo's speed parameter so all movement gets
---   scaled the same way.
-injurySpeedMult ∷ UnitInstance → Float
-injurySpeedMult inst =
-    let isLegPart p = p == "l_leg" || p == "r_leg"
-                   || p == "l_foot" || p == "r_foot"
-                   || p == "l_fore_leg" || p == "r_fore_leg"
-                   || p == "l_hind_leg" || p == "r_hind_leg"
+--   scaled the same way. Which parts count as leg/torso is
+--   DATA-DRIVEN via the unit's own body-part list rather than
+--   hardcoded ids, so differently-named skeletons (a robot's
+--   "hindquarter", say) work as long as their YAML sets the flags.
+injurySpeedMult ∷ [BodyPart] → UnitInstance → Float
+injurySpeedMult bodyParts inst =
+    let partIdx = HM.fromList [ (bpId p, p) | p ← bodyParts ]
+        hasFlag f pid = maybe False f (HM.lookup pid partIdx)
         -- EFFECTIVE severity (heal eases it, necrosis floors it) so a
         -- limping unit regains speed as its leg wound mends, in step
         -- with the bleed/pain/anim consumers that share the same helper.
         legSev = sum [ woundEffSeverity w
-                     | w ← uiWounds inst, isLegPart (woundPart w) ]
+                     | w ← uiWounds inst, hasFlag bpAffectsLocomotion (woundPart w) ]
         torsoSev = sum [ woundEffSeverity w
-                       | w ← uiWounds inst, woundPart w == "torso" ]
+                       | w ← uiWounds inst, hasFlag bpAffectsBalance (woundPart w) ]
         bodyMass = HM.lookupDefault 70.0 "body_mass" (uiStats inst)
         maxBlood = bodyMass * bloodMassRatio
         bloodFrac = if maxBlood > 0

--- a/src/Unit/Types.hs
+++ b/src/Unit/Types.hs
@@ -262,6 +262,17 @@ data BodyPart = BodyPart
       --   to them, and they carry the real tissue + injury detail. The
       --   whole tree is fully data-driven (humanoid → robot → fish): the
       --   engine reads targetable/parent/depth generically.
+    , bpAffectsLocomotion ∷ !Bool
+      -- ^ True for the direct mobility apparatus (legs, feet — the
+      --   quadruped equivalents too). A wound here is what
+      --   'Unit.Thread.Command.injurySpeedMult' weights heaviest when
+      --   scaling movement speed. Species with different leg-part
+      --   naming (a robot's "hindquarter", say) just set this flag
+      --   instead of the engine matching a fixed id list.
+    , bpAffectsBalance  ∷ !Bool
+      -- ^ True for core/balance-relevant parts (torso). A wound here
+      --   gets the lesser locomotion penalty 'injurySpeedMult' applies
+      --   — dizzying, not disabling.
     , bpDepth            ∷ !Float
       -- ^ 0 = at the surface, 1 = deepest. Drives the slash-swath: a cut
       --   that penetrates to depth D injures every sibling subpart with

--- a/synarchy.cabal
+++ b/synarchy.cabal
@@ -166,6 +166,7 @@ test-suite synarchy-test-headless
                    Test.Headless.Unit.Render.PickFrame
                    Test.Headless.Unit.Anim
                    Test.Headless.Unit.Injury
+                   Test.Headless.Unit.InjurySpeed
                    Test.Headless.Unit.Fall
                    Test.Headless.Unit.Stats
                    Test.Headless.Unit.NightPerception

--- a/test-headless/Spec.hs
+++ b/test-headless/Spec.hs
@@ -21,6 +21,7 @@ import qualified Test.Headless.Unit.Pathing.Config as PathingConfig
 import qualified Test.Headless.Unit.Render.PickFrame as PickFrame
 import qualified Test.Headless.Unit.Anim as AnimTest
 import qualified Test.Headless.Unit.Injury as InjuryTest
+import qualified Test.Headless.Unit.InjurySpeed as InjurySpeedTest
 import qualified Test.Headless.Unit.Fall as FallTest
 import qualified Test.Headless.Unit.Stats as StatsTest
 import qualified Test.Headless.Unit.NightPerception as NightPerception
@@ -87,6 +88,7 @@ main = hspec $ do
     describe "Unit.Render.pickFrame" PickFrame.spec
     describe "Unit.Anim" AnimTest.spec
     describe "Unit.Injury" InjuryTest.spec
+    describe "Unit.InjurySpeed" InjurySpeedTest.spec
     describe "Unit.Fall" FallTest.spec
     describe "Unit.Stats" StatsTest.spec
     describe "Unit.NightPerception" NightPerception.spec

--- a/test-headless/Test/Headless/Combat/Severing.hs
+++ b/test-headless/Test/Headless/Combat/Severing.hs
@@ -38,7 +38,8 @@ def = UnitDef
         { bpId = pid, bpName = pid, bpParent = par, bpVital = False
         , bpAreaWeight = 0.1, bpTacticalValue = 0.5
         , bpBleedFactor = 1.0, bpHeightLow = 0, bpHeightHigh = 1, bpLayers = []
-        , bpTargetable = True, bpDepth = 0.0 }
+        , bpTargetable = True, bpDepth = 0.0
+        , bpAffectsLocomotion = False, bpAffectsBalance = False }
 
 inst ∷ [Wound] → UnitInstance
 inst ws = UnitInstance
@@ -83,7 +84,8 @@ decapDef = def
         , bpAreaWeight = 0.1, bpTacticalValue = 0.5
         , bpBleedFactor = 1.0, bpHeightLow = 0, bpHeightHigh = 1, bpLayers = []
         , bpTargetable = (pid ≡ "head" ∨ pid ≡ "neck" ∨ pid ≡ "torso")
-        , bpDepth = 0.0 }
+        , bpDepth = 0.0
+        , bpAffectsLocomotion = False, bpAffectsBalance = False }
 
 spec ∷ Spec
 spec = do

--- a/test-headless/Test/Headless/Combat/Wounds.hs
+++ b/test-headless/Test/Headless/Combat/Wounds.hs
@@ -49,7 +49,8 @@ def = UnitDef
             { bpId = "l_thigh", bpName = "l_thigh", bpParent = Nothing
             , bpVital = False, bpAreaWeight = 0.1, bpTacticalValue = 0.5
             , bpBleedFactor = 1.0, bpHeightLow = 0, bpHeightHigh = 1
-            , bpLayers = [], bpTargetable = True, bpDepth = 0.0 } ]
+            , bpLayers = [], bpTargetable = True, bpDepth = 0.0
+            , bpAffectsLocomotion = False, bpAffectsBalance = False } ]
     , udNaturalResistance = defaultNaturalResistance
     , udNaturalWeapon = Nothing, udModifiers = [] }
 

--- a/test-headless/Test/Headless/Unit/Fall.hs
+++ b/test-headless/Test/Headless/Unit/Fall.hs
@@ -24,7 +24,8 @@ part pid parent vital hLow layers = BodyPart
     , bpAreaWeight = 0.1, bpTacticalValue = 0.5
     , bpBleedFactor = 1.0, bpHeightLow = hLow, bpHeightHigh = hLow + 0.5
     , bpLayers = [ (m, m, t) | (m, t) ← layers ]   -- name defaults to material
-    , bpTargetable = True, bpDepth = 0.0 }
+    , bpTargetable = True, bpDepth = 0.0
+    , bpAffectsLocomotion = False, bpAffectsBalance = False }
 
 humanoid ∷ UnitDef
 humanoid = UnitDef

--- a/test-headless/Test/Headless/Unit/InjurySpeed.hs
+++ b/test-headless/Test/Headless/Unit/InjurySpeed.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE Strict, UnicodeSyntax, OverloadedStrings #-}
+-- | Tests for Unit.Thread.Command.injurySpeedMult (#393): which parts
+--   count as "leg" (bpAffectsLocomotion) or "torso" (bpAffectsBalance)
+--   is DATA-DRIVEN off the unit's own body-part list, not a hardcoded
+--   id match — so a body plan using non-standard ids (a robot's
+--   "hindquarter", say) still slows down correctly as long as its YAML
+--   sets the flags.
+module Test.Headless.Unit.InjurySpeed (spec) where
+
+import UPrelude
+import Test.Hspec
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Map.Strict as Map
+import Engine.Asset.Handle (TextureHandle(..))
+import Unit.Types
+import World.Page.Types (WorldPageId(..))
+import Unit.Direction (Direction(..))
+import Unit.Thread.Command (injurySpeedMult)
+
+-- A body part builder: id plus the two locomotion-relevant flags.
+part ∷ Text → Bool → Bool → BodyPart
+part pid loco bal = BodyPart
+    { bpId = pid, bpName = pid, bpParent = Nothing, bpVital = False
+    , bpAreaWeight = 0.1, bpTacticalValue = 0.5, bpBleedFactor = 1.0
+    , bpHeightLow = 0, bpHeightHigh = 1, bpLayers = []
+    , bpTargetable = True, bpDepth = 0.0
+    , bpAffectsLocomotion = loco, bpAffectsBalance = bal }
+
+-- Non-standard ids on purpose: proves classification rides on the
+-- flag, not on matching "l_leg"/"torso"-style names.
+bodyParts ∷ [BodyPart]
+bodyParts =
+    [ part "chassis"     False True    -- torso-equivalent (balance)
+    , part "hindquarter" True  False   -- leg-equivalent (locomotion)
+    , part "tail"        False False   -- affects neither
+    ]
+
+-- A unit at full blood (bloodMul = 1.0) carrying the given wounds, so
+-- the tests isolate the leg/torso terms.
+inst ∷ [Wound] → UnitInstance
+inst ws = UnitInstance
+    { uiDefName = "t", uiName = "", uiPage = WorldPageId "test"
+    , uiTexture = TextureHandle 0, uiDirSprites = Map.empty
+    , uiBaseWidth = 0, uiGridX = 0, uiGridY = 0, uiGridZ = 0, uiRealZ = 0
+    , uiFacing = DirS, uiCurrentAnim = "", uiAnimStart = 0, uiAnimReverse = False
+    , uiActivity = "idle", uiPose = "standing", uiAnimStride = 1
+    , uiStats = HM.fromList [("body_mass", 70)]
+    , uiModifiers = HM.empty, uiSkills = HM.empty, uiKnowledge = HM.empty
+    , uiInventory = [], uiEquipment = HM.empty, uiAccessories = []
+    , uiFactionId = "t", uiWounds = ws, uiScars = []
+    , uiImmuneResponse = 0, uiImmunities = HM.empty, uiBlood = 70 * bloodMassRatio
+    , uiLastAttackerUid = Nothing, uiLastAttackerAt = 0
+    , uiAnimOverride = "", uiFrozen = False, uiForceLoop = False
+    , uiClimbDest = Nothing }
+
+wound ∷ Text → Float → Wound
+wound p sev = Wound
+    { woundPart = p, woundKind = "blunt", woundSeverity = sev
+    , woundAt = 0, woundBandage = 0.0, woundClot = 0.0, woundHeal = 0.0
+    , woundDressing = "", woundInfection = 0.0, woundClean = False
+    , woundInfectionType = "", woundNecrosis = 0.0 }
+
+speedMult ∷ [Wound] → Float
+speedMult ws = injurySpeedMult bodyParts (inst ws)
+
+spec ∷ Spec
+spec = describe "injurySpeedMult (data-driven leg/torso classification, #393)" $ do
+    it "an uninjured unit at full blood moves at full speed" $
+        speedMult [] `shouldBe` 1.0
+
+    it "a wound on a bpAffectsLocomotion part slows movement, even with a non-standard id" $
+        speedMult [wound "hindquarter" 0.5] `shouldSatisfy` (< 1.0)
+
+    it "a bpAffectsBalance (torso-equivalent) wound slows movement less than an equal-severity leg wound" $
+        let legMult   = speedMult [wound "hindquarter" 0.5]
+            torsoMult = speedMult [wound "chassis" 0.5]
+        in torsoMult `shouldSatisfy` (> legMult)
+
+    it "a wound on a part with neither flag doesn't affect movement speed" $
+        speedMult [wound "tail" 1.0] `shouldBe` 1.0
+
+    it "a wound on an id absent from the body-part list is inert, not a crash" $
+        speedMult [wound "nonexistent" 1.0] `shouldBe` 1.0
+
+    it "matches the severity -> multiplier formula for a leg wound" $
+        -- legCut = min 1 (0.5 * 1.2) = 0.6; raw = (1-0.6) * (1-0) * 1.0 = 0.4
+        speedMult [wound "hindquarter" 0.5] `shouldSatisfy` (\v → abs (v - 0.4) < 1e-4)
+
+    it "clamps the floor at 0.1 under a maximal combined leg+torso wound" $
+        speedMult [wound "hindquarter" 1.0, wound "chassis" 1.0] `shouldBe` 0.1


### PR DESCRIPTION
Closes #393

## Approach

`injurySpeedMult` (`src/Unit/Thread/Command.hs`) decided which wounds
slow a unit's movement by matching a fixed set of leg-part-name
strings (`l_leg`/`r_leg`/`l_foot`/`r_foot`/`l_fore_leg`/`r_fore_leg`/
`l_hind_leg`/`r_hind_leg`) plus a literal `"torso"`. A creature whose
skeleton uses different part ids would silently get zero leg-injury
slowdown, even though the rest of the body-part system (`bpVital`,
`bpTargetable`) is already fully data-driven.

Added two new `BodyPart` flags mirroring that existing pattern:
- `bpAffectsLocomotion` — the direct mobility apparatus (legs/feet);
  keeps the existing 1.2× cut weight.
- `bpAffectsBalance` — core/balance-relevant parts (torso); keeps the
  existing 0.3× cut weight.

`injurySpeedMult` now takes the unit's `[BodyPart]` list (already
available at its one call site via `umDefs`) and looks wounds up by
flag instead of by id. Retrofitted the 4 existing creature defs
(`acolyte`, `bear_brown`, `red_squirrel`, `technomule`) with the flags
on their existing leg/foot/torso parts so current gameplay behavior is
unchanged — the exact severity → speed-multiplier formula is
untouched, only how "is this a leg" is decided.

No save-version bump: `BodyPart` isn't itself serialized into saves
(it's loaded fresh from YAML defs each boot).

## Tested

- New `Test.Headless.Unit.InjurySpeed` hspec spec: locks the exact
  severity→multiplier formula, and proves a body part with a
  non-standard id (e.g. `"hindquarter"`) still slows movement as long
  as it's flagged `bpAffectsLocomotion` — the actual regression #393
  called out.
- Full `cabal test synarchy-test-headless` (673 examples) — green.
- `python3 tools/world_check.py --quick` (6 seeds) — green.
- `python3 tools/test_audit.py` — all 35 groups pass.
- A from-scratch build with `-Werror` (matching CI's gate) — clean,
  no warnings (the new/updated `BodyPart` record-construction sites
  across `src/` and `test-headless/` all got the two new fields).