### PR TITLE
Unify consciousness + mood into a state-of-mind model (#350)

### DIFF
--- a/scripts/brain.lua
+++ b/scripts/brain.lua
@@ -1,34 +1,112 @@
--- Brain / consciousness — the cognitive consequences of physiological
--- derangement. The sixth homeostasis layer.
+-- State of mind — the unified consciousness + mood model. The sixth
+-- homeostasis layer, now covering both axes of "what's going on in this
+-- unit's head":
 --
--- A single derived CONSCIOUSNESS value (0..1, 1 = fully alert) = the WORST of
--- the body's derangements: core-temperature extremes (hypothermic confusion /
--- heat-stroke delirium), low blood oxygen (drowsy → out), and salt imbalance
--- (hypo/hypernatremic confusion). All three drivers are already stats
--- (core_temp, blood_oxygen, salt_conc), so this just reads + combines them.
+--   PHYSIOLOGICAL — the original CONSCIOUSNESS value (0..1, 1 = fully
+--   alert) = the WORST of the body's derangements: core-temperature
+--   extremes (hypothermic confusion / heat-stroke delirium), low blood
+--   oxygen (drowsy → out), and salt imbalance (hypo/hypernatremic
+--   confusion). Unchanged from the original brain.lua — every existing
+--   consumer (the locomotor collapse↔crawl machine, the AI's delirious/
+--   confused checks, the unit-info panel) keeps reading this exact value
+--   with the exact same bands, so none of them regress:
+--     ≥ 0.70  alert      — normal
+--     ≥ 0.40  confused   — addled (Status condition; light)
+--     ≥ 0.15  delirious  — can't act purposefully → stumbles/wanders (unit_ai)
+--     <  0.15 unconscious → collapses (unit_resources), recovers at ≥ 0.40
 --
--- Bands → behaviour:
---   ≥ 0.70  alert      — normal
---   ≥ 0.40  confused   — addled (Status condition; light)
---   ≥ 0.15  delirious  — can't act purposefully → stumbles/wanders (unit_ai)
---   <  0.15 unconscious → collapses (unit_resources), recovers at ≥ 0.40
+--   PSYCHOLOGICAL — new mental values layered on top, persistent (they
+--   drift rather than snap, so a single bad moment doesn't instantly
+--   sour a unit's whole outlook):
+--     mood            — 0..1 (1 = content), drifts toward a target set by
+--                        current pain / hunger / exhaustion / consciousness.
+--     emotional_pain  — 0..1 (0 = none), rises quickly with physical pain
+--                        but decays slowly — the ache that outlasts the
+--                        wound.
+--     concentration   — 0..1, instantaneous (no integration, same
+--                        philosophy as consciousness): how well the unit
+--                        can focus right now, gated by consciousness and
+--                        eroded by pain/exhaustion.
 --
--- This is what makes a unit PASS OUT before a temperature/hypoxia/salt death
--- meter finishes — the "cooks in the desert, passes out, then dies" arc.
+--   state_of_mind — the UNIFIED aggregate: min(consciousness, wellbeing),
+--   the same "your worst problem wins" philosophy the original
+--   consciousness formula used, extended one level up. It does NOT drive
+--   the collapse/delirious/confused machinery (that stays physiological-
+--   only, on purpose — a heartbroken-but-healthy unit shouldn't pass
+--   out); it's the read-only summary value for logs, UI, and future
+--   tie-ins (thoughts #351, mood-gated efficiency #353).
+--
+-- This is what makes a unit PASS OUT before a temperature/hypoxia/salt
+-- death meter finishes — the "cooks in the desert, passes out, then
+-- dies" arc — and, on the psychological side, what gives #351's thought
+-- system a mood/emotional_pain substrate to read and move.
+
+local stats = require("scripts.unit_stats")
 
 local brain = {}
 
--- ---- Bands ----
+-- ---- Consciousness bands (unchanged) ----
 local CONFUSED_BELOW    = 0.70
 local DELIRIOUS_BELOW   = 0.40
 local UNCONSCIOUS_BELOW = 0.15   -- collapse trigger
 local RISE_AT           = 0.40   -- revive gate (hysteresis vs collapse)
 
+-- ---- Pain normalization ----
+-- Mirrors Combat.Resolution.painCeiling (5.0) / unit.getPain's raw sum —
+-- keep in lockstep if either changes.
+local PAIN_CEILING = 5.0
+
+-- ---- Mood ----
+-- Target mood is 1.0 (content) minus weighted deficits; mood DRIFTS toward
+-- that target rather than snapping to it, so mood reads as a persistent
+-- background state rather than a jumpy instant. Slow on purpose — much
+-- slower than the physiological drivers (cardio/thermo respond in
+-- seconds), since a mood swing over seconds would read as manic, not
+-- as a mental state.
+local MOOD_DRIFT       = 0.02   -- per second, toward target
+local MOOD_W_PAIN      = 0.45
+local MOOD_W_HUNGER    = 0.20
+local MOOD_W_EXHAUSTION = 0.20
+local MOOD_W_CONSCIOUS = 0.35
+
+-- ---- Emotional pain ----
+-- Asymmetric drift, same "fill fast / recover slow" shape the failure
+-- meters use: a fresh wound spikes emotional pain almost as fast as the
+-- physical pain itself, but it lingers well after the wound is treated.
+local EMOTIONAL_PAIN_RISE  = 0.5    -- per second, toward current pain
+local EMOTIONAL_PAIN_DECAY = 0.02   -- per second, absent fresh pain
+
+-- ---- Concentration ----
+-- Fully derived, no integration (same "no memory" philosophy as
+-- consciousness) — consciousness gates it hard, pain and exhaustion
+-- erode it but never zero it out on their own.
+local CONCENTRATION_PAIN_WEIGHT  = 0.6
+local CONCENTRATION_STAMINA_FLOOR = 0.4  -- factor at zero stamina
+
 local function clamp(x, lo, hi) return math.max(lo, math.min(hi, x)) end
 
--- Instantaneous consciousness from the physiological drivers (no integration —
--- the underlying stats already drift). min() = your worst problem knocks you out.
-local function compute(uid)
+-- current/max fraction via stats.get (so a Lua-derived max, e.g.
+-- max_stamina = endurance*10, resolves the same way tickResource does).
+-- A unit with no such resource at all (bears have no hunger) reads as
+-- neutral (1.0) rather than penalized.
+local function fracOf(uid, curName, maxFromName)
+    local maxVal = stats.get(uid, maxFromName)
+    if not maxVal or maxVal <= 0 then return 1.0 end
+    local cur = unit.getStat(uid, curName)
+    if not cur then return 1.0 end
+    return clamp(cur / maxVal, 0, 1)
+end
+
+-- 0..1, 0 = no pain. Mirrors Combat.Resolution.painFor's normalization
+-- (unit.getPain returns the same raw, unclamped sum).
+local function painFrac(uid)
+    return clamp((unit.getPain(uid) or 0) / PAIN_CEILING, 0, 1)
+end
+
+-- Instantaneous consciousness from the physiological drivers (no
+-- integration — the underlying stats already drift). min() = your worst
+-- problem knocks you out. UNCHANGED from the original brain.lua.
+local function computeConsciousness(uid)
     local core = unit.getStat(uid, "core_temp")   or 37.0
     local o2   = unit.getStat(uid, "blood_oxygen") or 1.0
     local conc = unit.getStat(uid, "salt_conc")    or 1.0
@@ -49,15 +127,77 @@ local function compute(uid)
     return math.min(tf, of, sf)
 end
 
--- Recompute + store the consciousness stat (called each physiology tick).
-function brain.tick(uid)
-    unit.setStat(uid, "consciousness", compute(uid))
+local function driftMood(uid, dt, consciousness, pain, hungerFrac, staminaFrac)
+    local target = clamp(1.0 - (MOOD_W_PAIN * pain
+                               + MOOD_W_HUNGER * (1.0 - hungerFrac)
+                               + MOOD_W_EXHAUSTION * (1.0 - staminaFrac)
+                               + MOOD_W_CONSCIOUS * (1.0 - consciousness)),
+                          0, 1)
+    local prev = unit.getStat(uid, "mood")
+    if prev == nil then return target end   -- first tick: seed at target, no fake drift-in
+    return prev + (target - prev) * clamp(MOOD_DRIFT * dt, 0, 1)
+end
+
+local function driftEmotionalPain(uid, dt, pain)
+    local prev = unit.getStat(uid, "emotional_pain") or 0.0
+    if pain > prev then
+        return prev + (pain - prev) * clamp(EMOTIONAL_PAIN_RISE * dt, 0, 1)
+    else
+        return math.max(0.0, prev - EMOTIONAL_PAIN_DECAY * dt)
+    end
+end
+
+local function computeConcentration(consciousness, pain, staminaFrac)
+    local staminaFactor = CONCENTRATION_STAMINA_FLOOR
+                        + (1.0 - CONCENTRATION_STAMINA_FLOOR) * staminaFrac
+    return clamp(consciousness * (1.0 - CONCENTRATION_PAIN_WEIGHT * pain)
+                               * staminaFactor, 0, 1)
+end
+
+-- Unified aggregate: the worst of the physiological floor (consciousness)
+-- and the psychological one (mood, dragged down by lingering emotional
+-- pain). Read-only summary — nothing gates on this directly.
+local function computeStateOfMind(consciousness, mood, emotionalPain)
+    local wellbeing = clamp(mood - 0.5 * emotionalPain, 0, 1)
+    return math.min(consciousness, wellbeing)
+end
+
+-- Recompute + store consciousness and the mental values (called each
+-- physiology tick).
+function brain.tick(uid, dt)
+    local consciousness = computeConsciousness(uid)
+    unit.setStat(uid, "consciousness", consciousness)
+
+    local pain        = painFrac(uid)
+    local hungerFrac   = fracOf(uid, "hunger", "max_hunger")
+    local staminaFrac  = fracOf(uid, "stamina", "max_stamina")
+
+    local mood = driftMood(uid, dt, consciousness, pain, hungerFrac, staminaFrac)
+    unit.setStat(uid, "mood", mood)
+
+    local emotionalPain = driftEmotionalPain(uid, dt, pain)
+    unit.setStat(uid, "emotional_pain", emotionalPain)
+
+    local concentration = computeConcentration(consciousness, pain, staminaFrac)
+    unit.setStat(uid, "concentration", concentration)
+
+    unit.setStat(uid, "state_of_mind",
+                 computeStateOfMind(consciousness, mood, emotionalPain))
 end
 
 function brain.consciousness(uid)
     return unit.getStat(uid, "consciousness") or 1.0
 end
 
+function brain.mood(uid)           return unit.getStat(uid, "mood") or 1.0 end
+function brain.emotionalPain(uid)  return unit.getStat(uid, "emotional_pain") or 0.0 end
+function brain.concentration(uid)  return unit.getStat(uid, "concentration") or 1.0 end
+function brain.stateOfMind(uid)    return unit.getStat(uid, "state_of_mind") or 1.0 end
+
+-- Consciousness-gated behaviour — UNCHANGED semantics, still keyed on
+-- consciousness alone (not the blended state_of_mind): the locomotor
+-- collapse machine and the AI's delirious/confused checks must keep
+-- firing exactly as before.
 function brain.isUnconscious(uid)  return brain.consciousness(uid) < UNCONSCIOUS_BELOW end
 function brain.canRise(uid)        return brain.consciousness(uid) >= RISE_AT end
 function brain.isDelirious(uid)
@@ -75,6 +215,19 @@ function brain.state(uid)
     elseif c < DELIRIOUS_BELOW then return "delirious"
     elseif c < CONFUSED_BELOW then return "confused"
     else return "alert" end
+end
+
+-- Everything in one table — the log, tests, and the debug console (table
+-- returns auto-serialize to JSON) want this rather than five round trips.
+function brain.summary(uid)
+    return {
+        consciousness = brain.consciousness(uid),
+        mood          = brain.mood(uid),
+        emotionalPain = brain.emotionalPain(uid),
+        concentration = brain.concentration(uid),
+        stateOfMind   = brain.stateOfMind(uid),
+        state         = brain.state(uid),
+    }
 end
 
 return brain

--- a/scripts/brain.lua
+++ b/scripts/brain.lua
@@ -19,7 +19,9 @@
 --   drift rather than snap, so a single bad moment doesn't instantly
 --   sour a unit's whole outlook):
 --     mood            — 0..1 (1 = content), drifts toward a target set by
---                        current pain / hunger / exhaustion / consciousness.
+--                        current pain / hunger / exhaustion / consciousness
+--                        / awareness (a unit that can barely perceive its
+--                        surroundings feels less secure).
 --     emotional_pain  — 0..1 (0 = none), rises quickly with physical pain
 --                        but decays slowly — the ache that outlasts the
 --                        wound.
@@ -68,6 +70,20 @@ local MOOD_W_PAIN      = 0.45
 local MOOD_W_HUNGER    = 0.20
 local MOOD_W_EXHAUSTION = 0.20
 local MOOD_W_CONSCIOUS = 0.35
+local MOOD_W_AWARENESS = 0.15
+
+-- ---- Awareness ----
+-- Read from the same 'perception' stat unitAwareness (Unit.LineOfSight)
+-- and vision (unitVisibleTiles) key off — the base sensory keenness that
+-- both combat dodge-gating and FOV scale by. 1.0 is the reference every
+-- species defaults to when perception is unset (see LineOfSight.hs); a
+-- unit AT OR ABOVE that baseline reads as fully aware (no mood penalty —
+-- keen senses don't inflate mood past content), only a below-baseline
+-- unit (poor perception, or anything that suppresses it) reads as less
+-- secure. unitAwareness's own bilateral (defender-vs-attacker) LOS/facing/
+-- night-time terms are a per-encounter combat quantity, not a per-unit
+-- background state, so they're deliberately NOT folded in here.
+local AWARENESS_BASELINE = 1.0
 
 -- ---- Emotional pain ----
 -- Asymmetric drift, same "fill fast / recover slow" shape the failure
@@ -103,6 +119,14 @@ local function painFrac(uid)
     return clamp((unit.getPain(uid) or 0) / PAIN_CEILING, 0, 1)
 end
 
+-- 0..1, 1 = fully aware (perception at or above the species baseline),
+-- 0 = perception has dropped to nothing. Deliberately a floor-only
+-- read (no bonus above 1.0) — see the ---- Awareness ---- block above.
+local function awareness(uid)
+    local perception = unit.getStat(uid, "perception") or AWARENESS_BASELINE
+    return clamp(perception / AWARENESS_BASELINE, 0, 1)
+end
+
 -- Instantaneous consciousness from the physiological drivers (no
 -- integration — the underlying stats already drift). min() = your worst
 -- problem knocks you out. UNCHANGED from the original brain.lua.
@@ -127,11 +151,13 @@ local function computeConsciousness(uid)
     return math.min(tf, of, sf)
 end
 
-local function driftMood(uid, dt, consciousness, pain, hungerFrac, staminaFrac)
+local function driftMood(uid, dt, consciousness, pain, hungerFrac, staminaFrac,
+                          awarenessFrac)
     local target = clamp(1.0 - (MOOD_W_PAIN * pain
                                + MOOD_W_HUNGER * (1.0 - hungerFrac)
                                + MOOD_W_EXHAUSTION * (1.0 - staminaFrac)
-                               + MOOD_W_CONSCIOUS * (1.0 - consciousness)),
+                               + MOOD_W_CONSCIOUS * (1.0 - consciousness)
+                               + MOOD_W_AWARENESS * (1.0 - awarenessFrac)),
                           0, 1)
     local prev = unit.getStat(uid, "mood")
     if prev == nil then return target end   -- first tick: seed at target, no fake drift-in
@@ -171,8 +197,10 @@ function brain.tick(uid, dt)
     local pain        = painFrac(uid)
     local hungerFrac   = fracOf(uid, "hunger", "max_hunger")
     local staminaFrac  = fracOf(uid, "stamina", "max_stamina")
+    local awarenessFrac = awareness(uid)
 
-    local mood = driftMood(uid, dt, consciousness, pain, hungerFrac, staminaFrac)
+    local mood = driftMood(uid, dt, consciousness, pain, hungerFrac, staminaFrac,
+                            awarenessFrac)
     unit.setStat(uid, "mood", mood)
 
     local emotionalPain = driftEmotionalPain(uid, dt, pain)
@@ -193,6 +221,10 @@ function brain.mood(uid)           return unit.getStat(uid, "mood") or 1.0 end
 function brain.emotionalPain(uid)  return unit.getStat(uid, "emotional_pain") or 0.0 end
 function brain.concentration(uid)  return unit.getStat(uid, "concentration") or 1.0 end
 function brain.stateOfMind(uid)    return unit.getStat(uid, "state_of_mind") or 1.0 end
+
+-- Live read (not persisted — perception is already a stat, this is just
+-- the same 0..1 normalization brain.tick feeds into the mood target).
+function brain.awareness(uid)      return awareness(uid) end
 
 -- Consciousness-gated behaviour — UNCHANGED semantics, still keyed on
 -- consciousness alone (not the blended state_of_mind): the locomotor
@@ -225,6 +257,7 @@ function brain.summary(uid)
         mood          = brain.mood(uid),
         emotionalPain = brain.emotionalPain(uid),
         concentration = brain.concentration(uid),
+        awareness     = brain.awareness(uid),
         stateOfMind   = brain.stateOfMind(uid),
         state         = brain.state(uid),
     }

--- a/scripts/unit_resources.lua
+++ b/scripts/unit_resources.lua
@@ -1098,8 +1098,11 @@ function unitResources.update(dt)
                 salts.tick(uid, dt)
                 -- Brain consciousness reads the above (core_temp, blood_oxygen,
                 -- salt_conc), so it ticks last. Low consciousness → collapse
-                -- (in tickInjuries); checkRevive keeps the unit down until lucid.
-                brain.tick(uid)
+                -- (in tickInjuries); checkRevive keeps the unit down until
+                -- lucid. Same call also drifts the psychological mental
+                -- values (mood / emotional_pain / concentration / the
+                -- unified state_of_mind) — dt-driven, unlike consciousness.
+                brain.tick(uid, dt)
                 -- Injuries first: a lethal injury kills the unit (skip the
                 -- rest of its tick); a disabling one collapses it.
                 if not tickInjuries(uid, info, pose0)

--- a/tools/state_of_mind_probe.py
+++ b/tools/state_of_mind_probe.py
@@ -21,6 +21,17 @@ model — to confirm:
      (physiological collapse itself is separately covered end-to-end by
      tools/collapse_crawl_probe.py and tools/concussion_revive_probe.py,
      which this change must also keep passing.)
+  5. The awareness/perception input (#350's "read from existing systems"
+     list): brain.awareness(uid) reads the 'perception' stat instantly
+     (no drift — same normalization Unit.LineOfSight uses), and an
+     otherwise-healthy unit with suppressed perception alone (no pain,
+     no hunger/stamina deficit) still sees its mood target dragged down
+     by the awareness term over a few ticks. Uses bear_brown (no
+     equipment) rather than the acolyte: acolytes spawn wearing
+     technogoggles (+perception buff, data/items/technogoggles.yaml),
+     and unit.setStat only overwrites the BASE stat — getStat still
+     returns base + active modifiers — so an equipped unit's effective
+     perception wouldn't land at the raw value this test writes.
 
 Usage: python3 tools/state_of_mind_probe.py [--port 9350]
 Exit 0 = pass.
@@ -210,6 +221,39 @@ def main():
         else:
             ok = False
             print(f"  [FAIL] psychological layer leaked into physiological gating: gate={gate}")
+
+        # ---- 5. Awareness/perception input, isolated from every other
+        # driver: a fresh, gear-free unit (no pain, full hunger/stamina)
+        # with its perception stat suppressed. bear_brown carries no
+        # equipment (no perception-buffing accessory to confound the
+        # read), so setStat's base overwrite lands exactly on getStat's
+        # effective value. brain.awareness() should reflect the drop
+        # immediately (no tick needed — it's a live read), and mood should
+        # drift down over a few ticks purely from the awareness term.
+        aware_uid = int(float(send(P, "local u=unit.spawn('bear_brown',9,0); return u")))
+        send(P, f"unit.setStat({aware_uid},'perception',0.2); return 'ok'")
+        aware_now = float(send(P,
+            f"return require('scripts.brain').awareness({aware_uid})"))
+        print(f"  awareness uid={aware_uid}: perception=0.2 -> brain.awareness()={aware_now:.3f}")
+        if close(aware_now, 0.2, tol=0.02):
+            print("  [pass] brain.awareness() reflects suppressed perception instantly")
+        else:
+            ok = False
+            print(f"  [FAIL] brain.awareness() {aware_now:.3f} != expected ~0.2")
+
+        aware_samples = []
+        for _ in range(8):
+            time.sleep(0.5)
+            aware_samples.append(summary(P, aware_uid))
+        aware_mood_trend = [s.get("mood", 1) for s in aware_samples]
+        print(f"  low-awareness mood trend: {[round(x,3) for x in aware_mood_trend]}")
+        # Expected asymptote: 1 - MOOD_W_AWARENESS*(1-0.2) = 1 - 0.15*0.8 = 0.88.
+        if aware_mood_trend[-1] < aware_mood_trend[0] - 0.002:
+            print(f"  [pass] mood drifts down from suppressed perception ALONE "
+                  f"({aware_mood_trend[0]:.4f} → {aware_mood_trend[-1]:.4f}, no pain/hunger/exhaustion)")
+        else:
+            ok = False
+            print(f"  [FAIL] mood didn't respond to the awareness input: {aware_mood_trend}")
 
         print(f"\n{'PASS' if ok else 'FAIL'} — unified state-of-mind model (#350)")
         return 0 if ok else 1

--- a/tools/state_of_mind_probe.py
+++ b/tools/state_of_mind_probe.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""State-of-mind probe (#350).
+
+Drives the REAL engine's brain.lua — now the unified consciousness + mood
+model — to confirm:
+
+  1. A fresh unit reads as fully alert/content: consciousness, mood,
+     concentration, and state_of_mind all 1.0, emotional_pain 0.0.
+  2. Physical pain immediately depresses concentration (an instantaneous,
+     non-integrated formula — checked against the exact expected value)
+     and, over a few ticks, drags mood down and emotional_pain up (the
+     "ache lingers" asymmetric-drift psychological layer).
+  3. A species with no hunger/hydration config (bear_brown) computes all
+     five values without error — the fracOf fallback (absent resource ⇒
+     neutral, not penalized).
+  4. THE REGRESSION GUARD this issue calls for: even once pain has
+     tanked mood/emotional_pain/state_of_mind, the unit stays standing
+     and brain.isUnconscious/isDelirious/isConfused all stay false — the
+     locomotor collapse machine and the AI's delirium gate key on
+     consciousness ALONE, unaffected by the new psychological layer.
+     (physiological collapse itself is separately covered end-to-end by
+     tools/collapse_crawl_probe.py and tools/concussion_revive_probe.py,
+     which this change must also keep passing.)
+
+Usage: python3 tools/state_of_mind_probe.py [--port 9350]
+Exit 0 = pass.
+"""
+from __future__ import annotations
+import argparse, glob, json, socket, subprocess, sys, time
+
+LOG = "/tmp/state_of_mind_probe_engine.log"
+PAIN_CEILING = 5.0  # brain.lua PAIN_CEILING — keep in lockstep
+
+
+def send(port, lua, timeout=10.0, idle=0.3):
+    with socket.create_connection(("localhost", port), timeout=timeout) as s:
+        s.sendall((lua + "\n").encode())
+        chunks = []
+        s.settimeout(idle)
+        try:
+            while True:
+                b = s.recv(4096)
+                if not b:
+                    break
+                chunks.append(b)
+        except socket.timeout:
+            pass
+    out = b"".join(chunks).decode(errors="replace")
+    res = [ln[2:].strip() for ln in out.splitlines() if ln.startswith("> ")]
+    res = [r for r in res if r]
+    return res[-1] if res else out.strip()
+
+
+def boot(port):
+    log = open(LOG, "w")
+    proc = subprocess.Popen(
+        ["cabal", "run", "-v0", "exe:synarchy", "--",
+         "--headless", "--port", str(port)],
+        stdout=log, stderr=subprocess.STDOUT)
+    deadline = time.time() + 300
+    while time.time() < deadline:
+        try:
+            if "READY" in open(LOG).read():
+                return proc
+        except FileNotFoundError:
+            pass
+        if proc.poll() is not None:
+            sys.exit(f"engine exited before READY; see {LOG}")
+        time.sleep(0.4)
+    proc.kill()
+    sys.exit("engine never printed READY")
+
+
+def bootstrap(port):
+    loaders = [
+        ("data/substances/*.yaml", "engine.loadSubstanceYaml"),
+        ("data/infections/*.yaml", "engine.loadInfectionYaml"),
+        ("data/items/*.yaml",      "engine.loadItemYaml"),
+        ("data/equipment/*.yaml",  "engine.loadEquipmentYaml"),
+        ("data/materials/*.yaml",  "engine.loadMaterialYaml"),
+        ("data/units/*.yaml",      "engine.loadUnitYaml"),
+    ]
+    for pattern, fn in loaders:
+        for path in sorted(glob.glob(pattern)):
+            send(port, f"{fn}('{path}'); return 'ok'")
+    send(port, "engine.loadScript('scripts/unit_stats.lua', 0.1); return 'ok'")
+    send(port, "engine.loadScript('scripts/unit_resources.lua', 0.2); return 'ok'")
+    # Neutralise the AI wander tick so units stay put — we're measuring the
+    # mental values, not pathing (the delirium/confusion gate is checked via
+    # brain.* predicates directly, not by watching AI behaviour).
+    send(port, "pcall(function() require('scripts.unit_ai').update = "
+               "function() end end); return 'ok'")
+    send(port, "require('scripts.movement_arena').buildCourse('flat'); return 'ok'")
+
+
+def summary(port, uid):
+    raw = send(port, f"return require('scripts.brain').summary({uid})")
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {"_raw": raw}
+
+
+def close(a, b, tol=0.02):
+    return abs(a - b) <= tol
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=9350)
+    args = ap.parse_args()
+    P = args.port
+
+    proc = boot(P)
+    ok = True
+    try:
+        bootstrap(P)
+
+        # ---- 1. Fresh unit reads as fully alert/content. ----
+        uid = send(P, "local u=unit.spawn('acolyte',1,0); return u")
+        uid = int(float(uid))
+        print(f"spawned acolyte uid={uid}")
+        s0 = summary(P, uid)
+        print(f"  fresh: {s0}")
+        fresh_ok = (s0.get("state") == "alert"
+                    and close(s0.get("consciousness", 0), 1.0)
+                    and close(s0.get("mood", 0), 1.0)
+                    and close(s0.get("emotionalPain", 1), 0.0)
+                    and close(s0.get("concentration", 0), 1.0)
+                    and close(s0.get("stateOfMind", 0), 1.0))
+        if fresh_ok:
+            print("  [pass] fresh unit: alert, mood/concentration/stateOfMind ~1.0, no emotional pain")
+        else:
+            ok = False
+            print(f"  [FAIL] fresh unit not at baseline: {s0}")
+
+        # ---- 3. Species with no hunger/hydration config computes cleanly. ----
+        bear = send(P, "local u=unit.spawn('bear_brown',5,0); return u")
+        bear = int(float(bear))
+        sb = summary(P, bear)
+        print(f"  bear_brown (no hunger config) uid={bear}: {sb}")
+        bear_ok = (sb.get("state") == "alert"
+                   and all(isinstance(sb.get(k), (int, float))
+                           for k in ("consciousness", "mood", "emotionalPain",
+                                     "concentration", "stateOfMind")))
+        if bear_ok:
+            print("  [pass] hunger-less species computes all mental values (fallback, no crash)")
+        else:
+            ok = False
+            print(f"  [FAIL] bear_brown summary malformed: {sb}")
+
+        # ---- 2. Physical pain: instantaneous concentration hit + drift. ----
+        send(P, f"return unit.injure({uid},'l_forearm','slash',0.6,0.0)")
+        rawpain = send(P, f"return unit.getPain({uid})")
+        pain_raw = float(rawpain)
+        pain_frac = max(0.0, min(1.0, pain_raw / PAIN_CEILING))
+        time.sleep(0.5)
+        s1 = summary(P, uid)
+        expected_conc = 1.0 * (1.0 - 0.6 * pain_frac) * 1.0  # stamina still ~full
+        print(f"  injured (raw pain={pain_raw:.3f}, frac={pain_frac:.3f}): {s1}")
+        if close(s1.get("concentration", 0), expected_conc, tol=0.05):
+            print(f"  [pass] concentration drops to ~{expected_conc:.3f} immediately on injury")
+        else:
+            ok = False
+            print(f"  [FAIL] concentration {s1.get('concentration')} != expected ~{expected_conc:.3f}")
+
+        # Let pain persist a few seconds — emotional_pain should climb toward
+        # pain_frac (fast rise), mood should drop below its fresh baseline.
+        samples = []
+        for _ in range(8):
+            time.sleep(0.5)
+            samples.append(summary(P, uid))
+        ep_trend = [s.get("emotionalPain", 0) for s in samples]
+        mood_trend = [s.get("mood", 1) for s in samples]
+        print(f"  emotionalPain trend: {[round(x,3) for x in ep_trend]}")
+        print(f"  mood trend:          {[round(x,3) for x in mood_trend]}")
+
+        rising = ep_trend[-1] > ep_trend[0] and ep_trend[-1] <= pain_frac + 0.05
+        if rising:
+            print(f"  [pass] emotional_pain rises toward pain fraction ({pain_frac:.3f}) over sustained pain")
+        else:
+            ok = False
+            print(f"  [FAIL] emotional_pain didn't rise sensibly: {ep_trend}")
+
+        mood_down = mood_trend[-1] < mood_trend[0] - 0.002
+        if mood_down:
+            print(f"  [pass] mood drifts down under sustained pain "
+                  f"({mood_trend[0]:.4f} → {mood_trend[-1]:.4f})")
+        else:
+            ok = False
+            print(f"  [FAIL] mood didn't drift down under sustained pain: {mood_trend}")
+
+        # ---- 4. Regression guard: psychological tanking must NOT trip the
+        # physiological collapse/delirium gates — those stay keyed on
+        # consciousness alone. (One table return, JSON-decoded, so the
+        # console's string-quoting doesn't need string-compare gymnastics.)
+        s2 = samples[-1]
+        gate = json.loads(send(P,
+            f"local u={uid} local b=require('scripts.brain') "
+            f"return {{pose=unit.getPose(u), uncon=b.isUnconscious(u), "
+            f"delir=b.isDelirious(u), conf=b.isConfused(u), state=b.state(u)}}"))
+        print(f"  post-pain gate check: state_of_mind={s2.get('stateOfMind'):.3f} gate={gate}")
+        guard_ok = (gate["pose"] == "standing" and not gate["uncon"] and not gate["delir"]
+                    and not gate["conf"] and gate["state"] == "alert"
+                    and s2.get("stateOfMind", 1.0) < s2.get("consciousness", 1.0))
+        if guard_ok:
+            print("  [pass] REGRESSION GUARD: collapse/delirious/confused gates stay off "
+                  "consciousness alone — unaffected by the depressed psychological layer "
+                  "(state_of_mind < consciousness, but pose/gates untouched)")
+        else:
+            ok = False
+            print(f"  [FAIL] psychological layer leaked into physiological gating: gate={gate}")
+
+        print(f"\n{'PASS' if ok else 'FAIL'} — unified state-of-mind model (#350)")
+        return 0 if ok else 1
+    finally:
+        send(P, "engine.quit(); return 'bye'")
+        time.sleep(0.5)
+        if proc.poll() is None:
+            proc.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Foundational piece of the [psychology] State-of-mind epic (#349). `brain.lua`'s physiological consciousness (temp/O2/salt derangement) is left exactly as it was — same formula, same bands, same `consciousness` stat name — since the locomotor collapse↔crawl machine, the AI's delirious/confused checks, and the unit-info panel all key off it directly and must not regress.

Layered on top of that, in the same module (`brain.lua`'s "consciousness ... refactored into this model, not run separately"):

- **`mood`** (0..1, 1 = content) — drifts (doesn't snap) toward a target set by current physical pain, hunger, exhaustion, and consciousness deficits. Slow drift constant on purpose, so mood reads as a persistent background state, not a jumpy instant.
- **`emotional_pain`** (0..1) — rises quickly with physical pain but decays slowly: "the ache that outlasts the wound." Same fill-fast/recover-slow shape the existing failure meters use.
- **`concentration`** (0..1) — fully derived, no integration (same philosophy as consciousness itself): gated hard by consciousness, eroded by pain and exhaustion.
- **`state_of_mind`** — the unified aggregate: `min(consciousness, wellbeing)`, the same "your worst problem wins" logic the original consciousness formula used, extended one level up. This is a read-only summary value — it does **not** drive collapse/delirium (a unit in a bad mood but physically fine shouldn't pass out); that stays consciousness-only by design.

All four new values are `uiStats`, recomputed each physiology tick alongside consciousness (`brain.tick(uid, dt)` — now takes `dt` since mood/emotional_pain need to integrate over time, unlike the original instantaneous consciousness). `brain.summary(uid)` bundles everything for logs/tests/debug-console use.

## What's deliberately left open (per the issue)

Aggregation weights, decay/recovery rates, and which values are primitive vs. derived were all called out as open design questions in #350 — I picked reasonable, documented, tunable values consistent with the existing homeostasis modules' style (see the `-- ---- Mood ----` / `-- ---- Emotional pain ----` etc. tunable blocks in `brain.lua`). Nothing here gates gameplay yet (no behavior changes to existing systems) — it's the substrate #351 (thought system) and the deferred #353 (combat/crafting mood tie-ins) will consume.

## Test plan

- [x] New gate: `python3 tools/state_of_mind_probe.py` — fresh-unit baseline (all values ~1.0/0.0 as expected), pain-driven instantaneous concentration drop (checked against the exact formula), sustained-pain mood/emotional_pain drift trends, a hunger/hydration-less species (`bear_brown`) computing all values without error (fallback path), and the key regression guard: even with mood/emotional_pain/state_of_mind tanked by pain, `pose`/`isUnconscious`/`isDelirious`/`isConfused` stay unaffected (consciousness-only gating preserved).
- [x] Existing regression gates still pass unchanged: `tools/collapse_crawl_probe.py`, `tools/concussion_revive_probe.py`, `tools/physiology_probe.py`.
- [x] `cabal test synarchy-test-headless` (673 examples, 0 failures).
- [x] `python3 tools/world_check.py` (21/21 seeds pass — no worldgen touched, sanity check only).
- [x] `python3 tools/test_audit.py` (35/35 groups pass).

No engine (Haskell) or save-format changes — pure Lua, using the existing generic `unit.getStat`/`setStat` stat storage the same way `consciousness` already did.

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)